### PR TITLE
Write language and direction for PDFs

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -8,6 +8,7 @@ use crate::geom::{
     Align, Em, Length, Numeric, Paint, Point, Shape, Size, Spec, Transform,
 };
 use crate::image::ImageId;
+use crate::library::text::Lang;
 use crate::util::{EcoString, MaybeShared};
 
 /// A finished layout with elements at fixed positions.
@@ -269,6 +270,8 @@ pub struct Text {
     pub size: Length,
     /// Glyph color.
     pub fill: Paint,
+    /// The natural language of the text.
+    pub lang: Lang,
     /// The glyphs.
     pub glyphs: Vec<Glyph>,
 }

--- a/src/library/text/lang.rs
+++ b/src/library/text/lang.rs
@@ -28,7 +28,7 @@ impl Lang {
     }
 
     /// The default direction for the language.
-    pub fn dir(&self) -> Dir {
+    pub fn dir(self) -> Dir {
         match self.as_str() {
             "ar" | "dv" | "fa" | "he" | "ks" | "pa" | "ps" | "sd" | "ug" | "ur"
             | "yi" => Dir::RTL,

--- a/src/library/text/shaping.rs
+++ b/src/library/text/shaping.rs
@@ -104,7 +104,13 @@ impl<'a> ShapedText<'a> {
                 })
                 .collect();
 
-            let text = Text { face_id, size: self.size, fill, glyphs };
+            let text = Text {
+                face_id,
+                size: self.size,
+                lang: self.styles.get(TextNode::LANG),
+                fill,
+                glyphs,
+            };
             let text_layer = frame.layer();
             let width = text.width();
 


### PR DESCRIPTION
Writes the `Lang` and `ViewerPreferences/Direction` dictionary entries in the document catalog using the language with the most glyphs in the document. `Lang` will be omitted if the document contains no text, `Direction` will default to `L2R`.

![grafik](https://user-images.githubusercontent.com/3874949/167859954-6766814d-6c08-459d-82f1-f1120c263b3b.png)
