### PR TITLE
Incremental Parser fixes

### DIFF
--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -841,25 +841,25 @@ impl NodeKind {
         }
     }
 
-    /// Whether this is a node that is not clearly delimited by a character and
-    /// may appear in markup.
-    pub fn is_unbounded(&self) -> bool {
-        matches!(
-            self,
-            Self::Strong
-                | Self::Emph
-                | Self::Raw(_)
-                | Self::Math(_)
-                | Self::LetExpr
-                | Self::SetExpr
-                | Self::ShowExpr
-                | Self::WrapExpr
-                | Self::IfExpr
-                | Self::WhileExpr
-                | Self::ForExpr
-                | Self::IncludeExpr
-                | Self::ImportExpr
-        )
+    /// Whether this is a node that is clearly delimited by a character and may
+    /// appear in markup.
+    pub fn is_bounded(&self) -> bool {
+        match self {
+            Self::CodeBlock
+            | Self::ContentBlock
+            | Self::Linebreak { .. }
+            | Self::NonBreakingSpace
+            | Self::Shy
+            | Self::EnDash
+            | Self::EmDash
+            | Self::Ellipsis
+            | Self::Quote { .. }
+            | Self::BlockComment
+            | Self::Space(_)
+            | Self::Escape(_) => true,
+            Self::Text(t) => t != "-" && !t.ends_with('.'),
+            _ => false,
+        }
     }
 
     /// A human-readable name for the kind.


### PR DESCRIPTION
This PR fixes two problems in the incremental parser:
- Constructs like `show` which may include a varying amount of tokens behind it now parse correctly when in markup
- Replacing markup elements in nodes with the same opening and closing bracket is now illegal, eliminating a class of bug