### PR TITLE
nix flake dev environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake .

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ bench/target
 # Node
 node_modules
 package-lock.json
+
+# Nix
+.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,94 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1677655039,
+        "narHash": "sha256-IsU0SSBUOr/qYTkiwIgXQ91Io/2bfXI7PG4MoJritLA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "96a40fa5e8dee644ba60c8a966adadd2d448104a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1665296151,
+        "narHash": "sha256-uOB0oxqxN9K7XGF1hcnY+PQnlQJ+3bP2vCn/+Ru/bbc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "14ccaaedd95a488dd7ae142757884d8e125b3363",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1676341851,
+        "narHash": "sha256-T8cmSiriXdpZfqlserNyJ1solTCR0DbD8A75epSDOVY=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "956ddb5047f98ea08b792b22004b94a9971932c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,56 @@
+{
+  description = "A Nix-flake-based Rust development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/release-22.11";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+
+  outputs =
+    { self
+    , nixpkgs
+    , flake-utils
+    , rust-overlay
+    }:
+
+    flake-utils.lib.eachDefaultSystem (system:
+    let
+      overlays = [
+        (import rust-overlay)
+        (self: super: {
+          rustToolchain =
+            let
+              rust = super.rust-bin;
+            in
+            if builtins.pathExists ./rust-toolchain.toml then
+              rust.fromRustupToolchainFile ./rust-toolchain.toml
+            else if builtins.pathExists ./rust-toolchain then
+              rust.fromRustupToolchainFile ./rust-toolchain
+            else
+              rust.stable.latest.default;
+        })
+      ];
+
+      pkgs = import nixpkgs { inherit system overlays; };
+    in
+    {
+      devShells.default = pkgs.mkShell {
+        packages = with pkgs; [
+          rustToolchain
+          openssl
+          pkg-config
+          cargo-deny
+          cargo-edit
+          cargo-watch
+          rust-analyzer
+        ] ++ lib.optionals stdenv.isDarwin [
+          pkgs.darwin.apple_sdk.frameworks.CoreServices
+        ];
+
+        shellHook = ''
+          ${pkgs.rustToolchain}/bin/cargo --version
+        '';
+      };
+    });
+}


### PR DESCRIPTION
This is a nix flake that supports seamless development environment for building typst from source. Either using `nix develop` or by installing direnv and running `direnv allow`, I confirmed this flake can build typst-cli on Apple Silicon Macs and x86_64 Linux (both need nix previously installed)