### PR TITLE
Fix typos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Continous integration
+name: Continuous integration
 on: [push, pull_request]
 
 jobs:

--- a/docs/src/general/changelog.md
+++ b/docs/src/general/changelog.md
@@ -11,7 +11,7 @@ description: |
     supported styles are APA, Chicago Author Date, IEEE, and MLA)
   - You can now [reference]($func/ref) sections, figures, formulas, and works
     from the bibliography with `[@label]`
-  - You can make an element referencable with a label:
+  - You can make an element referenceable with a label:
     - `[= Introduction <intro>]`
     - `[$ A = pi r^2 $ <area>]`
 
@@ -29,7 +29,7 @@ description: |
       document
     - State is modified in layout order and not in code order
   - [`query`]($func/query) function
-    - Find all occurances of an element or a label, either in the whole document
+    - Find all occurrences of an element or a label, either in the whole document
       or before/after some location
     - Link to elements, find out their position on the pages and access their
       fields

--- a/docs/src/tutorial/1-writing.md
+++ b/docs/src/tutorial/1-writing.md
@@ -141,7 +141,7 @@ that, first attach a label to figure. A label uniquely identifies an element in
 your document. Add one after the figure by enclosing some name in angle
 brackets. You can then reference the figure in your text by writing an `[@]`
 symbol followed by that name. Headings and equations can also be labelled to
-make them referencable.
+make them referenceable.
 
 ```example
 Glaciers as the one shown in

--- a/library/src/layout/flow.rs
+++ b/library/src/layout/flow.rs
@@ -75,7 +75,7 @@ struct FlowLayouter<'a> {
     regions: Regions<'a>,
     /// Whether the flow should expand to fill the region.
     expand: Axes<bool>,
-    /// The intial size of `regions.size` that was available before we started
+    /// The initial size of `regions.size` that was available before we started
     /// subtracting.
     initial: Size,
     /// Whether the last block was a paragraph.

--- a/library/src/layout/grid.rs
+++ b/library/src/layout/grid.rs
@@ -659,7 +659,7 @@ impl<'a, 'v> GridLayouter<'a, 'v> {
         assert!(x < self.cols.len());
         assert!(y < self.rows.len());
 
-        // Columns are reorded, but the cell slice is not.
+        // Columns are reorder, but the cell slice is not.
         if self.is_rtl {
             x = self.cols.len() - 1 - x;
         }

--- a/library/src/layout/par.rs
+++ b/library/src/layout/par.rs
@@ -395,7 +395,7 @@ impl SpanMapper {
 
 /// A layouted line, consisting of a sequence of layouted paragraph items that
 /// are mostly borrowed from the preparation phase. This type enables you to
-/// measure the size of a line in a range before comitting to building the
+/// measure the size of a line in a range before committing to building the
 /// line's frame.
 ///
 /// At most two paragraph items must be created individually for this line: The
@@ -889,7 +889,7 @@ fn linebreak_optimized<'a>(vt: &Vt, p: &'a Preparation<'a>, width: Abs) -> Vec<L
                 // The line is overfull. This is the case if
                 // - justification is on, but we'd need to shrink too much
                 // - justification is off and the line just doesn't fit
-                // Since any longer line will also be overfull, we can deactive
+                // Since any longer line will also be overfull, we can deactivate
                 // this breakpoint.
                 active = i + 1;
                 MAX_COST

--- a/library/src/layout/stack.rs
+++ b/library/src/layout/stack.rs
@@ -233,7 +233,7 @@ impl<'a> StackLayouter<'a> {
 
     /// Advance to the next region.
     fn finish_region(&mut self) {
-        // Determine the size of the stack in this region dependening on whether
+        // Determine the size of the stack in this region depending on whether
         // the region expands.
         let mut size = self
             .expand

--- a/library/src/meta/reference.rs
+++ b/library/src/meta/reference.rs
@@ -146,7 +146,7 @@ impl Show for RefElem {
 }
 
 impl RefElem {
-    /// Turn the rference into a citation.
+    /// Turn the reference into a citation.
     pub fn to_citation(&self, styles: StyleChain) -> CiteElem {
         let mut elem = CiteElem::new(vec![self.target().0]);
         elem.0.set_location(self.0.location().unwrap());

--- a/library/src/text/quotes.rs
+++ b/library/src/text/quotes.rs
@@ -109,7 +109,7 @@ fn is_opening_bracket(c: char) -> bool {
     matches!(c, '(' | '{' | '[')
 }
 
-/// Decides which quotes to subtitute smart quotes with.
+/// Decides which quotes to substitute smart quotes with.
 pub struct Quotes<'s> {
     /// The opening single quote.
     pub single_open: &'s str,

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -112,16 +112,16 @@ impl Display for Tracepoint {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
             Tracepoint::Call(Some(name)) => {
-                write!(f, "error occured in this call of function `{}`", name)
+                write!(f, "error occurred in this call of function `{}`", name)
             }
             Tracepoint::Call(None) => {
-                write!(f, "error occured in this function call")
+                write!(f, "error occurred in this function call")
             }
             Tracepoint::Show(name) => {
-                write!(f, "error occured while applying show rule to this {name}")
+                write!(f, "error occurred while applying show rule to this {name}")
             }
             Tracepoint::Import => {
-                write!(f, "error occured while importing this module")
+                write!(f, "error occurred while importing this module")
             }
         }
     }
@@ -180,7 +180,7 @@ where
 /// A result type with a file-related error.
 pub type FileResult<T> = Result<T, FileError>;
 
-/// An error that occured while trying to load of a file.
+/// An error that occurred while trying to load of a file.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum FileError {
     /// A file was not found at this path.

--- a/src/eval/array.rs
+++ b/src/eval/array.rs
@@ -114,7 +114,7 @@ impl Array {
         Ok(self.0.remove(i))
     }
 
-    /// Extract a contigous subregion of the array.
+    /// Extract a contiguous subregion of the array.
     pub fn slice(&self, start: i64, end: Option<i64>) -> StrResult<Self> {
         let len = self.len();
         let start = self

--- a/src/eval/str.rs
+++ b/src/eval/str.rs
@@ -72,7 +72,7 @@ impl Str {
         Ok(grapheme.into())
     }
 
-    /// Extract a contigous substring.
+    /// Extract a contiguous substring.
     pub fn slice(&self, start: i64, end: Option<i64>) -> StrResult<Self> {
         let start = self.locate(start)?;
         let end = self.locate(end.unwrap_or(self.len()))?.max(start);
@@ -251,7 +251,7 @@ impl Str {
         trimmed.into()
     }
 
-    /// Replace at most `count` occurances of the given pattern with a
+    /// Replace at most `count` occurrences of the given pattern with a
     /// replacement string (beginning from the start).
     pub fn replace(&self, pattern: StrPattern, with: Self, count: Option<usize>) -> Self {
         match pattern {

--- a/src/eval/value.rs
+++ b/src/eval/value.rs
@@ -250,7 +250,7 @@ impl Hash for Value {
 pub struct Dynamic(Arc<dyn Bounds>);
 
 impl Dynamic {
-    /// Create a new instance from any value that satisifies the required bounds.
+    /// Create a new instance from any value that satisfies the required bounds.
     pub fn new<T>(any: T) -> Self
     where
         T: Type + Debug + PartialEq + Hash + Sync + Send + 'static,

--- a/src/export/pdf/image.rs
+++ b/src/export/pdf/image.rs
@@ -86,7 +86,7 @@ fn encode_image(
             (data.into_inner(), Filter::DctDecode, true)
         }
 
-        // TODO: Encode flate streams with PNG-predictor?
+        // TODO: Encode flat streams with PNG-predictor?
 
         // 8-bit gray PNG.
         (RasterFormat::Png, DynamicImage::ImageLuma8(luma)) => {

--- a/src/geom/ratio.rs
+++ b/src/geom/ratio.rs
@@ -18,7 +18,7 @@ impl Ratio {
         Self(Scalar(1.0))
     }
 
-    /// Create a new ratio from a value, whre `1.0` means `100%`.
+    /// Create a new ratio from a value, where `1.0` means `100%`.
     pub const fn new(ratio: f64) -> Self {
         Self(Scalar(ratio))
     }

--- a/src/ide/complete.rs
+++ b/src/ide/complete.rs
@@ -195,7 +195,7 @@ fn markup_completions(ctx: &mut CompletionContext) {
     ctx.snippet_completion(
         "label",
         "<${name}>",
-        "Makes the preceding element referencable.",
+        "Makes the preceding element referenceable.",
     );
 
     ctx.snippet_completion(
@@ -517,7 +517,7 @@ fn show_rule_selector_completions(ctx: &mut CompletionContext) {
     ctx.snippet_completion(
         "text selector",
         "\"${text}\": ${}",
-        "Replace occurances of specific text.",
+        "Replace occurrences of specific text.",
     );
 
     ctx.snippet_completion(
@@ -794,19 +794,19 @@ fn code_completions(ctx: &mut CompletionContext, hashtag: bool) {
     ctx.snippet_completion(
         "while loop",
         "while ${1 < 2} {\n\t${}\n}",
-        "Computes or inserts somthing while a condition is met.",
+        "Computes or inserts something while a condition is met.",
     );
 
     ctx.snippet_completion(
         "for loop",
         "for ${value} in ${(1, 2, 3)} {\n\t${}\n}",
-        "Computes or inserts somthing for each value in a collection.",
+        "Computes or inserts something for each value in a collection.",
     );
 
     ctx.snippet_completion(
         "for loop (with key)",
         "for ${key}, ${value} in ${(a: 1, b: 2)} {\n\t${}\n}",
-        "Computes or inserts somthing for each key and value in a collection.",
+        "Computes or inserts something for each key and value in a collection.",
     );
 
     ctx.snippet_completion(

--- a/src/syntax/ast.rs
+++ b/src/syntax/ast.rs
@@ -652,7 +652,7 @@ impl Heading {
         self.0.cast_first_match().unwrap_or_default()
     }
 
-    /// The section depth (numer of equals signs).
+    /// The section depth (number of equals signs).
     pub fn level(&self) -> NonZeroUsize {
         self.0
             .children()
@@ -1085,7 +1085,7 @@ impl Array {
 pub enum ArrayItem {
     /// A bare expression: `12`.
     Pos(Expr),
-    /// A spreaded expression: `..things`.
+    /// A spread expression: `..things`.
     Spread(Expr),
 }
 
@@ -1117,14 +1117,14 @@ impl Dict {
     }
 }
 
-/// An item in an dictionary expresssion.
+/// An item in an dictionary expression.
 #[derive(Debug, Clone, Hash)]
 pub enum DictItem {
     /// A named pair: `thickness: 3pt`.
     Named(Named),
     /// A keyed pair: `"spacy key": true`.
     Keyed(Keyed),
-    /// A spreaded expression: `..things`.
+    /// A spread expression: `..things`.
     Spread(Expr),
 }
 
@@ -1484,7 +1484,7 @@ pub enum Arg {
     Pos(Expr),
     /// A named argument: `draw: false`.
     Named(Named),
-    /// A spreaded argument: `..things`.
+    /// A spread argument: `..things`.
     Spread(Expr),
 }
 

--- a/src/syntax/kind.rs
+++ b/src/syntax/kind.rs
@@ -212,7 +212,7 @@ pub enum SyntaxKind {
     FuncCall,
     /// A function call's argument list: `(12pt, y)`.
     Args,
-    /// Spreaded arguments or an argument sink: `..x`.
+    /// Spread arguments or an argument sink: `..x`.
     Spread,
     /// A closure: `(x, y) => z`.
     Closure,

--- a/src/syntax/source.rs
+++ b/src/syntax/source.rs
@@ -425,7 +425,7 @@ mod tests {
             assert_eq!(source.lines, result.lines);
         }
 
-        // Test inserting at the begining.
+        // Test inserting at the beginning.
         test("abc\n", 0..0, "hi\n", "hi\nabc\n");
         test("\nabc", 0..0, "hi\r", "hi\r\nabc");
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -52,7 +52,7 @@ testit --pdf
 
 ## Creating new tests
 To keep things small, please optimize reference images before committing them.
-When you use the approve buttom from the Test Helper (see the `tools` folder)
+When you use the approve button from the Test Helper (see the `tools` folder)
 this happens automatically if you have `oxipng` installed.
 ```bash
 # One image

--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -35,7 +35,7 @@ fn main() {
     let args = Args::new(env::args().skip(1));
     let mut filtered = Vec::new();
 
-    // Since differents tests can affect each other through the memoization
+    // Since different tests can affect each other through the memoization
     // cache, a deterministic order is important for reproducibility.
     for entry in WalkDir::new("typ").sort_by_file_name() {
         let entry = entry.unwrap();
@@ -554,7 +554,7 @@ fn print_error(source: &Source, line: usize, (range, message): &(Range<usize>, S
 /// same result as a clean parse.
 ///
 /// The method will first inject 10 strings once every 400 source characters
-/// and then select 5 leaf node boundries to inject an additional, randomly
+/// and then select 5 leaf node boundaries to inject an additional, randomly
 /// chosen string from the injection list.
 fn test_reparse(text: &str, i: usize, rng: &mut LinearShift) -> bool {
     let supplements = [

--- a/tests/typ/compiler/call.typ
+++ b/tests/typ/compiler/call.typ
@@ -4,7 +4,7 @@
 ---
 // Ref: true
 
-// Ommitted space.
+// Omitted space.
 #let f() = {}
 #[#f()*Bold*]
 

--- a/tests/typ/layout/list-marker.typ
+++ b/tests/typ/layout/list-marker.typ
@@ -1,4 +1,4 @@
-// Test list marker configuraiton.
+// Test list marker configuration.
 
 ---
 // Test en-dash.

--- a/tests/typ/meta/bibliography.typ
+++ b/tests/typ/meta/bibliography.typ
@@ -5,7 +5,7 @@
 #bibliography("/bad.bib")
 
 ---
-// Test ambigious reference.
+// Test ambiguous reference.
 = Introduction <arrgh>
 // Error: 1-7 label occurs in the document and its bibliography
 @arrgh

--- a/tools/support/typst.tmLanguage.json
+++ b/tools/support/typst.tmLanguage.json
@@ -96,7 +96,7 @@
           "name": "string.other.math.typst",
           "begin": "\\$",
           "end": "\\$",
-          "captures": { "0": { "name": "punctuation.defintion.string.math.typst" } }
+          "captures": { "0": { "name": "punctuation.definition.string.math.typst" } }
         },
         {
           "name": "markup.heading.typst",
@@ -364,7 +364,7 @@
           "name": "string.other.math.typst",
           "begin": "\\$",
           "end": "\\$",
-          "captures": { "0": { "name": "punctuation.defintion.string.math.typst" } }
+          "captures": { "0": { "name": "punctuation.definition.string.math.typst" } }
         }
       ]
     },


### PR DESCRIPTION
Found via `codespell -S target -L
crate,ist,thi,alle,dedented,ue,tung,nd,ende,overriden,dependant`