### PR TITLE
Fix build if not on a git checkout

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -5,6 +5,7 @@ fn main() {
         .args(&["rev-parse", "HEAD"])
         .output()
         .ok()
+        .and_then(|output| output.status.success().then(|| output))
         .and_then(|output| String::from_utf8(output.stdout[..8].into()).ok())
         .unwrap_or_else(|| "(unknown version)".into());
     println!("cargo:rustc-env=TYPST_VERSION={version}");


### PR DESCRIPTION
Check the exit status of the `git` invocation before parsing the output. If there's no `.git` the output may look like:

```
fatal: not a git repository (or any of the parent directories): .git
```

and the version shall be set to unknown.