### PR TITLE
strip cli target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,6 @@ debug = 0
 
 [profile.dev.package."*"]
 opt-level = 2
+
+[profile.release.package."typst-cli"]
+strip = true


### PR DESCRIPTION
Stripping `typst-cli` reduces the file size from 24 MB to 18 MB.