### PR TITLE
Add Nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ bench/target
 # Node
 node_modules
 package-lock.json
+
+# Nix
+/result
+.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1679262748,
+        "narHash": "sha256-DQCrrAFrkxijC6haUzOC5ZoFqpcv/tg2WxnyW3np1Cc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "60c1d71f2ba4c80178ec84523c2ca0801522e0a6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,76 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      inherit (builtins)
+        substring
+        ;
+      inherit (nixpkgs.lib)
+        genAttrs
+        optionals
+        ;
+
+      eachSystem = f: genAttrs
+        [
+          "aarch64-darwin"
+          "aarch64-linux"
+          "x86_64-darwin"
+          "x86_64-linux"
+        ]
+        (system: f nixpkgs.legacyPackages.${system});
+
+      rev = fallback:
+        if self ? rev then
+          substring 0 8 self.rev
+        else
+          fallback;
+    in
+    {
+      devShells = eachSystem (pkgs: {
+        default = pkgs.mkShell {
+          packages = with pkgs; [
+            cargo
+            clippy
+            rust-analyzer
+            rustc
+            rustfmt
+          ];
+
+          buildInputs = optionals pkgs.stdenv.isDarwin [
+            pkgs.darwin.apple_sdk.frameworks.CoreServices
+            pkgs.libiconv
+          ];
+
+          RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
+        };
+      });
+
+      formatter = eachSystem (pkgs: pkgs.nixpkgs-fmt);
+
+      packages = eachSystem (pkgs: {
+        default = pkgs.rustPlatform.buildRustPackage {
+          pname = "typst";
+          version = rev "00000000";
+
+          src = self;
+
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+            allowBuiltinFetchGit = true;
+          };
+
+          buildInputs = optionals pkgs.stdenv.isDarwin [
+            pkgs.darwin.apple_sdk.frameworks.CoreServices
+          ];
+
+          cargoBuildFlags = [ "-p" "typst-cli" ];
+          cargoTestFlags = [ "-p" "typst-cli" ];
+
+          TYPST_VERSION = rev "(unknown version)";
+        };
+      });
+    };
+}


### PR DESCRIPTION
Alternative to #96 
The differences are that this PR
- has a nix package
- has a minimal amount of flake inputs
- is less opinionated
- has formatter set up

Here is what I've tested
- Ran `nix flake check` on x86_64-linux
- Entered the dev shell using `nix develop` and built the package using `cargo build` on x86_64-linux
- Built the package using `nix build` on the following platforms
  - [x] aarch64-darwin
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] x86_64-linux