### PR TITLE
Add support for pattern based error matching in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,6 +1432,7 @@ dependencies = [
  "elsa",
  "iai",
  "once_cell",
+ "regex",
  "tiny-skia",
  "ttf-parser 0.17.1",
  "typst",

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -11,6 +11,7 @@ comemo = { git = "https://github.com/typst/comemo" }
 elsa = "1.7"
 iai = { git = "https://github.com/reknih/iai" }
 once_cell = "1"
+regex = "1.7.1"
 tiny-skia = "0.6.2"
 ttf-parser = "0.17"
 unscanny = "0.1"

--- a/tests/typ/compiler/import.typ
+++ b/tests/typ/compiler/import.typ
@@ -60,11 +60,11 @@
 #import "module.typ": a, c,
 
 ---
-// Error: 9-11 failed to load file (is a directory)
+// Error pattern: 9-11 ^failed to load file (\(is a directory\)|\(access denied\))$
 #import "": name
 
 ---
-// Error: 9-20 file not found (searched at typ/compiler/lib/0.2.1)
+// Error pattern: 9-20 ^file not found \(searched at typ(\\|/)compiler(\\|/)lib(\\|/)0.2.1\)$
 #import "lib/0.2.1"
 
 ---

--- a/tests/typ/compiler/include.typ
+++ b/tests/typ/compiler/include.typ
@@ -16,7 +16,7 @@
 
 ---
 #{
-  // Error: 19-38 file not found (searched at typ/compiler/modules/chap3.typ)
+  // Error pattern: 19-38 ^file not found \(searched at typ(\\|/)compiler(\\|/)modules(\\|/)chap3.typ\)$
   let x = include "modules/chap3.typ"
 }
 

--- a/tests/typ/compute/data.typ
+++ b/tests/typ/compute/data.typ
@@ -23,7 +23,7 @@
 #table(columns: data.at(0).len(), ..cells)
 
 ---
-// Error: 6-16 file not found (searched at typ/compute/nope.csv)
+// Error pattern: 6-16 ^file not found \(searched at typ(\\|/)compute(\\|/)nope.csv\)$
 #csv("nope.csv")
 
 ---

--- a/tests/typ/visualize/image.typ
+++ b/tests/typ/visualize/image.typ
@@ -50,7 +50,7 @@ A #box(image("/tiger.jpg", height: 1cm, width: 80%)) B
 #image("/pattern.svg")
 
 ---
-// Error: 8-29 file not found (searched at typ/visualize/path/does/not/exist)
+// Error pattern: 8-29 ^file not found \(searched at typ(\\|/)visualize(\\|/)path(\\|/)does(\\|/)not(\\|/)exist\)$
 #image("path/does/not/exist")
 
 ---


### PR DESCRIPTION
## Motivation:

I wanted to do this to unblock https://github.com/typst/typst/pull/126.

## Why should this be included:

I believe some kind of laxer error matching is sometimes warranted, its probably not desirable to unify file system interactions between linux and windows, more specifically error messages. It is probably usefull if the user recieves the original error message instead of some cross platform one, which would be the only alternative to this I believe.

## Technical details:

now test `.typ` files parsed by the integration test suite support a second type of expected error declaration in the following format:
```
// Error pattern: <start>-<end> <regex>
....code
```

Example:
```
// Error pattern: 9-11 ^failed to load file (\(is a directory\)|\(access denied\))$
#import "": name
```
this regex matches both windows (`\`) and normal (`/`) path separators in the error message.
