### PR TITLE
Allow changing `Figure`'s name and separator

### DIFF
--- a/library/src/layout/table.rs
+++ b/library/src/layout/table.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::layout::{AlignElem, GridLayouter, TrackSizings};
 use crate::meta::LocalName;
 use crate::prelude::*;
@@ -272,10 +274,10 @@ impl<T: Into<Value>> From<Celled<T>> for Value {
 }
 
 impl LocalName for TableElem {
-    fn local_name(&self, lang: Lang) -> &'static str {
-        match lang {
+    fn local_name(&self, lang: Lang) -> Cow<str> {
+        Cow::from(match lang {
             Lang::GERMAN => "Tabelle",
             Lang::ENGLISH | _ => "Table",
-        }
+        })
     }
 }

--- a/library/src/math/mod.rs
+++ b/library/src/math/mod.rs
@@ -17,6 +17,8 @@ mod stretch;
 mod style;
 mod underover;
 
+use std::borrow::Cow;
+
 pub use self::accent::*;
 pub use self::align::*;
 pub use self::attach::*;
@@ -264,11 +266,11 @@ impl Count for EquationElem {
 }
 
 impl LocalName for EquationElem {
-    fn local_name(&self, lang: Lang) -> &'static str {
-        match lang {
+    fn local_name(&self, lang: Lang) -> Cow<str> {
+        Cow::from(match lang {
             Lang::GERMAN => "Gleichung",
             Lang::ENGLISH | _ => "Equation",
-        }
+        })
     }
 }
 

--- a/library/src/meta/bibliography.rs
+++ b/library/src/meta/bibliography.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::path::Path;
@@ -180,11 +181,11 @@ impl Show for BibliographyElem {
 }
 
 impl LocalName for BibliographyElem {
-    fn local_name(&self, lang: Lang) -> &'static str {
-        match lang {
+    fn local_name(&self, lang: Lang) -> Cow<str> {
+        Cow::from(match lang {
             Lang::GERMAN => "Bibliographie",
             Lang::ENGLISH | _ => "Bibliography",
-        }
+        })
     }
 }
 

--- a/library/src/meta/heading.rs
+++ b/library/src/meta/heading.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use typst::font::FontWeight;
 
 use super::{Counter, CounterUpdate, LocalName, Numbering};
@@ -138,10 +140,10 @@ cast_from_value! {
 }
 
 impl LocalName for HeadingElem {
-    fn local_name(&self, lang: Lang) -> &'static str {
-        match lang {
+    fn local_name(&self, lang: Lang) -> Cow<str> {
+        Cow::from(match lang {
             Lang::GERMAN => "Abschnitt",
             Lang::ENGLISH | _ => "Section",
-        }
+        })
     }
 }

--- a/library/src/meta/mod.rs
+++ b/library/src/meta/mod.rs
@@ -13,6 +13,8 @@ mod query;
 mod reference;
 mod state;
 
+use std::borrow::Cow;
+
 pub use self::bibliography::*;
 pub use self::context::*;
 pub use self::counter::*;
@@ -31,5 +33,5 @@ use typst::doc::Lang;
 /// The named with which an element is referenced.
 pub trait LocalName {
     /// Get the name in the given language.
-    fn local_name(&self, lang: Lang) -> &'static str;
+    fn local_name(&self, lang: Lang) -> Cow<str>;
 }

--- a/library/src/meta/outline.rs
+++ b/library/src/meta/outline.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use super::{Counter, HeadingElem, LocalName};
 use crate::layout::{BoxElem, HElem, HideElem, ParbreakElem, RepeatElem};
 use crate::prelude::*;
@@ -174,10 +176,10 @@ impl Show for OutlineElem {
 }
 
 impl LocalName for OutlineElem {
-    fn local_name(&self, lang: Lang) -> &'static str {
-        match lang {
+    fn local_name(&self, lang: Lang) -> Cow<str> {
+        Cow::from(match lang {
             Lang::GERMAN => "Inhaltsverzeichnis",
             Lang::ENGLISH | _ => "Contents",
-        }
+        })
     }
 }

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -517,6 +517,7 @@ pub struct Lang([u8; 3], u8);
 impl Lang {
     pub const ENGLISH: Self = Self(*b"en ", 2);
     pub const GERMAN: Self = Self(*b"de ", 2);
+    pub const RUSSIAN: Self = Self(*b"ru ", 2);
 
     /// Return the language code as an all lowercase string slice.
     pub fn as_str(&self) -> &str {


### PR DESCRIPTION
Partially solves #142.

In the mentioned issue, I say that I want to put table in the figure. However, after looking into codebase I understand that it's not trivial to just use another counter for the figure, since counting applies to the element type itself. I also saw that table (an some other elements) has an element name. Although it's not possible at the moment, I presume that at some point in the future it will be possible to just add a caption to the table itself, as well as adding a label to it to be able to reference it. Is it right, @laurmaedje? Also curious if you want to support scenario where one can manipulate position and styling of the caption (for example, in my uni one should put it before the table, aligned to it's start).