### PR TITLE
link the binary to the cargo bin directory when building from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ cargo build -p typst-cli --release
 
 The optimized binary will be stored in `target/release/`.
 
+You can link the binary to your cargo bin folder for direct usage.
+
+```sh
+ln -s typst/target/release/typst ~/.cargo/bin/
+
+
 ## Contributing
 We would love to see contributions from the community. If you experience bugs,
 feel free to open an issue or send a PR with a fix. For new features, we would

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ You can link the binary to your cargo bin folder for direct usage.
 
 ```sh
 ln -s typst/target/release/typst ~/.cargo/bin/
-
+```
 
 ## Contributing
 We would love to see contributions from the community. If you experience bugs,

--- a/README.md
+++ b/README.md
@@ -131,16 +131,10 @@ To build Typst yourself, you need to have the [latest stable Rust][rust]
 installed. Then, you can build the CLI with the following command:
 
 ```sh
-cargo build -p typst-cli --release
+cargo build -p typst-cli --release --path cli
 ```
 
 The optimized binary will be stored in `target/release/`.
-
-You can link the binary to your cargo bin folder for direct usage.
-
-```sh
-ln -s typst/target/release/typst ~/.cargo/bin/
-```
 
 ## Contributing
 We would love to see contributions from the community. If you experience bugs,


### PR DESCRIPTION
Normally ~/.cargo/bin is in your PATH so symlinking the file there makes it easily executable when building it from source.