### PR TITLE
Replace infinite repeat layout panic with error

### DIFF
--- a/library/src/layout/repeat.rs
+++ b/library/src/layout/repeat.rs
@@ -9,6 +9,9 @@ use super::AlignElem;
 /// Space may be inserted between the instances of the body parameter, so be
 /// sure to include negative space if you need the instances to overlap.
 ///
+/// Errors if there no bounds on the available space, as it would create
+/// infinite content.
+///
 /// ## Example
 /// ```example
 /// Sign on the dotted line:
@@ -48,6 +51,11 @@ impl Layout for RepeatElem {
         let apart = remaining / (count - 1.0);
 
         let size = Size::new(regions.size.x, piece.height());
+
+        if !size.is_finite() {
+            bail!(self.span(), "repeat with no size restrictions");
+        }
+
         let mut frame = Frame::new(size);
         if piece.has_baseline() {
             frame.set_baseline(piece.baseline());

--- a/tests/typ/layout/repeat.typ
+++ b/tests/typ/layout/repeat.typ
@@ -37,3 +37,8 @@ A#box(width: 1fr, repeat(rect(width: 6em, height: 0.7em)))B
 
 #set text(dir: rtl)
 ريجين#box(width: 1fr, repeat(rect(width: 4em, height: 0.7em)))سون
+
+---
+// Error: 2:2-2:13 repeat with no size restrictions
+#set page(width: auto)
+#repeat(".")


### PR DESCRIPTION
When a page has auto width and there were no other constraints on the repetition width, this would previously panic. Now, there is an explicit check with a new error and test case.