### PR TITLE
replace deprecated angle brackets

### DIFF
--- a/library/src/symbols/sym.rs
+++ b/library/src/symbols/sym.rs
@@ -42,8 +42,8 @@ pub(crate) const SYM: &[(&'static str, Symbol)] = symbols! {
     fence: [l: '⧘', l.double: '⧚', r: '⧙', r.double: '⧛', dotted: '⦙'],
     angle: [
         '∠',
-        l: '〈',
-        r: '〉',
+        l: '⟨',
+        r: '⟩',
         l.double: '《',
         r.double: '》',
         acute: '⦟',


### PR DESCRIPTION
See page 17 of the [spec](https://www.unicode.org/reports/tr25/tr25-15.pdf) linked from the unicode-math-class repo. The angle bracket character was changed. Currently, using `angle.l 1/(1/2) angle.r` results in it not correctly resizing the brackets, whereas `⟨ 1/(1/2) ⟩` does. This fixes that.