### PR TITLE
Improve error message in lexer

### DIFF
--- a/src/syntax/lexer.rs
+++ b/src/syntax/lexer.rs
@@ -489,7 +489,7 @@ impl Lexer<'_> {
 
             c if is_id_start(c) => self.ident(start),
 
-            _ => self.error("this character is not valid in code"),
+            c => self.error(format!("The character `{c}` is not valid in code")),
         }
     }
 


### PR DESCRIPTION
In the error message for an invalid character, print which character triggered the error.