### PR TITLE
Add custom font search path support for typst cli

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -58,7 +58,7 @@ OPTIONS:
   -h, --help        Print this help
   -V, --version     Print the CLI's version
   -w, --watch       Watch the inputs and recompile on changes
-  --font-path <dir> Add extern dirs into the font search paths
+  --font-path <dir> Add additional directories to search for fonts
   --root <dir>      Configure the root for absolute paths
 
 SUBCOMMANDS:
@@ -78,8 +78,9 @@ USAGE:
   typst --fonts [OPTIONS]
 
 OPTIONS:
-  -h, --help     Print this help
-  --variants     Also list style variants of each font family
+  -h, --help        Print this help
+  --font-path <dir> Add additional directories to search for fonts
+  --variants        Also list style variants of each font family
 ";
 
 /// Entry point.


### PR DESCRIPTION
Added a `--font-path` option to typst cli to allow user add custom font search dir.

This parameter can be provided multiple times, eg `typst --fonts --font-path A --font-path B`.

A small step for solving issue #100.