### PR TITLE
Fix fill color obstructing page header and background

### DIFF
--- a/library/src/layout/page.rs
+++ b/library/src/layout/page.rs
@@ -326,10 +326,6 @@ impl PageElem {
 
         // Realize overlays.
         for frame in &mut fragment {
-            if let Some(fill) = fill {
-                frame.fill(fill);
-            }
-
             let size = frame.size();
             let pad = padding.resolve(styles).relative_to(size);
             let pw = size.x - pad.left - pad.right;
@@ -364,6 +360,10 @@ impl PageElem {
                 } else {
                     frame.push_frame(pos, sub);
                 }
+            }
+
+            if let Some(fill) = fill {
+                frame.fill(fill);
             }
         }
 


### PR DESCRIPTION
The page fill color was prepended first. Later on the header and background elements were prepended as well, which ends up before the page fill color

To make the page fill color the first item, we have to prepend it last.

Resolves #148 