### PR TITLE
Document behaviour of dictionary.insert() when key exists

### DIFF
--- a/docs/src/reference/types.md
+++ b/docs/src/reference/types.md
@@ -702,6 +702,7 @@ Fails with an error if the key is not part of the dictionary.
 
 ### insert()
 Insert a new pair into the dictionary and return the value.
+If the dictionary already contains this key, the value is updated.
 
 - key: string (positional, required)
   The key of the pair that should be inserted.

--- a/docs/src/reference/types.md
+++ b/docs/src/reference/types.md
@@ -659,6 +659,7 @@ instead of integers. You can access and create dictionary entries with the
 [field access notation]($scripting/#fields) (`.key`) to access
 the value. Dictionaries can be added with the `+` operator and
 [joined together]($scripting/#blocks).
+To check whether a key is present in the dictionary, use the `in` keyword.
 
 You can iterate over the pairs in a dictionary using a
 [for loop]($scripting/#loops).
@@ -682,6 +683,7 @@ special `(:)` syntax to create an empty dictionary.
 #dict.values() \
 #dict.at("born") \
 #dict.insert("city", "Berlin ")
+#("name" in dict)
 ```
 
 ## Methods


### PR DESCRIPTION
1. Current documentation for [`insert` method of dictionary](https://typst.app/docs/reference/types/dictionary#methods--insert) does not explain what happens if the `key` exists before inserting. Since our [implementation](https://github.com/typst/typst/blob/a253b47e7c6f5e9500a40ac73f949a431f62289d/src/eval/dict.rs#L77-L80) uses [`std::collection::BTreeMap`](https://doc.rust-lang.org/std/collections/struct.BTreeMap.html#method.insert), the actual behavior is to update the old value. This PR adds the corresponding description to the documentation.
2. Add Documentation for how to check if a key is present in the dictionary.