### PR TITLE
Synchronize page numbering in outline with page counter

### DIFF
--- a/library/src/meta/outline.rs
+++ b/library/src/meta/outline.rs
@@ -1,4 +1,4 @@
-use super::{Counter, HeadingElem, LocalName};
+use super::{Counter, CounterKey, HeadingElem, LocalName};
 use crate::layout::{BoxElem, HElem, HideElem, ParbreakElem, RepeatElem};
 use crate::prelude::*;
 use crate::text::{LinebreakElem, SpaceElem, TextElem};
@@ -160,7 +160,10 @@ impl Show for OutlineElem {
             }
 
             // Add the page number and linebreak.
-            let page = vt.introspector.page(location);
+            let page = Counter::new(CounterKey::Page)
+                // query the page counter state at location of heading
+                .at(vt, location)?
+                .first();
             let end = TextElem::packed(eco_format!("{page}"));
             seq.push(end.linked(Destination::Location(location)));
             seq.push(LinebreakElem::new().pack());


### PR DESCRIPTION
This PR addresses issue #275.

# Description

Instead of inserting the number of the page where a heading is located, we now take into account the state of the page counter and therefore query the page counter at the location of the heading.

# Discussion

1. Currently (with the changes in this PR), when we have

    ```
    #outline()
    
    #pagebreak()
    #counter(page).update(1)
    = heading
    #counter(page).step()
    ...
    ```
    
    the heading will be listed with page number 1 instead of 2 in the outline, that is, if the page counter is altered after the heading, the page number in the outline will not match the page number appearing in the footer.
    
    I will be happy to change that, however I am unsure how to specifically query the state of the page counter at the end of a page.
2. I tested what happens, if we have no numbering or footer set, that is, `#set page(numbering: none, footer: none)`. It seems to behave correctly, however as this is my first time working with this codebase I cannot fully understand why this is the case. I'd recommend that the reviewer double checks the correctness.
