### PR TITLE
Added return type to methods of colors in docs

### DIFF
--- a/docs/src/reference/types.md
+++ b/docs/src/reference/types.md
@@ -153,15 +153,19 @@ Lightens a color.
 
 - amount: ratio (positional, required)
   The factor to lighten the color by.
+- returns: color
 
 ### darken()
 Darkens a color.
 
 - amount: ratio (positional, required)
   The factor to darken the color by.
+- returns: color
 
 ### negate()
 Produces the negative of the color.
+
+- returns: color
 
 # Symbol
 A Unicode symbol.


### PR DESCRIPTION
In the documentation for [colors](https://typst.app/docs/reference/types/color/), the methods don't show the return types. This should fix this, I believe (let me know if I'm missing something).