### PR TITLE
Add algebra symbols

### DIFF
--- a/library/src/symbols/sym.rs
+++ b/library/src/symbols/sym.rs
@@ -191,8 +191,10 @@ pub(crate) const SYM: &[(&'static str, Symbol)] = symbols! {
         circle: '⊗',
         circle.big: '⨂',
         div: '⋇',
-        l: '⋋',
-        r: '⋌',
+        three.l: '⋋',
+        three.r: '⋌',
+        l: '⋉',
+        r: '⋊',
         square: '⊠',
         triangle: '⨻',
     ],
@@ -400,11 +402,6 @@ pub(crate) const SYM: &[(&'static str, Symbol)] = symbols! {
     perp: ['⟂', circle: '⦹'],
 
     // Algebra.
-    times: [
-        '⨯',
-        r: '⋊',
-        l: '⋉',
-    ],
     wreath: '≀',
     tri: [
         l: '⊲',

--- a/library/src/symbols/sym.rs
+++ b/library/src/symbols/sym.rs
@@ -399,6 +399,24 @@ pub(crate) const SYM: &[(&'static str, Symbol)] = symbols! {
     divides: ['∣', not: '∤'],
     perp: ['⟂', circle: '⦹'],
 
+    // Algebra.
+    times: [
+        '⨯',
+        r: '⋊',
+        l: '⋉',
+    ],
+    wreath: '≀',
+    tri: [
+        l: '⊲',
+        l.eq: '⊴',
+        l.not: '⋪',
+        l.eq.not: '⋬',
+        r: '⊳',
+        r.eq: '⊵',
+        r.not: '⋫',
+        r.eq.not: '⋭',
+    ],
+
     // Geometry.
     parallel: ['∥', circle: '⦷', not: '∦'],
 
@@ -407,7 +425,6 @@ pub(crate) const SYM: &[(&'static str, Symbol)] = symbols! {
     join: ['⨝', r: '⟖', l: '⟕', l.r: '⟗'],
     degree: ['°', c: '℃', f: '℉'],
     smash: '⨳',
-    wreath: '≀',
 
     // Currency.
     bitcoin: '₿',

--- a/library/src/symbols/sym.rs
+++ b/library/src/symbols/sym.rs
@@ -236,6 +236,10 @@ pub(crate) const SYM: &[(&'static str, Symbol)] = symbols! {
         small: '﹥',
         tilde: '≳',
         tilde.not: '≵',
+        tri: '⊳',
+        tri.eq: '⊵',
+        tri.eq.not: '⋭',
+        tri.not: '⋫',
         triple: '⋙',
         triple.nested: '⫸',
     ],
@@ -256,6 +260,10 @@ pub(crate) const SYM: &[(&'static str, Symbol)] = symbols! {
         small: '﹤',
         tilde: '≲',
         tilde.not: '≴',
+        tri: '⊲',
+        tri.eq: '⊴',
+        tri.eq.not: '⋬',
+        tri.not: '⋪',
         triple: '⋘',
         triple.nested: '⫷',
     ],
@@ -403,16 +411,6 @@ pub(crate) const SYM: &[(&'static str, Symbol)] = symbols! {
 
     // Algebra.
     wreath: '≀',
-    tri: [
-        l: '⊲',
-        l.eq: '⊴',
-        l.not: '⋪',
-        l.eq.not: '⋬',
-        r: '⊳',
-        r.eq: '⊵',
-        r.not: '⋫',
-        r.eq.not: '⋭',
-    ],
 
     // Geometry.
     parallel: ['∥', circle: '⦷', not: '∦'],


### PR DESCRIPTION
Fixes #309 with `tri.l.eq`.

I made a distinction between decorative `triangle`s and mathematical `tri`s; I feel this warrants some consideration and discussion before the final merge. Note the renaming of some symbols in `times`..