### PR TITLE
small fixes: applied small clippy lints

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -43,7 +43,7 @@ struct CompileCommand {
     font_paths: Vec<PathBuf>,
 }
 
-const HELP: &'static str = "\
+const HELP: &str = "\
 typst creates PDF files from .typ files
 
 USAGE:
@@ -71,7 +71,7 @@ struct FontsCommand {
     variants: bool,
 }
 
-const HELP_FONTS: &'static str = "\
+const HELP_FONTS: &str = "\
 typst --fonts lists all discovered fonts in system and custom font paths
 
 USAGE:
@@ -260,7 +260,7 @@ fn compile_once(world: &mut SystemWorld, command: &CompileCommand) -> StrResult<
         // Print diagnostics.
         Err(errors) => {
             status(command, Status::Error).unwrap();
-            print_diagnostics(&world, *errors)
+            print_diagnostics(world, *errors)
                 .map_err(|_| "failed to print diagnostics")?;
         }
     }

--- a/docs/src/html.rs
+++ b/docs/src/html.rs
@@ -33,17 +33,17 @@ impl Html {
     pub fn markdown(resolver: &dyn Resolver, md: &str) -> Self {
         let mut text = md;
         let mut description = None;
-        let document = YamlFrontMatter::parse::<Metadata>(&md);
+        let document = YamlFrontMatter::parse::<Metadata>(md);
         if let Ok(document) = &document {
             text = &document.content;
-            description = Some(document.metadata.description.clone())
+            description = Some(document.metadata.description.clone());
         }
 
         let options = md::Options::ENABLE_TABLES | md::Options::ENABLE_HEADING_ATTRIBUTES;
 
         let mut handler = Handler::new(resolver);
         let iter = md::Parser::new_ext(text, options)
-            .filter_map(|mut event| handler.handle(&mut event).then(|| event));
+            .filter_map(|mut event| handler.handle(&mut event).then_some(event));
 
         let mut raw = String::new();
         md::html::push_html(&mut raw, iter);
@@ -169,7 +169,7 @@ impl<'a> Handler<'a> {
 
     fn handle_image(&self, link: &str) -> String {
         if let Some(file) = IMAGES.get_file(link) {
-            self.resolver.image(&link, file.contents()).into()
+            self.resolver.image(link, file.contents())
         } else if let Some(url) = self.resolver.link(link) {
             url
         } else {

--- a/docs/src/lib.rs
+++ b/docs/src/lib.rs
@@ -1,5 +1,4 @@
 //! Documentation provider for Typst.
-
 mod html;
 
 pub use html::Html;
@@ -230,7 +229,7 @@ fn category_page(resolver: &dyn Resolver, category: &str) -> PageModel {
     for group in grouped {
         let mut functions = vec![];
         for name in &group.functions {
-            let value = focus.get(&name).unwrap();
+            let value = focus.get(name).unwrap();
             let Value::Func(func) = value else { panic!("not a function") };
             let info = func.info().unwrap();
             functions.push(func_model(resolver, func, info));
@@ -336,7 +335,7 @@ fn func_model(resolver: &dyn Resolver, func: &Func, info: &FuncInfo) -> FuncMode
     let mut s = unscanny::Scanner::new(info.docs);
     let docs = s.eat_until("\n## Methods").trim();
     FuncModel {
-        name: info.name.into(),
+        name: info.name,
         display: info.display,
         oneliner: oneliner(docs),
         showable: func.element().is_some(),
@@ -570,7 +569,7 @@ fn method_model(resolver: &dyn Resolver, part: &'static str) -> MethodModel {
                 "positional" => positional = true,
                 "required" => required = true,
                 "variadic" => variadic = true,
-                _ => panic!("unknown parameter flag {:?}", part),
+                _ => panic!("unknown parameter flag {part:?}"),
             }
         }
 
@@ -629,7 +628,7 @@ fn symbol_page(resolver: &dyn Resolver, parent: &str, name: &str) -> PageModel {
             if variant.is_empty() {
                 name.into()
             } else {
-                format!("{}.{}", name, variant)
+                format!("{name}.{variant}")
             }
         };
 
@@ -704,7 +703,7 @@ fn yaml<T: DeserializeOwned>(path: &str) -> T {
 fn details(key: &str) -> &str {
     DETAILS
         .get(&yaml::Value::String(key.into()))
-        .and_then(|value| value.as_str())
+        .and_then(yaml::Value::as_str)
         .unwrap_or_else(|| panic!("missing details for {key}"))
 }
 
@@ -722,7 +721,7 @@ pub fn urlify(title: &str) -> String {
 
 /// Extract the first line of documentation.
 fn oneliner(docs: &str) -> &str {
-    docs.lines().next().unwrap_or_default().into()
+    docs.lines().next().unwrap_or_default()
 }
 
 /// The order of types in the documentation.

--- a/library/src/compute/calc.rs
+++ b/library/src/compute/calc.rs
@@ -67,7 +67,7 @@ cast_from_value! {
     v: i64 => Self(Value::Int(v.abs())),
     v: f64 => Self(Value::Float(v.abs())),
     v: Length => Self(Value::Length(v.try_abs()
-        .ok_or_else(|| "cannot take absolute value of this length")?)),
+        .ok_or("cannot take absolute value of this length")?)),
     v: Angle => Self(Value::Angle(v.abs())),
     v: Ratio => Self(Value::Ratio(v.abs())),
     v: Fr => Self(Value::Fraction(v.abs())),
@@ -452,7 +452,7 @@ pub fn round(
         Num::Int(n) if digits == 0 => Value::Int(n),
         _ => {
             let n = value.float();
-            let factor = 10.0_f64.powi(digits as i32) as f64;
+            let factor = 10.0_f64.powi(digits as i32);
             Value::Float((n * factor).round() / factor)
         }
     }

--- a/library/src/layout/flow.rs
+++ b/library/src/layout/flow.rs
@@ -30,7 +30,7 @@ impl Layout for FlowElem {
             let mut styles = styles;
             if let Some((elem, map)) = child.to_styled() {
                 child = elem;
-                styles = outer.chain(&map);
+                styles = outer.chain(map);
             }
 
             if let Some(elem) = child.to::<VElem>() {
@@ -54,7 +54,7 @@ impl Layout for FlowElem {
                     true,
                 ));
             } else if child.can::<dyn Layout>() {
-                layouter.layout_multiple(vt, &child, styles)?;
+                layouter.layout_multiple(vt, child, styles)?;
             } else if child.is::<ColbreakElem>() {
                 if !layouter.regions.backlog.is_empty() || layouter.regions.last.is_some()
                 {

--- a/library/src/layout/fragment.rs
+++ b/library/src/layout/fragment.rs
@@ -20,6 +20,11 @@ impl Fragment {
         self.0.len()
     }
 
+    /// Whether the fragment is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
     /// Extract the first and only frame.
     ///
     /// Panics if there are multiple frames.

--- a/library/src/layout/grid.rs
+++ b/library/src/layout/grid.rs
@@ -267,7 +267,7 @@ impl<'a, 'v> GridLayouter<'a, 'v> {
 
         // We use these regions for auto row measurement. Since at that moment,
         // columns are already sized, we can enable horizontal expansion.
-        let mut regions = regions.clone();
+        let mut regions = regions;
         regions.expand = Axes::new(true, false);
 
         Self {

--- a/library/src/layout/list.rs
+++ b/library/src/layout/list.rs
@@ -197,7 +197,7 @@ cast_from_value! {
     ListMarker,
     v: Content => Self::Content(vec![v]),
     array: Array => {
-        if array.len() == 0 {
+        if array.is_empty() {
             Err("array must contain at least one marker")?;
         }
         Self::Content(array.into_iter().map(Value::display).collect())

--- a/library/src/layout/par.rs
+++ b/library/src/layout/par.rs
@@ -745,8 +745,8 @@ fn is_compatible(a: Script, b: Script) -> bool {
 
 /// Get a style property, but only if it is the same for all children of the
 /// paragraph.
-fn shared_get<'a, T: PartialEq>(
-    styles: StyleChain<'a>,
+fn shared_get<T: PartialEq>(
+    styles: StyleChain,
     children: &[Content],
     getter: fn(StyleChain) -> T,
 ) -> Option<T> {
@@ -754,8 +754,8 @@ fn shared_get<'a, T: PartialEq>(
     children
         .iter()
         .filter_map(|child| child.to_styled())
-        .all(|(_, local)| getter(styles.chain(&local)) == value)
-        .then(|| value)
+        .all(|(_, local)| getter(styles.chain(local)) == value)
+        .then_some(value)
 }
 
 /// Find suitable linebreaks.

--- a/library/src/layout/stack.rs
+++ b/library/src/layout/stack.rs
@@ -198,7 +198,7 @@ impl<'a> StackLayouter<'a> {
         let aligns = if let Some(align) = block.to::<AlignElem>() {
             align.alignment(styles)
         } else if let Some((_, local)) = block.to_styled() {
-            AlignElem::alignment_in(styles.chain(&local))
+            AlignElem::alignment_in(styles.chain(local))
         } else {
             AlignElem::alignment_in(styles)
         }

--- a/library/src/math/ctx.rs
+++ b/library/src/math/ctx.rs
@@ -61,7 +61,7 @@ impl<'a, 'b, 'v> MathContext<'a, 'b, 'v> {
         Self {
             vt,
             regions: Regions::one(regions.base(), Axes::splat(false)),
-            font: &font,
+            font,
             ttf: font.ttf(),
             table,
             constants,
@@ -120,7 +120,7 @@ impl<'a, 'b, 'v> MathContext<'a, 'b, 'v> {
 
     pub fn layout_content(&mut self, content: &Content) -> SourceResult<Frame> {
         Ok(content
-            .layout(&mut self.vt, self.outer.chain(&self.local), self.regions)?
+            .layout(self.vt, self.outer.chain(&self.local), self.regions)?
             .into_frame())
     }
 

--- a/library/src/math/mod.rs
+++ b/library/src/math/mod.rs
@@ -292,7 +292,7 @@ impl LayoutMath for Content {
         }
 
         if let Some((elem, styles)) = self.to_styled() {
-            if TextElem::font_in(ctx.styles().chain(&styles))
+            if TextElem::font_in(ctx.styles().chain(styles))
                 != TextElem::font_in(ctx.styles())
             {
                 let frame = ctx.layout_content(self)?;

--- a/library/src/math/row.rs
+++ b/library/src/math/row.rs
@@ -9,12 +9,11 @@ pub struct MathRow(Vec<MathFragment>);
 
 impl MathRow {
     pub fn new(fragments: Vec<MathFragment>) -> Self {
-        let mut iter = fragments.into_iter().peekable();
         let mut last: Option<usize> = None;
         let mut space: Option<MathFragment> = None;
         let mut resolved: Vec<MathFragment> = vec![];
 
-        while let Some(mut fragment) = iter.next() {
+        for mut fragment in fragments.into_iter().peekable() {
             match fragment {
                 // Keep space only if supported by spaced fragments.
                 MathFragment::Space(_) => {
@@ -178,9 +177,8 @@ impl MathRow {
             }
         }
 
-        let mut fragments = self.0.into_iter().peekable();
         let mut i = 0;
-        while let Some(fragment) = fragments.next() {
+        for fragment in self.0.into_iter().peekable() {
             if matches!(fragment, MathFragment::Align) {
                 if let Some(&point) = points.get(i) {
                     x = point;

--- a/library/src/meta/bibliography.rs
+++ b/library/src/meta/bibliography.rs
@@ -127,7 +127,7 @@ impl Show for BibliographyElem {
 
         let mut seq = vec![];
         if let Some(title) = self.title(styles) {
-            let title = title.clone().unwrap_or_else(|| {
+            let title = title.unwrap_or_else(|| {
                 TextElem::packed(self.local_name(TextElem::lang_in(styles)))
                     .spanned(self.span())
             });
@@ -453,7 +453,7 @@ fn create(
                         &mut *citation_style,
                         &[Citation {
                             entry,
-                            supplement: supplement.is_some().then(|| SUPPLEMENT),
+                            supplement: supplement.is_some().then_some(SUPPLEMENT),
                         }],
                     )
                     .display;
@@ -505,7 +505,7 @@ fn create(
             // Make link from citation to here work.
             let backlink = {
                 let mut content = Content::empty();
-                content.set_location(ref_location(&reference.entry));
+                content.set_location(ref_location(reference.entry));
                 MetaElem::set_data(vec![Meta::Elem(content)])
             };
 

--- a/library/src/meta/numbering.rs
+++ b/library/src/meta/numbering.rs
@@ -149,7 +149,7 @@ impl NumberingPattern {
     /// Apply the pattern to the given number.
     pub fn apply(&self, numbers: &[NonZeroUsize]) -> EcoString {
         let mut fmt = EcoString::new();
-        let mut numbers = numbers.into_iter();
+        let mut numbers = numbers.iter();
 
         for (i, ((prefix, kind, case), &n)) in
             self.pieces.iter().zip(&mut numbers).enumerate()

--- a/library/src/meta/outline.rs
+++ b/library/src/meta/outline.rs
@@ -73,7 +73,7 @@ impl Show for OutlineElem {
     fn show(&self, vt: &mut Vt, styles: StyleChain) -> SourceResult<Content> {
         let mut seq = vec![ParbreakElem::new().pack()];
         if let Some(title) = self.title(styles) {
-            let title = title.clone().unwrap_or_else(|| {
+            let title = title.unwrap_or_else(|| {
                 TextElem::packed(self.local_name(TextElem::lang_in(styles)))
                     .spanned(self.span())
             });

--- a/library/src/meta/reference.rs
+++ b/library/src/meta/reference.rs
@@ -123,7 +123,7 @@ impl Show for RefElem {
                 .map(TextElem::packed)
                 .unwrap_or_default(),
             Smart::Custom(None) => Content::empty(),
-            Smart::Custom(Some(Supplement::Content(content))) => content.clone(),
+            Smart::Custom(Some(Supplement::Content(content))) => content,
             Smart::Custom(Some(Supplement::Func(func))) => {
                 func.call_vt(vt, [elem.clone().into()])?.display()
             }

--- a/library/src/symbols/emoji.rs
+++ b/library/src/symbols/emoji.rs
@@ -10,7 +10,7 @@ pub fn emoji() -> Module {
 }
 
 /// A list of named emoji.
-const EMOJI: &[(&'static str, Symbol)] = symbols! {
+const EMOJI: &[(&str, Symbol)] = symbols! {
     abacus: '🧮',
     abc: '🔤',
     abcd: '🔡',

--- a/library/src/symbols/sym.rs
+++ b/library/src/symbols/sym.rs
@@ -10,7 +10,7 @@ pub fn sym() -> Module {
 }
 
 /// The list of general symbols.
-pub(crate) const SYM: &[(&'static str, Symbol)] = symbols! {
+pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
     // Control.
     wj: '\u{2060}',
     zwj: '\u{200D}',

--- a/library/src/text/raw.rs
+++ b/library/src/text/raw.rs
@@ -257,7 +257,7 @@ fn to_syn(RgbaColor { r, g, b, a }: RgbaColor) -> synt::Color {
 
 /// The syntect syntax definitions.
 static SYNTAXES: Lazy<syntect::parsing::SyntaxSet> =
-    Lazy::new(|| syntect::parsing::SyntaxSet::load_defaults_nonewlines());
+    Lazy::new(syntect::parsing::SyntaxSet::load_defaults_nonewlines);
 
 /// The default theme used for syntax highlighting.
 pub static THEME: Lazy<synt::Theme> = Lazy::new(|| synt::Theme {

--- a/library/src/text/shaping.rs
+++ b/library/src/text/shaping.rs
@@ -309,7 +309,7 @@ impl<'a> ShapedText<'a> {
         // RTL needs offset one because the left side of the range should be
         // exclusive and the right side inclusive, contrary to the normal
         // behaviour of ranges.
-        self.glyphs[idx].safe_to_break.then(|| idx + (!ltr) as usize)
+        self.glyphs[idx].safe_to_break.then_some(idx + (!ltr) as usize)
     }
 }
 
@@ -377,7 +377,7 @@ pub fn shape<'a>(
 }
 
 /// Shape text with font fallback using the `families` iterator.
-fn shape_segment<'a>(
+fn shape_segment(
     ctx: &mut ShapingContext,
     base: usize,
     text: &str,

--- a/library/src/text/shift.rs
+++ b/library/src/text/shift.rs
@@ -135,7 +135,7 @@ fn search_text(content: &Content, sub: bool) -> Option<EcoString> {
     } else if let Some(children) = content.to_sequence() {
         let mut full = EcoString::new();
         for item in children {
-            match search_text(&item, sub) {
+            match search_text(item, sub) {
                 Some(text) => full.push_str(&text),
                 None => return None,
             }

--- a/macros/src/element.rs
+++ b/macros/src/element.rs
@@ -138,7 +138,7 @@ fn prepare(stream: TokenStream, body: &syn::ItemStruct) -> Result<Elem> {
         .collect();
 
     let docs = documentation(&body.attrs);
-    let mut lines = docs.split("\n").collect();
+    let mut lines = docs.split('\n').collect();
     let category = meta_line(&mut lines, "Category")?.into();
     let display = meta_line(&mut lines, "Display")?.into();
     let docs = lines.join("\n").trim().into();

--- a/macros/src/func.rs
+++ b/macros/src/func.rs
@@ -73,7 +73,7 @@ fn prepare(item: &syn::ItemFn) -> Result<Func> {
     }
 
     let docs = documentation(&item.attrs);
-    let mut lines = docs.split("\n").collect();
+    let mut lines = docs.split('\n').collect();
     let returns = meta_line(&mut lines, "Returns")?
         .split(" or ")
         .map(Into::into)

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -112,7 +112,7 @@ impl Display for Tracepoint {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
             Tracepoint::Call(Some(name)) => {
-                write!(f, "error occurred in this call of function `{}`", name)
+                write!(f, "error occurred in this call of function `{name}`")
             }
             Tracepoint::Call(None) => {
                 write!(f, "error occurred in this function call")

--- a/src/eval/array.rs
+++ b/src/eval/array.rs
@@ -46,6 +46,11 @@ impl Array {
         self.0.len() as i64
     }
 
+    /// Whether the array is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
     /// The first value in the array.
     pub fn first(&self) -> StrResult<&Value> {
         self.0.first().ok_or_else(array_is_empty)
@@ -297,7 +302,7 @@ impl Array {
         let count = usize::try_from(n)
             .ok()
             .and_then(|n| self.0.len().checked_mul(n))
-            .ok_or_else(|| format!("cannot repeat this array {} times", n))?;
+            .ok_or_else(|| format!("cannot repeat this array {n} times"))?;
 
         Ok(self.iter().cloned().cycle().take(count).collect())
     }

--- a/src/eval/cast.rs
+++ b/src/eval/cast.rs
@@ -71,11 +71,11 @@ impl<T: Cast> Cast<Spanned<Value>> for Spanned<T> {
 }
 
 cast_to_value! {
-    v: u8 => Value::Int(v as i64)
+    v: u8 => Value::Int(i64::from(v))
 }
 
 cast_to_value! {
-    v: u16 => Value::Int(v as i64)
+    v: u16 => Value::Int(i64::from(v))
 }
 
 cast_from_value! {
@@ -90,11 +90,11 @@ cast_from_value! {
 }
 
 cast_to_value! {
-    v: u32 => Value::Int(v as i64)
+    v: u32 => Value::Int(i64::from(v))
 }
 
 cast_to_value! {
-    v: i32 => Value::Int(v as i64)
+    v: i32 => Value::Int(i64::from(v))
 }
 
 cast_from_value! {
@@ -116,7 +116,7 @@ cast_from_value! {
     NonZeroUsize,
     int: i64 => int
         .try_into()
-        .and_then(|int: usize| int.try_into())
+        .and_then(usize::try_into)
         .map_err(|_| if int <= 0 {
             "number must be positive"
         } else {

--- a/src/eval/func.rs
+++ b/src/eval/func.rs
@@ -115,7 +115,7 @@ impl Func {
             }
             Repr::With(arc) => {
                 args.items = arc.1.items.iter().cloned().chain(args.items).collect();
-                return arc.0.call_vm(vm, args);
+                arc.0.call_vm(vm, args)
             }
         }
     }
@@ -292,10 +292,7 @@ impl Closure {
         depth: usize,
         mut args: Args,
     ) -> SourceResult<Value> {
-        let closure = match &this.repr {
-            Repr::Closure(closure) => closure,
-            _ => panic!("`this` must be a closure"),
-        };
+        let Repr::Closure(closure) = &this.repr else { panic!("`this` must be a closure") };
 
         // Don't leak the scopes from the call site. Instead, we use the scope
         // of captured variables we collected earlier.
@@ -337,9 +334,8 @@ impl Closure {
         let result = closure.body.eval(&mut vm);
         match vm.flow {
             Some(Flow::Return(_, Some(explicit))) => return Ok(explicit),
-            Some(Flow::Return(_, None)) => {}
+            Some(Flow::Return(_, None)) | None => {}
             Some(flow) => bail!(flow.forbidden()),
-            None => {}
         }
 
         result

--- a/src/eval/methods.rs
+++ b/src/eval/methods.rs
@@ -27,7 +27,7 @@ pub fn call(
         },
 
         Value::Str(string) => match method {
-            "len" => Value::Int(string.len() as i64),
+            "len" => Value::Int(string.len()),
             "first" => Value::Str(string.first().at(span)?),
             "last" => Value::Str(string.last().at(span)?),
             "at" => Value::Str(string.at(args.expect("index")?).at(span)?),
@@ -73,7 +73,7 @@ pub fn call(
         Value::Content(content) => match method {
             "func" => content.func().into(),
             "has" => Value::Bool(content.has(&args.expect::<EcoString>("field")?)),
-            "at" => content.at(&args.expect::<EcoString>("field")?).at(span)?.clone(),
+            "at" => content.at(&args.expect::<EcoString>("field")?).at(span)?,
             "location" => content
                 .location()
                 .ok_or("this method can only be called on content returned by query(..)")

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -652,7 +652,7 @@ impl Eval for ast::MathIdent {
     type Output = Value;
 
     fn eval(&self, vm: &mut Vm) -> SourceResult<Self::Output> {
-        Ok(vm.scopes.get_in_math(self).cloned().at(self.span())?)
+        vm.scopes.get_in_math(self).cloned().at(self.span())
     }
 }
 
@@ -700,7 +700,7 @@ impl Eval for ast::Ident {
     type Output = Value;
 
     fn eval(&self, vm: &mut Vm) -> SourceResult<Self::Output> {
-        Ok(vm.scopes.get(self).cloned().at(self.span())?)
+        vm.scopes.get(self).cloned().at(self.span())
     }
 }
 
@@ -1306,8 +1306,7 @@ impl Eval for ast::WhileLoop {
 /// Whether the expression always evaluates to the same value.
 fn is_invariant(expr: &SyntaxNode) -> bool {
     match expr.cast() {
-        Some(ast::Expr::Ident(_)) => false,
-        Some(ast::Expr::MathIdent(_)) => false,
+        Some(ast::Expr::Ident(_) | ast::Expr::MathIdent(_)) => false,
         Some(ast::Expr::FieldAccess(access)) => {
             is_invariant(access.target().as_untyped())
         }

--- a/src/eval/module.rs
+++ b/src/eval/module.rs
@@ -60,7 +60,7 @@ impl Module {
 
     /// Try to access a definition in the module.
     pub fn get(&self, name: &str) -> StrResult<&Value> {
-        self.scope().get(&name).ok_or_else(|| {
+        self.scope().get(name).ok_or_else(|| {
             eco_format!("module `{}` does not contain `{name}`", self.name())
         })
     }

--- a/src/eval/str.rs
+++ b/src/eval/str.rs
@@ -39,6 +39,11 @@ impl Str {
         self.0.len() as i64
     }
 
+    /// Whether the string is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
     /// A string slice containing the entire string.
     pub fn as_str(&self) -> &str {
         self
@@ -118,7 +123,7 @@ impl Str {
     /// The text of the pattern's first match in this string.
     pub fn find(&self, pattern: StrPattern) -> Option<Self> {
         match pattern {
-            StrPattern::Str(pat) => self.0.contains(pat.as_str()).then(|| pat),
+            StrPattern::Str(pat) => self.0.contains(pat.as_str()).then_some(pat),
             StrPattern::Regex(re) => re.find(self).map(|m| m.as_str().into()),
         }
     }
@@ -271,7 +276,7 @@ impl Str {
         let n = usize::try_from(n)
             .ok()
             .and_then(|n| self.0.len().checked_mul(n).map(|_| n))
-            .ok_or_else(|| format!("cannot repeat this string {} times", n))?;
+            .ok_or_else(|| format!("cannot repeat this string {n} times"))?;
 
         Ok(Self(self.0.repeat(n)))
     }

--- a/src/eval/symbol.rs
+++ b/src/eval/symbol.rs
@@ -70,7 +70,7 @@ impl Symbol {
                 modifiers.push('.');
             }
             modifiers.push_str(modifier);
-            if find(list.variants(), &modifiers).is_some() {
+            if find(list.variants(), modifiers).is_some() {
                 return Ok(self);
             }
         }

--- a/src/export/pdf/mod.rs
+++ b/src/export/pdf/mod.rs
@@ -129,7 +129,7 @@ fn write_catalog(ctx: &mut PdfContext) {
     let authors = &ctx.document.author;
     if !authors.is_empty() {
         info.author(TextStr(&authors.join(", ")));
-        xmp.creator(authors.iter().map(|s| s.as_str()));
+        xmp.creator(authors.iter().map(ecow::EcoString::as_str));
     }
     info.creator(TextStr("Typst"));
     info.finish();

--- a/src/export/pdf/page.rs
+++ b/src/export/pdf/page.rs
@@ -63,7 +63,7 @@ pub fn construct_page(ctx: &mut PdfContext, frame: &Frame) {
 
 /// Write the page tree.
 pub fn write_page_tree(ctx: &mut PdfContext) {
-    for page in std::mem::take(&mut ctx.pages).into_iter() {
+    for page in std::mem::take(&mut ctx.pages) {
         write_page(ctx, page);
     }
 
@@ -217,7 +217,7 @@ impl PageContext<'_, '_> {
 
     fn set_fill(&mut self, fill: Paint) {
         if self.state.fill != Some(fill) {
-            let f = |c| c as f32 / 255.0;
+            let f = |c| f32::from(c) / 255.0;
             let Paint::Solid(color) = fill;
             match color {
                 Color::Luma(c) => {
@@ -250,7 +250,7 @@ impl PageContext<'_, '_> {
 
     fn set_stroke(&mut self, stroke: Stroke) {
         if self.state.stroke != Some(stroke) {
-            let f = |c| c as f32 / 255.0;
+            let f = |c| f32::from(c) / 255.0;
             let Paint::Solid(color) = stroke.paint;
             match color {
                 Color::Luma(c) => {
@@ -296,8 +296,7 @@ fn write_frame(ctx: &mut PageContext, frame: &Frame) {
             FrameItem::Image(image, size, _) => write_image(ctx, x, y, image, *size),
             FrameItem::Meta(meta, size) => match meta {
                 Meta::Link(dest) => write_link(ctx, pos, dest, *size),
-                Meta::Elem(_) => {}
-                Meta::Hide => {}
+                Meta::Elem(_) | Meta::Hide => {}
             },
         }
     }

--- a/src/export/render.rs
+++ b/src/export/render.rs
@@ -59,9 +59,7 @@ fn render_frame(
                 render_image(canvas, ts, mask, image, *size);
             }
             FrameItem::Meta(meta, _) => match meta {
-                Meta::Link(_) => {}
-                Meta::Elem(_) => {}
-                Meta::Hide => {}
+                Meta::Link(_) | Meta::Elem(_) | Meta::Hide => {}
             },
         }
     }
@@ -196,9 +194,9 @@ fn render_bitmap_glyph(
     // and maybe also for Noto Color Emoji. And: Is the size calculation
     // correct?
     let h = text.size;
-    let w = (image.width() as f64 / image.height() as f64) * h;
-    let dx = (raster.x as f32) / (image.width() as f32) * size;
-    let dy = (raster.y as f32) / (image.height() as f32) * size;
+    let w = (f64::from(image.width()) / f64::from(image.height())) * h;
+    let dx = f32::from(raster.x) / (image.width() as f32) * size;
+    let dy = f32::from(raster.y) / (image.height() as f32) * size;
     let ts = ts.pre_translate(dx, -size - dy);
     render_image(canvas, ts, mask, &image, Size::new(w, h))
 }
@@ -272,7 +270,7 @@ fn render_outline_glyph(
                 continue;
             }
 
-            let applied = alpha_mul(color, cov as u32);
+            let applied = alpha_mul(color, u32::from(cov));
             pixels[pi] = blend_src_over(applied, pixels[pi]);
         }
     }

--- a/src/font/book.rs
+++ b/src/font/book.rs
@@ -425,7 +425,7 @@ pub struct Coverage(Vec<u32>);
 impl Coverage {
     /// Encode a vector of codepoints.
     pub fn from_vec(mut codepoints: Vec<u32>) -> Self {
-        codepoints.sort();
+        codepoints.sort_unstable();
         codepoints.dedup();
 
         let mut runs = Vec::new();

--- a/src/font/variant.rs
+++ b/src/font/variant.rs
@@ -132,7 +132,7 @@ impl Debug for FontWeight {
 
 cast_from_value! {
     FontWeight,
-    v: i64 => Self::from_number(v.clamp(0, u16::MAX as i64) as u16),
+    v: i64 => Self::from_number(v.clamp(0, i64::from(u16::MAX)) as u16),
     /// Thin weight (100).
     "thin" => Self::THIN,
     /// Extra light weight (200).
@@ -226,7 +226,7 @@ impl FontStretch {
 
     /// The ratio between 0.5 and 2.0 corresponding to this stretch.
     pub fn to_ratio(self) -> Ratio {
-        Ratio::new(self.0 as f64 / 1000.0)
+        Ratio::new(f64::from(self.0) / 1000.0)
     }
 
     /// The absolute ratio distance between this and another font stretch.

--- a/src/geom/axes.rs
+++ b/src/geom/axes.rs
@@ -143,7 +143,7 @@ where
         if let Axes { x: Some(x), y: Some(y) } =
             self.as_ref().map(|v| (v as &dyn Any).downcast_ref::<Align>())
         {
-            write!(f, "{:?}-{:?}", x, y)
+            write!(f, "{x:?}-{y:?}")
         } else if (&self.x as &dyn Any).is::<Abs>() {
             write!(f, "Size({:?}, {:?})", self.x, self.y)
         } else {

--- a/src/geom/paint.rs
+++ b/src/geom/paint.rs
@@ -128,22 +128,22 @@ impl LumaColor {
     /// Convert to CMYK as a fraction of true black.
     pub fn to_cmyk(self) -> CmykColor {
         CmykColor::new(
-            round_u8(self.0 as f64 * 0.75),
-            round_u8(self.0 as f64 * 0.68),
-            round_u8(self.0 as f64 * 0.67),
-            round_u8(self.0 as f64 * 0.90),
+            round_u8(f64::from(self.0) * 0.75),
+            round_u8(f64::from(self.0) * 0.68),
+            round_u8(f64::from(self.0) * 0.67),
+            round_u8(f64::from(self.0) * 0.90),
         )
     }
 
     /// Lighten this color by a factor.
     pub fn lighten(self, factor: Ratio) -> Self {
-        let inc = round_u8((u8::MAX - self.0) as f64 * factor.get());
+        let inc = round_u8(f64::from(u8::MAX - self.0) * factor.get());
         Self(self.0.saturating_add(inc))
     }
 
     /// Darken this color by a factor.
     pub fn darken(self, factor: Ratio) -> Self {
-        let dec = round_u8(self.0 as f64 * factor.get());
+        let dec = round_u8(f64::from(self.0) * factor.get());
         Self(self.0.saturating_sub(dec))
     }
 
@@ -189,7 +189,7 @@ impl RgbaColor {
     /// The alpha channel is not affected.
     pub fn lighten(self, factor: Ratio) -> Self {
         let lighten =
-            |c: u8| c.saturating_add(round_u8((u8::MAX - c) as f64 * factor.get()));
+            |c: u8| c.saturating_add(round_u8(f64::from(u8::MAX - c) * factor.get()));
         Self {
             r: lighten(self.r),
             g: lighten(self.g),
@@ -202,7 +202,7 @@ impl RgbaColor {
     ///
     /// The alpha channel is not affected.
     pub fn darken(self, factor: Ratio) -> Self {
-        let darken = |c: u8| c.saturating_sub(round_u8(c as f64 * factor.get()));
+        let darken = |c: u8| c.saturating_sub(round_u8(f64::from(c) * factor.get()));
         Self {
             r: darken(self.r),
             g: darken(self.g),
@@ -311,9 +311,9 @@ impl CmykColor {
 
     /// Convert this color to RGBA.
     pub fn to_rgba(self) -> RgbaColor {
-        let k = self.k as f64 / 255.0;
+        let k = f64::from(self.k) / 255.0;
         let f = |c| {
-            let c = c as f64 / 255.0;
+            let c = f64::from(c) / 255.0;
             round_u8(255.0 * (1.0 - c) * (1.0 - k))
         };
 
@@ -322,7 +322,7 @@ impl CmykColor {
 
     /// Lighten this color by a factor.
     pub fn lighten(self, factor: Ratio) -> Self {
-        let lighten = |c: u8| c.saturating_sub(round_u8(c as f64 * factor.get()));
+        let lighten = |c: u8| c.saturating_sub(round_u8(f64::from(c) * factor.get()));
         Self {
             c: lighten(self.c),
             m: lighten(self.m),
@@ -334,7 +334,7 @@ impl CmykColor {
     /// Darken this color by a factor.
     pub fn darken(self, factor: Ratio) -> Self {
         let darken =
-            |c: u8| c.saturating_add(round_u8((u8::MAX - c) as f64 * factor.get()));
+            |c: u8| c.saturating_add(round_u8(f64::from(u8::MAX - c) * factor.get()));
         Self {
             c: darken(self.c),
             m: darken(self.m),
@@ -358,7 +358,7 @@ impl CmykColor {
 
 impl Debug for CmykColor {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let g = |c| 100.0 * (c as f64 / 255.0);
+        let g = |c| 100.0 * (f64::from(c) / 255.0);
         write!(
             f,
             "cmyk({:.1}%, {:.1}%, {:.1}%, {:.1}%)",

--- a/src/ide/complete.rs
+++ b/src/ide/complete.rs
@@ -83,7 +83,7 @@ fn complete_markup(ctx: &mut CompletionContext) -> bool {
     // Bail if we aren't even in markup.
     if !matches!(
         ctx.leaf.parent_kind(),
-        None | Some(SyntaxKind::Markup) | Some(SyntaxKind::Ref)
+        None | Some(SyntaxKind::Markup | SyntaxKind::Ref)
     ) {
         return false;
     }
@@ -122,7 +122,7 @@ fn complete_markup(ctx: &mut CompletionContext) -> bool {
     }
 
     // Directly after a raw block.
-    let mut s = Scanner::new(&ctx.text);
+    let mut s = Scanner::new(ctx.text);
     s.jump(ctx.leaf.offset());
     if s.eat_if("```") {
         s.eat_while('`');
@@ -251,10 +251,12 @@ fn markup_completions(ctx: &mut CompletionContext) {
 fn complete_math(ctx: &mut CompletionContext) -> bool {
     if !matches!(
         ctx.leaf.parent_kind(),
-        Some(SyntaxKind::Equation)
-            | Some(SyntaxKind::Math)
-            | Some(SyntaxKind::MathFrac)
-            | Some(SyntaxKind::MathAttach)
+        Some(
+            SyntaxKind::Equation
+                | SyntaxKind::Math
+                | SyntaxKind::MathFrac
+                | SyntaxKind::MathAttach
+        )
     ) {
         return false;
     }
@@ -651,7 +653,7 @@ fn param_completions(
                 kind: CompletionKind::Param,
                 label: param.name.into(),
                 apply: Some(eco_format!("{}: ${{}}", param.name)),
-                detail: Some(plain_docs_sentence(param.docs).into()),
+                detail: Some(plain_docs_sentence(param.docs)),
             });
         }
 
@@ -695,10 +697,12 @@ fn named_param_value_completions(
 fn complete_code(ctx: &mut CompletionContext) -> bool {
     if matches!(
         ctx.leaf.parent_kind(),
-        None | Some(SyntaxKind::Markup)
-            | Some(SyntaxKind::Math)
-            | Some(SyntaxKind::MathFrac)
-            | Some(SyntaxKind::MathAttach)
+        None | Some(
+            SyntaxKind::Markup
+                | SyntaxKind::Math
+                | SyntaxKind::MathFrac
+                | SyntaxKind::MathAttach
+        )
     ) {
         return false;
     }
@@ -896,8 +900,8 @@ impl<'a> CompletionContext<'a> {
             frames,
             library,
             source,
-            global: &library.global.scope(),
-            math: &library.math.scope(),
+            global: library.global.scope(),
+            math: library.math.scope(),
             text,
             before: &text[..cursor],
             after: &text[cursor..],
@@ -1002,9 +1006,7 @@ impl<'a> CompletionContext<'a> {
 
         let detail = docs.map(Into::into).or_else(|| match value {
             Value::Symbol(_) => None,
-            Value::Func(func) => {
-                func.info().map(|info| plain_docs_sentence(info.docs).into())
-            }
+            Value::Func(func) => func.info().map(|info| plain_docs_sentence(info.docs)),
             v => Some(v.repr().into()),
         });
 
@@ -1121,10 +1123,12 @@ impl<'a> CompletionContext<'a> {
 
         let in_math = matches!(
             self.leaf.parent_kind(),
-            Some(SyntaxKind::Equation)
-                | Some(SyntaxKind::Math)
-                | Some(SyntaxKind::MathFrac)
-                | Some(SyntaxKind::MathAttach)
+            Some(
+                SyntaxKind::Equation
+                    | SyntaxKind::Math
+                    | SyntaxKind::MathFrac
+                    | SyntaxKind::MathAttach
+            )
         );
 
         let scope = if in_math { self.math } else { self.global };

--- a/src/ide/tooltip.rs
+++ b/src/ide/tooltip.rs
@@ -123,7 +123,7 @@ fn ref_tooltip(
     let target = leaf.text().trim_start_matches('@');
     for (label, detail) in analyze_labels(world, frames).0 {
         if label.0 == target {
-            return Some(Tooltip::Text(detail?.into()));
+            return Some(Tooltip::Text(detail?));
         }
     }
 

--- a/src/model/content.rs
+++ b/src/model/content.rs
@@ -111,7 +111,7 @@ impl Content {
         C: ?Sized + 'static,
     {
         let vtable = (self.func.0.vtable)(TypeId::of::<C>())?;
-        let data = self as *const Self as *const ();
+        let data = (self as *const Self).cast::<()>();
         Some(unsafe { &*crate::util::fat::from_raw_parts(data, vtable) })
     }
 
@@ -122,7 +122,7 @@ impl Content {
         C: ?Sized + 'static,
     {
         let vtable = (self.func.0.vtable)(TypeId::of::<C>())?;
-        let data = self as *mut Self as *mut ();
+        let data = (self as *mut Self).cast::<()>();
         Some(unsafe { &mut *crate::util::fat::from_raw_parts_mut(data, vtable) })
     }
 
@@ -296,7 +296,7 @@ impl Content {
     /// Repeat this content `n` times.
     pub fn repeat(&self, n: i64) -> StrResult<Self> {
         let count = usize::try_from(n)
-            .map_err(|_| format!("cannot repeat this content {} times", n))?;
+            .map_err(|_| format!("cannot repeat this content {n} times"))?;
 
         Ok(Self::sequence(vec![self.clone(); count]))
     }

--- a/src/model/introspect.rs
+++ b/src/model/introspect.rs
@@ -175,7 +175,9 @@ impl Introspector {
         self.elems
             .iter()
             .find(|(elem, _)| elem.location() == Some(location))
-            .map(|(_, loc)| *loc)
-            .unwrap_or(Position { page: NonZeroUsize::ONE, point: Point::zero() })
+            .map_or(
+                Position { page: NonZeroUsize::ONE, point: Point::zero() },
+                |(_, loc)| *loc,
+            )
     }
 }

--- a/src/syntax/ast.rs
+++ b/src/syntax/ast.rs
@@ -316,49 +316,49 @@ impl AstNode for Expr {
 impl Expr {
     /// Can this expression be embedded into markup with a hashtag?
     pub fn hashtag(&self) -> bool {
-        match self {
-            Self::Ident(_) => true,
-            Self::None(_) => true,
-            Self::Auto(_) => true,
-            Self::Bool(_) => true,
-            Self::Int(_) => true,
-            Self::Float(_) => true,
-            Self::Numeric(_) => true,
-            Self::Str(_) => true,
-            Self::Code(_) => true,
-            Self::Content(_) => true,
-            Self::Array(_) => true,
-            Self::Dict(_) => true,
-            Self::Parenthesized(_) => true,
-            Self::FieldAccess(_) => true,
-            Self::FuncCall(_) => true,
-            Self::Let(_) => true,
-            Self::Set(_) => true,
-            Self::Show(_) => true,
-            Self::Conditional(_) => true,
-            Self::While(_) => true,
-            Self::For(_) => true,
-            Self::Import(_) => true,
-            Self::Include(_) => true,
-            Self::Break(_) => true,
-            Self::Continue(_) => true,
-            Self::Return(_) => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            Self::Ident(_)
+                | Self::None(_)
+                | Self::Auto(_)
+                | Self::Bool(_)
+                | Self::Int(_)
+                | Self::Float(_)
+                | Self::Numeric(_)
+                | Self::Str(_)
+                | Self::Code(_)
+                | Self::Content(_)
+                | Self::Array(_)
+                | Self::Dict(_)
+                | Self::Parenthesized(_)
+                | Self::FieldAccess(_)
+                | Self::FuncCall(_)
+                | Self::Let(_)
+                | Self::Set(_)
+                | Self::Show(_)
+                | Self::Conditional(_)
+                | Self::While(_)
+                | Self::For(_)
+                | Self::Import(_)
+                | Self::Include(_)
+                | Self::Break(_)
+                | Self::Continue(_)
+                | Self::Return(_)
+        )
     }
 
     /// Is this a literal?
     pub fn is_literal(&self) -> bool {
-        match self {
-            Self::None(_) => true,
-            Self::Auto(_) => true,
-            Self::Bool(_) => true,
-            Self::Int(_) => true,
-            Self::Float(_) => true,
-            Self::Numeric(_) => true,
-            Self::Str(_) => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            Self::None(_)
+                | Self::Auto(_)
+                | Self::Bool(_)
+                | Self::Int(_)
+                | Self::Float(_)
+                | Self::Numeric(_)
+                | Self::Str(_)
+        )
     }
 }
 
@@ -1174,7 +1174,7 @@ impl Keyed {
     pub fn key(&self) -> Str {
         self.0
             .children()
-            .find_map(|node| node.cast::<Str>())
+            .find_map(SyntaxNode::cast)
             .unwrap_or_default()
     }
 

--- a/src/syntax/lexer.rs
+++ b/src/syntax/lexer.rs
@@ -357,7 +357,7 @@ impl Lexer<'_> {
     }
 
     fn in_word(&self) -> bool {
-        let alphanum = |c: Option<char>| c.map_or(false, |c| c.is_alphanumeric());
+        let alphanum = |c: Option<char>| c.map_or(false, char::is_alphanumeric);
         let prev = self.s.scout(-2);
         let next = self.s.peek();
         alphanum(prev) && alphanum(next)

--- a/src/syntax/node.rs
+++ b/src/syntax/node.rs
@@ -62,6 +62,11 @@ impl SyntaxNode {
         }
     }
 
+    /// Whether the node is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// The span of the node.
     pub fn span(&self) -> Span {
         match &self.0 {
@@ -144,7 +149,7 @@ impl SyntaxNode {
         } else {
             self.children()
                 .filter(|node| node.erroneous())
-                .flat_map(|node| node.errors())
+                .flat_map(SyntaxNode::errors)
                 .collect()
         }
     }
@@ -472,7 +477,7 @@ impl InnerNode {
                 .start
                 .checked_sub(1)
                 .and_then(|i| self.children.get(i))
-                .map_or(self.span.number() + 1, |child| child.upper());
+                .map_or(self.span.number() + 1, SyntaxNode::upper);
 
             // The upper bound for renumbering is either
             // - the span number of the first child after the to-be-renumbered

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -1315,7 +1315,7 @@ impl<'s> Parser<'s> {
         while self
             .nodes
             .last()
-            .map_or(false, |child| child.kind() == SyntaxKind::Error && child.len() == 0)
+            .map_or(false, |child| child.kind() == SyntaxKind::Error && child.is_empty())
         {
             self.nodes.pop();
         }

--- a/src/syntax/reparser.rs
+++ b/src/syntax/reparser.rs
@@ -72,7 +72,7 @@ fn try_reparse(
                     return node
                         .replace_children(i..i + 1, vec![newborn])
                         .is_ok()
-                        .then(|| new_range);
+                        .then_some(new_range);
                 }
             }
         }
@@ -157,7 +157,7 @@ fn try_reparse(
                 return node
                     .replace_children(start..end, newborns)
                     .is_ok()
-                    .then(|| new_range);
+                    .then_some(new_range);
             }
         }
     }

--- a/src/syntax/source.rs
+++ b/src/syntax/source.rs
@@ -212,7 +212,7 @@ impl Source {
             k += c.len_utf16();
         }
 
-        (k == utf16_idx).then(|| self.text.len())
+        (k == utf16_idx).then_some(self.text.len())
     }
 
     /// Return the byte position at which the given line starts.

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -205,7 +205,7 @@ pub fn pretty_comma_list(pieces: &[impl AsRef<str>], trailing_comma: bool) -> St
 /// Tries to format horizontally, but falls back to vertical formatting if the
 /// pieces are too long.
 pub fn pretty_array_like(parts: &[impl AsRef<str>], trailing_comma: bool) -> String {
-    let list = pretty_comma_list(&parts, trailing_comma);
+    let list = pretty_comma_list(parts, trailing_comma);
     let mut buf = String::new();
     buf.push('(');
     if list.contains('\n') {

--- a/tests/src/benches.rs
+++ b/tests/src/benches.rs
@@ -30,8 +30,8 @@ fn bench_decode(iai: &mut Iai) {
         // We don't use chars().count() because that has a special
         // superfast implementation.
         let mut count = 0;
-        let mut chars = black_box(TEXT).chars();
-        while let Some(_) = chars.next() {
+        let chars = black_box(TEXT).chars();
+        for _ in chars {
             count += 1;
         }
         count
@@ -42,7 +42,7 @@ fn bench_scan(iai: &mut Iai) {
     iai.run(|| {
         let mut count = 0;
         let mut scanner = Scanner::new(black_box(TEXT));
-        while let Some(_) = scanner.eat() {
+        while scanner.eat().is_some() {
             count += 1;
         }
         count

--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -325,7 +325,7 @@ fn read(path: &Path) -> FileResult<Vec<u8>> {
         .unwrap_or_else(|_| path.into());
 
     let f = |e| FileError::from_io(e, &suffix);
-    let mut file = File::open(&path).map_err(f)?;
+    let mut file = File::open(path).map_err(f)?;
     if file.metadata().map_err(f)?.is_file() {
         let mut data = vec![];
         file.read_to_end(&mut data).map_err(f)?;
@@ -383,7 +383,7 @@ fn test(
     if compare_ever {
         if let Some(pdf_path) = pdf_path {
             let pdf_data = typst::export::pdf(&document);
-            fs::create_dir_all(&pdf_path.parent().unwrap()).unwrap();
+            fs::create_dir_all(pdf_path.parent().unwrap()).unwrap();
             fs::write(pdf_path, pdf_data).unwrap();
         }
 
@@ -394,7 +394,7 @@ fn test(
         }
 
         let canvas = render(&document.pages);
-        fs::create_dir_all(&png_path.parent().unwrap()).unwrap();
+        fs::create_dir_all(png_path.parent().unwrap()).unwrap();
         canvas.save_png(png_path).unwrap();
 
         if let Ok(ref_pixmap) = sk::Pixmap::load_png(ref_path) {
@@ -442,7 +442,7 @@ fn test_part(
         println!("Syntax Tree:\n{:#?}\n", source.root())
     }
 
-    let (local_compare_ref, mut ref_errors) = parse_metadata(&source);
+    let (local_compare_ref, mut ref_errors) = parse_metadata(source);
     let compare_ref = local_compare_ref.unwrap_or(compare_ref);
 
     ok &= test_spans(source.root());
@@ -486,14 +486,14 @@ fn test_part(
         for error in errors.iter() {
             if !ref_errors.contains(error) {
                 print!("    Not annotated | ");
-                print_error(&source, line, error);
+                print_error(source, line, error);
             }
         }
 
         for error in ref_errors.iter() {
             if !errors.contains(error) {
                 print!("    Not emitted   | ");
-                print_error(&source, line, error);
+                print_error(source, line, error);
             }
         }
     }


### PR DESCRIPTION
in general just cleaned up syntax and removed a lot of "as" casts if permitted. only included small changes that dont really require much effort to review if u know it compiles.
- Usually we have a bunch of branches that result in the same thing. I think personally that condensing them makes it way cleaner/readable to group common evaluation and overall looks cleaner. It only doesn't make sense to me when there are plans to make wide unique functionality or merging explicit cases to a wildcard (in this instance i agree its better to be explicit about the 2 separate cases because u lose intent when merging them) but since this is more of a readability thing, figured id hear if anyone opposed to it for some reason.

Edit: I didn't include all clippy lints, because a lot of them I think most people would just disagree with in the instances they are used (e.g replacing if else with match cmp is just unnecessary and doesnt add anything that the existing code doesnt)