### PR TITLE
fix: allow access to label of sequence

### DIFF
--- a/src/model/content.rs
+++ b/src/model/content.rs
@@ -165,11 +165,10 @@ impl Content {
 
     /// Access a field on the content.
     pub fn field(&self, name: &str) -> Option<Value> {
-        if let Some(iter) = self.to_sequence() {
-            (name == "children")
-                .then(|| Value::Array(iter.cloned().map(Value::Content).collect()))
-        } else if let Some((child, _)) = self.to_styled() {
-            (name == "child").then(|| Value::Content(child.clone()))
+        if let (Some(iter), "children") = (self.to_sequence(), name) {
+            Some(Value::Array(iter.cloned().map(Value::Content).collect()))
+        } else if let (Some((child, _)), "child") = (self.to_styled(), "child") {
+            Some(Value::Content(child.clone()))
         } else {
             self.field_ref(name).cloned()
         }


### PR DESCRIPTION
Previously, the following file would fail to compile

```typ
 #show: it => {
   let sequence = it.children.at(0)
   repr(sequence)
   sequence.label
   //       ^^^^^~~~ error: content does not contain field "label"
 }
 #[
   = Heading
   text
 ] <label>
```

however, both the `repr` and the IDE autocomplete say that the field "label" does indeed exist in the sequence. This commit fixes the issue by falling back to regular field access on `Content` when it is a sequence and the user isn't trying to access the "children" field.

`repr(sequence)` is

```
sequence(
  label: <label>,
  children: (
    [ ],
    heading(body: [Heading], level: 1),
    [ ],
    [text],
    [ ],
  ),
),
```