### PR TITLE
Add scaling of inner fences in lr

### DIFF
--- a/library/src/math/delimited.rs
+++ b/library/src/math/delimited.rs
@@ -55,6 +55,13 @@ impl LayoutMath for LrElem {
             .max()
             .unwrap_or_default();
 
+        let mut fences = vec![];
+        for (index, fragment) in fragments.iter().enumerate() {
+            if matches!(fragment.class(), Some(MathClass::Fence)) {
+                fences.push(index);
+            }
+        }
+
         let height = self
             .size(ctx.styles())
             .unwrap_or(Rel::one())
@@ -63,9 +70,12 @@ impl LayoutMath for LrElem {
 
         match fragments.as_mut_slice() {
             [one] => scale(ctx, one, height, None),
-            [first, .., last] => {
-                scale(ctx, first, height, Some(MathClass::Opening));
-                scale(ctx, last, height, Some(MathClass::Closing));
+            frags if frags.len() >= 2 => {
+                scale(ctx, &mut frags[0], height, Some(MathClass::Opening));
+                scale(ctx, &mut frags[frags.len() - 1], height, Some(MathClass::Closing));
+                for fence in fences {
+                    scale(ctx, &mut frags[fence], height, Some(MathClass::Fence));
+                }
             }
             _ => {}
         }

--- a/tests/typ/math/delimited.typ
+++ b/tests/typ/math/delimited.typ
@@ -3,11 +3,11 @@
 ---
 // Test automatic matching.
 $ (a) + {b/2} + |a|/2 + (b) $
-$f(x/2) < zeta(c^2 + |a + b/2|)$
+$ f(x/2) < zeta(c^2 + |a + b/2|) $
 
 ---
 // Test unmatched.
-$[1,2[ = [1,2) != zeta\(x/2\) $
+$ [1,2[ = [1,2) != zeta\(x/2\) $
 
 ---
 // Test manual matching.
@@ -35,7 +35,7 @@ $ lr(]sum_(x=1)^n x], size: #70%)
 
 ---
 // Test predefined delimiter pairings.
-$floor(x/2), ceil(x/2), abs(x), norm(x)$
+$ floor(x/2), ceil(x/2), abs(x), norm(x) $
 
 ---
 // Test fence between automatic delimiters.

--- a/tests/typ/math/delimited.typ
+++ b/tests/typ/math/delimited.typ
@@ -36,3 +36,11 @@ $ lr(]sum_(x=1)^n x], size: #70%)
 ---
 // Test predefined delimiter pairings.
 $floor(x/2), ceil(x/2), abs(x), norm(x)$
+
+---
+// Test fence between automatic delimiters.
+$ ((x / 4) / 2 | y) $
+
+---
+// Test fence between manual delimiters.
+$ lr(brace.l x in CC | (norm(x) / 2)^2 = 1 brace.r) $


### PR DESCRIPTION
:bangbang: __Breaking change__

### Description

This modifies the lr function such that inner fences `|` scale with the outer delimiters. I also updated the visual tests file accordingly.

Here are two examples of the new behavior

```
$ ((x / 4) / 2 | y) $
$ lr(brace.l x in CC | (norm(x) / 2)^2 = 1 brace.r) $
```

![20230326_21h15m56s_grim](https://user-images.githubusercontent.com/52462375/227818338-efd90747-3624-435f-918c-4539995ac20c.png)

### Missing feature

It would be nice if there was a simple way to turn that behavior off. I was hoping that using something like `bar.v` instead of `|` could prevent the scaling, but I didn't figure out how to do it. Another solution is to add a boolean argument to `lr` to turn the fence scaling on or off. I can implement that, but I would prefer to have some feedback before.

### Tests 

Looking at the CI outcome, I understand I need to update the reference PNG figures. I have no idea how to do this. I also fix the spacing around different tests to make everything more uniform.