### PR TITLE
Make release builds using LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,5 +49,9 @@ debug = 0
 [profile.dev.package."*"]
 opt-level = 2
 
+[profile.release]
+lto = "thin"
+codegen-units = 1
+
 [profile.release.package."typst-cli"]
 strip = true


### PR DESCRIPTION
Adding LinkTimeOptimization (LTO) improves runtime performance, I also changed codegen-units to maximize the runtime performance of release builds, this should not affect debug builds, It also reduces the binary size of the executable.
LTO = "thin" is prefered over "fat" as the differences are small but have large compile time increases.