### PR TITLE
cli: Allow passing everything but directories as input

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -563,10 +563,10 @@ impl PathHash {
 /// Read a file.
 fn read(path: &Path) -> FileResult<Vec<u8>> {
     let f = |e| FileError::from_io(e, path);
-    if fs::metadata(&path).map_err(f)?.is_file() {
-        fs::read(&path).map_err(f)
-    } else {
+    if fs::metadata(&path).map_err(f)?.is_dir() {
         Err(FileError::IsDirectory)
+    } else {
+        fs::read(&path).map_err(f)
     }
 }
 

--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -324,10 +324,10 @@ fn read(path: &Path) -> FileResult<Vec<u8>> {
         .unwrap_or_else(|_| path.into());
 
     let f = |e| FileError::from_io(e, &suffix);
-    if fs::metadata(&path).map_err(f)?.is_file() {
-        fs::read(&path).map_err(f)
-    } else {
+    if fs::metadata(&path).map_err(f)?.is_dir() {
         Err(FileError::IsDirectory)
+    } else {
+        fs::read(&path).map_err(f)
     }
 }
 


### PR DESCRIPTION
By allowing every file but directories as input typst supports reading from fifos (and stdin).

Example:
`$ echo 'Test' | typst /dev/stdin out.pdf`

#410 