### PR TITLE
Fix file watching when only file name is given

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -192,8 +192,9 @@ fn compile(command: CompileCommand) -> StrResult<()> {
     } else if let Some(dir) = command
         .input
         .canonicalize()
-        .map_err(|_| "given input path does not exist")?
-        .parent()
+        .ok()
+        .as_ref()
+        .and_then(|path| path.parent())
     {
         dir.into()
     } else {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -189,7 +189,12 @@ fn dispatch(command: Command) -> StrResult<()> {
 fn compile(command: CompileCommand) -> StrResult<()> {
     let root = if let Some(root) = &command.root {
         root.clone()
-    } else if let Some(dir) = command.input.parent() {
+    } else if let Some(dir) = command
+        .input
+        .canonicalize()
+        .map_err(|_| "given input path does not exist")?
+        .parent()
+    {
         dir.into()
     } else {
         PathBuf::new()


### PR DESCRIPTION
Currently, file watching does not work when you supply only a file name as input, e.g. `typst -w main.typ`. This is because [here](https://github.com/typst/typst/blob/e13fc04c3e973da60d5f4e9cc6fc38105cd2ddf9/cli/src/main.rs#L192) the parent of the given input path is queried which according to the [documentation](https://doc.rust-lang.org/stable/std/path/struct.PathBuf.html#method.parent) "returns `Some("")` for relative paths with one component".

This PR fixes this issue by applying [`fn canonicalize`](https://doc.rust-lang.org/stable/std/path/struct.PathBuf.html#method.canonicalize) on the given input path which resolves it to an absolute path and then getting the parent (which must be the directory the given input file is located in as only the file name is removed from the path by calling `fn parent`).

I assume that this should be the expected behavior as it allows a user to watch a file without specifying the root directory using the `--root` argument.

Fixes typst#300