### PR TITLE
CI runs all tests 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,5 +8,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo build --all
-      - run: cargo test --all
+      - run: cargo build --workspace
+      - run: cargo test --workspace --no-fail-fast


### PR DESCRIPTION
* use `--workspace` instead of `--all` as it is deprecated.

* Add `--no-fast-fail`  as it runs all the tests, even if one fails. 
This is appropriate for CI, while it may not be strictly appropriate for developing code.