### PR TITLE
Implement pandoc output (and thus indirectly Markdown, HTML, ePub, docx output)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,6 +800,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
+name = "pandoc_types"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16172f24b8ad7f0ded9947f3d33f0344bc4d4e7c4937a2a0c405447403211434"
+dependencies = [
+ "serde",
+ "serde_tuple",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,13 +1090,34 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
+checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
 dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_tuple"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f025b91216f15a2a32aa39669329a475733590a015835d1783549a56d09427"
+dependencies = [
+ "serde",
+ "serde_tuple_macros",
+]
+
+[[package]]
+name = "serde_tuple_macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4076151d1a2b688e25aaf236997933c66e18b870d0369f8b248b8ab2be630d7e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1365,8 +1396,10 @@ dependencies = [
  "memmap2",
  "notify",
  "once_cell",
+ "pandoc_types",
  "pico-args",
  "same-file",
+ "serde_json",
  "siphasher",
  "typst",
  "typst-library",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,6 +27,8 @@ pico-args = "0.4"
 same-file = "1"
 siphasher = "0.3"
 walkdir = "2"
+pandoc_types = "0.6.0"
+serde_json = "1.0.95"
 
 [features]
 default = ["embed-fonts"]

--- a/cli/src/pandoc.rs
+++ b/cli/src/pandoc.rs
@@ -1,0 +1,269 @@
+use std::collections::HashMap;
+
+use typst::{
+    geom::GenAlign,
+    model::{Content, StyleChain}, doc::Destination,
+};
+
+use typst_library::{
+    layout::{
+        AlignElem, BlockElem, EnumItem, HElem, ListItem, ParbreakElem,
+        TableElem, TermItem, VElem,
+    },
+    math::EquationElem,
+    meta::{HeadingElem, LinkElem, LinkTarget},
+    text::{EmphElem, LinebreakElem, RawElem, SpaceElem, StrongElem, TextElem, SmartQuoteElem},
+    visualize::ImageElem,
+};
+use pandoc_types::definition::{self as p};
+
+#[derive(Debug)]
+// pandoc separates the concepts of Inlines and Blocks but typst doesn't
+enum BlockOrInlines {
+    Blocks(Vec<p::Block>),
+    Inlines(Vec<p::Inline>),
+}
+impl From<p::Inline> for BlockOrInlines {
+    fn from(value: p::Inline) -> Self {
+        BlockOrInlines::Inlines(vec![value])
+    }
+}
+impl From<p::Block> for BlockOrInlines {
+    fn from(value: p::Block) -> Self {
+        BlockOrInlines::Blocks(vec![value])
+    }
+}
+
+pub fn pandoc(content: &Content) -> Vec<u8> {
+    // eprintln!("input: {:?}", content);
+    serde_json::to_vec(&serde_json::json!(pandoc_types::definition::Pandoc {
+        meta: HashMap::new(),
+        blocks: to_block(to_pandoc_ast(content))
+    }))
+    .unwrap()
+}
+
+fn to_inline(v: &BlockOrInlines) -> Result<Vec<p::Inline>, String> {
+    match v {
+        BlockOrInlines::Blocks(b) => Err(format!("not inline: {:?}", b)),
+        BlockOrInlines::Inlines(i) => Ok(i.clone()),
+    }
+}
+fn to_block(v: BlockOrInlines) -> Vec<p::Block> {
+    match v {
+        BlockOrInlines::Blocks(b) => b,
+        BlockOrInlines::Inlines(i) => vec![p::Block::Plain(i)],
+    }
+}
+
+fn to_pandoc_ast(content: &Content) -> BlockOrInlines {
+    if let Some((e, _)) = content.to_styled() {
+        return to_pandoc_ast(e);
+    }
+    if let Some(t) = content.to::<TextElem>() {
+        return p::Inline::Str(t.text().to_string()).into();
+    }
+    if let Some(_) = content.to::<SpaceElem>() {
+        return p::Inline::Space.into();
+    }
+    if let Some(_) = content.to::<HElem>() {
+        // pandoc doesn't really handle flexible horizontal spacing
+        return p::Inline::Space.into();
+    }
+    if let Some(_) = content.to::<VElem>() {
+        // pandoc doesn't really handle flexible vertical spacing, return empty para
+        return p::Block::Para(vec![]).into();
+    }
+    if let Some(e) = content.to::<EmphElem>() {
+        return p::Inline::Emph(
+            to_inline(&to_pandoc_ast(&e.body())).expect("content of emph not inline"),
+        )
+        .into();
+    }
+    if let Some(e) = content.to::<EquationElem>() {
+        // todo: pandoc represents math as latex math. parse typst equations into latex math?
+        return p::Inline::Math(
+            if e.block(StyleChain::default()) {
+                p::MathType::DisplayMath
+            } else {
+                p::MathType::InlineMath
+            },
+            r#"\text{\[equation\]}"#.to_string(),
+        )
+        .into();
+    }
+    if let Some(e) = content.to::<ImageElem>() {
+        return p::Inline::Image(
+            p::Attr::default(),
+            vec![],
+            p::Target { url: e.path().to_string(), title: "".to_string() },
+        )
+        .into();
+    }
+    if let Some(_) = content.to::<LinebreakElem>() {
+        return (p::Inline::LineBreak).into();
+    }
+    if let Some(e) = content.to::<StrongElem>() {
+        return p::Inline::Strong(
+            to_inline(&to_pandoc_ast(&e.body())).expect("content of strong not inline"),
+        )
+        .into();
+    }
+    if let Some(e) = content.to::<LinkElem>() {
+        let dest = e.dest();
+        let dstr = match dest {
+            LinkTarget::Dest(Destination::Url(u)) => u.to_string(),
+            LinkTarget::Dest(Destination::Position(p)) => format!("#pos:{:?}", p),
+            LinkTarget::Dest(Destination::Location(p)) => format!("#loc:{:?}", p),
+            LinkTarget::Label(l) => format!("#label:{:?}", l),
+        };
+        return p::Inline::Link(
+            p::Attr::default(),
+            to_inline(&to_pandoc_ast(&e.body())).expect("content of href not inline"),
+            p::Target { title: "".to_string(), url: dstr },
+        )
+        .into();
+    }
+    if let Some(e) = content.to::<RawElem>() {
+        let mut a = p::Attr::default();
+        if let Some(l) = e.lang(StyleChain::default()) {
+            a.classes.push(l.to_string());
+        }
+        if e.block(StyleChain::default()) {
+            return p::Block::CodeBlock(a, e.text().to_string()).into();
+        } else {
+            return p::Inline::Code(a, e.text().to_string()).into();
+        }
+    }
+    if let Some(e) = content.to::<BlockElem>() {
+        // todo: parse width, height, styling?
+        return p::Block::Div(
+            p::Attr::default(),
+            to_block(
+                e.body(StyleChain::default())
+                    .map(|e| to_pandoc_ast(&e))
+                    .unwrap_or(BlockOrInlines::Blocks(vec![])),
+            ),
+        )
+        .into();
+    }
+    if let Some(e) = content.to::<AlignElem>() {
+        let mut attr = p::Attr::default();
+        let align = e.alignment(StyleChain::default());
+        let horiz_align = align.x;
+        let vert_align = align.y;
+        if horiz_align != GenAlign::Start {
+            attr.attributes
+                .push(("align".to_string(), format!("{:?}", horiz_align)));
+        }
+        if vert_align != GenAlign::Specific(typst::geom::Align::Top) {
+            // vertical align is kinda meaningless in the pandoc document model
+            attr.attributes
+                .push(("vertical-align".to_string(), format!("{:?}", vert_align)));
+        }
+        return p::Block::Div(attr, to_block(to_pandoc_ast(&e.body()))).into();
+    }
+
+    // typst does not track which list an item belongs to in the AST, it only does this in the layout phase with ListBuilder.
+    // but we skip the layout phase. todo: invoke ListBuilder ourselves during handling of sequences (?)
+    if let Some(e) = content.to::<ListItem>() {
+        return p::Block::BulletList(vec![to_block(to_pandoc_ast(&e.body()))]).into();
+    }
+    if let Some(e) = content.to::<EnumItem>() {
+        return p::Block::OrderedList(
+            p::ListAttributes::default(),
+            vec![to_block(to_pandoc_ast(&e.body()))],
+        )
+        .into();
+    }
+    if let Some(e) = content.to::<TermItem>() {
+        return p::Block::DefinitionList(vec![(
+            to_inline(&to_pandoc_ast(&e.term())).expect("term item not inlines"),
+            vec![to_block(to_pandoc_ast(&e.description()))],
+        )])
+        .into();
+    }
+    if let Some(e) = content.to::<SmartQuoteElem>() {
+        // todo: use state machine?
+        let t = if e.double(StyleChain::default()) {'"'} else {'\''};
+        return p::Inline::Str(t.to_string()).into();
+    }
+    if let Some(e) = content.to::<TableElem>() {
+        let body: Vec<_> = e
+            .children()
+            .chunks_exact(e.columns(StyleChain::default()).0.len())
+            .map(|row| p::Row {
+                attr: p::Attr::default(),
+                cells: row
+                    .into_iter()
+                    .map(to_pandoc_ast)
+                    .map(|content| p::Cell {
+                        content: to_block(content),
+                        ..Default::default()
+                    })
+                    .collect(),
+            })
+            .collect();
+        //let header = body.remove(0); // typst doesn't have a concept of header rows but pandoc needs them
+        let body = p::TableBody { body, ..Default::default() };
+        let tbl = p::Table {
+            //head: p::TableHead { rows: vec![header], attr: p::Attr::default() },
+            bodies: vec![body],
+            colspecs: e
+                .columns(StyleChain::default())
+                .0
+                .into_iter()
+                .map(|_| {
+                    // todo: convert sizing and alignment
+                    p::ColSpec::default()
+                })
+                .collect(),
+            ..Default::default()
+        };
+        return p::Block::Table(tbl).into();
+    }
+
+    if let Some(l) = content.to_sequence() {
+        let mut blocks = vec![];
+        let mut latest_inlines: Vec<p::Inline> = vec![];
+        for ele in l {
+            if ele.is::<ParbreakElem>() {
+                let inlines = std::mem::replace(&mut latest_inlines, vec![]);
+                blocks.push(p::Block::Para(inlines));
+            } else {
+                match to_pandoc_ast(ele) {
+                    BlockOrInlines::Blocks(b) => {
+                        if latest_inlines.len() > 0 {
+                            let inlines = std::mem::replace(&mut latest_inlines, vec![]);
+
+                            blocks.push(p::Block::Plain(inlines));
+                        }
+                        blocks.extend(b);
+                    }
+                    BlockOrInlines::Inlines(i) => latest_inlines.extend(i),
+                }
+            }
+        }
+        if latest_inlines.len() > 0 {
+            if blocks.len() == 0 {
+                // no blocks at all, everything inline
+                return BlockOrInlines::Inlines(latest_inlines);
+            }
+            let inlines = std::mem::replace(&mut latest_inlines, vec![]);
+
+            blocks.push(p::Block::Plain(inlines));
+        }
+        return BlockOrInlines::Blocks(blocks);
+    }
+    if let Some(h) = content.to::<HeadingElem>() {
+        let level = h.level(StyleChain::default()).get().try_into().unwrap(); // why is stylechain is needed here?
+        return p::Block::Header(
+            level,
+            p::Attr::default(),
+            to_inline(&to_pandoc_ast(&h.body())).expect("heading content not inline"),
+        )
+        .into();
+    }
+    eprintln!("conversion not implemented for {:?}", content);
+    return p::Inline::Str("[unk]".to_string()).into();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ pub mod syntax;
 use std::path::Path;
 
 use comemo::{Prehashed, Track};
+use model::Content;
 
 use crate::diag::{FileResult, SourceResult};
 use crate::doc::Document;
@@ -61,6 +62,17 @@ use crate::eval::{Library, Route, Tracer};
 use crate::font::{Font, FontBook};
 use crate::syntax::{Source, SourceId};
 use crate::util::Buffer;
+
+/// Compile a source file into a unlayouted content object
+pub fn compile_to_content(world: &(dyn World + 'static)) -> SourceResult<Content> {
+    // Evaluate the source file into a module.
+    let route = Route::default();
+    let mut tracer = Tracer::default();
+    let module =
+        eval::eval(world.track(), route.track(), tracer.track_mut(), world.main())?;
+
+    Ok(module.content())
+}
 
 /// Compile a source file into a fully layouted document.
 pub fn compile(world: &(dyn World + 'static)) -> SourceResult<Document> {


### PR DESCRIPTION
This (kinda dirty) PR implements outputting a [pandoc](https://pandoc.org/index.html) JSON AST from the CLI instead of PDF.

That means it indirectly allows outputting all kinds of formats such as Markdown, HTML, ePub, docx. 

The pandoc AST is not infinitely powerful so this conversion has a fair bit of information loss, but in exchange it gives access to many different output formats without specific implementations.

For example this typst document:

```````typst
#set page(width: 10cm, height: auto)
#set heading(numbering: "1.")

= Test1
== Test2

#v(3mm)
#align(center)[
  #set par(leading: 3mm)
  #text(1.2em)[*3. Übungsblatt Computerorientierte Mathematik II*] \
  *Abgabe: 03.05.2019* (bis 10:10 Uhr in MA 001) \
  *Alle Antworten sind zu beweisen.*
]

*1. Aufgabe* #h(1fr) (1 + 1 + 2 Punkte)

Ein _Binärbaum_ ist ein Wurzelbaum, in dem jeder Knoten ≤ 2 Kinder hat.
Die Tiefe eines Knotens _v_ ist die Länge des eindeutigen Weges von der Wurzel
zu _v_.

#align(center, image("/graph.png", width: 75%))


#table(
  columns: 4,
  [], [*Q1*], [*Q2*], [*Q3*],
  [Revenue:], [1000 €], [2000 €], [3000 €],
  [Expenses:], [500 €], [1000 €], [1500 €],
  [Profit:], [500 €], [1000 €], [1500 €],
)

- hello
- world
- foo


```rust
fn fun() {}
```
```````

run via these commands:

```bash
typst test.typ --output-format pandoc-json  test.pandoc.json
pandoc test.pandoc.json -o test.md
```

results in this:

## markdown

`````markdown
# Test1

## Test2

::: {align="center"}
**3. Übungsblatt Computerorientierte Mathematik II** \
**Abgabe: 03.05.2019** (bis 10:10 Uhr in MA 001) \
**Alle Antworten sind zu beweisen.**
:::

**1. Aufgabe** (1 + 1 + 2 Punkte)

Ein *Binärbaum* ist ein Wurzelbaum, in dem jeder Knoten ≤ 2 Kinder hat.
Die Tiefe eines Knotens *v*
ist die Länge des eindeutigen Weges von der Wurzel zu *v*.

::: {align="center"}
![](/home/phire/data/dev/2023/typst/graph.png)
:::

  ----------- -------- -------- --------
              **Q1**   **Q2**   **Q3**
  Revenue:    1000 €   2000 €   3000 €
  Expenses:   500 €    1000 €   1500 €
  Profit:     500 €    1000 €   1500 €
  ----------- -------- -------- --------

-   hello

-   world

-   foo

``` rust
fn fun() {}
```
``````

The exact output format can be controlled within pandoc, for example to prevent it from outputting standard commonmark (without fenced divs etc) use `pandoc -t commonmark`

## HTML

```html
<h1>Test1</h1>

<h2>Test2</h2>

<div data-align="center">
<strong>3. Übungsblatt Computerorientierte Mathematik II</strong> <br />
<strong>Abgabe: 03.05.2019</strong> (bis 10:10 Uhr in MA 001) <br />
<strong>Alle Antworten sind zu beweisen.</strong>
</div>
<p><strong>1. Aufgabe</strong> (1 + 1 + 2 Punkte)</p>
<p>Ein <em>Binärbaum</em> ist ein Wurzelbaum, in dem jeder Knoten ≤ 2
Kinder hat. Die Tiefe eines Knotens <em>v</em> ist die Länge des
eindeutigen Weges von der Wurzel zu <em>v</em>.</p>
<div data-align="center">
<img src="/home/phire/data/dev/2023/typst/graph.png" />
</div>
<table>
<tbody>
<tr class="odd">
<td></td>
<td><strong>Q1</strong></td>
<td><strong>Q2</strong></td>
<td><strong>Q3</strong></td>
</tr>
<tr class="even">
<td>Revenue:</td>
<td>1000 €</td>
<td>2000 €</td>
<td>3000 €</td>
</tr>
<tr class="odd">
<td>Expenses:</td>
<td>500 €</td>
<td>1000 €</td>
<td>1500 €</td>
</tr>
<tr class="even">
<td>Profit:</td>
<td>500 €</td>
<td>1000 €</td>
<td>1500 €</td>
</tr>
</tbody>
</table>
<ul>
<li>hello</li>
</ul>

<ul>
<li>world</li>
</ul>

<ul>
<li>foo</li>
</ul>
<div class="sourceCode" id="cb1"><pre
class="sourceCode rust"><code class="sourceCode rust"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="kw">fn</span> fun() <span class="op">{}</span></span></code></pre></div>
```

## docx

screenshot:
![image](https://user-images.githubusercontent.com/2303841/228883397-c34576ee-b230-448a-a9a3-96365b1ed6fc.png)

# Issues

fixable:

- many attributes are not transferred even though they probably do have an equivalent (e.g. image width)
- the code might be more messy than needed
- lists are not numbered correctly since the ListBuilder in typst happens during the layout stage which is skipped here
- equations are not supported since this would require conversion to latex math which is not trivial (or rendered)
- columns could kinda be supported via pandoc but not for every format
- drawings are not supported. they could be converted to vector images and included that way i guess
- grid layout is not supported. that could kinda be fixed by using tables or by deconstructing the grid in some order


probably unfixable:
- lines, horizontal and vertical alignment, more exact styling instructions
- everything regarding pages, page breaks, page sizes (obviously)
- general loss of control over how exactly the output looks