### PR TITLE
Address zero width math under/overline glyphs

### DIFF
--- a/library/src/math/underover.rs
+++ b/library/src/math/underover.rs
@@ -4,6 +4,9 @@ const LINE_GAP: Em = Em::new(0.15);
 const BRACE_GAP: Em = Em::new(0.25);
 const BRACKET_GAP: Em = Em::new(0.25);
 
+const COMBINING_OVERLINE: char = '\u{305}';
+const COMBINING_LOW_LINE: char = '\u{332}';
+
 /// A horizontal line under content.
 ///
 /// ## Example
@@ -22,7 +25,7 @@ pub struct UnderlineElem {
 
 impl LayoutMath for UnderlineElem {
     fn layout_math(&self, ctx: &mut MathContext) -> SourceResult<()> {
-        layout(ctx, &self.body(), &None, '\u{305}', LINE_GAP, false, self.span())
+        layout(ctx, &self.body(), &None, COMBINING_LOW_LINE, LINE_GAP, false, self.span())
     }
 }
 
@@ -44,7 +47,7 @@ pub struct OverlineElem {
 
 impl LayoutMath for OverlineElem {
     fn layout_math(&self, ctx: &mut MathContext) -> SourceResult<()> {
-        layout(ctx, &self.body(), &None, '\u{332}', LINE_GAP, true, self.span())
+        layout(ctx, &self.body(), &None, COMBINING_OVERLINE, LINE_GAP, true, self.span())
     }
 }
 


### PR DESCRIPTION
This PR addresses the issues seen in New Computer Modern Math and some other math fonts where underlines of thin characters are badly placed.  #441

Although the primary complaint has be addressed, testing afterwords shows that the general over/underline strategy that Typst uses probably needs rethinking. Unlike under/overbraces, lines are intrinsically more flexible. As a result, the strategy of finding a "best fit" over/underline from a few variant characters leads to quantum jumps in line length that poorly match the variety of widths of single characters.  The end result is font-dependent: pretty good for CM, but especially bad for Cambria Math and STIX Two Math.  

<img width="990" alt="image" src="https://user-images.githubusercontent.com/918465/229021270-15145055-832a-4691-88a5-d5de3c4a70e6.png">

<img width="1009" alt="image" src="https://user-images.githubusercontent.com/918465/229021386-9352e50f-c73a-42d0-a725-043617e595c8.png">

By contrast, Microsoft Word does a good job at creating overlines for Cambria Math that fit the individual letters much better.  I looked at the PDF output and it's overlines are simply filled rectangles (i.e. simple paths). This is the same kind of approach used by TeX, where `\underline` is implemented internally with an`\hrule`.

Note also:  Garamond-Math seems to be missing variants of over/underlines entirely.  So all underlines have a single width.

All this is to say, I think it would be fine to merge this PR now to fix the egregious placement errors seen in CM. But something better needs to be done in the future, probably based on simply using custom width lines.