### PR TITLE
CLI: open flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,10 +953,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
+name = "open"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075c5203b3a2b698bc72c6c10b1f6263182135751d5013ea66e8a4b3d0562a43"
+dependencies = [
+ "pathdiff",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pdf-writer"
@@ -1539,6 +1554,7 @@ dependencies = [
  "memmap2",
  "notify",
  "once_cell",
+ "open",
  "same-file",
  "siphasher",
  "typst",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,6 +27,7 @@ same-file = "1"
 siphasher = "0.3"
 walkdir = "2"
 clap = { version = "4.2.1", features = ["derive"] }
+open = "4.0.1"
 
 [features]
 default = ["embed-fonts"]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -84,7 +84,7 @@ pub struct WatchCommand {
 /// List all discovered fonts in system and custom font paths
 #[derive(Debug, Clone, Parser)]
 pub struct FontsCommand {
-    /// Add additional directories to search for fonts
+    /// Also list style variants of each font family
     #[arg(long)]
     variants: bool,
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -55,7 +55,7 @@ enum Command {
     Compile(CompileCommand),
 
     /// Watches the input file and recompiles on changes
-    Watch(WatchCommand),
+    Watch(CompileCommand),
 
     /// List all discovered fonts in system and custom font paths
     Fonts(FontsCommand),
@@ -69,16 +69,10 @@ pub struct CompileCommand {
 
     /// Path to output PDF file
     output: Option<PathBuf>,
-}
 
-/// Watches the input file and recompiles on changes
-#[derive(Debug, Clone, Parser)]
-pub struct WatchCommand {
-    /// Path to input Typst file
-    input: PathBuf,
-
-    /// Path to output PDF file
-    output: Option<PathBuf>,
+    /// Open the output file after compilation using the default PDF viewer
+    #[arg(short = 'O', long = "open")]
+    open: bool,
 }
 
 /// List all discovered fonts in system and custom font paths


### PR DESCRIPTION
Adds the `--open` flag to open the outputted PDF file using the default PDF viewer on the system (platform agnostic) or the user can manually specify the executable using `--open=my_pdf_viewer`.

# Dependencies

It adds a dependency to [open](https://docs.rs/open/latest/open/) which is an actively maintained, widely used rust crate. It only modifies the `cli` subdirectory.

# Additional cleanup

There was a wrong description for a flag that was added yesterday, it has since been fixed, I am bundling it with this PR as it is a very small fix. I also merge the `BuildCommand` and `WatchCommand` structs as they were identical and redundant.