### PR TITLE
Add aliases for subcommands

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -52,12 +52,15 @@ pub struct CliArguments {
 #[command()]
 enum Command {
     /// Compiles the input file into a PDF file
+    #[command(visible_alias = "c")]
     Compile(CompileCommand),
 
     /// Watches the input file and recompiles on changes
+    #[command(visible_alias = "w")]
     Watch(WatchCommand),
 
     /// List all discovered fonts in system and custom font paths
+    #[command(visible_alias = "f")]
     Fonts(FontsCommand),
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -60,7 +60,6 @@ enum Command {
     Watch(WatchCommand),
 
     /// List all discovered fonts in system and custom font paths
-    #[command(visible_alias = "f")]
     Fonts(FontsCommand),
 }
 


### PR DESCRIPTION
This is so you can use just `typst c` instead of having to type out `compile`