### PR TITLE
Fixed extraneous spacing in sign operators

### DIFF
--- a/library/src/math/row.rs
+++ b/library/src/math/row.rs
@@ -50,7 +50,7 @@ impl MathRow {
             }
 
             // Convert variable operators into binary operators if something
-            // precedes them.
+            // precedes them and they are not preceded by a operator or comparator.
             if fragment.class() == Some(MathClass::Vary)
                 && matches!(
                     last.and_then(|i| resolved[i].class()),

--- a/library/src/math/row.rs
+++ b/library/src/math/row.rs
@@ -57,10 +57,8 @@ impl MathRow {
                     Some(
                         MathClass::Normal
                             | MathClass::Alphabetic
-                            | MathClass::Binary
                             | MathClass::Closing
                             | MathClass::Fence
-                            | MathClass::Relation
                     )
                 )
             {


### PR DESCRIPTION
Fix for issue #487 

Previously, Vary fragments (basically the numerical sign unary operators) would have a space between them and whatever they were describing, as long as they were not at the start of a math row, as shown below:
![image](https://user-images.githubusercontent.com/40590448/229289020-a10dc695-4ed1-4c03-a831-22b668272601.png)

The relevant code:
![image](https://user-images.githubusercontent.com/40590448/229288977-3687b0a7-ec70-4cda-917c-5c1e08ce1421.png)

Removing the disjunctive conditions for MathClass::Binary and MathClass::Relation fix this problem by assuming that a numerical sign operator, that follows either a binary operator or a relation, to be a unary operator, and therefore not have any spacing following it.
