### PR TITLE
docs: Mention single-letter variables more prominently

### DIFF
--- a/docs/src/reference/details.yml
+++ b/docs/src/reference/details.yml
@@ -34,6 +34,8 @@ math: |
   $ "area" = pi dot.op "radius"^2 $
   $ cal(A) :=
       { x in RR | x "is natural" } $
+  #let x = 5
+  $ #x < 17 $
   ```
 
   Math mode makes a wide selection of [symbols]($category/symbols/sym) like

--- a/docs/src/reference/syntax.md
+++ b/docs/src/reference/syntax.md
@@ -55,7 +55,7 @@ follows:
 | Fraction               | `[$1 + (a+b)/5$]`        | [`frac`]($func/frac)     |
 | Line break             | `[$x \ y ]`              | [`linebreak`]($func/linebreak) |
 | Alignment point        | `[$x &= 2 \ &= 3$]`      | [Math]($category/math)   |
-| Variable access        | `[$pi$]`                 | [Math]($category/math)   |
+| Variable access        | `[$#x$, $pi$]`           | [Math]($category/math)   |
 | Field access           | `[$arrow.r.long$]`       | [Scripting]($scripting/#fields) |
 | Implied multiplication | `[$x y$]`                | [Math]($category/math)   |
 | Symbol shorthand       | `[$->, !=$]`             | [Symbols]($category/symbols/sym) |


### PR DESCRIPTION
The math table in `syntax.md` doesn't feature single-letter variables at all. The math section of `details.yml` mentions them, but doesn't show an example.