### PR TITLE
Add .idea to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # General
 .vscode
+.idea/
 _things
 desktop.ini
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # General
 .vscode
-.idea/
+.idea
 _things
 desktop.ini
 .DS_Store

--- a/library/src/compute/calc.rs
+++ b/library/src/compute/calc.rs
@@ -94,7 +94,7 @@ pub fn pow(
         Num::Int(i) if i > u32::MAX as i64 => {
             bail!(exponent.span, "exponent too large");
         }
-        Num::Int(i) => exponent.v,
+        Num::Int(_) => exponent.v,
         Num::Float(f) if f.is_normal() || f == 0 as f64 => exponent.v,
         _ => {
             bail!(

--- a/library/src/compute/calc.rs
+++ b/library/src/compute/calc.rs
@@ -94,7 +94,7 @@ pub fn pow(
         Num::Int(i) if i > u32::MAX as i64 => {
             bail!(exponent.span, "exponent too large");
         }
-        Num::Int(_) => exponent.v,
+        Num::Int(i) => exponent.v,
         Num::Float(f) if f.is_normal() || f == 0 as f64 => exponent.v,
         _ => {
             bail!(


### PR DESCRIPTION
This PR adds `.idea` folder to gitignore, a folder used by Jetbrains IDEs, like Intellij Idea to store project files.