### PR TITLE
parse bases 2, 8 & 16

### DIFF
--- a/src/syntax/ast.rs
+++ b/src/syntax/ast.rs
@@ -912,7 +912,12 @@ node! {
 impl Int {
     /// Get the integer value.
     pub fn get(&self) -> i64 {
-        self.0.text().parse().unwrap_or_default()
+        match self.0.text() {
+            v if v.starts_with("0x") => i64::from_str_radix(&v[2..], 16).unwrap_or_default(),
+            v if v.starts_with("0o") => i64::from_str_radix(&v[2..], 8).unwrap_or_default(),
+            v if v.starts_with("0b") => i64::from_str_radix(&v[2..], 2).unwrap_or_default(),
+            _ => self.0.text().parse().unwrap_or_default(),
+        }
     }
 }
 

--- a/src/syntax/lexer.rs
+++ b/src/syntax/lexer.rs
@@ -525,6 +525,36 @@ impl Lexer<'_> {
     }
 
     fn number(&mut self, start: usize, c: char) -> SyntaxKind {
+        if c == '0' {
+            if self.s.eat_if("x") {
+                self.s.eat_while(char::is_ascii_hexdigit);
+
+                let num = self.s.get(start+2..self.s.cursor());
+
+                if i64::from_str_radix(num, 16).is_err() {
+                    return self.error("invalid hexadecimal number");
+                }
+                return SyntaxKind::Int;
+            }
+            else if self.s.eat_if("b") {
+                self.s.eat_while(|c| matches!(c, '0' | '1'));
+
+                let num = self.s.get(start+2..self.s.cursor());
+                if i64::from_str_radix(num, 2).is_err() {
+                    return self.error("invalid binary number");
+                }
+                return SyntaxKind::Int;
+            } else if self.s.eat_if("o") {
+                self.s.eat_while(|c| matches!(c, '0'..='7'));
+
+                let num = self.s.get(start+2..self.s.cursor());
+                if i64::from_str_radix(num, 8).is_err() {
+                    return self.error("invalid octal number");
+                }
+                return SyntaxKind::Int;
+            }
+        }
+
         // Read the first part (integer or fractional depending on `first`).
         self.s.eat_while(char::is_ascii_digit);
 


### PR DESCRIPTION
Merging this PR will allow bases 2, 8 & 16 to be used in scripts:
```typ
#let hex(num) = {
  let digits = "0123456789ABCDEF";
  let res = "";
  while true {
    let x = int(calc.mod(num, 16));
    res = digits.at(x) + res;
    num = int(num / 16);
    if num == 0 {
      if calc.mod(res.len(), 2) == 1 {
        res = "0" + res;
      }
      break;
    }
  }
  "0x" + res
}

#hex(0o200)
#hex(0b100110)
```