### PR TITLE
transform: Fix documentation

### DIFF
--- a/library/src/layout/transform.rs
+++ b/library/src/layout/transform.rs
@@ -52,7 +52,7 @@ impl Layout for MoveElem {
     }
 }
 
-/// Rotate content with affecting layout.
+/// Rotate content without affecting layout.
 ///
 /// Rotate an element by a given angle. The layout will act as if the element
 /// was not rotated.


### PR DESCRIPTION
Fixes documentation: `rotate` does not affect the layout.

#528 