### PR TITLE
docs: fix typos in reference/syntax.md

### DIFF
--- a/docs/src/reference/syntax.md
+++ b/docs/src/reference/syntax.md
@@ -53,7 +53,7 @@ follows:
 | Bottom attachment      | `[$x_1$]`                | [`attach`]($category/math/attach) |
 | Top attachment         | `[$x^2$]`                | [`attach`]($category/math/attach) |
 | Fraction               | `[$1 + (a+b)/5$]`        | [`frac`]($func/frac)     |
-| Line break             | `[$x \ y ]`              | [`linebreak`]($func/linebreak) |
+| Line break             | `[$x \ y$]`              | [`linebreak`]($func/linebreak) |
 | Alignment point        | `[$x &= 2 \ &= 3$]`      | [Math]($category/math)   |
 | Variable access        | `[$#x$, $pi$]`           | [Math]($category/math)   |
 | Field access           | `[$arrow.r.long$]`       | [Scripting]($scripting/#fields) |


### PR DESCRIPTION
`[$x \ y ]` -> `[$x \ y$]`
