### PR TITLE
Appends a hint if length is expected but hint provided.

### DIFF
--- a/src/eval/cast.rs
+++ b/src/eval/cast.rs
@@ -7,6 +7,8 @@ use ecow::EcoString;
 
 use super::{Array, Str, Value};
 use crate::diag::StrResult;
+use crate::eval::Type;
+use crate::geom::Length;
 use crate::syntax::Spanned;
 use crate::util::separated_list;
 
@@ -291,6 +293,14 @@ impl CastInfo {
             msg.push_str(", found ");
             msg.push_str(found.type_name());
         }
+        if_chain::if_chain! {
+            if let Value::Int(i) = found;
+            if parts.iter().any(|p| p == Length::TYPE_NAME);
+            if !matching_type;
+            then {
+                msg.push_str(&format!(": a length needs a unit – did you mean {i}pt?"));
+            }
+        };
 
         msg.into()
     }

--- a/tests/typ/compiler/hint.typ
+++ b/tests/typ/compiler/hint.typ
@@ -1,0 +1,6 @@
+// Test diagnostics.
+// Ref: false
+
+---
+// Error: 1:17-1:19 expected length, found integer: a length needs a unit – did you mean 12pt?
+#set text(size: 12)


### PR DESCRIPTION
Closes #564

Adds a test that should pass but doesn't cause of the test infrastructure.

Note that the test currently fails due to the test infrastructure most likely, how to handle newline in errors?

The hint currently is appended to the error, ask if you want a different behavior.
