### PR TITLE
Array sorting by key

### DIFF
--- a/docs/src/reference/types.md
+++ b/docs/src/reference/types.md
@@ -657,6 +657,8 @@ Combine all items in the array into one.
 ### sorted()
 Return a new array with the same items, but sorted.
 
+- key: function (named)
+  If given, applies this function to the elements in the array to determine the keys to sort by.
 - returns: array
 
 # Dictionary

--- a/src/eval/array.rs
+++ b/src/eval/array.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::fmt::{self, Debug, Formatter};
 use std::ops::{Add, AddAssign};
@@ -287,39 +288,81 @@ impl Array {
         span: Span,
         key: Option<Func>,
     ) -> SourceResult<Self> {
-        let mut result = Ok(());
-        let mut vec = self.0.clone();
-        let mut key_ = |x: Value| match &key {
-            Some(f) => f.call_vm(vm, Args::new(f.span(), [x])),
-            None => Ok(x),
-        };
-        vec.make_mut().sort_by(|a, b| {
-            // Until we get `try` blocks :)
-            match (key_(a.clone()), key_(b.clone())) {
-                (Ok(a), Ok(b)) => a.partial_cmp(&b).unwrap_or_else(|| {
-                    if result.is_ok() {
-                        result = Err(eco_format!(
-                            "cannot order {} and {}",
-                            a.type_name(),
-                            b.type_name(),
-                        ))
-                        .at(span);
-                    }
-                    Ordering::Equal
-                }),
-                (Err(mut e), _) | (_, Err(mut e)) => {
-                    if result.is_ok() {
-                        e.push(SourceError::new(
-                            span,
-                            "error while evaluating key for sorting",
-                        ));
-                        result = Err(e);
-                    }
-                    Ordering::Equal
-                }
+        match key {
+            None => {
+                let mut result = Ok(());
+                let mut vec = self.0.clone();
+                vec.make_mut().sort_by(|a, b| {
+                    PartialOrd::partial_cmp(a, b).unwrap_or_else(|| {
+                        if result.is_ok() {
+                            result = Err(eco_format!(
+                                "cannot order {} and {}",
+                                a.type_name(),
+                                b.type_name(),
+                            ))
+                            .at(span);
+                        }
+                        Ordering::Equal
+                    })
+                });
+                result.map(|_| Self::from_vec(vec))
             }
-        });
-        result.map(|_| Self::from_vec(vec))
+            Some(key) => {
+                struct Key<T, F: Fn(&T, &T) -> Ordering>(Option<T>, F);
+                impl<T, F: Fn(&T, &T) -> Ordering> PartialEq for Key<T, F> {
+                    fn eq(&self, other: &Self) -> bool {
+                        Ord::cmp(self, other) == Ordering::Equal
+                    }
+                }
+                impl<T, F: Fn(&T, &T) -> Ordering> Eq for Key<T, F> {}
+                impl<T, F: Fn(&T, &T) -> Ordering> PartialOrd for Key<T, F> {
+                    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+                        Some(Ord::cmp(self, other))
+                    }
+                }
+                impl<T, F: Fn(&T, &T) -> Ordering> Ord for Key<T, F> {
+                    fn cmp(&self, other: &Self) -> Ordering {
+                        match (&self.0, &other.0) {
+                            (Some(a), Some(b)) => (self.1)(a, b),
+                            (None, _) | (_, None) => Ordering::Equal, // XXX
+                        }
+                    }
+                }
+                let result = RefCell::new(Ok(()));
+                let mut vec = self.0.clone();
+                vec.make_mut().sort_by_cached_key(|x| {
+                    Key(
+                        match key.call_vm(vm, Args::new(key.span(), [x.clone()])) {
+                            Ok(x) => Some(x),
+                            Err(mut e) => {
+                                if result.borrow().is_ok() {
+                                    e.push(SourceError::new(
+                                        span,
+                                        "error while evaluating key for sorting",
+                                    ));
+                                    *result.borrow_mut() = Err(e);
+                                }
+                                None
+                            }
+                        },
+                        |a, b| {
+                            PartialOrd::partial_cmp(a, b).unwrap_or_else(|| {
+                                if result.borrow().is_ok() {
+                                    *result.borrow_mut() = Err(eco_format!(
+                                        "cannot order {} and {}",
+                                        a.type_name(),
+                                        b.type_name(),
+                                    ))
+                                    .at(span);
+                                }
+                                Ordering::Equal
+                            })
+                        },
+                    )
+                });
+                result.into_inner().map(|_| Self::from_vec(vec))
+            }
+        }
     }
 
     /// Repeat this array `n` times.

--- a/src/eval/array.rs
+++ b/src/eval/array.rs
@@ -290,6 +290,8 @@ impl Array {
         let mut result = Ok(());
         let mut vec = self.0.clone();
         let mut key_ = |x: Value| match &key {
+            // NOTE: we are relying on `comemo`'s memoization of function evaluation to not
+            //       excessively reevaluate the `key`.
             Some(f) => f.call_vm(vm, Args::new(f.span(), [x])),
             None => Ok(x),
         };

--- a/src/eval/array.rs
+++ b/src/eval/array.rs
@@ -277,9 +277,10 @@ impl Array {
         Ok(result)
     }
 
-    /// Return a sorted version of this array.
+    /// Return a sorted version of this array, optionally by a given key function.
     ///
-    /// Returns an error if two values could not be compared.
+    /// Returns an error if two values could not be compared or if the key function (if given)
+    /// yields an error.
     pub fn sorted(
         &self,
         vm: &mut Vm,

--- a/src/eval/methods.rs
+++ b/src/eval/methods.rs
@@ -115,7 +115,7 @@ pub fn call(
                 let last = args.named("last")?;
                 array.join(sep, last).at(span)?
             }
-            "sorted" => Value::Array(array.sorted().at(span)?),
+            "sorted" => Value::Array(array.sorted(vm, span, args.named("key")?)?),
             "enumerate" => Value::Array(array.enumerate()),
             _ => return missing(),
         },

--- a/tests/typ/compiler/array.typ
+++ b/tests/typ/compiler/array.typ
@@ -203,6 +203,10 @@
 #test((2, 1, 3, -10, -5, 8, 6, -7, 2).sorted(key: x => x * x), (1, 2, 2, 3, -5, 6, -7, 8, -10))
 
 ---
+// Error: 32-37 cannot divide by zero
+#(1, 2, 0, 3).sorted(key: x => 5 / x)
+
+---
 // Error: 2-26 cannot order content and content
 #([Hi], [There]).sorted()
 

--- a/tests/typ/compiler/array.typ
+++ b/tests/typ/compiler/array.typ
@@ -193,9 +193,14 @@
 ---
 // Test the `sorted` method.
 #test(().sorted(), ())
+#test(().sorted(key: x => x), ())
 #test(((true, false) * 10).sorted(), (false,) * 10 + (true,) * 10)
 #test(("it", "the", "hi", "text").sorted(), ("hi", "it", "text", "the"))
+#test(("I", "the", "hi", "text").sorted(key: x => x), ("I", "hi", "text", "the"))
+#test(("I", "the", "hi", "text").sorted(key: x => x.len()), ("I", "hi", "the", "text"))
 #test((2, 1, 3, 10, 5, 8, 6, -7, 2).sorted(), (-7, 1, 2, 2, 3, 5, 6, 8, 10))
+#test((2, 1, 3, -10, -5, 8, 6, -7, 2).sorted(key: x => x), (-10, -7, -5, 1, 2, 2, 3, 6, 8))
+#test((2, 1, 3, -10, -5, 8, 6, -7, 2).sorted(key: x => x * x), (1, 2, 2, 3, -5, 6, -7, 8, -10))
 
 ---
 // Error: 2-26 cannot order content and content


### PR DESCRIPTION
This PR adds an optional named argument `key:` to `array`'s `.sorted()` method.
If not given, the behaviour is the same as the current one.
If given a function, then it is applied on the array's elements to get keys to then perform comparisons on (think Rust's `Vec::sort_by_key` or Python's `sorted(..., key=...)`).

E.g.,

```
(1, -2, 3).sorted()
// => (-2, 1, 3)
(1, -2, 3).sorted(key: x => x*x)
// => (1, -2, 3)
```

Mostly done, just missing tests (will add tomorrow).

I think I properly edited the Typst docs (how can I check?).
Also, code got a little bit messy, might clean up tomorrow (if possible).