### PR TITLE
Fix RU translation for raw block

### DIFF
--- a/library/src/text/raw.rs
+++ b/library/src/text/raw.rs
@@ -204,7 +204,7 @@ impl LocalName for RawElem {
         match lang {
             Lang::CHINESE => "代码",
             Lang::ITALIAN => "Codice",
-            Lang::RUSSIAN => "код",
+            Lang::RUSSIAN => "Листинг",
             Lang::FRENCH => "Liste",
             Lang::UKRAINIAN => "Лістинг",
             Lang::ENGLISH | Lang::GERMAN | _ => "Listing",


### PR DESCRIPTION
Previous translation of the listing was informal and written improperly.