### PR TITLE
Swap the misplaced top/bottom style in AttachElem::layout_math()

### DIFF
--- a/library/src/math/attach.rs
+++ b/library/src/math/attach.rs
@@ -34,14 +34,14 @@ impl LayoutMath for AttachElem {
 
         let base = ctx.layout_fragment(&base)?;
 
-        ctx.style(ctx.style.for_subscript());
+        ctx.style(ctx.style.for_superscript());
         let top = self
             .top(ctx.styles())
             .map(|elem| ctx.layout_fragment(&elem))
             .transpose()?;
         ctx.unstyle();
 
-        ctx.style(ctx.style.for_superscript());
+        ctx.style(ctx.style.for_subscript());
         let bottom = self
             .bottom(ctx.styles())
             .map(|elem| ctx.layout_fragment(&elem))


### PR DESCRIPTION
The tests are still passing.