### PR TITLE
Read font path from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ typst --font-path path/to/fonts compile file.typ
 
 # Lists all of the discovered fonts in the system and the given directory.
 typst --font-path path/to/fonts fonts
+
+# Or via environement variable (Linux syntax).
+TYPST_FONT_DIR=path/to/fonts typst fonts
 ```
 
 If you prefer an integrated IDE-like experience with autocompletion and instant

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -26,7 +26,7 @@ once_cell = "1"
 same-file = "1"
 siphasher = "0.3"
 walkdir = "2"
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "4.2.1", features = ["derive", "env"] }
 open = "4.0.1"
 
 [build-dependencies]

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -7,11 +7,11 @@ use clap::{ArgAction, Parser, Subcommand};
 #[clap(name = "typst", version = crate::typst_version(), author)]
 pub struct CliArguments {
     /// Add additional directories to search for fonts
-    #[clap(long = "font-path", value_name = "DIR", action = ArgAction::Append)]
+    #[clap(long = "font-path", value_name = "DIR", env = "TYPST_FONT_DIR", action = ArgAction::Append)]
     pub font_paths: Vec<PathBuf>,
 
     /// Configure the root for absolute paths
-    #[clap(long = "root", value_name = "DIR")]
+    #[clap(long = "root", value_name = "DIR", env = "TYPST_ROOT_DIR")]
     pub root: Option<PathBuf>,
 
     /// The typst command to run


### PR DESCRIPTION
It would be great if we could read font paths from the environment variables (env vars).

Advantages:
- Easy way to set a global font path on a system
- command preprocessing tools (e.g. https://github.com/casey/just) can set env vars for all commands; this makes the definitions cleaner
- Docker containers and similar systems often use env vars for configuration. E.g., useful when using dev containers

This change enables the "env" feature of clap, which handles the env parsing for us. Command line arguments will take precedence.