### PR TITLE
Add docs for Newton's notation for derivatives

### DIFF
--- a/library/src/math/accent.rs
+++ b/library/src/math/accent.rs
@@ -29,21 +29,24 @@ pub struct AccentElem {
     ///
     /// Supported accents include:
     ///
-    /// | Accent       | Name            | Codepoint |
-    /// | ------------ | --------------- | --------- |
-    /// | Grave        | `grave`         | <code>&DiacriticalGrave;</code> |
-    /// | Acute        | `acute`         | `´`       |
-    /// | Circumflex   | `hat`           | `^`       |
-    /// | Tilde        | `tilde`         | `~`       |
-    /// | Macron       | `macron`        | `¯`       |
-    /// | Breve        | `breve`         | `˘`       |
-    /// | Dot          | `dot`           | `.`       |
-    /// | Diaeresis    | `diaer`         | `¨`       |
-    /// | Circle       | `circle`        | `∘`       |
-    /// | Double acute | `acute.double`  | `˝`       |
-    /// | Caron        | `caron`         | `ˇ`       |
-    /// | Right arrow  | `arrow`, `->`   | `→`       |
-    /// | Left arrow   | `arrow.l`, `<-` | `←`       |
+    /// | Accent        | Name            | Codepoint |
+    /// | ------------- | --------------- | --------- |
+    /// | Grave         | `grave`         | <code>&DiacriticalGrave;</code> |
+    /// | Acute         | `acute`         | `´`       |
+    /// | Circumflex    | `hat`           | `^`       |
+    /// | Tilde         | `tilde`         | `~`       |
+    /// | Macron        | `macron`        | `¯`       |
+    /// | Breve         | `breve`         | `˘`       |
+    /// | Dot           | `dot`           | `.`       |
+    /// | Double dot    | `dot.double`    | `¨`       |
+    /// | Triple dot    | `dot.triple`    | <code>&tdot;</code> |
+    /// | Quadruple dot | `dot.quad`      | <code>&DotDot;</code> |
+    /// | Diaeresis     | `diaer`         | `¨`       |
+    /// | Circle        | `circle`        | `∘`       |
+    /// | Double acute  | `acute.double`  | `˝`       |
+    /// | Caron         | `caron`         | `ˇ`       |
+    /// | Right arrow   | `arrow`, `->`   | `→`       |
+    /// | Left arrow    | `arrow.l`, `<-` | `←`       |
     #[required]
     pub accent: Accent,
 }


### PR DESCRIPTION
Add missing documentation of some accents in `math.accent` introduced by #281. Fixes #425.

I wasn't sure whether to combine `diaer` and `dot.double`.