### PR TITLE
Allow treating ratios as floats

### DIFF
--- a/library/src/compute/construct.rs
+++ b/library/src/compute/construct.rs
@@ -45,6 +45,7 @@ cast_from_value! {
 ///
 /// - Booleans are converted to `0.0` or `1.0`.
 /// - Integers are converted to the closest 64-bit float.
+/// - Ratios are divided by 100%.
 /// - Strings are parsed in base 10 to the closest 64-bit float.
 ///   Exponential notation is supported.
 ///
@@ -53,6 +54,7 @@ cast_from_value! {
 /// #float(false) \
 /// #float(true) \
 /// #float(4) \
+/// #float(40%) \
 /// #float("2.7") \
 /// #float("1e5")
 /// ```
@@ -76,6 +78,7 @@ cast_from_value! {
     v: bool => Self(v as i64 as f64),
     v: i64 => Self(v as f64),
     v: f64 => Self(v),
+    v: Ratio => Self(v.get()),
     v: EcoString => Self(v.parse().map_err(|_| "not a valid float")?),
 }
 

--- a/src/eval/ops.rs
+++ b/src/eval/ops.rs
@@ -179,6 +179,7 @@ pub fn mul(lhs: Value, rhs: Value) -> StrResult<Value> {
         (Int(a), Angle(b)) => Angle(a as f64 * b),
         (Float(a), Angle(b)) => Angle(a * b),
 
+        (Ratio(a), Ratio(b)) => Ratio(a * b),
         (Ratio(a), Int(b)) => Ratio(a * b as f64),
         (Ratio(a), Float(b)) => Ratio(a * b),
         (Float(a), Ratio(b)) => Ratio(a * b),
@@ -214,8 +215,10 @@ pub fn div(lhs: Value, rhs: Value) -> StrResult<Value> {
     Ok(match (lhs, rhs) {
         (Int(a), Int(b)) => Float(a as f64 / b as f64),
         (Int(a), Float(b)) => Float(a as f64 / b),
+        (Int(a), Ratio(b)) => Float(a as f64 / b),
         (Float(a), Int(b)) => Float(a / b as f64),
         (Float(a), Float(b)) => Float(a / b),
+        (Float(a), Ratio(b)) => Float(a / b),
 
         (Length(a), Int(b)) => Length(a / b as f64),
         (Length(a), Float(b)) => Length(a / b),

--- a/src/geom/ratio.rs
+++ b/src/geom/ratio.rs
@@ -110,6 +110,14 @@ impl Div<f64> for Ratio {
     }
 }
 
+impl Div<Ratio> for f64 {
+    type Output = Self;
+
+    fn div(self, other: Ratio) -> Self {
+        self / other.get()
+    }
+}
+
 impl Div for Ratio {
     type Output = f64;
 

--- a/tests/typ/compute/calc.typ
+++ b/tests/typ/compute/calc.typ
@@ -9,6 +9,7 @@
 #test(int("150"), 150)
 #test(int(10 / 3), 3)
 #test(float(10), 10.0)
+#test(float(50% * 30%), 0.15)
 #test(float("31.4e-1"), 3.14)
 #test(type(float(10)), "float")
 
@@ -21,7 +22,7 @@
 #int(10pt)
 
 ---
-// Error: 8-13 expected boolean, integer, float, or string, found function
+// Error: 8-13 expected boolean, integer, float, ratio, or string, found function
 #float(float)
 
 ---


### PR DESCRIPTION
**Adds:**
- conversion from ratio to float
- multiplication of ratios
- division of float or int with ratio

**Examples:**
```
float(40%) = 0.4

50% * 30% = 15%

1 / 40% = 2.5
```

Resolves #651, resolves #652