### PR TITLE
Remove '#' from FracElem docs

### DIFF
--- a/library/src/math/frac.rs
+++ b/library/src/math/frac.rs
@@ -2,7 +2,6 @@ use super::*;
 
 const FRAC_AROUND: Em = Em::new(0.1);
 
-/// Fraction
 /// A mathematical fraction.
 ///
 /// ## Example

--- a/library/src/math/frac.rs
+++ b/library/src/math/frac.rs
@@ -2,7 +2,7 @@ use super::*;
 
 const FRAC_AROUND: Em = Em::new(0.1);
 
-/// # Fraction
+/// Fraction
 /// A mathematical fraction.
 ///
 /// ## Example


### PR DESCRIPTION
Currently there's an extraneous `#` on the line describing `frac` on https://typst.app/docs/reference/math/. This PR removes it.