### PR TITLE
Fixes typst/typst#704 -- CLI can block upon opening pdf viewer

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -348,13 +348,9 @@ fn print_diagnostics(
 /// - The given viewer provided by `open` if it is `Some`.
 fn open_file(open: Option<&str>, path: &Path) -> StrResult<()> {
     if let Some(app) = open {
-        open::with(path, app).map_err(|err| {
-            format!("failed to open `{}` with `{}`, reason: {}", path.display(), app, err)
-        })?;
+        open::with_in_background(path, app);
     } else {
-        open::that(path).map_err(|err| {
-            format!("failed to open `{}`, reason: {}", path.display(), err)
-        })?;
+        open::that_in_background(path);
     }
 
     Ok(())


### PR DESCRIPTION
Fixes issue typst/typst#704 by making opening a pdf viewer non-blocking. This does remove error reporting when the pdf viewer fails to be opened. This error reporting is difficult to regain since the error happens on a different thread.