### PR TITLE
fix parenthesized binding

### DIFF
--- a/docs/src/reference/scripting.md
+++ b/docs/src/reference/scripting.md
@@ -96,7 +96,7 @@ The last element is #b.
   "Homer": "The Odyssey",
   "Austen": "Persuasion",
 )
-#let (Austen) = books
+#let (Austen,) = books
 Austen wrote #Austen.
 
 #let (Homer: h) = books

--- a/src/syntax/ast.rs
+++ b/src/syntax/ast.rs
@@ -1620,7 +1620,11 @@ pub enum DestructuringKind {
 impl Pattern {
     /// The kind of the pattern.
     pub fn kind(&self) -> PatternKind {
-        if self.0.children().len() <= 1 {
+        let has_sink =
+            self.0.children().find(|c| c.kind() == SyntaxKind::Spread).is_some();
+
+        // Check if pattern only has one child and two parenthesese and is not a sink
+        if self.0.children().len() <= 3 && !has_sink {
             return PatternKind::Ident(self.0.cast_first_match().unwrap_or_default());
         }
 

--- a/src/syntax/ast.rs
+++ b/src/syntax/ast.rs
@@ -1620,11 +1620,14 @@ pub enum DestructuringKind {
 impl Pattern {
     /// The kind of the pattern.
     pub fn kind(&self) -> PatternKind {
-        let has_sink =
-            self.0.children().find(|c| c.kind() == SyntaxKind::Spread).is_some();
-
-        // Check if pattern only has one child and two parentheses and is not a sink
-        if self.0.children().len() <= 3 && !has_sink {
+        if self
+            .0
+            .children()
+            .map(SyntaxNode::kind)
+            .skip_while(|&kind| kind == SyntaxKind::LeftParen)
+            .take_while(|&kind| kind != SyntaxKind::RightParen)
+            .eq([SyntaxKind::Ident])
+        {
             return PatternKind::Ident(self.0.cast_first_match().unwrap_or_default());
         }
 

--- a/src/syntax/ast.rs
+++ b/src/syntax/ast.rs
@@ -1623,7 +1623,7 @@ impl Pattern {
         let has_sink =
             self.0.children().find(|c| c.kind() == SyntaxKind::Spread).is_some();
 
-        // Check if pattern only has one child and two parenthesese and is not a sink
+        // Check if pattern only has one child and two parentheses and is not a sink
         if self.0.children().len() <= 3 && !has_sink {
             return PatternKind::Ident(self.0.cast_first_match().unwrap_or_default());
         }

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -847,11 +847,15 @@ fn pattern(p: &mut Parser) -> PatternKind {
     let m = p.marker();
 
     if p.at(SyntaxKind::LeftParen) {
-        collection(p, false);
+        let kind = collection(p, false);
         validate_destruct_pattern(p, m);
         p.wrap(m, SyntaxKind::Pattern);
 
-        PatternKind::Destructuring
+        if kind == SyntaxKind::Parenthesized {
+            PatternKind::Normal
+        } else {
+            PatternKind::Destructuring
+        }
     } else {
         let success = p.expect(SyntaxKind::Ident);
         if p.at(SyntaxKind::Comma) {

--- a/tests/typ/compiler/let.typ
+++ b/tests/typ/compiler/let.typ
@@ -33,11 +33,21 @@ Three
 #test(v3, 3)
 
 ---
+// Test parenthesised assignments.
+// Ref: false
+#let (a) = (1, 2)
+
+---
 // Ref: false
 // Simple destructuring.
 #let (a, b) = (1, 2)
 #test(a, 1)
 #test(b, 2)
+
+---
+// Ref: false
+#let (a,) = (1,)
+#test(a, 1)
 
 ---
 // Ref: false
@@ -114,10 +124,6 @@ Three
 ---
 // Error: 13-14 not enough elements to destructure
 #let (a, b, c) = (1, 2)
-
----
-// Error: 6-9 too many elements to destructure
-#let (a) = (1, 2)
 
 ---
 // Error: 6-20 not enough elements to destructure


### PR DESCRIPTION
Currently `let (a) = (3,)` is used to bind one-tuples. But this is inconsistent with the behaviour of destructuring introduced in #703. So this PR changes the syntax to `let (a,) = (1,)` which is consistent with rust.
This PR also allows `let (a) = 3` which was not before. This is also because of consistency.