### PR TITLE
Workaround: SVG rendering issue(#689)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,6 +554,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "fontconfig-parser"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ab2e12762761366dcb876ab8b6e0cfa4797ddcd890575919f008b5ba655672a"
+dependencies = [
+ "roxmltree 0.18.0",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52186a39c335aa6f79fc0bf1c3cf854870b6ad4e50a7bb8a59b4ba1331f478a"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "ttf-parser 0.17.1",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1250,6 +1271,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "roxmltree"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f595a457b6b8c6cda66a48503e92ee8d19342f905948f29c383200ec9eb1d8"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1604,6 +1634,7 @@ dependencies = [
  "comemo",
  "ecow",
  "flate2",
+ "fontdb",
  "if_chain",
  "image",
  "log",
@@ -1613,7 +1644,7 @@ dependencies = [
  "pixglyph",
  "regex",
  "resvg",
- "roxmltree",
+ "roxmltree 0.14.1",
  "rustybuzz",
  "serde",
  "siphasher",
@@ -1686,7 +1717,7 @@ dependencies = [
  "lipsum",
  "log",
  "once_cell",
- "roxmltree",
+ "roxmltree 0.14.1",
  "rustybuzz",
  "serde_json",
  "serde_yaml",
@@ -1814,6 +1845,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1858,14 +1895,21 @@ dependencies = [
  "data-url",
  "flate2",
  "float-cmp",
+ "fontdb",
  "kurbo",
  "log",
  "pico-args",
  "rctree",
- "roxmltree",
+ "roxmltree 0.14.1",
+ "rustybuzz",
  "simplecss",
  "siphasher",
  "svgtypes",
+ "ttf-parser 0.15.2",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
 ]
 
 [[package]]
@@ -2079,6 +2123,12 @@ name = "xmlparser"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "xmp-writer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,8 @@ unicode-math-class = "0.1"
 unicode-segmentation = "1"
 unicode-xid = "0.2"
 unscanny = "0.1"
-usvg = { version = "0.22", default-features = false }
+usvg = "0.22"
+fontdb = "0.9"
 xmp-writer = "0.1"
 
 [profile.dev]

--- a/src/image.rs
+++ b/src/image.rs
@@ -55,7 +55,9 @@ impl Image {
     pub fn decode(&self) -> StrResult<Arc<DecodedImage>> {
         Ok(Arc::new(match self.format {
             ImageFormat::Vector(VectorFormat::Svg) => {
-                let opts = usvg::Options::default();
+                let mut opts = usvg::Options::default();
+                opts.fontdb = fontdb::Database::new();
+                opts.fontdb.load_system_fonts();
                 let tree = usvg::Tree::from_data(&self.data, &opts.to_ref())
                     .map_err(format_usvg_error)?;
                 DecodedImage::Svg(tree)


### PR DESCRIPTION
I think we can simply call `load_system_fonts` in this circumstance because there are some internal `#[cfg]` checks in that function, and only supported systems will execute those codes. 

Maybe making this available would be better for preliminary usage.