### PR TITLE
Optimization to `Introspector::extract`

### DIFF
--- a/src/model/introspect.rs
+++ b/src/model/introspect.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt::{self, Debug, Formatter};
 use std::hash::Hash;
 use std::num::NonZeroUsize;
@@ -83,7 +84,7 @@ impl StabilityProvider {
 /// Can be queried for elements and their positions.
 pub struct Introspector {
     pages: usize,
-    elems: Vec<(Content, Position)>,
+    elems: HashMap<Option<Location>, (Content, Position)>,
     // Indexed by page number.
     page_numberings: Vec<Value>,
 }
@@ -93,7 +94,7 @@ impl Introspector {
     pub fn new(frames: &[Frame]) -> Self {
         let mut introspector = Self {
             pages: frames.len(),
-            elems: vec![],
+            elems: HashMap::new(),
             page_numberings: vec![],
         };
         for (i, frame) in frames.iter().enumerate() {
@@ -105,7 +106,7 @@ impl Introspector {
 
     /// Iterate over all elements.
     pub fn all(&self) -> impl Iterator<Item = &Content> {
-        self.elems.iter().map(|(elem, _)| elem)
+        self.elems.values().map(|(elem, _)| elem)
     }
 
     /// Extract metadata from a frame.
@@ -119,13 +120,14 @@ impl Introspector {
                     self.extract(&group.frame, page, ts);
                 }
                 FrameItem::Meta(Meta::Elem(content), _)
-                    if !self
-                        .elems
-                        .iter()
-                        .any(|(prev, _)| prev.location() == content.location()) =>
+                    if !self.elems.contains_key(&content.location()) =>
                 {
                     let pos = pos.transform(ts);
-                    self.elems.push((content.clone(), Position { page, point: pos }));
+                    let ret = self.elems.insert(
+                        content.location(),
+                        (content.clone(), Position { page, point: pos }),
+                    );
+                    assert!(ret.is_none(), "duplicate locations");
                 }
                 FrameItem::Meta(Meta::PageNumbering(numbering), _) => {
                     self.page_numberings.push(numbering.clone());
@@ -202,8 +204,7 @@ impl Introspector {
     /// Find the position for the given location.
     pub fn position(&self, location: Location) -> Position {
         self.elems
-            .iter()
-            .find(|(elem, _)| elem.location() == Some(location))
+            .get(&Some(location))
             .map(|(_, loc)| *loc)
             .unwrap_or(Position { page: NonZeroUsize::ONE, point: Point::zero() })
     }


### PR DESCRIPTION
The big change is changing `Introspector::elems` to, instead of being backed by a `Vec` (thus requiring many linear searches), be backed by a `HashMap` (so that search can be done in roughly constant time).

They key for the HashMap is `Option<Location>` in the spirit of staying close in behaviour to the original code.
However, we should be able to change it into a plain `Location`, providing more clarity.

From what I understood (+ discussion on Discord), this key should be stable, so keeping it separate from the `Content` in the HashMap should not be a problem.

This change has led to a massive improvement in performance for an apparently pathological document of mine -- time to compile it seems to have gone from 30s-1m30s to 3s-6s.
I have not benchmarked this in other documents, though.