### PR TITLE
Install scripts forked from Deno

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ Typst's CLI is available from different sources:
 - You can get sources and pre-built binaries for the latest release of Typst
   from the [releases page][releases].
 
+  We have convenient scripts to download them to `$HOME/.typst`:
+  - Windows: `irm https://raw.githubusercontent.com/typst/typst/main/tools/install-scripts/install.ps1 | iex`
+  - MacOS, Linux: `curl -fsSL https://raw.githubusercontent.com/typst/typst/main/tools/install-scripts/install.sh | sh`
+
 - You can install Typst through different package managers. Note that the
   versions in the package managers might lag behind the latest release.
   - macOS/Linux: `brew install typst`

--- a/tools/install-scripts/install.ps1
+++ b/tools/install-scripts/install.ps1
@@ -1,0 +1,51 @@
+#!/usr/bin/env pwsh
+# Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+# TODO(everyone): Keep this script simple and easily auditable.
+# Forked from Deno's install.ps1 script
+
+$ErrorActionPreference = 'Stop'
+
+if ($v) {
+  $Version = "v${v}"
+}
+if ($Args.Length -eq 1) {
+  $Version = $Args.Get(0)
+}
+
+$TypstInstall = $env:TYPST_INSTALL
+$BinDir = if ($TypstInstall) {
+  "${TypstInstall}\bin"
+} else {
+  "${Home}\.typst\bin"
+}
+
+$TypstZip = "$BinDir\typst.zip"
+$TypstExe = "$BinDir\typst.exe"
+$Target = 'x86_64-pc-windows-msvc'
+
+$DownloadUrl = if (!$Version) {
+  "https://github.com/typst/typst/releases/latest/download/typst-${Target}.zip"
+} else {
+  "https://github.com/typst/typst/releases/download/${Version}/typst-${Target}.zip"
+}
+
+if (!(Test-Path $BinDir)) {
+  New-Item $BinDir -ItemType Directory | Out-Null
+}
+
+curl.exe -Lo $TypstZip $DownloadUrl
+
+tar.exe xf $TypstZip -C $BinDir --strip-components=1
+
+Remove-Item $TypstZip
+
+$User = [System.EnvironmentVariableTarget]::User
+$Path = [System.Environment]::GetEnvironmentVariable('Path', $User)
+if (!(";${Path};".ToLower() -like "*;${BinDir};*".ToLower())) {
+  [System.Environment]::SetEnvironmentVariable('Path', "${Path};${BinDir}", $User)
+  $Env:Path += ";${BinDir}"
+}
+
+Write-Output "Typst was installed successfully to ${TypstExe}"
+Write-Output "Run 'typst --help' to get started"
+Write-Output "Stuck? Join our Discord https://discord.gg/2uDybryKPe"

--- a/tools/install-scripts/install.sh
+++ b/tools/install-scripts/install.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+# Copyright 2019 the Deno authors. All rights reserved. MIT license.
+# TODO(everyone): Keep this script simple and easily auditable.
+# Forked from Deno's install.sh script
+
+set -e
+
+use_unzip=false
+
+if [ "$OS" = "Windows_NT" ]; then
+	target="x86_64-pc-windows-msvc"
+	use_unzip=true
+else
+	case $(uname -sm) in
+	"Darwin x86_64") target="x86_64-apple-darwin" ;;
+	"Darwin arm64")
+		echo "Error: Official Typst builds for Darwin arm64 are not available." 1>&2 # (see: https://github.com/denoland/deno/issues/1846 )" 1>&2
+		exit 1
+		;;
+	"Linux aarch64")
+		echo "Error: Official Typst builds for Linux aarch64 are not available." 1>&2 # (see: https://github.com/denoland/deno/issues/1846 )" 1>&2
+		exit 1
+		;;
+	*) target="x86_64-unknown-linux-gnu" ;;
+	esac
+fi
+
+if [ "$use_unzip" = true ] && ! command -v unzip >/dev/null; then
+	echo "Error: unzip is required to install Typst." 1>&2 # (see: https://github.com/denoland/deno_install#unzip-is-required )." 1>&2
+	exit 1
+fi
+
+typst_install="${TYPST_INSTALL:-$HOME/.typst}"
+bin_dir="$typst_install/bin"
+exe="$bin_dir/typst"
+
+if [ ! -d "$bin_dir" ]; then
+	mkdir -p "$bin_dir"
+fi
+
+if [ "$use_unzip" = true ]; then
+	if [ $# -eq 0 ]; then
+		typst_uri="https://github.com/typst/typst/releases/latest/download/typst-${target}.zip"
+	else
+		typst_uri="https://github.com/typst/typst/releases/download/${1}/typst-${target}.zip"
+ 	fi
+
+	curl --fail --location --progress-bar --output "$exe.zip" "$typst_uri"
+	unzip -d "$bin_dir" -o "$exe.zip"
+	mv "$bin_dir/typst-${target}/*" "$bin_dir"
+	chmod +x "$exe"
+	rm -r "$bin_dir/typst-${target}/*"
+	rm "$exe.zip"
+else
+	if [ $# -eq 0 ]; then
+		typst_uri="https://github.com/typst/typst/releases/latest/download/typst-${target}.tar.gz"
+	else
+		typst_uri="https://github.com/typst/typst/releases/download/${1}/typst-${target}.tar.gz"
+	fi
+
+	curl --fail --location --progress-bar --output "$exe.tar.gz" "$typst_uri"
+	tar -xf "$exe.tar.gz" -C "$bin_dir" --strip-components=1
+	chmod +x "$exe"
+	rm "$exe.tar.gz"
+fi
+
+echo "Typst was installed successfully to $exe"
+if command -v typst >/dev/null; then
+	echo "Run 'typst --help' to get started"
+else
+	case $SHELL in
+	/bin/zsh) shell_profile=".zshrc" ;;
+	*) shell_profile=".bashrc" ;;
+	esac
+	echo "Manually add the directory to your \$HOME/$shell_profile (or similar)"
+	echo "  export TYPST_INSTALL=\"$typst_install\""
+	echo "  export PATH=\"\$TYPST_INSTALL/bin:\$PATH\""
+	echo "Run '$exe --help' to get started"
+fi
+echo
+echo "Stuck? Join our Discord https://discord.gg/2uDybryKPe"


### PR DESCRIPTION
This could be helpful for people who want to get started with Typst.

The scripts are forked from denoland/deno_install@82dcc3f76914be571bd1bb5287e14b60f62168b2, which is available under MIT License.

I didn't change much from the original version. Deno zip file doesn't have a containing folder inside the zip so I added the `--strip-components=1`.

Also, Deno uses all zip files so I edited a little bit to use `tar` in the shell file. Works on my GitHub Codespaces, but `glibc` is outdated (20.04 vs 22.04 I think) so I couldn't run the executable.

Haven't tested on MacOS yet. Would be nice if someone can try.