### PR TITLE
Fix `pow` overflow

### DIFF
--- a/library/src/compute/calc.rs
+++ b/library/src/compute/calc.rs
@@ -108,7 +108,13 @@ pub fn pow(
     };
 
     let result = match (base, exponent.v) {
-        (Num::Int(a), Num::Int(b)) if b >= 0 => Num::Int(a.pow(b as u32)),
+        (Num::Int(a), Num::Int(b)) if b >= 0 => {
+            let raw = a.checked_pow(b as u32);
+            if raw.is_none() {
+                bail!(exponent.span, "the result is too large")
+            }
+            Num::Int(raw.unwrap())
+        }
         (a, Num::Int(b)) => Num::Float(a.float().powi(b as i32)),
         (a, b) => Num::Float(a.float().powf(b.float())),
     };

--- a/library/src/compute/calc.rs
+++ b/library/src/compute/calc.rs
@@ -108,13 +108,11 @@ pub fn pow(
     };
 
     let result = match (base, exponent.v) {
-        (Num::Int(a), Num::Int(b)) if b >= 0 => {
-            let raw = a.checked_pow(b as u32);
-            if raw.is_none() {
-                bail!(exponent.span, "the result is too large")
-            }
-            Num::Int(raw.unwrap())
-        }
+        (Num::Int(a), Num::Int(b)) if b >= 0 => a
+            .checked_pow(b as u32)
+            .map(Num::Int)
+            .ok_or("the result is too large")
+            .at(args.span)?,
         (a, Num::Int(b)) => Num::Float(a.float().powi(b as i32)),
         (a, b) => Num::Float(a.float().powf(b.float())),
     };

--- a/tests/typ/compute/calc.typ
+++ b/tests/typ/compute/calc.typ
@@ -91,7 +91,7 @@
 #calc.pow(2, 10000000000000000)
 
 ---
-// Error: 14-24 the result is too large
+// Error: 10-25 the result is too large
 #calc.pow(2, 2147483647)
 
 ---

--- a/tests/typ/compute/calc.typ
+++ b/tests/typ/compute/calc.typ
@@ -91,6 +91,10 @@
 #calc.pow(2, 10000000000000000)
 
 ---
+// Error: 14-31 the result is too large
+#calc.pow(2, 2147483647)
+
+---
 // Error: 14-36 exponent may not be infinite, subnormal, or NaN
 #calc.pow(2, calc.pow(2.0, 10000.0))
 

--- a/tests/typ/compute/calc.typ
+++ b/tests/typ/compute/calc.typ
@@ -91,7 +91,7 @@
 #calc.pow(2, 10000000000000000)
 
 ---
-// Error: 14-31 the result is too large
+// Error: 14-24 the result is too large
 #calc.pow(2, 2147483647)
 
 ---


### PR DESCRIPTION
This PR fixes an overflow caused by the `pow` method. For instance, `#calc.pow(2, 2147483647)` would make the compiler crash before.