### PR TITLE
Bump `chinese-number` version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,22 +172,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chinese-number"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365a2e504d6cb41e85fba5d01a6baf7f13cad4424102859193c4674e7fdff933"
+checksum = "9f9a8cffacecd7f477f8395021158af07c8a3f74523e9b90e4e4bb0105deaa74"
 dependencies = [
- "chinese-numerals",
  "chinese-variant",
  "enum-ordinalize",
  "num-bigint",
  "num-traits",
 ]
-
-[[package]]
-name = "chinese-numerals"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a5a40575256b55eebe3e39fa41e53bdaea5d67ac5a7092fa8756020c798d1e"
 
 [[package]]
 name = "chinese-variant"

--- a/library/Cargo.toml
+++ b/library/Cargo.toml
@@ -38,4 +38,4 @@ unicode-math-class = "0.1"
 unicode-script = "0.5"
 unicode-segmentation = "1"
 xi-unicode = "0.3"
-chinese-number = { version = "0.7", default-features = false, features = ["number-to-chinese"] }
+chinese-number = { version = "0.7.1", default-features = false, features = ["number-to-chinese"] }


### PR DESCRIPTION
Fixes #788 (the new release removed the AGPL dependency, `chinese-numerals` - see also https://github.com/magiclen/chinese-number/issues/2).