### PR TITLE
Fix compiler crash when ref converts to cite

### DIFF
--- a/library/src/meta/reference.rs
+++ b/library/src/meta/reference.rs
@@ -159,7 +159,7 @@ impl Show for RefElem {
                 bail!(self.span(), "label occurs in the document and its bibliography");
             }
 
-            return Ok(self.to_citation(vt, styles)?.pack());
+            return Ok(self.to_citation(vt, styles)?.pack().spanned(self.span()));
         }
 
         let elem = elem.at(self.span())?;


### PR DESCRIPTION
Partial fix for #796:

Given the MWE by @leo848 below, the compiler will try to emit an error but crash due to an invalid span. Replacing `@name` by `#cite("name")` properly emits the error. Upon investigation, this was because `@name`, when translated to `#ref("name")`, would try to convert itself to a `cite`, but forget to keep its own span. This PR fixes that.

However, the error itself seems to be unexpected, which is why I don't consider this PR a full fix for #796 (the heading itself works fine, but adding an outline for it is the problem, as it seems to display the outline before the citations can be fetched, or something like that).

Indeed, for any unknown label this would print "label does not exist in the document"; when the label _does_ exist in the bibliography, it changes the error to "bibliography does not contain this key" when `#outline()` is present, suggesting heading bodies (and figures, from the issue) in the outline somehow recognize what their refs are pointing to, but are not waiting for the document to be re-drawn. This error, however, is still better than receiving an unhelpful compiler crash message.

Not sure if I should add tests for this, as the error behavior itself seems to be unexpected, given the above (and could require a more complex fix). However, there could maybe be some test specifically for the span conversion part.

Minimal working example:
**doc.typ**:
```
#outline()
= Heading @name
#bibliography("bib.bib")
```

**bib.bib**:
```bib
@misc{name,}
```

**Without this PR:**
```
thread 'main' panicked at 'index out of bounds: the len is 1 but the index is 65535', /home/leo/.cargo/registry/src/github.com-1ecc6299db9ec823/elsa-1.8.0/src/vec.rs:231:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

**With this PR:**
```
error: bibliography does not contain this key
  ┌─ doc.typ:3:10
  │
3 │ = Heading @name
  │ 
  ```