### PR TITLE
bibliography: Respect heading numbering

### DIFF
--- a/library/src/meta/bibliography.rs
+++ b/library/src/meta/bibliography.rs
@@ -151,12 +151,7 @@ impl Show for BibliographyElem {
                     .spanned(self.span())
             });
 
-            seq.push(
-                HeadingElem::new(title)
-                    .with_level(NonZeroUsize::ONE)
-                    .with_numbering(None)
-                    .pack(),
-            );
+            seq.push(HeadingElem::new(title).with_level(NonZeroUsize::ONE).pack());
         }
 
         if !vt.introspector.init() {

--- a/library/src/meta/outline.rs
+++ b/library/src/meta/outline.rs
@@ -143,7 +143,6 @@ impl Show for OutlineElem {
             seq.push(
                 HeadingElem::new(title)
                     .with_level(NonZeroUsize::ONE)
-                    .with_numbering(None)
                     .with_outlined(false)
                     .pack(),
             );

--- a/tests/typ/meta/outline.typ
+++ b/tests/typ/meta/outline.typ
@@ -1,9 +1,11 @@
+#set heading(numbering: none)
 #set page("a7", margin: 20pt, numbering: "1")
-#set heading(numbering: "(1/a)")
 #show heading.where(level: 1): set text(12pt)
 #show heading.where(level: 2): set text(10pt)
 
 #outline()
+
+#set heading(numbering: "(1/a)")
 
 = Einleitung
 #lorem(12)

--- a/tests/typ/meta/query-before-after.typ
+++ b/tests/typ/meta/query-before-after.typ
@@ -10,6 +10,7 @@
   #it
 
   #set text(size: 12pt, weight: "regular")
+  #set heading(numbering: none)
   #outline(
       title: "Chapter outline",
       indent: true,


### PR DESCRIPTION
Makes `bibliography` use the current setting of `numbering` for its heading. This allows for having a heading number for the bibliography. To restore the old behaviour of not adding a heading number, one can put `#set heading(numbering: none)` before rendering the bibliography.