### PR TITLE
Add more release build targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ name: Build Release Binaries
 on:
   release:
     types: [created]
+  workflow_dispatch:
 
 jobs:
   build-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Build release binary
       shell: bash
       run: |
-        if [ ${{ matrix.crossBuildDocker}} ]; then
+        if ${{ matrix.crossBuildDocker}}; then
           cargo install cross --git https://github.com/cross-rs/cross
           git clone https://github.com/cross-rs/cross
           cd cross
@@ -50,7 +50,7 @@ jobs:
           cargo build-docker-image ${{ matrix.target }}-cross
           # cd ..
         fi
-        if [ ${{matrix.cross }}]; then
+        if ${{matrix.cross }}; then
           echo test
         else
           cargo build -p typst-cli --release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           echo test1
           cp target/release/typst $directory
           tar cJf $directory.tar.xz $directory
-        elif [ -f target/release/typst.exe]; then
+        elif [ -f target/release/typst.exe ]; then
           echo test2
           cp target/release/typst.exe $directory
           7z a -r $directory.zip $directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,16 +9,19 @@ on:
 jobs:
   build-release:
     name: release ${{ matrix.target }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
         - target: x86_64-unknown-linux-gnu
           archive: tar.gz
+          os: ubuntu-latest
         - target: x86_64-apple-darwin
           archive: tar.gz
+          os: macos-latest
         - target: x86_64-pc-windows-msvc
           archive: zip
+          os: windows-latest
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,11 @@ jobs:
         mkdir $directory
         cp README.md LICENSE NOTICE $directory
         if [ -f target/release/typst ]; then
+          echo test1
           cp target/release/typst $directory
           tar cJf $directory.tar.xz $directory
-        else
+        elif [ -f target/release/typst.exe]; then
+          echo test2
           cp target/release/typst.exe $directory
           7z a -r $directory.zip $directory
         fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,14 @@ jobs:
     - name: Build release binary
       run: cross build -p typst-cli --release --target ${{ matrix.target }}
 
+    - name: create artifact directory
+      shell: bash
+      run: |
+        directory=typst-${{ matrix.target }}
+        mkdir $directory
+        cp README.md LICENCE NOTICE $directory
+        if [ -e target/release/typst ]; then cp target/release/typst $directory; else cp target/release/typst.exe $directory; fi
+        if [ ${{ matrix.archive}} == zip ]; then zip $directory; else tar -czvf directory; fi
     # - name: Strip binary (Linux and macOS)
     #   if: matrix.build == 'linux' || matrix.build == 'macos'
     #   run: strip "target/release/typst"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,13 +51,13 @@ jobs:
         mkdir $directory
         cp README.md LICENSE NOTICE $directory
         ls target/release
-        if [ -f target/release/typst ]; then
+        if [ -f target/${{ matrix.target }}/release/typst ]; then
           echo test1
-          cp target/release/typst $directory
+          cp target/${{ matrix.target }}/release/typst $directory
           tar cJf $directory.tar.xz $directory
-        elif [ -f target/release/typst.exe ]; then
+        elif [ -f target/${{ matrix.target }}/release/typst.exe ]; then
           echo test2
-          cp target/release/typst.exe $directory
+          cp target/${{ matrix.target }}/release/typst.exe $directory
           7z a -r $directory.zip $directory
         fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
 
     - name: Build release binary
+      shell: bash
       run: |
         if [ ${{ matrix.cross }} ]; then
           cargo install cross --git https://github.com/cross-rs/cross

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,18 +17,22 @@ jobs:
           archive: tar.gz
           os: ubuntu-latest
           cross: false
+          crossBuildDocker: false
         - target: x86_64-apple-darwin
           archive: tar.gz
           os: macos-latest
-          cross: true
+          cross: false
+          crossBuildDocker: false
         - target: aarch64-apple-darwin
           archive: tar.gz
           os: macos-latest
-          cross: false
+          cross: true
+          crossBuildDocker: true
         - target: x86_64-pc-windows-msvc
           archive: zip
           os: windows-latest
           cross: false
+          crossBuildDocker: false
 
     steps:
     - uses: actions/checkout@v3
@@ -37,13 +41,14 @@ jobs:
     - name: Build release binary
       shell: bash
       run: |
-        if [ ${{ matrix.cross }} ]; then
+        if [ ${{ matrix.crossBuildDocker}} ]; then
           cargo install cross --git https://github.com/cross-rs/cross
           git clone https://github.com/cross-rs/cross
           cd cross
           git submodule update --init --remote
-          cargo build-docker-image aarch64-apple-darwin-cross
-          cd ..
+          cargo build-docker-image ${{ matrix.target }}-cross
+          # cd ..
+        if [ ${{matrix.cross }}]; then
         else
           cargo build -p typst-cli --release
         fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,46 +15,33 @@ jobs:
       matrix:
         include:
         - target: x86_64-unknown-linux-musl
-          archive: tar.gz
           os: ubuntu-latest
           cross: false
-          crossBuildDocker: false
         - target: x86_64-apple-darwin
-          archive: tar.gz
           os: macos-latest
           cross: false
-          crossBuildDocker: false
         - target: aarch64-apple-darwin
-          archive: tar.gz
           os: macos-latest
-          cross: true
-          crossBuildDocker: true
+          cross: false
         - target: x86_64-pc-windows-msvc
-          archive: zip
           os: windows-latest
           cross: false
-          crossBuildDocker: false
 
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
+      with:
+        target: ${{ matrix.target }}
 
-    - name: Build release binary
-      shell: bash
+    - name: Run Cross
+      if: ${{ matrix.cross}}
       run: |
-        if ${{ matrix.crossBuildDocker}}; then
-          cargo install cross --git https://github.com/cross-rs/cross
-          git clone https://github.com/cross-rs/cross
-          cd cross
-          git submodule update --init --remote
-          cargo build-docker-image ${{ matrix.target }}-cross
-          # cd ..
-        fi
-        if ${{matrix.cross }}; then
-          echo test
-        else
-          cargo build -p typst-cli --release
-        fi
+        cargo install cross --git https://github.com/cross-rs/cross.git
+        cross build -p typst-cli --release --target ${{ matrix.target }}
+
+    - name: Run Cargo
+      if: ${{ !matrix.cross }}
+      run: cargo build -p typst-cli --release --target ${{ matrix.target }}
 
     - name: create artifact directory
       shell: bash
@@ -62,12 +49,17 @@ jobs:
         directory=typst-${{ matrix.target }}
         mkdir $directory
         cp README.md LICENSE NOTICE $directory
-        if [ -e target/release/typst ]; then cp target/release/typst $directory; else cp target/release/typst.exe $directory; fi
-        if [ ${{ matrix.archive}} == zip ]; then zip $directory; else tar -czvf directory; fi
+        if [ -e target/release/typst ]; then
+          cp target/release/typst $directory
+          tar cJf $directory.tar.xz $directory
+        else
+          cp target/release/typst.exe $directory
+        7z a -r $directory.zip $directory
+        fi
 
     - uses: ncipollo/release-action@v1
       with:
-        artifacts: "directory*"
+        artifacts: "directory.*"
     # - name: Strip binary (Linux and macOS)
     #   if: matrix.build == 'linux' || matrix.build == 'macos'
     #   run: strip "target/release/typst"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ jobs:
         - target: aarch64-unknown-linux-musl
           os: ubuntu-latest
           cross: false
+        - target: riscv64gc-unknown-linux-gnu
+          os: ubuntu-latest
+          cross: false
         - target: x86_64-apple-darwin
           os: macos-latest
           cross: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         directory=typst-${{ matrix.target }}
         mkdir $directory
-        cp README.md LICENCE NOTICE $directory
+        cp README.md LICENSE NOTICE $directory
         if [ -e target/release/typst ]; then cp target/release/typst $directory; else cp target/release/typst.exe $directory; fi
         if [ ${{ matrix.archive}} == zip ]; then zip $directory; else tar -czvf directory; fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,16 @@ jobs:
     permissions:
       contents: write
     strategy:
+      fail-fast: false
       matrix:
         include:
         - target: x86_64-unknown-linux-musl
           os: ubuntu-latest
           cross: false
         - target: aarch64-unknown-linux-musl
+          os: ubuntu-latest
+          cross: true
+        - target: armv7-unknown-linux-musleabi
           os: ubuntu-latest
           cross: true
         - target: riscv64gc-unknown-linux-gnu
@@ -33,6 +37,9 @@ jobs:
         - target: x86_64-pc-windows-msvc
           os: windows-latest
           cross: false
+        - target: aarch64-pc-windows-msvc
+          os: windows-latest
+          cross: true
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
         directory=typst-${{ matrix.target }}
         mkdir $directory
         cp README.md LICENSE NOTICE $directory
+        ls target/release
         if [ -f target/release/typst ]; then
           echo test1
           cp target/release/typst $directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,5 +62,5 @@ jobs:
 
     - uses: ncipollo/release-action@v1
       with:
-        artifacts: "directory.*"
+        artifacts: "typst-${{ matrix.target }}.*"
         allowUpdates: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,10 @@ jobs:
           cross: false
         - target: aarch64-unknown-linux-musl
           os: ubuntu-latest
-          cross: false
+          cross: true
         - target: riscv64gc-unknown-linux-gnu
           os: ubuntu-latest
-          cross: false
+          cross: true
         - target: x86_64-apple-darwin
           os: macos-latest
           cross: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
           cargo build-docker-image ${{ matrix.target }}-cross
           # cd ..
         if [ ${{matrix.cross }}]; then
+          echo test
         else
           cargo build -p typst-cli --release
         fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
         - target: x86_64-apple-darwin
           archive: tar.gz
           os: macos-latest
+        - target: aarch64-apple-darwin
+          archive: tar.gz
+          os: macos-latest
         - target: x86_64-pc-windows-msvc
           archive: zip
           os: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,10 @@ jobs:
         cp README.md LICENCE NOTICE $directory
         if [ -e target/release/typst ]; then cp target/release/typst $directory; else cp target/release/typst.exe $directory; fi
         if [ ${{ matrix.archive}} == zip ]; then zip $directory; else tar -czvf directory; fi
+
+    - uses: ncipollo/release-action@v1
+      with:
+        artifacts: "directory*"
     # - name: Strip binary (Linux and macOS)
     #   if: matrix.build == 'linux' || matrix.build == 'macos'
     #   run: strip "target/release/typst"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,14 +50,12 @@ jobs:
         directory=typst-${{ matrix.target }}
         mkdir $directory
         cp README.md LICENSE NOTICE $directory
-        if [ -f target/${{ matrix.target }}/release/typst ]; then
-          echo test1
-          cp target/${{ matrix.target }}/release/typst $directory
-          tar cJf $directory.tar.xz $directory
-        elif [ -f target/${{ matrix.target }}/release/typst.exe ]; then
-          echo test2
+        if [ -f target/${{ matrix.target }}/release/typst.exe ]; then
           cp target/${{ matrix.target }}/release/typst.exe $directory
           7z a -r $directory.zip $directory
+        else
+          cp target/${{ matrix.target }}/release/typst $directory
+          tar cJf $directory.tar.xz $directory
         fi
 
     - uses: ncipollo/release-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,12 +49,12 @@ jobs:
         directory=typst-${{ matrix.target }}
         mkdir $directory
         cp README.md LICENSE NOTICE $directory
-        if [ -e target/release/typst ]; then
+        if [ -f target/release/typst ]; then
           cp target/release/typst $directory
           tar cJf $directory.tar.xz $directory
         else
           cp target/release/typst.exe $directory
-        7z a -r $directory.zip $directory
+          7z a -r $directory.zip $directory
         fi
 
     - uses: ncipollo/release-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
           git submodule update --init --remote
           cargo build-docker-image ${{ matrix.target }}-cross
           # cd ..
+        fi
         if [ ${{matrix.cross }}]; then
           echo test
         else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ jobs:
         - target: x86_64-unknown-linux-musl
           os: ubuntu-latest
           cross: false
+        - target: aarch64-unknown-linux-musl
+          os: ubuntu-latest
+          cross: false
         - target: x86_64-apple-darwin
           os: macos-latest
           cross: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,6 @@ jobs:
         directory=typst-${{ matrix.target }}
         mkdir $directory
         cp README.md LICENSE NOTICE $directory
-        ls target/release
         if [ -f target/${{ matrix.target }}/release/typst ]; then
           echo test1
           cp target/${{ matrix.target }}/release/typst $directory
@@ -64,3 +63,4 @@ jobs:
     - uses: ncipollo/release-action@v1
       with:
         artifacts: "directory.*"
+        allowUpdates: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,55 +8,52 @@ on:
 
 jobs:
   build-release:
-    name: build-release
-    runs-on: ${{ matrix.os }}
+    name: release ${{ matrix.target }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        build: [linux, macos, win-msvc]
         include:
-        - build: linux
-          os: ubuntu-22.04
-          target: x86_64-unknown-linux-gnu
-        - build: macos
-          os: macos-12
-          target: x86_64-apple-darwin
-        - build: win-msvc
-          os: windows-2022
-          target: x86_64-pc-windows-msvc
+        - target: x86_64-unknown-linux-gnu
+          archive: tar.gz
+        - target: x86_64-apple-darwin
+          archive: tar.gz
+        - target: x86_64-pc-windows-msvc
+          archive: zip
 
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
+    - run: cargo install cross --git https://github.com/cross-rs/cross
 
     - name: Build release binary
-      run: cargo build -p typst-cli --release
+      run: cross build -p typst-cli --release --target ${{ matrix.target }}
 
-    - name: Strip binary (Linux and macOS)
-      if: matrix.build == 'linux' || matrix.build == 'macos'
-      run: strip "target/release/typst"
+    # - name: Strip binary (Linux and macOS)
+    #   if: matrix.build == 'linux' || matrix.build == 'macos'
+    #   run: strip "target/release/typst"
 
-    - name: Build archive
-      shell: bash
-      run: |
-        directory="typst-${{ matrix.target }}"
-        mkdir "$directory"
-        cp {README.md,LICENSE,NOTICE} "$directory/"
-        if [ "${{ matrix.os }}" = "windows-2022" ]; then
-          cp "target/release/typst.exe" "$directory/"
-          7z a "$directory.zip" "$directory"
-          echo "ASSET=$directory.zip" >> $GITHUB_ENV
-        else
-          cp "target/release/typst" "$directory/"
-          tar czf "$directory.tar.gz" "$directory"
-          echo "ASSET=$directory.tar.gz" >> $GITHUB_ENV
-        fi
+    # - name: Build archive
+    #   shell: bash
+    #   run: |
+    #     directory="typst-${{ matrix.target }}"
+    #     mkdir "$directory"
+    #     cp {README.md,LICENSE,NOTICE} "$directory/"
+    #     if [ "${{ matrix.os }}" = "windows-2022" ]; then
+    #       cp "target/release/typst.exe" "$directory/"
+    #       7z a "$directory.zip" "$directory"
+    #       echo "ASSET=$directory.zip" >> $GITHUB_ENV
+    #     else
+    #       cp "target/release/typst" "$directory/"
+    #       tar czf "$directory.tar.gz" "$directory"
+    #       echo "ASSET=$directory.tar.gz" >> $GITHUB_ENV
+    #     fi
 
-    - name: Upload release archive
-      uses: actions/upload-release-asset@v1.0.2
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ${{ env.ASSET }}
-        asset_name: ${{ env.ASSET }}
-        asset_content_type: application/octet-stream
+    # - name: Upload release archive
+    #   uses: actions/upload-release-asset@v1.0.2
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #   with:
+    #     upload_url: ${{ github.event.release.upload_url }}
+    #     asset_path: ${{ env.ASSET }}
+    #     asset_name: ${{ env.ASSET }}
+    #     asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,26 +13,39 @@ jobs:
     strategy:
       matrix:
         include:
-        - target: x86_64-unknown-linux-gnu
+        - target: x86_64-unknown-linux-musl
           archive: tar.gz
           os: ubuntu-latest
+          cross: false
         - target: x86_64-apple-darwin
           archive: tar.gz
           os: macos-latest
+          cross: true
         - target: aarch64-apple-darwin
           archive: tar.gz
           os: macos-latest
+          cross: false
         - target: x86_64-pc-windows-msvc
           archive: zip
           os: windows-latest
+          cross: false
 
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
-    - run: cargo install cross --git https://github.com/cross-rs/cross
 
     - name: Build release binary
-      run: cross build -p typst-cli --release --target ${{ matrix.target }}
+      run: |
+        if [ ${{ matrix.cross }} ]; then
+          cargo install cross --git https://github.com/cross-rs/cross
+          git clone https://github.com/cross-rs/cross
+          cd cross
+          git submodule update --init --remote
+          cargo build-docker-image aarch64-apple-darwin-cross
+          cd ..
+        else
+          cargo build -p typst-cli --release
+        fi
 
     - name: create artifact directory
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,13 @@ name: Build Release Binaries
 on:
   release:
     types: [created]
-  workflow_dispatch:
 
 jobs:
   build-release:
     name: release ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     strategy:
       matrix:
         include:
@@ -63,32 +64,3 @@ jobs:
     - uses: ncipollo/release-action@v1
       with:
         artifacts: "directory.*"
-    # - name: Strip binary (Linux and macOS)
-    #   if: matrix.build == 'linux' || matrix.build == 'macos'
-    #   run: strip "target/release/typst"
-
-    # - name: Build archive
-    #   shell: bash
-    #   run: |
-    #     directory="typst-${{ matrix.target }}"
-    #     mkdir "$directory"
-    #     cp {README.md,LICENSE,NOTICE} "$directory/"
-    #     if [ "${{ matrix.os }}" = "windows-2022" ]; then
-    #       cp "target/release/typst.exe" "$directory/"
-    #       7z a "$directory.zip" "$directory"
-    #       echo "ASSET=$directory.zip" >> $GITHUB_ENV
-    #     else
-    #       cp "target/release/typst" "$directory/"
-    #       tar czf "$directory.tar.gz" "$directory"
-    #       echo "ASSET=$directory.tar.gz" >> $GITHUB_ENV
-    #     fi
-
-    # - name: Upload release archive
-    #   uses: actions/upload-release-asset@v1.0.2
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   with:
-    #     upload_url: ${{ github.event.release.upload_url }}
-    #     asset_path: ${{ env.ASSET }}
-    #     asset_name: ${{ env.ASSET }}
-    #     asset_content_type: application/octet-stream


### PR DESCRIPTION
This resolves #561 and #156, as well as adding a RISC-V binary. Resolving #156 was a matter of setting the target in the build while resolving #561 required adding cross.rs to the build system. While I was rewriting the build system, I also swapped the deprecated actions/upload-release-asset for ncipollo/release-action.