### PR TITLE
CI and `flake.lock`

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,10 @@
+name: 'Update flake lock file'
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 1'
+
+jobs:
+  createPullRequest:
+    uses: loophp/flake-lock-update-workflow/.github/workflows/upgrade-flakes.yaml@main

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1679262748,
-        "narHash": "sha256-DQCrrAFrkxijC6haUzOC5ZoFqpcv/tg2WxnyW3np1Cc=",
+        "lastModified": 1681648924,
+        "narHash": "sha256-pzi3HISK8+7mpEtv08Yr80wswyHKsz+RP1CROG1Qf6s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "60c1d71f2ba4c80178ec84523c2ca0801522e0a6",
+        "rev": "f294325aed382b66c7a188482101b0f336d1d7db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This PR:

- Provides 1 new CI workflow
  - One to keep the file `flake.lock` up to date, the CI will propose a PR every monday
- Update `flake.lock` manually (`nix flake update`)

To test this quickly: `nix develop github:drupol/typst/update-flake-lock`

![image](https://user-images.githubusercontent.com/252042/232607566-09424ca2-ebdd-4fbd-8eea-46eb1ce5c399.png)

CC @dccsillag