### PR TITLE
use clap for parsing tests.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2081,6 +2081,7 @@ dependencies = [
 name = "typst-tests"
 version = "0.2.0"
 dependencies = [
+ "clap 4.2.4",
  "comemo",
  "elsa",
  "iai",

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -17,6 +17,7 @@ tiny-skia = "0.6.2"
 ttf-parser = "0.17"
 unscanny = "0.1"
 walkdir = "2"
+clap = { version = "4.2.1", features = ["derive"] }
 
 [[test]]
 name = "tests"


### PR DESCRIPTION
add a subtest option (to run only one subtest)

This has proven useful to me while testing, I can remove the subset option or we could make it better (you can specify ranges).

One thing I do not like which should be considered before merging is that the subset selected will be the same for all file selected (it only make sense for when you're testing one file) should I make it an error then?