### PR TITLE
Added rust minimum version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "typst"
 version = "0.2.0"
+rust-version = "1.65"
 authors = ["The Typst Project Developers"]
 edition = "2021"
 description = "A new markup-based typesetting system that is powerful and easy to learn."


### PR DESCRIPTION
This PR makes sure that typst is compiled the minimum rust version. Currently, it is set to `1.65` since that typst uses [let-else statments](https://doc.rust-lang.org/rust-by-example/flow_control/let_else.html), which were stabilized in `1.65`

The compiler will exit with an error if the rust version is too old. For very old rust versions, it will only emit a warning telling that the rust version is too old. See the [documentation about that](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field) for more informations.