### PR TITLE
Fix overflows with operators

### DIFF
--- a/src/eval/ops.rs
+++ b/src/eval/ops.rs
@@ -53,7 +53,7 @@ pub fn pos(value: Value) -> StrResult<Value> {
 /// Compute the negation of a value.
 pub fn neg(value: Value) -> StrResult<Value> {
     Ok(match value {
-        Int(v) => Int(v.checked_neg().ok_or("value is too big or too small")?),
+        Int(v) => Int(v.checked_neg().ok_or("value is too large")?),
         Float(v) => Float(-v),
         Length(v) => Length(-v),
         Angle(v) => Angle(-v),
@@ -71,7 +71,7 @@ pub fn add(lhs: Value, rhs: Value) -> StrResult<Value> {
         (None, b) => b,
 
         (Int(a), Int(b)) => {
-            Int(a.checked_add(b).ok_or("value is too big or too small")?)
+            Int(a.checked_add(b).ok_or("value is too large")?)
         }
         (Int(a), Float(b)) => Float(a as f64 + b),
         (Float(a), Int(b)) => Float(a + b as f64),
@@ -140,7 +140,7 @@ pub fn add(lhs: Value, rhs: Value) -> StrResult<Value> {
 pub fn sub(lhs: Value, rhs: Value) -> StrResult<Value> {
     Ok(match (lhs, rhs) {
         (Int(a), Int(b)) => {
-            Int(a.checked_sub(b).ok_or("value is too big or too small")?)
+            Int(a.checked_sub(b).ok_or("value is too large")?)
         }
         (Int(a), Float(b)) => Float(a as f64 - b),
         (Float(a), Int(b)) => Float(a - b as f64),
@@ -170,7 +170,7 @@ pub fn sub(lhs: Value, rhs: Value) -> StrResult<Value> {
 pub fn mul(lhs: Value, rhs: Value) -> StrResult<Value> {
     Ok(match (lhs, rhs) {
         (Int(a), Int(b)) => {
-            Int(a.checked_mul(b).ok_or("value is too big or too small")?)
+            Int(a.checked_mul(b).ok_or("value is too large")?)
         }
         (Int(a), Float(b)) => Float(a as f64 * b),
         (Float(a), Int(b)) => Float(a * b as f64),

--- a/src/eval/ops.rs
+++ b/src/eval/ops.rs
@@ -53,7 +53,7 @@ pub fn pos(value: Value) -> StrResult<Value> {
 /// Compute the negation of a value.
 pub fn neg(value: Value) -> StrResult<Value> {
     Ok(match value {
-        Int(v) => Int(-v),
+        Int(v) => Int(v.checked_neg().ok_or("value is too big or too small")?),
         Float(v) => Float(-v),
         Length(v) => Length(-v),
         Angle(v) => Angle(-v),
@@ -70,7 +70,7 @@ pub fn add(lhs: Value, rhs: Value) -> StrResult<Value> {
         (a, None) => a,
         (None, b) => b,
 
-        (Int(a), Int(b)) => Int(a + b),
+        (Int(a), Int(b)) => Int(a.checked_add(b).ok_or("value is too big or too small")?),
         (Int(a), Float(b)) => Float(a as f64 + b),
         (Float(a), Int(b)) => Float(a + b as f64),
         (Float(a), Float(b)) => Float(a + b),
@@ -137,7 +137,7 @@ pub fn add(lhs: Value, rhs: Value) -> StrResult<Value> {
 /// Compute the difference of two values.
 pub fn sub(lhs: Value, rhs: Value) -> StrResult<Value> {
     Ok(match (lhs, rhs) {
-        (Int(a), Int(b)) => Int(a - b),
+        (Int(a), Int(b)) => Int(a.checked_sub(b).ok_or("value is too big or too small")?),
         (Int(a), Float(b)) => Float(a as f64 - b),
         (Float(a), Int(b)) => Float(a - b as f64),
         (Float(a), Float(b)) => Float(a - b),
@@ -162,10 +162,11 @@ pub fn sub(lhs: Value, rhs: Value) -> StrResult<Value> {
     })
 }
 
+
 /// Compute the product of two values.
 pub fn mul(lhs: Value, rhs: Value) -> StrResult<Value> {
     Ok(match (lhs, rhs) {
-        (Int(a), Int(b)) => Int(a * b),
+        (Int(a), Int(b)) => Int(a.checked_mul(b).ok_or("value is too big or too small")?),
         (Int(a), Float(b)) => Float(a as f64 * b),
         (Float(a), Int(b)) => Float(a * b as f64),
         (Float(a), Float(b)) => Float(a * b),

--- a/src/eval/ops.rs
+++ b/src/eval/ops.rs
@@ -70,7 +70,9 @@ pub fn add(lhs: Value, rhs: Value) -> StrResult<Value> {
         (a, None) => a,
         (None, b) => b,
 
-        (Int(a), Int(b)) => Int(a.checked_add(b).ok_or("value is too big or too small")?),
+        (Int(a), Int(b)) => {
+            Int(a.checked_add(b).ok_or("value is too big or too small")?)
+        }
         (Int(a), Float(b)) => Float(a as f64 + b),
         (Float(a), Int(b)) => Float(a + b as f64),
         (Float(a), Float(b)) => Float(a + b),
@@ -137,7 +139,9 @@ pub fn add(lhs: Value, rhs: Value) -> StrResult<Value> {
 /// Compute the difference of two values.
 pub fn sub(lhs: Value, rhs: Value) -> StrResult<Value> {
     Ok(match (lhs, rhs) {
-        (Int(a), Int(b)) => Int(a.checked_sub(b).ok_or("value is too big or too small")?),
+        (Int(a), Int(b)) => {
+            Int(a.checked_sub(b).ok_or("value is too big or too small")?)
+        }
         (Int(a), Float(b)) => Float(a as f64 - b),
         (Float(a), Int(b)) => Float(a - b as f64),
         (Float(a), Float(b)) => Float(a - b),
@@ -162,11 +166,12 @@ pub fn sub(lhs: Value, rhs: Value) -> StrResult<Value> {
     })
 }
 
-
 /// Compute the product of two values.
 pub fn mul(lhs: Value, rhs: Value) -> StrResult<Value> {
     Ok(match (lhs, rhs) {
-        (Int(a), Int(b)) => Int(a.checked_mul(b).ok_or("value is too big or too small")?),
+        (Int(a), Int(b)) => {
+            Int(a.checked_mul(b).ok_or("value is too big or too small")?)
+        }
         (Int(a), Float(b)) => Float(a as f64 * b),
         (Float(a), Int(b)) => Float(a * b as f64),
         (Float(a), Float(b)) => Float(a * b),

--- a/src/eval/ops.rs
+++ b/src/eval/ops.rs
@@ -70,9 +70,7 @@ pub fn add(lhs: Value, rhs: Value) -> StrResult<Value> {
         (a, None) => a,
         (None, b) => b,
 
-        (Int(a), Int(b)) => {
-            Int(a.checked_add(b).ok_or("value is too large")?)
-        }
+        (Int(a), Int(b)) => Int(a.checked_add(b).ok_or("value is too large")?),
         (Int(a), Float(b)) => Float(a as f64 + b),
         (Float(a), Int(b)) => Float(a + b as f64),
         (Float(a), Float(b)) => Float(a + b),
@@ -139,9 +137,7 @@ pub fn add(lhs: Value, rhs: Value) -> StrResult<Value> {
 /// Compute the difference of two values.
 pub fn sub(lhs: Value, rhs: Value) -> StrResult<Value> {
     Ok(match (lhs, rhs) {
-        (Int(a), Int(b)) => {
-            Int(a.checked_sub(b).ok_or("value is too large")?)
-        }
+        (Int(a), Int(b)) => Int(a.checked_sub(b).ok_or("value is too large")?),
         (Int(a), Float(b)) => Float(a as f64 - b),
         (Float(a), Int(b)) => Float(a - b as f64),
         (Float(a), Float(b)) => Float(a - b),
@@ -169,9 +165,7 @@ pub fn sub(lhs: Value, rhs: Value) -> StrResult<Value> {
 /// Compute the product of two values.
 pub fn mul(lhs: Value, rhs: Value) -> StrResult<Value> {
     Ok(match (lhs, rhs) {
-        (Int(a), Int(b)) => {
-            Int(a.checked_mul(b).ok_or("value is too large")?)
-        }
+        (Int(a), Int(b)) => Int(a.checked_mul(b).ok_or("value is too large")?),
         (Int(a), Float(b)) => Float(a as f64 * b),
         (Float(a), Int(b)) => Float(a * b as f64),
         (Float(a), Float(b)) => Float(a * b),

--- a/tests/typ/compiler/ops.typ
+++ b/tests/typ/compiler/ops.typ
@@ -34,7 +34,7 @@
 #test((a: 1) + (b: 2, c: 3), (a: 1, b: 2, c: 3))
 
 ---
-// Error: 3-26 value is too big or too small
+// Error: 3-26 value is too large
 #(9223372036854775807 + 1)
 
 ---

--- a/tests/typ/compiler/ops.typ
+++ b/tests/typ/compiler/ops.typ
@@ -33,10 +33,16 @@
 #test((1, 2) + (3, 4), (1, 2, 3, 4))
 #test((a: 1) + (b: 2, c: 3), (a: 1, b: 2, c: 3))
 
+---
+// Error: 2-7 value is too big or too small
+#(9223372036854775807 + 1)
+
+---
 // Subtraction.
 #test(1-4, 3*-1)
 #test(4cm - 2cm, 2cm)
 #test(1e+2-1e-2, 99.99)
+
 
 // Multiplication.
 #test(2 * 4, 8)

--- a/tests/typ/compiler/ops.typ
+++ b/tests/typ/compiler/ops.typ
@@ -34,7 +34,7 @@
 #test((a: 1) + (b: 2, c: 3), (a: 1, b: 2, c: 3))
 
 ---
-// Error: 2-7 value is too big or too small
+// Error: 3-26 value is too big or too small
 #(9223372036854775807 + 1)
 
 ---

--- a/tests/typ/compiler/ops.typ
+++ b/tests/typ/compiler/ops.typ
@@ -43,7 +43,6 @@
 #test(4cm - 2cm, 2cm)
 #test(1e+2-1e-2, 99.99)
 
-
 // Multiplication.
 #test(2 * 4, 8)
 


### PR DESCRIPTION
This PR fixes an overflow which might occur, with expressions like `#(9223372036854775807 + 1)` for instance.