### PR TITLE
hint for unknown variable containing dash

### DIFF
--- a/src/eval/scope.rs
+++ b/src/eval/scope.rs
@@ -42,13 +42,7 @@ impl<'a> Scopes<'a> {
             .chain(self.scopes.iter().rev())
             .chain(self.base.map(|base| base.global.scope()))
             .find_map(|scope| scope.get(var))
-            .ok_or_else(|| {
-                if var.contains('-') {
-                    eco_format!("unknown variable: {} – if you meant to use subtraction, try adding space around the minus sign.", var)
-                } else {
-                    eco_format!("unknown variable: {}", var)
-                }
-            })
+            .ok_or_else(|| unknown_variable(var))
     }
 
     /// Try to access a variable immutably in math.
@@ -68,15 +62,19 @@ impl<'a> Scopes<'a> {
             .ok_or_else(|| {
                 match self.base.and_then(|base| base.global.scope().get(var)) {
                     Some(_) => eco_format!("cannot mutate a constant: {}", var),
-                    _ => {
-                        if var.contains('-') {
-                            eco_format!("unknown variable: {} – if you meant to use subtraction, try adding space around the minus sign.", var)
-                        } else {
-                            eco_format!("unknown variable: {}", var)
-                        }
-                    },
+                    _ => unknown_variable(var),
                 }
             })?
+    }
+}
+
+/// The error message when a variable is not found.
+#[cold]
+fn unknown_variable(var: &str) -> EcoString {
+    if var.contains('-') {
+        eco_format!("unknown variable: {} – if you meant to use subtraction, try adding spaces around the minus sign.", var)
+    } else {
+        eco_format!("unknown variable: {}", var)
     }
 }
 

--- a/src/eval/scope.rs
+++ b/src/eval/scope.rs
@@ -43,8 +43,8 @@ impl<'a> Scopes<'a> {
             .chain(self.base.map(|base| base.global.scope()))
             .find_map(|scope| scope.get(var))
             .ok_or_else(|| {
-                if let Some((a, b)) = var.split_once('-') {
-                    eco_format!("unknown variable: {} – did you mean {} - {}?", var, a, b)
+                if var.contains('-') {
+                    eco_format!("unknown variable: {} – if you meant to use subtraction, try adding space around the minus sign.", var)
                 } else {
                     eco_format!("unknown variable: {}", var)
                 }
@@ -68,7 +68,13 @@ impl<'a> Scopes<'a> {
             .ok_or_else(|| {
                 match self.base.and_then(|base| base.global.scope().get(var)) {
                     Some(_) => eco_format!("cannot mutate a constant: {}", var),
-                    _ => eco_format!("unknown variable: {}", var),
+                    _ => {
+                        if var.contains('-') {
+                            eco_format!("unknown variable: {} – if you meant to use subtraction, try adding space around the minus sign.", var)
+                        } else {
+                            eco_format!("unknown variable: {}", var)
+                        }
+                    },
                 }
             })?
     }

--- a/src/eval/scope.rs
+++ b/src/eval/scope.rs
@@ -43,7 +43,7 @@ impl<'a> Scopes<'a> {
             .chain(self.base.map(|base| base.global.scope()))
             .find_map(|scope| scope.get(var))
             .ok_or_else(|| {
-                if let Some((a, b)) = var.split_once("-") {
+                if let Some((a, b)) = var.split_once('-') {
                     eco_format!("unknown variable: {} – did you mean {} - {}?", var, a, b)
                 } else {
                     eco_format!("unknown variable: {}", var)

--- a/src/eval/scope.rs
+++ b/src/eval/scope.rs
@@ -42,7 +42,13 @@ impl<'a> Scopes<'a> {
             .chain(self.scopes.iter().rev())
             .chain(self.base.map(|base| base.global.scope()))
             .find_map(|scope| scope.get(var))
-            .ok_or_else(|| eco_format!("unknown variable: {}", var))
+            .ok_or_else(|| {
+                if let Some((a, b)) = var.split_once("-") {
+                    eco_format!("unknown variable: {} – did you mean {} - {}?", var, a, b)
+                } else {
+                    eco_format!("unknown variable: {}", var)
+                }
+            })
     }
 
     /// Try to access a variable immutably in math.

--- a/tests/typ/compiler/hint.typ
+++ b/tests/typ/compiler/hint.typ
@@ -4,3 +4,13 @@
 ---
 // Error: 1:17-1:19 expected length, found integer: a length needs a unit – did you mean 12pt?
 #set text(size: 12)
+
+---
+#{
+    let a = 2
+    a = 1-a
+    a = a -1
+
+    // Error: 9-12 unknown variable: a-1 – did you mean a - 1?
+    a = a-1
+}

--- a/tests/typ/compiler/hint.typ
+++ b/tests/typ/compiler/hint.typ
@@ -11,6 +11,12 @@
     a = 1-a
     a = a -1
 
-    // Error: 9-12 unknown variable: a-1 – did you mean a - 1?
+    // Error: 9-12 unknown variable: a-1 – if you meant to use subtraction, try adding space around the minus sign.
     a = a-1
+}
+
+---
+#{
+    // Error: 5-8 unknown variable: a-1 – if you meant to use subtraction, try adding space around the minus sign.
+    a-1 = 2
 }

--- a/tests/typ/compiler/hint.typ
+++ b/tests/typ/compiler/hint.typ
@@ -7,16 +7,16 @@
 
 ---
 #{
-    let a = 2
-    a = 1-a
-    a = a -1
+  let a = 2
+  a = 1-a
+  a = a -1
 
-    // Error: 9-12 unknown variable: a-1 – if you meant to use subtraction, try adding space around the minus sign.
-    a = a-1
+  // Error: 7-10 unknown variable: a-1 – if you meant to use subtraction, try adding spaces around the minus sign.
+  a = a-1
 }
 
 ---
 #{
-    // Error: 5-8 unknown variable: a-1 – if you meant to use subtraction, try adding space around the minus sign.
-    a-1 = 2
+  // Error: 3-6 unknown variable: a-1 – if you meant to use subtraction, try adding spaces around the minus sign.
+  a-1 = 2
 }


### PR DESCRIPTION
Fixes #868. When a unknown variable contains `-` the error message suggests subtraction. Currently this is just done at the first dash: `a-b-c` will result in `did you mean a - b-c`. It would also be possible to check if any split results in valid variables, but it would be more complicated to implement and would not be that much more helpful.