### PR TITLE
[Feature] Allow function as argument for string.replace

### DIFF
--- a/docs/src/reference/types.md
+++ b/docs/src/reference/types.md
@@ -361,8 +361,8 @@ string and returns the resulting string.
 
 - pattern: string or regex (positional, required)
   The pattern to search for.
-- replacement: string (positional, required)
-  The string to replace the matches with.
+- replacement: string or function (positional, required)
+  The string to replace the matches with or a function that is passed a match dictionary if a regex was used.
 - count: integer (named)
   If given, only the first `count` matches of the pattern are placed.
 - returns: string

--- a/src/eval/methods.rs
+++ b/src/eval/methods.rs
@@ -56,9 +56,9 @@ pub fn call(
             "matches" => Value::Array(string.matches(args.expect("pattern")?)),
             "replace" => {
                 let pattern = args.expect("pattern")?;
-                let with = args.expect("replacement string")?;
+                let with = args.expect("function or string")?;
                 let count = args.named("count")?;
-                Value::Str(string.replace(pattern, with, count))
+                Value::Str(string.replace(vm, span, pattern, with, count)?)
             }
             "trim" => {
                 let pattern = args.eat()?;

--- a/src/eval/methods.rs
+++ b/src/eval/methods.rs
@@ -56,9 +56,9 @@ pub fn call(
             "matches" => Value::Array(string.matches(args.expect("pattern")?)),
             "replace" => {
                 let pattern = args.expect("pattern")?;
-                let with = args.expect("function or string")?;
+                let with = args.expect("string or function")?;
                 let count = args.named("count")?;
-                Value::Str(string.replace(vm, span, pattern, with, count)?)
+                Value::Str(string.replace(vm, pattern, with, count)?)
             }
             "trim" => {
                 let pattern = args.eat()?;

--- a/tests/typ/compiler/string.typ
+++ b/tests/typ/compiler/string.typ
@@ -111,9 +111,7 @@
 #test(timesum("1:20, 2:10, 0:40"), "4:10")
 
 ---
-// Test the `replace` method.
-
-// with `Str` replacements
+// Test the `replace` method with `Str` replacements.
 #test("ABC".replace("", "-"), "-A-B-C-")
 #test("Ok".replace("Ok", "Nope", count: 0), "Ok")
 #test("to add?".replace("", "How ", count: 1), "How to add?")
@@ -128,40 +126,42 @@
 #test("123".replace(regex("\d$"), "_"), "12_")
 #test("123".replace(regex("\d{1,2}$"), "__"), "1__")
 
-// with `Func` replacements
+---
+// Test the `replace` method with `Func` replacements.
 
-//  with regex
-//    multiple matches
 #test("abc".replace(regex("[a-z]"), m => {
   str(m.start) + m.text + str(m.end)
 }), "0a11b22c3")
 #test("abcd, efgh".replace(regex("\w+"), m => {
   upper(m.text)
 }), "ABCD, EFGH")
-//    with capture groups - one match
 #test("hello : world".replace(regex("^(.+)\s*(:)\s*(.+)$"), m => {
   upper(m.captures.at(0)) + m.captures.at(1) + " " + upper(m.captures.at(2))
 }), "HELLO : WORLD")
-//    with capture groups - multiple matches
 #test("hello world, lorem ipsum".replace(regex("(\w+) (\w+)"), m => {
   m.captures.at(1) + " " + m.captures.at(0)
 }), "world hello, ipsum lorem")
-#test("hello world, lorem ipsum".replace(regex("(\w+) (\w+)"), m => {
+#test("hello world, lorem ipsum".replace(regex("(\w+) (\w+)"), count: 1, m => {
   m.captures.at(1) + " " + m.captures.at(0)
-}, count: 1), "world hello, lorem ipsum")
-//    no matches
+}), "world hello, lorem ipsum")
 #test("123 456".replace(regex("[a-z]+"), "a"), "123 456")
-//  with str
-//    multiple matches
-#test("abc".replace("", s => "-"), "-a-b-c-")
-#test("abc".replace("", s => "-", count: 1), "-abc")
-//    no matches
-#test("123".replace("abc", s => ""), "123")
-#test("123".replace("abc", s => "", count: 2), "123")
+
+#test("abc".replace("", m => "-"), "-a-b-c-")
+#test("abc".replace("", m => "-", count: 1), "-abc")
+#test("123".replace("abc", m => ""), "123")
+#test("123".replace("abc", m => "", count: 2), "123")
+#test("a123b123c".replace("123", m => {
+  str(m.start) + "-" + str(m.end)
+}), "a1-4b5-8c")
+#test("halla warld".replace("a", m => {
+  if m.start == 1 { "e" }
+  else if m.start == 4 or m.start == 7 { "o" }
+}), "hello world")
+#test("aaa".replace("a", m => str(m.captures.len())), "000")
 
 ---
 // Error: 23-24 expected string, found integer
-#"123".replace("123", s => 1)
+#"123".replace("123", m => 1)
 
 ---
 // Error: 23-32 expected string or function, found array

--- a/tests/typ/compiler/string.typ
+++ b/tests/typ/compiler/string.typ
@@ -112,6 +112,8 @@
 
 ---
 // Test the `replace` method.
+
+// with `Str` replacements
 #test("ABC".replace("", "-"), "-A-B-C-")
 #test("Ok".replace("Ok", "Nope", count: 0), "Ok")
 #test("to add?".replace("", "How ", count: 1), "How to add?")
@@ -125,6 +127,45 @@
 )
 #test("123".replace(regex("\d$"), "_"), "12_")
 #test("123".replace(regex("\d{1,2}$"), "__"), "1__")
+
+// with `Func` replacements
+
+//  with regex
+//    multiple matches
+#test("abc".replace(regex("[a-z]"), m => {
+  str(m.start) + m.text + str(m.end)
+}), "0a11b22c3")
+#test("abcd, efgh".replace(regex("\w+"), m => {
+  upper(m.text)
+}), "ABCD, EFGH")
+//    with capture groups - one match
+#test("hello : world".replace(regex("^(.+)\s*(:)\s*(.+)$"), m => {
+  upper(m.captures.at(0)) + m.captures.at(1) + " " + upper(m.captures.at(2))
+}), "HELLO : WORLD")
+//    with capture groups - multiple matches
+#test("hello world, lorem ipsum".replace(regex("(\w+) (\w+)"), m => {
+  m.captures.at(1) + " " + m.captures.at(0)
+}), "world hello, ipsum lorem")
+#test("hello world, lorem ipsum".replace(regex("(\w+) (\w+)"), m => {
+  m.captures.at(1) + " " + m.captures.at(0)
+}, count: 1), "world hello, lorem ipsum")
+//    no matches
+#test("123 456".replace(regex("[a-z]+"), "a"), "123 456")
+//  with str
+//    multiple matches
+#test("abc".replace("", s => "-"), "-a-b-c-")
+#test("abc".replace("", s => "-", count: 1), "-abc")
+//    no matches
+#test("123".replace("abc", s => ""), "123")
+#test("123".replace("abc", s => "", count: 2), "123")
+
+---
+// Error: 23-24 expected string, found integer
+#"123".replace("123", s => 1)
+
+---
+// Error: 23-32 expected string or function, found array
+#"123".replace("123", (1, 2, 3))
 
 ---
 // Test the `trim` method.


### PR DESCRIPTION
# Description
As per issue #393, this PR allows the `string.replace` function to either take a string as replacement *or a function which is called for every match*.

- When using a string for matching, the replacement function is only called once.
- When using a regex for matching, the replacement function is called with a ['match dictionary'](https://typst.app/docs/reference/types/string/#methods--match) just like the return type of `string.match`.
- Apart from the mentioned breaking changes, the behaviour when using a replacement string stays unchanged.

# Breaking changes

Previously, when using a `Str` replacement and a `regex`, the `re.replace` function was used which only replaces **the first match**. Now, the `re.replace_all` function is called to make this consistent over different argument type combinations. More specifically, in case both string for matching and replacing was used, the `&str.replace` was called which replaces **all** occurrences.

# Discussion

- The documentation is still a bit lacking. Especially, the type of the dictionary passed to the replacement function should be more prominently displayed. I think it would be best to provide an example, however I am not sure how to correctly do that for method. I have only seen examples at the top-level.
- Using `count.unwrap_or(usize::MAX)` increases readability, however this limits the amount of matches to 2^32 or 2^64, though this should not be a problem in practice.

# Examples

```
#test("hello world, lorem ipsum".replace(regex("(\w+) (\w+)"), m => {
  m.captures.at(1) + " " + m.captures.at(0)
}, count: 1), "world hello, ipsum lorem")

#test("abcd, efgh".replace(regex("\w+"), m => {
  upper(m.text)
}), "ABCD, EFGH")
```