### PR TITLE
Proposal: Add `get` to safely get values from array/dict with default values

### DIFF
--- a/src/eval/array.rs
+++ b/src/eval/array.rs
@@ -87,6 +87,11 @@ impl Array {
             .ok_or_else(|| out_of_bounds(index, len))
     }
 
+    /// Borrow the value of the given key or return a given default value
+    pub fn get<'a>(&'a self, index: i64, default: &'a Value) -> &Value {
+        self.locate(index).and_then(|i| self.0.get(i)).unwrap_or(default)
+    }
+
     /// Push a value to the end of the array.
     pub fn push(&mut self, value: Value) {
         self.0.push(value);

--- a/src/eval/dict.rs
+++ b/src/eval/dict.rs
@@ -65,6 +65,11 @@ impl Dict {
             .ok_or_else(|| missing_key(key))
     }
 
+    /// Borrow the value of the given key or return a given default value
+    pub fn get<'a>(&'a self, key: &str, default: &'a Value) -> &Value {
+        self.0.get(key).unwrap_or(default)
+    }
+
     /// Remove the value if the dictionary contains the given key.
     pub fn take(&mut self, key: &str) -> StrResult<Value> {
         Arc::make_mut(&mut self.0)

--- a/src/eval/methods.rs
+++ b/src/eval/methods.rs
@@ -87,6 +87,9 @@ pub fn call(
             "first" => array.first().at(span)?.clone(),
             "last" => array.last().at(span)?.clone(),
             "at" => array.at(args.expect("index")?).at(span)?.clone(),
+            "get" => array
+                .get(args.expect("index")?, &args.expect::<Value>("default")?)
+                .clone(),
             "slice" => {
                 let start = args.expect("start")?;
                 let mut end = args.eat()?;
@@ -123,6 +126,9 @@ pub fn call(
         Value::Dict(dict) => match method {
             "len" => Value::Int(dict.len()),
             "at" => dict.at(&args.expect::<Str>("key")?).at(span)?.clone(),
+            "get" => dict
+                .get(&args.expect::<Str>("key")?, &args.expect::<Value>("default")?)
+                .clone(),
             "keys" => Value::Array(dict.keys()),
             "values" => Value::Array(dict.values()),
             "pairs" => Value::Array(dict.pairs()),
@@ -297,6 +303,7 @@ pub fn methods_on(type_name: &str) -> &[(&'static str, bool)] {
             ("all", true),
             ("any", true),
             ("at", true),
+            ("get", true),
             ("contains", true),
             ("filter", true),
             ("find", true),
@@ -320,6 +327,7 @@ pub fn methods_on(type_name: &str) -> &[(&'static str, bool)] {
         ],
         "dictionary" => &[
             ("at", true),
+            ("get", true),
             ("insert", true),
             ("keys", false),
             ("len", false),

--- a/tests/typ/compiler/array.typ
+++ b/tests/typ/compiler/array.typ
@@ -241,3 +241,12 @@
 // Keyed pair after this is already identified as an array.
 // Error: 6-14 expected expression, found keyed pair
 #(1, "key": 2)
+
+---
+// Test get
+#{
+  let arr = (1, 2)
+  test(arr.get(0, 0), 1)
+  test(arr.get(1, 0), 2)
+  test(arr.get(2, 0), 0)
+}

--- a/tests/typ/compiler/dict.typ
+++ b/tests/typ/compiler/dict.typ
@@ -88,3 +88,12 @@
   // Error: 3-9 expected dictionary, found none
   object.property = "value"
 }
+
+---
+// Test get
+#{
+  let dict = (a: 1, b: 2)
+  test(dict.get("a", 0), 1)
+  test(dict.get("b", 0), 2)
+  test(dict.get("c", 0), 0)
+}


### PR DESCRIPTION
It's like `at`, but also takes a default value which is returned when the specified index/element was not found.

The current workaround that I have in all my typst codebases:

```
// safely get a value from a list, or return a default value
#let get(list, key, default) = {
  if key in list {
    list.at(key)
  } else {
    default
  }
}
```

If you agree with this proposal, I would write the necessary documentation.