### PR TITLE
Remove unnecessary closing bracket in example

### DIFF
--- a/library/src/visualize/shape.rs
+++ b/library/src/visualize/shape.rs
@@ -132,7 +132,7 @@ pub struct RectElem {
     /// current [text edges]($func/text.top-edge).
     ///
     /// ```example
-    /// #rect(inset: 0pt)[Tight])
+    /// #rect(inset: 0pt)[Tight]
     /// ```
     #[resolve]
     #[fold]


### PR DESCRIPTION
Fixes a bug in the example of [Rectangle Function -- inset](https://typst.app/docs/reference/visualize/rect/#parameters--inset).

![Typst_rect_inset_error](https://user-images.githubusercontent.com/8125678/234013156-bc310f8f-2531-4ee9-82a7-5582e0bd51d8.png)

The extra closing bracket seems to be unnecessary.