### PR TITLE
Add translation for Chinese (Traditional) 

### DIFF
--- a/library/src/math/mod.rs
+++ b/library/src/math/mod.rs
@@ -34,6 +34,7 @@ use ttf_parser::{GlyphId, Rect};
 use typst::eval::{Module, Scope};
 use typst::font::{Font, FontWeight};
 use typst::model::Guard;
+use typst::util::option_eq;
 use unicode_math_class::MathClass;
 
 use self::ctx::*;
@@ -277,10 +278,11 @@ impl Count for EquationElem {
 }
 
 impl LocalName for EquationElem {
-    fn local_name(&self, lang: Lang, _: Option<Region>) -> &'static str {
+    fn local_name(&self, lang: Lang, region: Option<Region>) -> &'static str {
         match lang {
             Lang::ARABIC => "معادلة",
             Lang::BOKMÅL => "Ligning",
+            Lang::CHINESE if option_eq(region, "TW") => "方程式",
             Lang::CHINESE => "等式",
             Lang::CZECH => "Rovnice",
             Lang::FRENCH => "Équation",

--- a/library/src/meta/bibliography.rs
+++ b/library/src/meta/bibliography.rs
@@ -7,6 +7,7 @@ use ecow::{eco_vec, EcoVec};
 use hayagriva::io::{BibLaTeXError, YamlBibliographyError};
 use hayagriva::style::{self, Brackets, Citation, Database, DisplayString, Formatting};
 use hayagriva::Entry;
+use typst::util::option_eq;
 
 use super::{LinkElem, LocalName, RefElem};
 use crate::layout::{BlockElem, GridElem, ParElem, Sizing, TrackSizings, VElem};
@@ -210,10 +211,11 @@ impl Finalize for BibliographyElem {
 }
 
 impl LocalName for BibliographyElem {
-    fn local_name(&self, lang: Lang, _: Option<Region>) -> &'static str {
+    fn local_name(&self, lang: Lang, region: Option<Region>) -> &'static str {
         match lang {
             Lang::ARABIC => "المراجع",
             Lang::BOKMÅL => "Bibliografi",
+            Lang::CHINESE if option_eq(region, "TW") => "書目",
             Lang::CHINESE => "参考文献",
             Lang::CZECH => "Bibliografie",
             Lang::FRENCH => "Bibliographie",

--- a/library/src/meta/heading.rs
+++ b/library/src/meta/heading.rs
@@ -1,4 +1,5 @@
 use typst::font::FontWeight;
+use typst::util::option_eq;
 
 use super::{Counter, CounterUpdate, LocalName, Numbering, Refable};
 use crate::layout::{BlockElem, HElem, VElem};
@@ -234,10 +235,11 @@ impl Refable for HeadingElem {
 }
 
 impl LocalName for HeadingElem {
-    fn local_name(&self, lang: Lang, _: Option<Region>) -> &'static str {
+    fn local_name(&self, lang: Lang, region: Option<Region>) -> &'static str {
         match lang {
             Lang::ARABIC => "الفصل",
             Lang::BOKMÅL => "Kapittel",
+            Lang::CHINESE if option_eq(region, "TW") => "小節",
             Lang::CHINESE => "小节",
             Lang::CZECH => "Kapitola",
             Lang::FRENCH => "Chapitre",


### PR DESCRIPTION
This PR is the cleanup version of #911 since #926 has landed.

Some notable changes:

- `zh_TW` for Traditional Chinese; `zh` without region code for Simplified Chinese.
- The numbering feature can't be implemented as we can't distinguish translations of the 1st number in `zht` and `zhs`. It is better to add a `lang` flag to indicate which numbering kind should be used. I mark it as `#[allow(unused)]` and add a `TODO` on it.
