### PR TITLE
Remove reference to before and after arguments in query docs

### DIFF
--- a/library/src/meta/query.rs
+++ b/library/src/meta/query.rs
@@ -112,8 +112,6 @@ pub fn query(
     /// the query's result is reduced. If you could call it directly at the top
     /// level of a module, the evaluation of the whole module and its exports
     /// could depend on the query's result.
-    ///
-    /// Only one of this, `before`, and `after` shall be given.
     location: Location,
 ) -> Value {
     let _ = location;


### PR DESCRIPTION
This PR removes the ‘Only one of this, `before`, and `after` shall be given.’ in the docs for the `location` parameter for the `query` function.