### PR TITLE
Add `calc.random(seed, min, max)` function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,6 +646,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "git+https://github.com/smol-rs/fastrand.git#46527e07b095a2a00be75cb5ee521cc27fe6c571"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "fdeflate"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2055,7 +2063,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
- "fastrand",
+ "fastrand 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.3.5",
  "rustix",
  "windows-sys 0.45.0",
@@ -2378,6 +2386,7 @@ dependencies = [
  "comemo",
  "csv",
  "ecow",
+ "fastrand 1.9.0 (git+https://github.com/smol-rs/fastrand.git)",
  "hayagriva",
  "hypher",
  "kurbo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,14 +646,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "1.9.0"
-source = "git+https://github.com/smol-rs/fastrand.git#46527e07b095a2a00be75cb5ee521cc27fe6c571"
-dependencies = [
- "instant",
-]
-
-[[package]]
 name = "fdeflate"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2063,7 +2055,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
- "fastrand 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fastrand",
  "redox_syscall 0.3.5",
  "rustix",
  "windows-sys 0.45.0",
@@ -2386,7 +2378,7 @@ dependencies = [
  "comemo",
  "csv",
  "ecow",
- "fastrand 1.9.0 (git+https://github.com/smol-rs/fastrand.git)",
+ "fastrand",
  "hayagriva",
  "hypher",
  "kurbo",

--- a/library/Cargo.toml
+++ b/library/Cargo.toml
@@ -43,4 +43,4 @@ unicode-math-class = "0.1"
 unicode-script = "0.5"
 unicode-segmentation = "1"
 xi-unicode = "0.3"
-fastrand = {git = "https://github.com/smol-rs/fastrand.git"}
+fastrand = "1.9.0"

--- a/library/Cargo.toml
+++ b/library/Cargo.toml
@@ -43,3 +43,4 @@ unicode-math-class = "0.1"
 unicode-script = "0.5"
 unicode-segmentation = "1"
 xi-unicode = "0.3"
+fastrand = {git = "https://github.com/smol-rs/fastrand.git"}

--- a/library/src/compute/calc.rs
+++ b/library/src/compute/calc.rs
@@ -972,7 +972,7 @@ pub fn quo(
 /// ## Example
 /// ```example
 /// #assert(calc.random(seed: 1) == calc.random(seed: 1))
-/// #assert(calc.random(seed: 1) == calc.random(seed: 2))
+/// #assert(calc.random(seed: 1) != calc.random(seed: 2))
 /// ```
 ///
 /// Display: Random

--- a/library/src/compute/calc.rs
+++ b/library/src/compute/calc.rs
@@ -983,10 +983,10 @@ pub fn random(
     #[named]
     #[default(0x4d595df4d0f33173)]
     seed: u64,
-    /// The minimum number that can be returned
+    /// The minimum number that can be returned, inclusive
     #[default(0)]
     min: i64,
-    /// The maximum number that can be returned
+    /// The maximum number that can be returned, exclusive
     #[default(100)]
     max: i64,
 ) -> Value {

--- a/library/src/compute/calc.rs
+++ b/library/src/compute/calc.rs
@@ -980,7 +980,7 @@ pub fn quo(
 ///
 /// Display: Random integer
 /// Category: Calculate
-/// Returns: integer
+/// Returns: [integer]
 pub fn rand_int(
     /// The seed, optional
     #[named]
@@ -992,13 +992,23 @@ pub fn rand_int(
     /// The maximum number that can be returned, exclusive
     #[default(100)]
     max: i64,
+    /// How many numbers are returned
+    #[named]
+    #[default(1)]
+    out: u64,
 ) -> Value {
+    let mut vec = Vec::new();
     if seed != DEFAULT_SEED {
         fastrand::seed(seed);
-        Value::Int(fastrand::i64(min..max))
+        for _ in 0..out {
+            vec.push(Value::Int(fastrand::i64(min..max)))
+        }
     } else {
-        Value::Int(fastrand::i64(min..max))
+        for _ in 0..out {
+            vec.push(Value::Int(fastrand::i64(min..max)))
+        }
     }
+    vec.into()
 }
 
 #[comemo::memoize]
@@ -1019,13 +1029,23 @@ pub fn rand_float(
     #[named]
     #[default(DEFAULT_SEED)]
     seed: u64,
+    /// How many numbers are returned
+    #[named]
+    #[default(1)]
+    out: u64,
 ) -> Value {
+    let mut vec = Vec::new();
     if seed != DEFAULT_SEED {
         fastrand::seed(seed);
-        Value::Float(fastrand::f64())
+        for _ in 0..out {
+            vec.push(Value::Float(fastrand::f64()))
+        }
     } else {
-        Value::Float(fastrand::f64())
+        for _ in 0..out {
+            vec.push(Value::Float(fastrand::f64()))
+        }
     }
+    vec.into()
 }
 
 /// A value which can be passed to functions that work with integers and floats.

--- a/library/src/compute/calc.rs
+++ b/library/src/compute/calc.rs
@@ -971,7 +971,8 @@ pub fn quo(
 ///
 /// ## Example
 /// ```example
-/// #assert(calc.random() != calc.random())
+/// #assert(calc.random(seed: 1) == calc.random(seed: 1))
+/// #assert(calc.random(seed: 1) == calc.random(seed: 2))
 /// ```
 ///
 /// Display: Random
@@ -982,8 +983,12 @@ pub fn random(
     #[named]
     #[default(0x4d595df4d0f33173)]
     seed: u64,
-    #[default(0)] min: i64,
-    #[default(100)] max: i64,
+    /// The minimum number that can be returned
+    #[default(0)]
+    min: i64,
+    /// The maximum number that can be returned
+    #[default(100)]
+    max: i64,
 ) -> Value {
     if seed != 0x4d595df4d0f33173 {
         fastrand::seed(seed);

--- a/library/src/compute/calc.rs
+++ b/library/src/compute/calc.rs
@@ -45,6 +45,7 @@ pub fn module() -> Module {
     scope.define("mod", mod_);
     scope.define("quo", quo);
     scope.define("random", random);
+    scope.define("random_float", random_float);
     scope.define("inf", Value::Float(f64::INFINITY));
     scope.define("nan", Value::Float(f64::NAN));
     scope.define("pi", Value::Float(std::f64::consts::PI));
@@ -995,6 +996,33 @@ pub fn random(
         Value::Int(fastrand::i64(min..max))
     } else {
         Value::Int(fastrand::i64(min..max))
+    }
+}
+
+#[comemo::memoize]
+#[func]
+/// Returns a random number between 0 and 1
+///
+/// ## Example
+/// ```example
+/// #assert(calc.random_float(seed: 1) == calc.random_float(seed: 1))
+/// #assert(calc.random_float(seed: 1) != calc.random_float(seed: 2))
+/// ```
+///
+/// Display: Random
+/// Category: Calculate
+/// Returns: float
+pub fn random_float(
+    /// The seed, optional
+    #[named]
+    #[default(0x4d595df4d0f33173)]
+    seed: u64,
+) -> Value {
+    if seed != 0x4d595df4d0f33173 {
+        fastrand::seed(seed);
+        Value::Float(fastrand::f64())
+    } else {
+        Value::Float(fastrand::f64())
     }
 }
 

--- a/library/src/compute/calc.rs
+++ b/library/src/compute/calc.rs
@@ -44,8 +44,8 @@ pub fn module() -> Module {
     scope.define("rem", rem);
     scope.define("mod", mod_);
     scope.define("quo", quo);
-    scope.define("random", random);
-    scope.define("random_float", random_float);
+    scope.define("rand_int", rand_int);
+    scope.define("rand_float", rand_float);
     scope.define("inf", Value::Float(f64::INFINITY));
     scope.define("nan", Value::Float(f64::NAN));
     scope.define("pi", Value::Float(std::f64::consts::PI));
@@ -972,14 +972,14 @@ pub fn quo(
 ///
 /// ## Example
 /// ```example
-/// #assert(calc.random(seed: 1) == calc.random(seed: 1))
-/// #assert(calc.random(seed: 1) != calc.random(seed: 2))
+/// #assert(calc.rand_int(seed: 1) == calc.rand_int(seed: 1))
+/// #assert(calc.rand_int(seed: 1) != calc.rand_int(seed: 2))
 /// ```
 ///
-/// Display: Random
+/// Display: Random integer
 /// Category: Calculate
 /// Returns: integer
-pub fn random(
+pub fn rand_int(
     /// The seed, optional
     #[named]
     #[default(0x4d595df4d0f33173)]
@@ -1005,14 +1005,14 @@ pub fn random(
 ///
 /// ## Example
 /// ```example
-/// #assert(calc.random_float(seed: 1) == calc.random_float(seed: 1))
-/// #assert(calc.random_float(seed: 1) != calc.random_float(seed: 2))
+/// #assert(calc.rand_float(seed: 1) == calc.rand_float(seed: 1))
+/// #assert(calc.rand_float(seed: 1) != calc.rand_float(seed: 2))
 /// ```
 ///
-/// Display: Random
+/// Display: Random float
 /// Category: Calculate
 /// Returns: float
-pub fn random_float(
+pub fn rand_float(
     /// The seed, optional
     #[named]
     #[default(0x4d595df4d0f33173)]

--- a/library/src/compute/calc.rs
+++ b/library/src/compute/calc.rs
@@ -9,6 +9,8 @@ use typst::eval::{Module, Scope};
 
 use crate::prelude::*;
 
+const DEFAULT_SEED: u64 = 0x4d595df4d0f33173;
+
 /// A module with computational functions.
 pub fn module() -> Module {
     let mut scope = Scope::new();
@@ -982,7 +984,7 @@ pub fn quo(
 pub fn rand_int(
     /// The seed, optional
     #[named]
-    #[default(0x4d595df4d0f33173)]
+    #[default(DEFAULT_SEED)]
     seed: u64,
     /// The minimum number that can be returned, inclusive
     #[default(0)]
@@ -991,7 +993,7 @@ pub fn rand_int(
     #[default(100)]
     max: i64,
 ) -> Value {
-    if seed != 0x4d595df4d0f33173 {
+    if seed != DEFAULT_SEED {
         fastrand::seed(seed);
         Value::Int(fastrand::i64(min..max))
     } else {
@@ -1015,10 +1017,10 @@ pub fn rand_int(
 pub fn rand_float(
     /// The seed, optional
     #[named]
-    #[default(0x4d595df4d0f33173)]
+    #[default(DEFAULT_SEED)]
     seed: u64,
 ) -> Value {
-    if seed != 0x4d595df4d0f33173 {
+    if seed != DEFAULT_SEED {
         fastrand::seed(seed);
         Value::Float(fastrand::f64())
     } else {

--- a/library/src/compute/calc.rs
+++ b/library/src/compute/calc.rs
@@ -4,6 +4,7 @@ use std::cmp;
 use std::cmp::Ordering;
 use std::ops::{Div, Rem};
 
+use fastrand;
 use typst::eval::{Module, Scope};
 
 use crate::prelude::*;
@@ -43,6 +44,7 @@ pub fn module() -> Module {
     scope.define("rem", rem);
     scope.define("mod", mod_);
     scope.define("quo", quo);
+    scope.define("random", random);
     scope.define("inf", Value::Float(f64::INFINITY));
     scope.define("nan", Value::Float(f64::NAN));
     scope.define("pi", Value::Float(std::f64::consts::PI));
@@ -960,6 +962,35 @@ pub fn quo(
         Num::Int(i) => i,
         Num::Float(f) => f.floor() as i64, // Note: the result should be an integer but floats doesn't have the same precision as i64.
     })
+}
+
+#[comemo::memoize]
+#[func]
+/// Returns a random number
+///
+///
+/// ## Example
+/// ```example
+/// #assert(calc.random() != calc.random())
+/// ```
+///
+/// Display: Random
+/// Category: Calculate
+/// Returns: integer
+pub fn random(
+    /// The seed, optional
+    #[named]
+    #[default(0x4d595df4d0f33173)]
+    seed: u64,
+    #[default(0)] min: i64,
+    #[default(100)] max: i64,
+) -> Value {
+    if seed != 0x4d595df4d0f33173 {
+        fastrand::seed(seed);
+        Value::Int(fastrand::i64(min..max))
+    } else {
+        Value::Int(fastrand::i64(min..max))
+    }
 }
 
 /// A value which can be passed to functions that work with integers and floats.

--- a/tests/typ/compute/calc.typ
+++ b/tests/typ/compute/calc.typ
@@ -221,3 +221,10 @@
 ---
 // Error: 18-19 number must not be zero
 #range(10, step: 0)
+
+---
+ 
+#assert(calc.random(seed: 1) == calc.random(seed: 1))
+#assert(calc.random() == calc.random()) // Even if not explicitly seed, the function uses an internal seed, so it should return the same.
+#assert(calc.random(1, 2) < 2) // v Checking for ranges (maybe test a few times) 
+#assert(calc.random(1, 2) > 0) // <

--- a/tests/typ/compute/calc.typ
+++ b/tests/typ/compute/calc.typ
@@ -225,6 +225,13 @@
 ---
  
 #assert(calc.random(seed: 1) == calc.random(seed: 1))
+#assert(calc.random(seed: 1) != calc.random(seed: 2))
 #assert(calc.random() == calc.random()) // Even if not explicitly seed, the function uses an internal seed, so it should return the same.
 #assert(calc.random(1, 2) < 2) // v Checking for ranges (maybe test a few times) 
 #assert(calc.random(1, 2) > 0) // <
+
+---
+
+#assert(calc.random_float(seed: 1) == calc.random_float(seed: 1))
+#assert(calc.random(seed: 1) != calc.random(seed: 2))
+#assert(calc.random() == calc.random())

--- a/tests/typ/compute/calc.typ
+++ b/tests/typ/compute/calc.typ
@@ -224,14 +224,16 @@
 
 ---
  
-#assert(calc.rand_int(seed: 1) == calc.rand_int(seed: 1))
-#assert(calc.rand_int(seed: 1) != calc.rand_int(seed: 2))
-#assert(calc.rand_int() == calc.rand_int()) // Even if not explicitly seed, the function uses an internal seed, so it should return the same.
-#assert(calc.rand_int(1, 2) < 2) // v Checking for ranges (maybe test a few times) 
-#assert(calc.rand_int(1, 2) > 0) // <
+#assert(calc.rand_int(seed: 1, out: 1) == calc.rand_int(seed: 1, out: 1))
+#assert(calc.rand_int(seed: 1, out: 1) != calc.rand_int(seed: 1, out: 2))
+#assert(calc.rand_int(seed: 1, out: 2).at(1) != calc.rand_int(seed: 2, out: 2).at(1))
+#assert(calc.rand_int(out: 1) == calc.rand_int(out: 1)) // Even if not explicitly seed, the function uses an internal seed, so it should return the same.
+#assert(calc.rand_int(1, 2, out: 1).at(0) < 2) // v Checking for ranges (maybe test a few times) 
+#assert(calc.rand_int(1, 2).at(0) > 0) // <
 
 ---
 
-#assert(calc.rand_float(seed: 1) == calc.rand_float(seed: 1))
-#assert(calc.rand_float(seed: 1) != calc.rand_float(seed: 2))
-#assert(calc.rand_float() == calc.rand_float())
+#assert(calc.rand_float(seed: 1, out: 1) == calc.rand_float(seed: 1, out: 1))
+#assert(calc.rand_float(seed: 1, out: 1) != calc.rand_float(seed: 1, out: 2))
+#assert(calc.rand_float(seed: 1, out: 10) != calc.rand_float(seed: 2, out: 10))
+#assert(calc.rand_float(out: 3) == calc.rand_float(out: 3))

--- a/tests/typ/compute/calc.typ
+++ b/tests/typ/compute/calc.typ
@@ -224,14 +224,14 @@
 
 ---
  
-#assert(calc.random(seed: 1) == calc.random(seed: 1))
-#assert(calc.random(seed: 1) != calc.random(seed: 2))
-#assert(calc.random() == calc.random()) // Even if not explicitly seed, the function uses an internal seed, so it should return the same.
-#assert(calc.random(1, 2) < 2) // v Checking for ranges (maybe test a few times) 
-#assert(calc.random(1, 2) > 0) // <
+#assert(calc.rand_int(seed: 1) == calc.rand_int(seed: 1))
+#assert(calc.rand_int(seed: 1) != calc.rand_int(seed: 2))
+#assert(calc.rand_int() == calc.rand_int()) // Even if not explicitly seed, the function uses an internal seed, so it should return the same.
+#assert(calc.rand_int(1, 2) < 2) // v Checking for ranges (maybe test a few times) 
+#assert(calc.rand_int(1, 2) > 0) // <
 
 ---
 
-#assert(calc.random_float(seed: 1) == calc.random_float(seed: 1))
-#assert(calc.random(seed: 1) != calc.random(seed: 2))
-#assert(calc.random() == calc.random())
+#assert(calc.rand_float(seed: 1) == calc.rand_float(seed: 1))
+#assert(calc.rand_float(seed: 1) != calc.rand_float(seed: 2))
+#assert(calc.rand_float() == calc.rand_float())


### PR DESCRIPTION
Adds a `random()` function to the `calc` category. This function takes 3 optional arguments:

- `seed`: The RNG seed (default: `0x4d595df4d0f33173`)
- `min`: The minimum number in range (default: 0)
- `max`: The maximum number in range (default: 100)

Note that this RNG is deterministic, as we considered that, the same input should **always** return the same output.

Fixes #984