### PR TITLE
Add `.yaml` to supported bib file exts and update uknown bib format message

### DIFF
--- a/library/src/meta/bibliography.rs
+++ b/library/src/meta/bibliography.rs
@@ -628,7 +628,7 @@ fn parse_bib(path_str: &str, src: &str) -> StrResult<Vec<hayagriva::Entry>> {
                 .map(|error| format_biblatex_error(path_str, src, error))
                 .unwrap_or_else(|| eco_format!("failed to parse {path_str}"))
         }),
-        _ => Err("unknown bibliography format".into()),
+        _ => Err("unknown bibliography format (must be .yml/.yaml or .bib)".into()),
     }
 }
 

--- a/library/src/meta/bibliography.rs
+++ b/library/src/meta/bibliography.rs
@@ -614,12 +614,14 @@ fn load(
     }
 }
 
-/// Parse a bibliography file (bib/yml)
+/// Parse a bibliography file (bib/yml/yaml)
 fn parse_bib(path_str: &str, src: &str) -> StrResult<Vec<hayagriva::Entry>> {
     let path = Path::new(path_str);
     let ext = path.extension().and_then(OsStr::to_str).unwrap_or_default();
     match ext.to_lowercase().as_str() {
-        "yml" => hayagriva::io::from_yaml_str(src).map_err(format_hayagriva_error),
+        "yml" | "yaml" => {
+            hayagriva::io::from_yaml_str(src).map_err(format_hayagriva_error)
+        }
         "bib" => hayagriva::io::from_biblatex_str(src).map_err(|err| {
             err.into_iter()
                 .next()


### PR DESCRIPTION
Adds support for the `.yaml` file extension when parsing bibliography files.

Also updates the `unknown format` error message to include the valid extensions, as per [@PgBiel's comment](https://github.com/typst/typst/issues/1048#issuecomment-1529133160).

@PgBiel 

Let me know if there is something missing.

Closes: #1048 