### PR TITLE
Add models.not

### DIFF
--- a/library/src/symbols/sym.rs
+++ b/library/src/symbols/sym.rs
@@ -396,7 +396,7 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
     not: '¬',
     and: ['∧', big: '⋀', curly: '⋏', dot: '⟑', double: '⩓'],
     or: ['∨', big: '⋁', curly: '⋎', dot: '⟇', double: '⩔'],
-    models: '⊧',
+    models: ['⊨', not: '⊭'],
     therefore: '∴',
     because: '∵',
     qed: '∎',


### PR DESCRIPTION
Adds the models.not symbol (U+22AD "Not True") and replaces the previous models (U+22A7 "Models") with (U+22A8 "True").

@laurmaedje's concern was:
> I think we need good reasons if we decide to ignore/override what Unicode did. 

I think ease of use and just the fact that people know this sign under the name "models" not "true" beats the fact that it doesn't align with the old unicode name. And this is already a thing with other symbols in typst. Only a few people who use typst actually think about the unicode characters behind the symbols they use. And lastly if TeX can do it I think we can too :) It will way make more people unhappy when they can't find the ⊭ symbol under the name models than people who feel betrayed when models actually refers to the unicode symbol "true".