### PR TITLE
Extract version for Nix from the workspace

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,7 +56,7 @@
         '';
 
         GEN_ARTIFACTS = "artifacts";
-        TYPST_VERSION = "${(importTOML ./cli/Cargo.toml).package.version} (${rev "unknown hash"})";
+        TYPST_VERSION = "${(importTOML ./Cargo.toml).package.version} (${rev "unknown hash"})";
       };
     in
     {


### PR DESCRIPTION
Not so far ago `cli/Cargo.toml` was changed to use the same crate version as the whole workspace. It has broken Typst's flake since it extracted the Typst version from that file. This PR fixes it by making it extract the version from the workspace `Cargo.toml`.