### PR TITLE
Forced size command in math

### DIFF
--- a/library/src/math/mod.rs
+++ b/library/src/math/mod.rs
@@ -97,6 +97,7 @@ pub fn module() -> Module {
     math.define("frak", frak);
     math.define("mono", mono);
     math.define("bb", bb);
+    math.define("withsize", withsize);
 
     // Text operators.
     math.define("op", OpElem::func());

--- a/library/src/math/style.rs
+++ b/library/src/math/style.rs
@@ -178,6 +178,34 @@ pub fn bb(
         .into()
 }
 
+/// Forced size style in math.
+///
+/// Size style may be one of:
+/// - display
+/// - text
+/// - script
+/// - script-script
+///
+/// ## Example
+/// ```example
+/// $ withsize("display", sum_i (x_i mu_i)/sigma_i^2)/withsize("script", sum_i (mu_i^2)/sigma_i^2) $
+/// ```
+///
+/// Display: With Size
+/// Category: math
+/// Returns: content
+#[func]
+pub fn withsize(
+    /// The content to style.
+    size: MathSize,
+    body: Content,
+) -> Value {
+    MathStyleElem::new(body)
+        .with_size(Some(size))
+        .pack()
+        .into()
+}
+
 /// A font variant in math.
 ///
 /// Display: Bold
@@ -196,6 +224,9 @@ pub struct MathStyleElem {
 
     /// Whether to use italic glyphs.
     pub italic: Option<bool>,
+
+    /// Whether to use forced size
+    pub size: Option<MathSize>
 }
 
 impl LayoutMath for MathStyleElem {
@@ -210,6 +241,9 @@ impl LayoutMath for MathStyleElem {
         }
         if let Some(italic) = self.italic(StyleChain::default()) {
             style = style.with_italic(italic);
+        }
+        if let Some(size) = self.size(StyleChain::default()) {
+            style = style.with_size(size);
         }
         ctx.style(style);
         self.body().layout_math(ctx)?;
@@ -295,7 +329,7 @@ impl MathStyle {
 /// The size of elements in an equation.
 ///
 /// See the TeXbook p. 141.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Cast)]
 pub enum MathSize {
     /// Second-level sub- and superscripts.
     ScriptScript,


### PR DESCRIPTION
Hello, I have recently seen #1117 and #1116, where to make a thing in fraction bigger there were suggested ugly constructions with boxes. It is quite common need if typing large math fractions and exponentials. I was a bit disgusted by currently available solutions to change the size type in math, so I thought it would be sensible to add to math library analogues of `\displaystyle` in LaTex. I made it work the same way as `bb`, `italic` and others. Though, I use there a string argument to select size instead of separate functions for each size.

Probably, it would be better to create a separate function for each size like it is done with `MathVariant`, but that seemed to me a bit of excessive for the start. If this feature *fits* the library, the proper names for these functions have to be selected as I'm still new to typst and don't know most of it's conventions.

> P.S. I'm sorry if I messed with something, that is actually my first PR.