### PR TITLE
Verbose Errors

### DIFF
--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -1567,7 +1567,8 @@ impl<'s> Parser<'s> {
 
     fn error(&mut self, message: impl Into<EcoString>) {
         self.unskip();
-        self.nodes.push(SyntaxNode::error(message, self.current_text(), ErrorPos::Full));
+        self.nodes
+            .push(SyntaxNode::error(message, self.current_text(), ErrorPos::Full));
         self.skip();
     }
 

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -1052,7 +1052,7 @@ fn for_loop(p: &mut Parser) {
     pattern(p);
     if p.at(SyntaxKind::Comma) {
         p.expected("keyword `in`");
-        p.error("Did you mean to use a destructuring pattern?")
+        p.error("Did you mean to use a destructuring pattern?");
         if !p.eat_if(SyntaxKind::Ident) {
             p.eat_if(SyntaxKind::Underscore);
         }


### PR DESCRIPTION
Seperated Error Logging and Expected, for easy custom errors when needed. 
Expected functions now log out what they found instead aswell.

Solves issues #1123 