### PR TITLE
Fix typo in text fractions tooltip

### DIFF
--- a/library/src/text/mod.rs
+++ b/library/src/text/mod.rs
@@ -418,7 +418,7 @@ pub struct TextElem {
     #[default(false)]
     pub slashed_zero: bool,
 
-    /// Whether to turns numbers into fractions. Setting this to `{true}`
+    /// Whether to turn numbers into fractions. Setting this to `{true}`
     /// enables the OpenType `frac` font feature.
     ///
     /// ```example


### PR DESCRIPTION
This typo shows up in the web UI as a tooltip.
![grafik](https://github.com/typst/typst/assets/40455076/8cdca554-7b9d-4e91-b0b1-df63a1f489c5)

Loving Typst by the way. Keep it up!