### PR TITLE
CLI option for emitting diagnostics in a unix-style short format

### DIFF
--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -21,6 +21,10 @@ pub struct CliArguments {
     /// Sets the level of verbosity: 0 = none, 1 = warning & error, 2 = info, 3 = debug, 4 = trace
     #[clap(short, long, action = ArgAction::Count)]
     pub verbosity: u8,
+
+    /// Whether to emit diagnostics in a unix-style short form
+    #[clap(long, default_value_t = false)]
+    pub message_format_short: bool,
 }
 
 /// What to do.


### PR DESCRIPTION
Addresses #1168.

The newly added command line argument `--message-format-short` allows diagnostics to be emitted in an easy to parse format that is supported out of the box by common tool such as vim: `chap1.typ:15:10: error message`.

The current implementation adds the flag to `CliArguments` and `CompileSettings` and passes the information to function `print_diagnostics` as a new boolean argument. I considered adding the flag to `SystemWorld` instead of `CompileSettings` because it's passed to `print_diagnostics` already, but it didn't really seem like something that belonged in there conceptually.

I'm open to feedback on that point specifically and on the implementation in general!