### PR TITLE
cli: Emit escape codes only if output is a tty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2323,6 +2323,7 @@ dependencies = [
 name = "typst-cli"
 version = "0.3.0"
 dependencies = [
+ "atty",
  "chrono",
  "clap 4.2.5",
  "clap_complete",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,6 +22,7 @@ doc = false
 [dependencies]
 typst = { path = ".." }
 typst-library = { path = "../library" }
+atty = "0.2"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 clap = { version = "4.2.4", features = ["derive", "env"] }
 codespan-reporting = "0.11"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -9,6 +9,7 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process;
 
+use atty::Stream;
 use clap::Parser;
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use codespan_reporting::term::{self, termcolor};
@@ -282,7 +283,9 @@ fn status(command: &CompileSettings, status: Status) -> io::Result<()> {
     let color = status.color();
 
     let mut w = StandardStream::stderr(ColorChoice::Auto);
-    write!(w, "{esc}c{esc}[1;1H")?;
+    if atty::is(Stream::Stderr) {
+        write!(w, "{esc}c{esc}[1;1H")?;
+    }
 
     w.set_color(&color)?;
     write!(w, "watching")?;


### PR DESCRIPTION
Emit escape code for clearing the terminal only if output (stderr) is a tty.

Fixes #1179.

Not tested on windows but `atty` should handle it correctly.