### PR TITLE
Update string doc: index can be negative

### DIFF
--- a/docs/src/reference/types.md
+++ b/docs/src/reference/types.md
@@ -219,7 +219,8 @@ Typst provides utility methods for string manipulation. Many of these methods
 either a string or a [regular expression]($func/regex). This makes the methods
 quite versatile.
 
-All lengths and indices are expressed in terms of UTF-8 bytes.
+All lengths and indices are expressed in terms of UTF-8 characters. Indices are
+zero-based and negative indices wrap around to the end of the string.
 
 ### Example
 ```example

--- a/tests/typ/compiler/string.typ
+++ b/tests/typ/compiler/string.typ
@@ -24,6 +24,8 @@
 // Test the `at` method.
 #test("Hello".at(1), "e")
 #test("Hello".at(4), "o")
+#test("Hello".at(-1), "o")
+#test("Hello".at(-2), "l")
 #test("Hey: 🏳️‍🌈 there!".at(5), "🏳️‍🌈")
 
 ---


### PR DESCRIPTION
The unit test verifies this with test cases on `at()` and `slice()` methods, where the cases for `at()` were newly added by this patch.