### PR TITLE
Print the string that is not castable to number

### DIFF
--- a/library/src/compute/construct.rs
+++ b/library/src/compute/construct.rs
@@ -38,7 +38,7 @@ cast_from_value! {
     v: bool => Self(v as i64),
     v: i64 => Self(v),
     v: f64 => Self(v as i64),
-    v: EcoString => Self(v.parse().map_err(|_| "not a valid integer")?),
+    v: EcoString => Self(v.parse().map_err(|_| eco_format!("invalid integer: {}", v))?),
 }
 
 /// Convert a value to a float.
@@ -79,7 +79,7 @@ cast_from_value! {
     v: i64 => Self(v as f64),
     v: f64 => Self(v),
     v: Ratio => Self(v.get()),
-    v: EcoString => Self(v.parse().map_err(|_| "not a valid float")?),
+    v: EcoString => Self(v.parse().map_err(|_| eco_format!("invalid float: {}", v))?),
 }
 
 /// Create a grayscale color.

--- a/tests/typ/compute/calc.typ
+++ b/tests/typ/compute/calc.typ
@@ -26,11 +26,11 @@
 #float(float)
 
 ---
-// Error: 6-12 not a valid integer
+// Error: 6-12 invalid integer: nope
 #int("nope")
 
 ---
-// Error: 8-15 not a valid float
+// Error: 8-15 invalid float: 1.2.3
 #float("1.2.3")
 
 ---


### PR DESCRIPTION
Hi, this is a small nit I wish you could consider: when developing a package I found sometimes the error messages "not a valid integer"/"not a valid float" are not as direct as I'd like them to be, because the squiggles point to the source code at the call sites of numeric conversions, which may be a string constructed during runtime e.g.
```
Error: ... not a valid integer
let num = int(a_very_convoluted_function() + another_function())
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: ... not a valid integer
let num = int(if some_function() { ... } else { ... })
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
instead of a plain and simple static string e.g.
```
Error: ... not a valid integer
let num = int("blah")
          ^^^^^^^^^^^
```
I think adding this patch that displays the actual offending strings is able to simplify the debugging process, at little cost to Typst performance. Therefore, I took the liberty and made this patch for you to review. Thanks:)