### PR TITLE
Fix tests on windows

### DIFF
--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -375,7 +375,7 @@ fn test(
     let mut compare_ever = false;
     let mut rng = LinearShift::new();
 
-    let parts: Vec<_> = text.split("\n---").collect();
+    let parts: Vec<_> = text.split("\n---").map(|s| s.trim_end_matches('\r')).collect();
     for (i, &part) in parts.iter().enumerate() {
         if let Some(x) = args.subtest {
             let x = usize::try_from(


### PR DESCRIPTION
Fixes #1206

- Docs tests are fixed by first collecting all lines before running the example code blocks
- Compiler test is fixed by removing the trailing carriage return that remains after splitting at `\n---`