### PR TITLE
adding dotless i & j to sym.rs

### DIFF
--- a/library/src/symbols/sym.rs
+++ b/library/src/symbols/sym.rs
@@ -831,4 +831,5 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
      kelvin: 'K',
      Re: 'ℜ',
      Im: 'ℑ',
+     dotless: [i: '\U+1D6A4', j: '\U+1D6A5']
 };

--- a/library/src/symbols/sym.rs
+++ b/library/src/symbols/sym.rs
@@ -831,5 +831,5 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
      kelvin: 'K',
      Re: 'ℜ',
      Im: 'ℑ',
-     dotless: [i: '\U+1D6A4', j: '\U+1D6A5']
+     dotless: [i: '𝚤', j: '𝚥']
 };

--- a/library/src/symbols/sym.rs
+++ b/library/src/symbols/sym.rs
@@ -831,5 +831,5 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
      kelvin: 'K',
      Re: 'ℜ',
      Im: 'ℑ',
-     dotless: [i: '𝚤', j: '𝚥']
+     dotless: [i: '𝚤', j: '𝚥'],
 };


### PR DESCRIPTION
Adding the dotless i & j to sym.rs as suggested by Issue #1126 