### PR TITLE
Fixed crash on invalid let bindings

### DIFF
--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -1399,7 +1399,7 @@ impl ast::Pattern {
                 vm.define(ident, value);
                 Ok(Value::None)
             }
-            _ => unreachable!(),
+            err => Err(Box::new(vec![SourceError::new(err.span(), "Invalid Pattern")])),
         })
     }
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -26,6 +26,10 @@ name = "tests"
 path = "src/tests.rs"
 harness = false
 
+[[test]]
+name = "ide_tests"
+path = "src/ide_tests.rs"
+
 [[bench]]
 name = "benches"
 path = "src/benches.rs"

--- a/tests/src/ide_tests.rs
+++ b/tests/src/ide_tests.rs
@@ -1,0 +1,75 @@
+use std::path::Path;
+
+use comemo::Prehashed;
+use typst::{
+    diag::FileError,
+    eval::Library,
+    font::FontBook,
+    syntax::{Source, SourceId},
+    World,
+};
+
+struct TestWorld {
+    library: Prehashed<Library>,
+    fonts: Prehashed<FontBook>,
+    main_src: Source,
+}
+
+impl TestWorld {
+    fn new(src: String) -> Self {
+        Self {
+            library: Prehashed::new(typst_library::build()),
+            fonts: Prehashed::new(FontBook::new()),
+            main_src: Source::new(SourceId::detached(), Path::new("main.typ"), src),
+        }
+    }
+}
+
+impl World for TestWorld {
+    fn library(&self) -> &Prehashed<Library> {
+        &self.library
+    }
+
+    fn main(&self) -> &Source {
+        &self.main_src
+    }
+
+    fn resolve(
+        &self,
+        path: &std::path::Path,
+    ) -> typst::diag::FileResult<typst::syntax::SourceId> {
+        Err(FileError::NotFound(path.to_path_buf()))
+    }
+
+    fn source(&self, _id: typst::syntax::SourceId) -> &Source {
+        &self.main_src
+    }
+
+    fn book(&self) -> &Prehashed<FontBook> {
+        &self.fonts
+    }
+
+    fn font(&self, _id: usize) -> Option<typst::font::Font> {
+        None
+    }
+
+    fn file(
+        &self,
+        path: &std::path::Path,
+    ) -> typst::diag::FileResult<typst::util::Buffer> {
+        Err(FileError::NotFound(path.to_path_buf()))
+    }
+}
+
+#[test]
+fn invalid_let() {
+    // Make sure that generating a tooltip for the below code does not crash the compiler
+    const SRC: &str = r"#let 5 = 6";
+
+    let world = TestWorld::new(SRC.to_string());
+    let source = world.main();
+
+    let cursor = 2;
+
+    typst::ide::tooltip(&world, &[], source, cursor);
+}


### PR DESCRIPTION
This PR attempts to fix #1232.

When calling `typst::ide::tooltip()` on the `let` of the above statement, the compiler will crash with
`thread 'main' panicked at 'internal error: entered unreachable code', [...]\src\eval\mod.rs:1402:18`.

I hope I did not miss any open issues for this bug.