### PR TITLE
Fix broken link for "Let binding" in loop docs

### DIFF
--- a/docs/src/reference/scripting.md
+++ b/docs/src/reference/scripting.md
@@ -198,7 +198,7 @@ For loops can iterate over a variety of collections:
 
 - `{for value in array {..}}` \
   Iterates over the items in the [array]($type/array). The destructuring syntax
-  described in [Let binding]($scripting/bindings) can also be used here.
+  described in [Let binding]($scripting/#bindings) can also be used here.
 
 - `{for pair in dict {..}}` \
   Iterates over the key-value pairs of the [dictionary]($type/dictionary).


### PR DESCRIPTION
Also wanted to fix `optionalw` to `optional` on https://typst.app/docs/reference/text/raw/, but cfad59967c417e385e77421d1dbd3ed24d9dc90f did that already 3 weeks ago, which just seems to be not on the website yet.