### PR TITLE
Fix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,7 @@
         genAttrs
         importTOML
         optionals
+        cleanSource
         ;
 
       eachSystem = f: genAttrs
@@ -27,7 +28,7 @@
         pname = "typst";
         inherit ((importTOML ./Cargo.toml).workspace.package) version;
 
-        src = self;
+        src = cleanSource ./.;
 
         cargoLock = {
           lockFile = ./Cargo.lock;

--- a/flake.nix
+++ b/flake.nix
@@ -21,10 +21,7 @@
         (system: f nixpkgs.legacyPackages.${system});
 
       rev = fallback:
-        if self ? shortRev then
-          self.shortRev
-        else
-          fallback;
+        self.shortRev or fallback;
 
       packageFor = pkgs: pkgs.rustPlatform.buildRustPackage rec {
         pname = "typst";

--- a/flake.nix
+++ b/flake.nix
@@ -29,9 +29,9 @@
         else
           fallback;
 
-      packageFor = pkgs: pkgs.rustPlatform.buildRustPackage {
+      packageFor = pkgs: pkgs.rustPlatform.buildRustPackage rec {
         pname = "typst";
-        version = rev "00000000";
+        inherit ((importTOML ./Cargo.toml).workspace.package) version;
 
         src = self;
 
@@ -56,7 +56,7 @@
         '';
 
         GEN_ARTIFACTS = "artifacts";
-        TYPST_VERSION = "${(importTOML ./Cargo.toml).package.version} (${rev "unknown hash"})";
+        TYPST_VERSION = "${version} (${rev "unknown hash"})";
       };
     in
     {

--- a/flake.nix
+++ b/flake.nix
@@ -5,9 +5,6 @@
 
   outputs = { self, nixpkgs }:
     let
-      inherit (builtins)
-        substring
-        ;
       inherit (nixpkgs.lib)
         genAttrs
         importTOML
@@ -24,8 +21,8 @@
         (system: f nixpkgs.legacyPackages.${system});
 
       rev = fallback:
-        if self ? rev then
-          substring 0 8 self.rev
+        if self ? shortRev then
+          self.shortRev
         else
           fallback;
 


### PR DESCRIPTION
The flake was broken after 8565573 because the version of the package moved from package.version to workspace.package.version.
That's accounted for in this PR as well as using the actual typst version as the package version (instead of rev 0000000, that seemed odd to me but if it is intentional I'll revert it).

I introduced `cleanSource ./.` as well.
I found a [good explanation](https://stonecode.ca/clean-the-source) but in short: It removes the files that are not actually part of the source-code such as version control files.
This means that same source code == same package.


On a personal note: I thank all of you wholeheartedly for this project!! I love the overall design and I am finally able to type up lectures in real-time. :heart:
I have already recommended the project to everyone who was and wasn't interested and I'm thrilled to see where it goes.