### PR TITLE
hotfix for readme.md docker command 

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Typst's CLI is available from different sources:
   run the bleeding edge version with `nix run github:typst/typst -- --version`.
 
 - Docker users can run a prebuilt image with
-  `docker run -it ghcr.io/typst/typst:main`.
+  `docker run -it ghcr.io/typst/typst:latest`.
 
 ## Usage
 Once you have installed Typst, you can use it like this:


### PR DESCRIPTION
Changed docker image tag from main to latest in readme.md. This seemed like the simplest fix.

Previous command `docker run -it ghcr.io/typst/typst:main` returned:
` docker: Error response from daemon: manifest unknown where as latest works as expected.`

New commad works as expected.

Linked to issue #800 