### PR TITLE
Fix version extracting in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,7 +56,7 @@
         '';
 
         GEN_ARTIFACTS = "artifacts";
-        TYPST_VERSION = "${(importTOML ./Cargo.toml).package.version} (${rev "unknown hash"})";
+        TYPST_VERSION = "${(importTOML ./Cargo.toml).workspace.package.version} (${rev "unknown hash"})";
       };
     in
     {


### PR DESCRIPTION
Nix package of Typst is broken... again. This is the fix.