### PR TITLE
Allow ints for CMYK to ensure consistency

### DIFF
--- a/library/src/compute/construct.rs
+++ b/library/src/compute/construct.rs
@@ -359,6 +359,7 @@ pub fn datetime_today(
 /// ## Example { #example }
 /// ```example
 /// #square(
+///   stroke: cmyk(0, 94, 100, 0),
 ///   fill: cmyk(27%, 0%, 3%, 5%)
 /// )
 /// ````
@@ -369,27 +370,15 @@ pub fn datetime_today(
 #[func]
 pub fn cmyk(
     /// The cyan component.
-    cyan: RatioComponent,
+    cyan: Component,
     /// The magenta component.
-    magenta: RatioComponent,
+    magenta: Component,
     /// The yellow component.
-    yellow: RatioComponent,
+    yellow: Component,
     /// The key component.
-    key: RatioComponent,
+    key: Component,
 ) -> Value {
     Value::Color(CmykColor::new(cyan.0, magenta.0, yellow.0, key.0).into())
-}
-
-/// A component that must be a ratio.
-struct RatioComponent(u8);
-
-cast_from_value! {
-    RatioComponent,
-    v: Ratio => if (0.0 ..= 1.0).contains(&v.get()) {
-        Self((v.get() * 255.0).round() as u8)
-    } else {
-        Err("ratio must be between 0% and 100%")?
-    },
 }
 
 /// Create a custom symbol with modifiers.

--- a/src/geom/paint.rs
+++ b/src/geom/paint.rs
@@ -358,15 +358,7 @@ impl CmykColor {
 
 impl Debug for CmykColor {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let g = |c| 100.0 * (c as f64 / 255.0);
-        write!(
-            f,
-            "cmyk({:.1}%, {:.1}%, {:.1}%, {:.1}%)",
-            g(self.c),
-            g(self.m),
-            g(self.y),
-            g(self.k),
-        )
+        write!(f, "cmyk({}, {}, {}, {})", self.c, self.m, self.y, self.k)
     }
 }
 

--- a/tests/typ/compute/construct.typ
+++ b/tests/typ/compute/construct.typ
@@ -15,6 +15,14 @@
 #test(white.lighten(100%), white)
 
 ---
+// Ensure consistency when using integers with CMYK.
+#let colorA = cmyk(51, 102, 102, 51)
+#let colorB = cmyk(20%, 40%, 40%, 20%)
+#test(colorA, colorB)
+#test(repr(colorA), "cmyk(51, 102, 102, 51)")
+#test(repr(colorB), repr(colorA))
+
+---
 // Test gray color conversion.
 // Ref: true
 #stack(dir: ltr, rect(fill: luma(0)), rect(fill: luma(80%)))
@@ -23,6 +31,18 @@
 // Error for values that are out of range.
 // Error: 11-14 number must be between 0 and 255
 #test(rgb(-30, 15, 50))
+
+---
+// Error: 7-9 number must be between 0 and 255
+#cmyk(-1, 1, 2, 3)
+
+---
+// Error: 7-10 number must be between 0 and 255
+#cmyk(299, 1, 2, 3)
+
+---
+// Error: 7-11 ratio must be between 0% and 100%
+#cmyk(200%, 5%, 3%, 1%)
 
 ---
 // Error: 6-11 color string contains non-hexadecimal letters


### PR DESCRIPTION
Small PR, fixes #787 by reutilizing `rgb`'s parameter type (which accepts both int and ratio) for `cmyk`.

Ratios given to `cmyk()` are converted to ints internally, so might as well allow int arguments to CMYK for more consistent and accurate specification of a CMYK color. Also, this changes the output of `repr` for a cmyk color to display the ints instead, as that's more useful info (and also more reliable) - the ratios that currently appear are approximations which aren't very predictable.
(This would also make sense in the context of #790, where one would be able to obtain the CMYK's integer values through a field or something... and maybe even change them at some point in the future.)

Added tests.