### PR TITLE
ignore utf-8 bom

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -556,7 +556,11 @@ impl World for SystemWorld {
         self.slot(path)?
             .source
             .get_or_init(|| {
-                let buf = read(path)?;
+                let mut buf = read(path)?;
+                if buf.starts_with(b"\xef\xbb\xbf") {
+                    // avoid copy by overwritting BOM with a "nop"
+                    buf.iter_mut().take(3).for_each(|b| *b = b'\n');
+                }
                 let text = String::from_utf8(buf)?;
                 Ok(self.insert(path, text))
             })


### PR DESCRIPTION
This PR will ignore UTF-8's BOM and overwrite it with `\n`s.
Should UTF-16 be added as well? (It's already in Rust's stdlib...)

Resolves #1010.