### PR TITLE
Add ⊬ to symbols.rs

### DIFF
--- a/library/src/symbols/sym.rs
+++ b/library/src/symbols/sym.rs
@@ -718,6 +718,8 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
     ],
     tack: [
         r: '⊢',
+        not: '⊬',
+        r.not: '⊬',
         r.long: '⟝',
         r.double: '⊨',
         r.double.not: '⊭',


### PR DESCRIPTION
Add ⊬ as tack.not and tack.r.not
When I write ⊬ in a content it displays correctly, but gets very short in a math environment,
![image](https://github.com/typst/typst/assets/28257008/c64c3555-d57f-4796-ae32-7f3e4efc5411)
So I'm not sure if this is the correct way to add tack.not