### PR TITLE
Fix `.at(default: ...)` for strings and content

### DIFF
--- a/src/eval/methods.rs
+++ b/src/eval/methods.rs
@@ -34,7 +34,7 @@ pub fn call(
             "at" => {
                 let index = args.expect("index")?;
                 let default = args.named::<EcoString>("default")?;
-                Value::Str(string.at(index, default.as_ref().map(|x| &**x)).at(span)?)
+                Value::Str(string.at(index, default.as_deref()).at(span)?)
             }
             "slice" => {
                 let start = args.expect("start")?;

--- a/src/eval/methods.rs
+++ b/src/eval/methods.rs
@@ -33,7 +33,7 @@ pub fn call(
             "last" => Value::Str(string.last().at(span)?),
             "at" => {
                 let index = args.expect("index")?;
-                let default = args.named::<Str>("default")?;
+                let default = args.named::<EcoString>("default")?;
                 Value::Str(string.at(index, default.as_ref().map(|x| &**x)).at(span)?)
             }
             "slice" => {

--- a/src/eval/methods.rs
+++ b/src/eval/methods.rs
@@ -31,7 +31,11 @@ pub fn call(
             "len" => Value::Int(string.len()),
             "first" => Value::Str(string.first().at(span)?),
             "last" => Value::Str(string.last().at(span)?),
-            "at" => Value::Str(string.at(args.expect("index")?, None).at(span)?),
+            "at" => {
+                let index = args.expect("index")?;
+                let default = args.named::<Str>("default")?;
+                Value::Str(string.at(index, default.as_ref().map(|x| &**x)).at(span)?)
+            }
             "slice" => {
                 let start = args.expect("start")?;
                 let mut end = args.eat()?;

--- a/src/eval/methods.rs
+++ b/src/eval/methods.rs
@@ -78,7 +78,9 @@ pub fn call(
         Value::Content(content) => match method {
             "func" => content.func().into(),
             "has" => Value::Bool(content.has(&args.expect::<EcoString>("field")?)),
-            "at" => content.at(&args.expect::<EcoString>("field")?, None).at(span)?,
+            "at" => content
+                .at(&args.expect::<EcoString>("field")?, args.named("default")?)
+                .at(span)?,
             "location" => content
                 .location()
                 .ok_or("this method can only be called on content returned by query(..)")

--- a/src/eval/str.rs
+++ b/src/eval/str.rs
@@ -71,9 +71,9 @@ impl Str {
     /// Extract the grapheme cluster at the given index.
     pub fn at<'a>(&'a self, index: i64, default: Option<&'a str>) -> StrResult<Self> {
         let len = self.len();
-        let grapheme = self.0[self.locate(index)?..]
-            .graphemes(true)
-            .next()
+        let grapheme = self
+            .locate_opt(index)?
+            .and_then(|i| self.0[i..].graphemes(true).next())
             .or(default)
             .ok_or_else(|| no_default_and_out_of_bounds(index, len))?;
         Ok(grapheme.into())
@@ -325,21 +325,27 @@ impl Str {
         Ok(Self(self.0.repeat(n)))
     }
 
-    /// Resolve an index.
-    fn locate(&self, index: i64) -> StrResult<usize> {
+    /// Resolve an index, if it is within bounds.
+    /// Errors on invalid char boundaries.
+    fn locate_opt(&self, index: i64) -> StrResult<Option<usize>> {
         let wrapped =
             if index >= 0 { Some(index) } else { self.len().checked_add(index) };
 
         let resolved = wrapped
             .and_then(|v| usize::try_from(v).ok())
-            .filter(|&v| v <= self.0.len())
-            .ok_or_else(|| out_of_bounds(index, self.len()))?;
+            .filter(|&v| v <= self.0.len());
 
-        if !self.0.is_char_boundary(resolved) {
+        if resolved.map_or(false, |i| !self.0.is_char_boundary(i)) {
             return Err(not_a_char_boundary(index));
         }
 
         Ok(resolved)
+    }
+
+    /// Resolve an index or throw an out of bounds error.
+    fn locate(&self, index: i64) -> StrResult<usize> {
+        self.locate_opt(index)?
+            .ok_or_else(|| out_of_bounds(index, self.len()))
     }
 }
 

--- a/tests/typ/compiler/methods.typ
+++ b/tests/typ/compiler/methods.typ
@@ -34,9 +34,6 @@
 #test(auto, [a].at("doesn't exist", default: auto))
 
 ---
-
-
----
 // Error: 2:2-2:15 type array has no method `fun`
 #let numbers = ()
 #numbers.fun()

--- a/tests/typ/compiler/methods.typ
+++ b/tests/typ/compiler/methods.typ
@@ -34,6 +34,9 @@
 #test(auto, [a].at("doesn't exist", default: auto))
 
 ---
+
+
+---
 // Error: 2:2-2:15 type array has no method `fun`
 #let numbers = ()
 #numbers.fun()

--- a/tests/typ/compiler/methods.typ
+++ b/tests/typ/compiler/methods.typ
@@ -27,10 +27,7 @@
 }
 
 ---
-// Test .at() default values.
-#test(auto, (1, 2, 3).at(100, default: auto))
-#test(auto, (a: 10, b: 50).at("z", default: auto))
-#test("z", "abc".at(100, default: "z"))
+// Test .at() default values for content.
 #test(auto, [a].at("doesn't exist", default: auto))
 
 ---

--- a/tests/typ/compiler/methods.typ
+++ b/tests/typ/compiler/methods.typ
@@ -27,6 +27,13 @@
 }
 
 ---
+// Test .at() default values.
+#test(auto, (1, 2, 3).at(100, default: auto))
+#test(auto, (a: 10, b: 50).at("z", default: auto))
+#test("z", "abc".at(100, default: "z"))
+#test(auto, [a].at("doesn't exist", default: auto))
+
+---
 // Error: 2:2-2:15 type array has no method `fun`
 #let numbers = ()
 #numbers.fun()

--- a/tests/typ/compiler/string.typ
+++ b/tests/typ/compiler/string.typ
@@ -29,12 +29,20 @@
 #test("Hey: 🏳️‍🌈 there!".at(5), "🏳️‍🌈")
 
 ---
+// Test `at`'s 'default' parameter.
+#test("z", "Hello".at(5, default: "z"))
+
+---
 // Error: 2-14 string index 2 is not a character boundary
 #"🏳️‍🌈".at(2)
 
 ---
 // Error: 2-15 no default value was specified and string index out of bounds (index: 5, len: 5)
 #"Hello".at(5)
+
+---
+// Error: 25-32 expected string, found dictionary
+#"Hello".at(5, default: (a: 10))
 
 ---
 // Test the `slice` method.


### PR DESCRIPTION
Fixes #1334.

# Highlights
- Fixing `content.at(default: ...)` was rather trivial, as the `default` parameter was simply not being read (but the code already supported it).
- Fixing `str.at(default: ...)`, however, required a few more changes (the `default` parameter was also not being read, but there was more to it), as `Str::locate` seemed to error when given out of bounds indices, even if the caller function (`at`) had been given a default value for such a case. To make this work, I made a `Str::locate_opt` method which returns an `Option`, which could be used by `Str::at`. (An alternative implementation would be to add a `default: Option<...>` parameter to `locate`, but I didn't feel like taking such an approach. Feel free to tell me if you prefer it to be this way instead.)
- Added tests (!).