### PR TITLE
feat: Add Swedish

### DIFF
--- a/library/src/layout/table.rs
+++ b/library/src/layout/table.rs
@@ -314,6 +314,7 @@ impl LocalName for TableElem {
             Lang::RUSSIAN => "Таблица",
             Lang::SLOVENIAN => "Tabela",
             Lang::SPANISH => "Tabla",
+            Lang::SWEDISH => "Tabell",
             Lang::UKRAINIAN => "Таблиця",
             Lang::VIETNAMESE => "Bảng",
             Lang::ENGLISH | _ => "Table",

--- a/library/src/math/mod.rs
+++ b/library/src/math/mod.rs
@@ -331,6 +331,7 @@ impl LocalName for EquationElem {
             Lang::RUSSIAN => "Уравнение",
             Lang::SLOVENIAN => "Enačba",
             Lang::SPANISH => "Ecuación",
+            Lang::SWEDISH => "Ekvation",
             Lang::UKRAINIAN => "Рівняння",
             Lang::VIETNAMESE => "Phương trình",
             Lang::ENGLISH | _ => "Equation",

--- a/library/src/meta/bibliography.rs
+++ b/library/src/meta/bibliography.rs
@@ -227,6 +227,7 @@ impl LocalName for BibliographyElem {
             Lang::RUSSIAN => "Библиография",
             Lang::SLOVENIAN => "Literatura",
             Lang::SPANISH => "Bibliografía",
+            Lang::SWEDISH => "Bibliografi",
             Lang::UKRAINIAN => "Бібліографія",
             Lang::VIETNAMESE => "Tài liệu tham khảo",
             Lang::ENGLISH | _ => "Bibliography",

--- a/library/src/meta/heading.rs
+++ b/library/src/meta/heading.rs
@@ -226,6 +226,7 @@ impl LocalName for HeadingElem {
             Lang::RUSSIAN => "Раздел",
             Lang::SLOVENIAN => "Poglavje",
             Lang::SPANISH => "Sección",
+            Lang::SWEDISH => "Kapitel",
             Lang::UKRAINIAN => "Розділ",
             Lang::VIETNAMESE => "Phần", // TODO: This may be wrong.
             Lang::ENGLISH | _ => "Section",

--- a/library/src/meta/outline.rs
+++ b/library/src/meta/outline.rs
@@ -280,6 +280,7 @@ impl LocalName for OutlineElem {
             Lang::RUSSIAN => "Содержание",
             Lang::SLOVENIAN => "Kazalo",
             Lang::SPANISH => "Índice",
+            Lang::SWEDISH => "Innehåll",
             Lang::UKRAINIAN => "Зміст",
             Lang::VIETNAMESE => "Mục lục",
             Lang::ENGLISH | _ => "Contents",

--- a/library/src/text/raw.rs
+++ b/library/src/text/raw.rs
@@ -237,7 +237,7 @@ impl LocalName for RawElem {
             Lang::POLISH => "Program",
             Lang::RUSSIAN => "Листинг",
             Lang::SLOVENIAN => "Program",
-            Lang::SWEDISH => "Utdrag", // TODO: not easy to translate, utskrift/utdrag?
+            Lang::SWEDISH => "Listing",
             Lang::UKRAINIAN => "Лістинг",
             Lang::VIETNAMESE => "Chương trình", // TODO: This may be wrong.
             Lang::ENGLISH | _ => "Listing",

--- a/library/src/text/raw.rs
+++ b/library/src/text/raw.rs
@@ -237,6 +237,7 @@ impl LocalName for RawElem {
             Lang::POLISH => "Program",
             Lang::RUSSIAN => "Листинг",
             Lang::SLOVENIAN => "Program",
+            Lang::SWEDISH => "Utdrag", // TODO: not easy to translate, utskrift/utdrag?
             Lang::UKRAINIAN => "Лістинг",
             Lang::VIETNAMESE => "Chương trình", // TODO: This may be wrong.
             Lang::ENGLISH | _ => "Listing",

--- a/library/src/visualize/image.rs
+++ b/library/src/visualize/image.rs
@@ -143,6 +143,7 @@ impl LocalName for ImageElem {
             Lang::RUSSIAN => "Рисунок",
             Lang::SLOVENIAN => "Slika",
             Lang::SPANISH => "Figura",
+            Lang::SWEDISH => "Figur",
             Lang::UKRAINIAN => "Рисунок",
             Lang::VIETNAMESE => "Hình",
             Lang::ENGLISH | _ => "Figure",

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -528,6 +528,7 @@ impl Lang {
     pub const RUSSIAN: Self = Self(*b"ru ", 2);
     pub const SLOVENIAN: Self = Self(*b"sl ", 2);
     pub const SPANISH: Self = Self(*b"es ", 2);
+    pub const SWEDISH: Self = Self(*b"sv ", 2);
     pub const UKRAINIAN: Self = Self(*b"ua ", 2);
     pub const VIETNAMESE: Self = Self(*b"vi ", 2);
 


### PR DESCRIPTION
Added Swedish captions.

Referred to https://ftp.acc.umu.se/mirror/CTAN/macros/latex/contrib/babel-contrib/swedish/swedish.pdf when I was not sure. some terms still do not have a perfect 1:1 translation (but that is the case for other languages too I noticed, such as Nynorsk and Bokmål, so maybe it's not a big deal).

Just curious, if and when this is merged, when will it be usable in the web editor? 🙂