### PR TITLE
Add Dutch LocalNames

### DIFF
--- a/library/src/layout/table.rs
+++ b/library/src/layout/table.rs
@@ -305,6 +305,7 @@ impl LocalName for TableElem {
             Lang::BOKMÅL => "Tabell",
             Lang::CHINESE => "表",
             Lang::CZECH => "Tabulka",
+            Lang::DUTCH => "Tabel",
             Lang::FRENCH => "Tableau",
             Lang::GERMAN => "Tabelle",
             Lang::ITALIAN => "Tabella",

--- a/library/src/math/mod.rs
+++ b/library/src/math/mod.rs
@@ -322,6 +322,7 @@ impl LocalName for EquationElem {
             Lang::CHINESE if option_eq(region, "TW") => "方程式",
             Lang::CHINESE => "等式",
             Lang::CZECH => "Rovnice",
+            Lang::DUTCH => "Vergelijking",
             Lang::FRENCH => "Équation",
             Lang::GERMAN => "Gleichung",
             Lang::ITALIAN => "Equazione",

--- a/library/src/meta/bibliography.rs
+++ b/library/src/meta/bibliography.rs
@@ -218,6 +218,7 @@ impl LocalName for BibliographyElem {
             Lang::CHINESE if option_eq(region, "TW") => "書目",
             Lang::CHINESE => "参考文献",
             Lang::CZECH => "Bibliografie",
+            Lang::DUTCH => "Bibliografie",
             Lang::FRENCH => "Bibliographie",
             Lang::GERMAN => "Bibliographie",
             Lang::ITALIAN => "Bibliografia",

--- a/library/src/meta/heading.rs
+++ b/library/src/meta/heading.rs
@@ -217,6 +217,7 @@ impl LocalName for HeadingElem {
             Lang::CHINESE if option_eq(region, "TW") => "小節",
             Lang::CHINESE => "小节",
             Lang::CZECH => "Kapitola",
+            Lang::DUTCH => "Hoofdstuk",
             Lang::FRENCH => "Chapitre",
             Lang::GERMAN => "Abschnitt",
             Lang::ITALIAN => "Sezione",

--- a/library/src/meta/outline.rs
+++ b/library/src/meta/outline.rs
@@ -271,6 +271,7 @@ impl LocalName for OutlineElem {
             Lang::CHINESE if option_eq(region, "TW") => "目錄",
             Lang::CHINESE => "目录",
             Lang::CZECH => "Obsah",
+            Lang::DUTCH => "Inhoudsopgave",
             Lang::FRENCH => "Table des matières",
             Lang::GERMAN => "Inhaltsverzeichnis",
             Lang::ITALIAN => "Indice",

--- a/library/src/text/raw.rs
+++ b/library/src/text/raw.rs
@@ -230,6 +230,7 @@ impl LocalName for RawElem {
             Lang::BOKMÅL => "Utskrift",
             Lang::CHINESE => "代码",
             Lang::CZECH => "Seznam",
+            Lang::DUTCH => "Listing",
             Lang::FRENCH => "Liste",
             Lang::GERMAN => "Listing",
             Lang::ITALIAN => "Codice",

--- a/library/src/visualize/image.rs
+++ b/library/src/visualize/image.rs
@@ -134,6 +134,7 @@ impl LocalName for ImageElem {
             Lang::BOKMÅL => "Figur",
             Lang::CHINESE => "图",
             Lang::CZECH => "Obrázek",
+            Lang::DUTCH => "Figuur",
             Lang::FRENCH => "Figure",
             Lang::GERMAN => "Abbildung",
             Lang::ITALIAN => "Figura",

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -518,6 +518,7 @@ impl Lang {
     pub const BOKMÅL: Self = Self(*b"nb ", 2);
     pub const CHINESE: Self = Self(*b"zh ", 2);
     pub const CZECH: Self = Self(*b"cs ", 2);
+    pub const DUTCH: Self = Self(*b"nl ", 2);
     pub const ENGLISH: Self = Self(*b"en ", 2);
     pub const FRENCH: Self = Self(*b"fr ", 2);
     pub const GERMAN: Self = Self(*b"de ", 2);


### PR DESCRIPTION
Mimicking #1353, I looked at LaTeX's [babel-contrib/dutch/dutch.pdf](https://ftp.acc.umu.se/mirror/CTAN/macros/latex/contrib/babel-contrib/dutch/dutch.pdf) terminology when possible, and otherwise relied on my intuition. Dutch is my native language.

(Just like #1353 I found it hard to translate _listing_. There are similar-sounding Dutch words that mean "list", but that's not really what it is. _Programma_ is tempting, as in some other languages, but listings can be example input/output and not just code, so I find it unsatisfying. In the end I went with… loaning the English _listing_, which seems to be what German does 🙂)