### PR TITLE
Add sym.bullet, which is different from sym.circle.filled.small

### DIFF
--- a/library/src/symbols/sym.rs
+++ b/library/src/symbols/sym.rs
@@ -446,6 +446,7 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
     suit: [club: '♣', diamond: '♦', heart: '♥', spade: '♠'],
 
     // Shapes.
+    bullet: '•',
     circle: [
         stroked: '○',
         stroked.tiny: '∘',


### PR DESCRIPTION
This closes [#1328](https://github.com/typst/typst/issues/1328).