### PR TITLE
Bugfix of CJK punctuation adjustment

### DIFF
--- a/tests/typ/layout/par-justify-cjk.typ
+++ b/tests/typ/layout/par-justify-cjk.typ
@@ -35,6 +35,8 @@
   《书名》《测试》。
 ]
 
+「『引号』」。“‘引号’”。
+
 ---
 // Test Variants of Mainland China, Hong Kong, and Japan.
 


### PR DESCRIPTION
Previously, there was a bug where the left bracket was not being adjusted correctly. This PR fixes it.

Before: 
![image](https://github.com/typst/typst/assets/12483662/96ba0512-8f2a-4741-bc25-66991f3a5a36)

After:
![image](https://github.com/typst/typst/assets/12483662/4d886def-977c-4ae1-91d5-fb1ff6188d05)
