### PR TITLE
Remove link to `Option::contains`, since it has been removed

### DIFF
--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -227,8 +227,6 @@ pub fn pretty_array_like(parts: &[impl AsRef<str>], trailing_comma: bool) -> Str
 }
 
 /// Check if the [`Option`]-wrapped L is same to R.
-///
-/// This is the stable version of [`Option::contains`].
 pub fn option_eq<L, R>(left: Option<L>, other: R) -> bool
 where
     L: PartialEq<R>,


### PR DESCRIPTION
this should fix the CI failure in #1397