### PR TITLE
Clarify markup details in the documentation

### DIFF
--- a/library/src/layout/enum.rs
+++ b/library/src/layout/enum.rs
@@ -72,6 +72,11 @@ pub struct EnumElem {
     /// [leading]($func/par.leading) instead. This makes the enumeration more
     /// compact, which can look better if the items are short.
     ///
+    /// In markup mode, the value of this parameter is determined based on
+    /// whether items are separated with a blank line. If items directly follow
+    /// each other, this is set to `{true}`; if items are separated by a blank
+    /// line, this is set to `{false}`.
+    ///
     /// ```example
     /// + If an enum has a lot of text, and
     ///   maybe other inline content, it

--- a/library/src/layout/list.rs
+++ b/library/src/layout/list.rs
@@ -47,6 +47,11 @@ pub struct ListElem {
     /// [leading]($func/par.leading) instead. This makes the list more compact,
     /// which can look better if the items are short.
     ///
+    /// In markup mode, the value of this parameter is determined based on
+    /// whether items are separated with a blank line. If items directly follow
+    /// each other, this is set to `{true}`; if items are separated by a blank
+    /// line, this is set to `{false}`.
+    ///
     /// ```example
     /// - If a list has a lot of text, and
     ///   maybe other inline content, it

--- a/library/src/layout/terms.rs
+++ b/library/src/layout/terms.rs
@@ -32,6 +32,11 @@ pub struct TermsElem {
     /// [leading]($func/par.leading) instead. This makes the term list more
     /// compact, which can look better if the items are short.
     ///
+    /// In markup mode, the value of this parameter is determined based on
+    /// whether items are separated with a blank line. If items directly follow
+    /// each other, this is set to `{true}`; if items are separated by a blank
+    /// line, this is set to `{false}`.
+    ///
     /// ```example
     /// / Fact: If a term list has a lot
     ///   of text, and maybe other inline

--- a/library/src/text/raw.rs
+++ b/library/src/text/raw.rs
@@ -63,6 +63,9 @@ pub struct RawElem {
 
     /// Whether the raw text is displayed as a separate block.
     ///
+    /// In markup mode, using one-backtick notation makes this `{false}`,
+    /// whereas using three-backtick notation makes it `{true}`.
+    ///
     /// ````example
     /// // Display inline code in a small box
     /// // that retains the correct baseline.


### PR DESCRIPTION
This makes explicit the fact that:
* A markup-defined list is tight iff its items are separated using a blank line.
* Markup-defined text is a block iff three backticks are used.