### PR TITLE
Better `columns` example

### DIFF
--- a/library/src/layout/columns.rs
+++ b/library/src/layout/columns.rs
@@ -13,7 +13,7 @@ use crate::text::TextElem;
 /// ```example
 /// = Towards Advanced Deep Learning
 ///
-/// #box(height: 68pt,
+/// #box(height: 60pt,
 ///  columns(2, gutter: 11pt)[
 ///    #set par(justify: true)
 ///    This research was funded by the
@@ -22,6 +22,7 @@ use crate::text::TextElem;
 ///    tests and interviews with a
 ///    grant of up to USD 40.000 for a
 ///    period of 6 months.
+///    #lorem(40)
 ///  ]
 /// )
 ///


### PR DESCRIPTION
The `columns` [example](https://typst.app/docs/reference/layout/columns/) is not really informative because it happens to put everything into one column:

![image](https://github.com/typst/typst/assets/7661193/a031355d-86d9-47e6-9c4a-c9916cd6cfc5)

By making the box vertically smaller and the text longer, it should be rendered within two columns. I don't know how to compile the docs though (`cargo b --package typst-docs`?), so I'm not sure if this displays nicely.