### PR TITLE
Fix Nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,33 @@
 {
   "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1686291735,
+        "narHash": "sha256-mpq2m6TN3ImqqUqA4u93NvkZu5vH//3spqjmPRbRlvA=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "6e6a94c4d0cac4821b6452fbae46609b89a8ddcf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1679262748,
-        "narHash": "sha256-DQCrrAFrkxijC6haUzOC5ZoFqpcv/tg2WxnyW3np1Cc=",
+        "lastModified": 1686226982,
+        "narHash": "sha256-nLuiPoeiVfqqzeq9rmXxpybh77VS37dsY/k8N2LoxVg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "60c1d71f2ba4c80178ec84523c2ca0801522e0a6",
+        "rev": "a64b73e07d4aa65cfcbda29ecf78eaf9e72e44bd",
         "type": "github"
       },
       "original": {
@@ -18,7 +39,25 @@
     },
     "root": {
       "inputs": {
+        "fenix": "fenix",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1686239338,
+        "narHash": "sha256-c6Mm7UnDf3j3akY3YB3rELFA76QRbB8ttSBsh00LWi0=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "9c03aa1ac2e67051db83a85baf3cfee902e4dd84",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,13 @@
 {
   inputs = {
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
   };
 
-  outputs = { self, nixpkgs }:
+  outputs = { self, fenix, nixpkgs }:
     let
       inherit (nixpkgs.lib)
         genAttrs
@@ -24,53 +28,65 @@
       rev = fallback:
         self.shortRev or fallback;
 
-      packageFor = pkgs: pkgs.rustPlatform.buildRustPackage rec {
-        pname = "typst";
-        inherit ((importTOML ./Cargo.toml).workspace.package) version;
+      packageFor = pkgs:
+        let
+          rust = fenix.packages.${pkgs.stdenv.hostPlatform.system}.minimal.toolchain;
+          rustPlatform = pkgs.makeRustPlatform {
+            cargo = rust;
+            rustc = rust;
+          };
+        in
+        rustPlatform.buildRustPackage rec {
+          pname = "typst";
+          inherit ((importTOML ./Cargo.toml).workspace.package) version;
 
-        src = cleanSource ./.;
+          src = cleanSource ./.;
 
-        cargoLock = {
-          lockFile = ./Cargo.lock;
-          allowBuiltinFetchGit = true;
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+            allowBuiltinFetchGit = true;
+          };
+
+          nativeBuildInputs = [
+            pkgs.installShellFiles
+          ];
+
+          buildInputs = optionals pkgs.stdenv.isDarwin [
+            pkgs.darwin.apple_sdk.frameworks.CoreServices
+          ];
+
+          postInstall = ''
+            installManPage cli/artifacts/*.1
+            installShellCompletion \
+              cli/artifacts/typst.{bash,fish} \
+              --zsh cli/artifacts/_typst
+          '';
+
+          GEN_ARTIFACTS = "artifacts";
+          TYPST_VERSION = "${version} (${rev "unknown hash"})";
         };
-
-        nativeBuildInputs = [
-          pkgs.installShellFiles
-        ];
-
-        buildInputs = optionals pkgs.stdenv.isDarwin [
-          pkgs.darwin.apple_sdk.frameworks.CoreServices
-        ];
-
-        postInstall = ''
-          installManPage cli/artifacts/*.1
-          installShellCompletion \
-            cli/artifacts/typst.{bash,fish} \
-            --zsh cli/artifacts/_typst
-        '';
-
-        GEN_ARTIFACTS = "artifacts";
-        TYPST_VERSION = "${version} (${rev "unknown hash"})";
-      };
     in
     {
       devShells = eachSystem (pkgs: {
         default = pkgs.mkShell {
-          packages = with pkgs; [
-            cargo
-            clippy
-            rust-analyzer
-            rustc
-            rustfmt
-          ];
+          packages =
+            let
+              fenix' = fenix.packages.${pkgs.stdenv.hostPlatform.system};
+            in
+            [
+              (fenix'.default.withComponents [
+                "cargo"
+                "clippy"
+                "rustc"
+                "rustfmt"
+              ])
+              fenix'.rust-analyzer
+            ];
 
           buildInputs = optionals pkgs.stdenv.isDarwin [
             pkgs.darwin.apple_sdk.frameworks.CoreServices
             pkgs.libiconv
           ];
-
-          RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
         };
       });
 


### PR DESCRIPTION
Typst now requires Rust 1.70 which is not available in nixpkgs yet, so we switch to fenix instead

built on {aarch64,x86_64}-{darwin,linux}