### PR TITLE
Export font coverage structure again

### DIFF
--- a/src/font/mod.rs
+++ b/src/font/mod.rs
@@ -3,7 +3,7 @@
 mod book;
 mod variant;
 
-pub use self::book::{FontBook, FontFlags, FontInfo};
+pub use self::book::{Coverage, FontBook, FontFlags, FontInfo};
 pub use self::variant::{FontStretch, FontStyle, FontVariant, FontWeight};
 
 use std::fmt::{self, Debug, Formatter};


### PR DESCRIPTION
In some cases, such as compiler with web fonts, font information needs to be manually constructed.
As such, `the typst::font::book::Coverage` that was accidentally made private in https://github.com/typst/typst/commit/fd417da04f7ca4b995de7f6510abafd3e9c31307 needs to be exported again.