### PR TITLE
Resolve #1141: Add hint for missing numbering, improve hint format consistency

### DIFF
--- a/library/src/meta/reference.rs
+++ b/library/src/meta/reference.rs
@@ -180,7 +180,7 @@ impl Show for RefElem {
         let numbering = refable
             .numbering()
             .ok_or_else(|| {
-                eco_format!("cannot reference {0} without numbering. Did you forget a #set {0}(numbering: \"1.\")?", elem.func().name())
+                eco_format!("cannot reference {0} without numbering - did you mean to use `#set {0}(numbering: \"1.\")`?", elem.func().name())
             })
             .at(span)?;
 

--- a/library/src/meta/reference.rs
+++ b/library/src/meta/reference.rs
@@ -180,7 +180,7 @@ impl Show for RefElem {
         let numbering = refable
             .numbering()
             .ok_or_else(|| {
-                eco_format!("cannot reference {} without numbering", elem.func().name())
+                eco_format!("cannot reference {0} without numbering. Did you forget a #set {0}(numbering: \"1.\")?", elem.func().name())
             })
             .at(span)?;
 

--- a/src/eval/cast.rs
+++ b/src/eval/cast.rs
@@ -242,7 +242,7 @@ impl CastInfo {
             if parts.iter().any(|p| p == "length");
             if !matching_type;
             then {
-                write!(msg, ": a length needs a unit – did you mean {i}pt?").unwrap();
+                write!(msg, ": a length needs a unit - did you mean {i}pt?").unwrap();
             }
         };
 

--- a/src/eval/scope.rs
+++ b/src/eval/scope.rs
@@ -72,7 +72,7 @@ impl<'a> Scopes<'a> {
 #[cold]
 fn unknown_variable(var: &str) -> EcoString {
     if var.contains('-') {
-        eco_format!("unknown variable: {} – if you meant to use subtraction, try adding spaces around the minus sign.", var)
+        eco_format!("unknown variable: {} - if you meant to use subtraction, try adding spaces around the minus sign.", var)
     } else {
         eco_format!("unknown variable: {}", var)
     }

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -1060,7 +1060,7 @@ fn for_loop(p: &mut Parser) {
     p.assert(SyntaxKind::For);
     pattern(p);
     if p.at(SyntaxKind::Comma) {
-        p.expected("keyword `in`. did you mean to use a destructuring pattern?");
+        p.expected("keyword `in` - did you mean to use a destructuring pattern?");
         if !p.eat_if(SyntaxKind::Ident) {
             p.eat_if(SyntaxKind::Underscore);
         }

--- a/tests/typ/compiler/for.typ
+++ b/tests/typ/compiler/for.typ
@@ -92,7 +92,7 @@
 
 ---
 // Destructuring without parentheses.
-// Error: 7 expected keyword `in`. did you mean to use a destructuring pattern?
+// Error: 7 expected keyword `in` - did you mean to use a destructuring pattern?
 #for k, v in (a: 4, b: 5) {
   dont-care
 }

--- a/tests/typ/compiler/hint.typ
+++ b/tests/typ/compiler/hint.typ
@@ -2,7 +2,7 @@
 // Ref: false
 
 ---
-// Error: 1:17-1:19 expected length, found integer: a length needs a unit – did you mean 12pt?
+// Error: 1:17-1:19 expected length, found integer: a length needs a unit - did you mean 12pt?
 #set text(size: 12)
 
 ---

--- a/tests/typ/compiler/hint.typ
+++ b/tests/typ/compiler/hint.typ
@@ -11,13 +11,13 @@
   a = 1-a
   a = a -1
 
-  // Error: 7-10 unknown variable: a-1 – if you meant to use subtraction, try adding spaces around the minus sign.
+  // Error: 7-10 unknown variable: a-1 - if you meant to use subtraction, try adding spaces around the minus sign.
   a = a-1
 }
 
 ---
 #{
-  // Error: 3-6 unknown variable: a-1 – if you meant to use subtraction, try adding spaces around the minus sign.
+  // Error: 3-6 unknown variable: a-1 - if you meant to use subtraction, try adding spaces around the minus sign.
   a-1 = 2
 }
 

--- a/tests/typ/compiler/hint.typ
+++ b/tests/typ/compiler/hint.typ
@@ -20,3 +20,8 @@
   // Error: 3-6 unknown variable: a-1 – if you meant to use subtraction, try adding spaces around the minus sign.
   a-1 = 2
 }
+
+---
+= Heading <intro>
+// Error: 1:20-1:26 cannot reference heading without numbering - did you mean to use `#set heading(numbering: "1.")`?
+Can not be used as @intro


### PR DESCRIPTION
I kept the recommendation really short, as [codespan reporting](https://docs.rs/codespan-reporting/0.11.1/codespan_reporting/diagnostic/struct.Diagnostic.html) recommends:

> Message:  These should not include line breaks, and in order support the ‘short’ diagnostic display mod, the message should be specific enough to make sense on its own, without additional context provided by labels and notes.

I think it would make sense to have a way to report additional recommendations/fixes internally, so that the message can contain multiple parts while adhering to the codespan reporting recommendations. Maybe using codespan reporting's `notes`?

How to reproduce:

Create a `.typ` file with the following content:

```
= Introduction <intro>
In @intro, we see how to turn
Sections into Chapters. And
in @intro[Part], it is done
manually.
```

The content is straight out of the example for headings, with the `#set heading(numbering: "1.")` removed.

The user get's shown the following message now:

![image](https://github.com/typst/typst/assets/10061519/2abf403c-7492-4bec-ae9a-cb2e0393957a)

Is a test for this needed? If so, I'll happily write one.

This is my first contribution here, so if there is anything I can do better, no matter what, feel free to tell me!
