### PR TITLE
Add translation for Turkish

### DIFF
--- a/library/src/layout/table.rs
+++ b/library/src/layout/table.rs
@@ -318,6 +318,7 @@ impl LocalName for TableElem {
             Lang::SLOVENIAN => "Tabela",
             Lang::SPANISH => "Tabla",
             Lang::SWEDISH => "Tabell",
+            Lang::TURKISH => "Tablo",
             Lang::UKRAINIAN => "Таблиця",
             Lang::VIETNAMESE => "Bảng",
             Lang::ENGLISH | _ => "Table",

--- a/library/src/math/mod.rs
+++ b/library/src/math/mod.rs
@@ -332,6 +332,7 @@ impl LocalName for EquationElem {
             Lang::SLOVENIAN => "Enačba",
             Lang::SPANISH => "Ecuación",
             Lang::SWEDISH => "Ekvation",
+            Lang::TURKISH => "Denklem",
             Lang::UKRAINIAN => "Рівняння",
             Lang::VIETNAMESE => "Phương trình",
             Lang::ENGLISH | _ => "Equation",

--- a/library/src/meta/bibliography.rs
+++ b/library/src/meta/bibliography.rs
@@ -227,6 +227,7 @@ impl LocalName for BibliographyElem {
             Lang::SLOVENIAN => "Literatura",
             Lang::SPANISH => "Bibliografía",
             Lang::SWEDISH => "Bibliografi",
+            Lang::TURKISH => "Kaynakça",
             Lang::UKRAINIAN => "Бібліографія",
             Lang::VIETNAMESE => "Tài liệu tham khảo",
             Lang::ENGLISH | _ => "Bibliography",

--- a/library/src/meta/heading.rs
+++ b/library/src/meta/heading.rs
@@ -227,6 +227,7 @@ impl LocalName for HeadingElem {
             Lang::SLOVENIAN => "Poglavje",
             Lang::SPANISH => "Sección",
             Lang::SWEDISH => "Kapitel",
+            Lang::TURKISH => "Bölüm",
             Lang::UKRAINIAN => "Розділ",
             Lang::VIETNAMESE => "Phần", // TODO: This may be wrong.
             Lang::ENGLISH | _ => "Section",

--- a/library/src/meta/outline.rs
+++ b/library/src/meta/outline.rs
@@ -296,6 +296,7 @@ impl LocalName for OutlineElem {
             Lang::SLOVENIAN => "Kazalo",
             Lang::SPANISH => "Índice",
             Lang::SWEDISH => "Innehåll",
+            Lang::TURKISH => "İçindekiler",
             Lang::UKRAINIAN => "Зміст",
             Lang::VIETNAMESE => "Mục lục",
             Lang::ENGLISH | _ => "Contents",

--- a/library/src/text/raw.rs
+++ b/library/src/text/raw.rs
@@ -243,6 +243,7 @@ impl LocalName for RawElem {
             Lang::RUSSIAN => "Листинг",
             Lang::SLOVENIAN => "Program",
             Lang::SWEDISH => "Listing",
+            Lang::TURKISH => "Liste",
             Lang::UKRAINIAN => "Лістинг",
             Lang::VIETNAMESE => "Chương trình", // TODO: This may be wrong.
             Lang::ENGLISH | _ => "Listing",

--- a/library/src/visualize/image.rs
+++ b/library/src/visualize/image.rs
@@ -146,6 +146,7 @@ impl LocalName for ImageElem {
             Lang::SLOVENIAN => "Slika",
             Lang::SPANISH => "Figura",
             Lang::SWEDISH => "Figur",
+            Lang::TURKISH => "Şekil",
             Lang::UKRAINIAN => "Рисунок",
             Lang::VIETNAMESE => "Hình",
             Lang::ENGLISH | _ => "Figure",

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -532,6 +532,7 @@ impl Lang {
     pub const SLOVENIAN: Self = Self(*b"sl ", 2);
     pub const SPANISH: Self = Self(*b"es ", 2);
     pub const SWEDISH: Self = Self(*b"sv ", 2);
+    pub const TURKISH: Self = Self(*b"tr ", 2);
     pub const UKRAINIAN: Self = Self(*b"ua ", 2);
     pub const VIETNAMESE: Self = Self(*b"vi ", 2);
 


### PR DESCRIPTION
This PR adds Turkish language code 
`    pub const TURKISH: Self = Self(*b"tr ", 2);
`
and implements translation for LocalNames 
- ImageElem => 'Şekil'
- RawElem => "Liste"
- OutlineELem => "İçindekiler"
- HeadingElem => "Bölüm"
- BibliographyElem => "Kaynakça"
- EquationElem => "Denklem"
- TableElem => "Table"