### PR TITLE
Add infrastructure to enrich errors with hints

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -23,7 +23,7 @@ use std::cell::OnceCell;
 use termcolor::{ColorChoice, StandardStream, WriteColor};
 use typst::diag::{bail, FileError, FileResult, SourceError, StrResult};
 use typst::doc::Document;
-use typst::eval::{Datetime, Library};
+use typst::eval::{eco_format, Datetime, Library};
 use typst::font::{Font, FontBook, FontInfo, FontVariant};
 use typst::geom::Color;
 use typst::syntax::{Source, SourceId};
@@ -436,6 +436,13 @@ fn print_diagnostics(
         let range = error.range(world);
         let diag = Diagnostic::error()
             .with_message(error.message)
+            .with_notes(
+                error
+                    .hints
+                    .iter()
+                    .map(|e| (eco_format!("hint: {e}")).into())
+                    .collect(),
+            )
             .with_labels(vec![Label::primary(error.span.source(), range)]);
 
         term::emit(&mut w, &config, world, &diag)?;

--- a/library/src/meta/reference.rs
+++ b/library/src/meta/reference.rs
@@ -1,3 +1,5 @@
+use typst::diag::Hint;
+
 use super::{BibliographyElem, CiteElem, Counter, Figurable, Numbering};
 use crate::prelude::*;
 use crate::text::TextElem;
@@ -178,11 +180,14 @@ impl Show for RefElem {
                 .numbering()
                 .ok_or_else(|| {
                     eco_format!(
-                        "cannot reference {0} without numbering \
-                        - did you mean to use `#set {0}(numbering: \"1.\")`?",
+                        "cannot reference {} without numbering",
                         elem.func().name()
                     )
                 })
+                .hint(eco_format!(
+                    "did you mean to use `#set {}(numbering: \"1.\")`?",
+                    elem.func().name()
+                ))
                 .at(span)?;
 
             let numbers = refable

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -82,6 +82,8 @@ pub struct SourceError {
     pub message: EcoString,
     /// The trace of function calls leading to the error.
     pub trace: Vec<Spanned<Tracepoint>>,
+    /// Additonal hints to the user, indicating how this error could be avoided or worked around.
+    pub hints: Vec<EcoString>,
 }
 
 impl SourceError {
@@ -92,6 +94,7 @@ impl SourceError {
             pos: ErrorPos::Full,
             trace: vec![],
             message: message.into(),
+            hints: vec![],
         }
     }
 

--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -586,17 +586,19 @@ fn test_part(
     unexpected_outputs.sort_by_key(|&o| o.start());
     missing_outputs.sort_by_key(|&o| o.start());
 
+    // This prints all unexpected emits first, then all missing emits.
+    // Is this reasonable or subject to change?
     if !(unexpected_outputs.is_empty() && missing_outputs.is_empty()) {
         writeln!(output, "  Subtest {i} does not match expected errors.").unwrap();
         ok = false;
 
         for unexpected in unexpected_outputs {
-            write!(output, "    Not emitted   | ").unwrap();
+            write!(output, "    Not annotated | ").unwrap();
             print_user_output(output, source, line, unexpected)
         }
 
         for missing in missing_outputs {
-            write!(output, "    Not annotated | ").unwrap();
+            write!(output, "    Not emitted   | ").unwrap();
             print_user_output(output, source, line, missing)
         }
     }

--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -494,7 +494,7 @@ fn get_metadata<'a>(line: &'a str, key: &str) -> Option<&'a str> {
     line.strip_prefix(eco_format!("// {key}: ").as_str())
 }
 
-fn get_flag_metadata<'a>(line: &'a str, key: &str) -> Option<bool> {
+fn get_flag_metadata(line: &str, key: &str) -> Option<bool> {
     get_metadata(line, key).map(|value| value == "true")
 }
 
@@ -565,8 +565,8 @@ fn test_part(
         .flat_map(|error| {
             let output_error =
                 UserOutput::Error(error.range(world), error.message.replace('\\', "/"));
-            let hints = error.hints.to_owned();
-            let hints = hints
+            let hints = error
+                .hints
                 .iter()
                 .filter(|_| validate_hints) // No unexpected hints should be verified if disabled.
                 .map(|hint| UserOutput::Hint(error.range(world), hint.to_string()));

--- a/tests/typ/compiler/hint.typ
+++ b/tests/typ/compiler/hint.typ
@@ -23,5 +23,6 @@
 
 ---
 = Heading <intro>
-// Error: 1:20-1:26 cannot reference heading without numbering - did you mean to use `#set heading(numbering: "1.")`?
+// Error: 1:20-1:26 cannot reference heading without numbering
+// Hint: 1:20-1:26 did you mean to use `#set heading(numbering: "1.")`?
 Can not be used as @intro

--- a/tests/typ/compiler/hint.typ
+++ b/tests/typ/compiler/hint.typ
@@ -26,3 +26,10 @@
 // Error: 1:20-1:26 cannot reference heading without numbering
 // Hint: 1:20-1:26 did you mean to use `#set heading(numbering: "1.")`?
 Can not be used as @intro
+
+---
+// Hints: false
+// This test is more of a tooling test. It checks if hint annotation validation can be turned off.
+= Heading <intro>
+// Error: 1:20-1:26 cannot reference heading without numbering
+Can not be used as @intro


### PR DESCRIPTION
Followup for #1456.

Goals during implementation:

* As little changes to existing code as possible, as few changes in signatures as possible
  * I did refactor some test code however - feel free to critique!
* Incremental shifts are possible - any existing code must be easily enriched with hints without huge changes
* Hints always belong to errors, and there can be as many as preferred
* Hints are currently `codespan_reporting` labels, but this can theoretically be changed in the future
* The typ-file based tests can be extended with expected hints and they fail if a hint is not emitted or not annotated
  * Hint validation (for un-annotated output) can be disabled to avoid cluttering duplicated hints in technical tests

I did evaluate some more complex options (like a new result type) but nothing was convenient, really. There are some drafts in my fork but I don't think they're worth looking at.

What can be done after this:

* All "did you" messages can be converted into hints
* Richer hint output in the cli could be an option, but this might require moving away from `codespan_reporting` or simply abusing it by printing an additoinal information output as hint, which will then be unrelated to the error, at least technically.