### PR TITLE
Add Filipino (`fil`/`tl`) translations

### DIFF
--- a/library/src/layout/table.rs
+++ b/library/src/layout/table.rs
@@ -312,6 +312,7 @@ impl LocalName for TableElem {
             Lang::CZECH => "Tabulka",
             Lang::DANISH => "Tabel",
             Lang::DUTCH => "Tabel",
+            Lang::FILIPINO => "Talaan",
             Lang::FRENCH => "Tableau",
             Lang::GERMAN => "Tabelle",
             Lang::ITALIAN => "Tabella",

--- a/library/src/math/mod.rs
+++ b/library/src/math/mod.rs
@@ -323,6 +323,7 @@ impl LocalName for EquationElem {
             Lang::CZECH => "Rovnice",
             Lang::DANISH => "Ligning",
             Lang::DUTCH => "Vergelijking",
+            Lang::FILIPINO => "Ekwasyon",
             Lang::FRENCH => "Équation",
             Lang::GERMAN => "Gleichung",
             Lang::ITALIAN => "Equazione",

--- a/library/src/meta/bibliography.rs
+++ b/library/src/meta/bibliography.rs
@@ -216,6 +216,7 @@ impl LocalName for BibliographyElem {
             Lang::CZECH => "Bibliografie",
             Lang::DANISH => "Bibliografi",
             Lang::DUTCH => "Bibliografie",
+            Lang::FILIPINO => "Bibliograpiya",
             Lang::FRENCH => "Bibliographie",
             Lang::GERMAN => "Bibliographie",
             Lang::ITALIAN => "Bibliografia",

--- a/library/src/meta/heading.rs
+++ b/library/src/meta/heading.rs
@@ -218,6 +218,7 @@ impl LocalName for HeadingElem {
             Lang::CZECH => "Kapitola",
             Lang::DANISH => "Afsnit",
             Lang::DUTCH => "Hoofdstuk",
+            Lang::FILIPINO => "Seksyon",
             Lang::FRENCH => "Chapitre",
             Lang::GERMAN => "Abschnitt",
             Lang::ITALIAN => "Sezione",

--- a/library/src/meta/outline.rs
+++ b/library/src/meta/outline.rs
@@ -262,6 +262,7 @@ impl LocalName for OutlineElem {
             Lang::CZECH => "Obsah",
             Lang::DANISH => "Indhold",
             Lang::DUTCH => "Inhoudsopgave",
+            Lang::FILIPINO => "Talaan ng mga Nilalaman",
             Lang::FRENCH => "Table des matières",
             Lang::GERMAN => "Inhaltsverzeichnis",
             Lang::ITALIAN => "Indice",

--- a/library/src/text/raw.rs
+++ b/library/src/text/raw.rs
@@ -236,6 +236,7 @@ impl LocalName for RawElem {
             Lang::CZECH => "Seznam",
             Lang::DANISH => "Liste",
             Lang::DUTCH => "Listing",
+            Lang::FILIPINO => "Listahan",
             Lang::FRENCH => "Liste",
             Lang::GERMAN => "Listing",
             Lang::ITALIAN => "Codice",

--- a/library/src/visualize/image.rs
+++ b/library/src/visualize/image.rs
@@ -137,6 +137,7 @@ impl LocalName for ImageElem {
             Lang::CZECH => "Obrázek",
             Lang::DANISH => "Figur",
             Lang::DUTCH => "Figuur",
+            Lang::FILIPINO => "Pigura",
             Lang::FRENCH => "Figure",
             Lang::GERMAN => "Abbildung",
             Lang::ITALIAN => "Figura",

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -522,6 +522,7 @@ impl Lang {
     pub const DANISH: Self = Self(*b"da ", 2);
     pub const DUTCH: Self = Self(*b"nl ", 2);
     pub const ENGLISH: Self = Self(*b"en ", 2);
+    pub const FILIPINO: Self = Self(*b"tl ", 2);
     pub const FRENCH: Self = Self(*b"fr ", 2);
     pub const GERMAN: Self = Self(*b"de ", 2);
     pub const ITALIAN: Self = Self(*b"it ", 2);


### PR DESCRIPTION
Added Filipino (`fil`/`tl`) translations for the following terms:

| English             | Filipino                    |
| ------------------- | --------------------------- |
| Bibliography        | **Bibliograpiya**           |
| Equation            | **Ekwasyon**                |
| Figure              | **Pigura**                  |
| Listing (or List)   | **Listahan**                |
| Section             | **Seksyon**                 |
| (Table of) Contents | **Talaan ng mga Nilalaman** |
| Table               | **Talaan**                  |

> **Note**
> - `Seksyon` could be `Kabanata` if the word `Section` specifically pertains to `Chapter`.
> - Otherwise, `Seksyon` is used for a general term like `Section`.