### PR TITLE
Swallow broken pipe errors

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -46,7 +46,7 @@ fn main() -> ExitCode {
     let _guard = match crate::trace::init_tracing(&arguments) {
         Ok(guard) => guard,
         Err(err) => {
-            eprintln!("failed to initialize tracing {}", err);
+            _ = writeln!(io::stderr().lock(), "failed to initialize tracing {err}");
             None
         }
     };
@@ -476,11 +476,15 @@ fn fonts(command: FontsSettings) -> StrResult<()> {
     searcher.search(&command.font_paths);
 
     for (name, infos) in searcher.book.families() {
-        println!("{name}");
+        let mut stdout = io::stdout().lock();
+        _ = writeln!(stdout, "{name}");
         if command.variants {
             for info in infos {
                 let FontVariant { style, weight, stretch } = info.variant;
-                println!("- Style: {style:?}, Weight: {weight:?}, Stretch: {stretch:?}");
+                _ = writeln!(
+                    stdout,
+                    "- Style: {style:?}, Weight: {weight:?}, Stretch: {stretch:?}"
+                );
             }
         }
     }

--- a/cli/src/trace.rs
+++ b/cli/src/trace.rs
@@ -1,5 +1,6 @@
 use std::fs::File;
-use std::io::{BufReader, BufWriter, Error, ErrorKind, Seek, SeekFrom};
+use std::io;
+use std::io::{BufReader, BufWriter, Error, ErrorKind, Seek, SeekFrom, Write};
 use std::path::PathBuf;
 
 use inferno::flamegraph::Options;
@@ -55,7 +56,10 @@ impl Drop for TracingGuard {
             if let Err(e) = self.finish() {
                 // Since we are finished, we cannot rely on tracing to log the
                 // error.
-                eprintln!("Failed to flush tracing flamegraph: {e}");
+                _ = writeln!(
+                    io::stderr().lock(),
+                    "Failed to flush tracing flamegraph: {e}"
+                );
             }
         }
     }


### PR DESCRIPTION
### What does this resolve?

Swallow broken pipe errors by using `writeln!` instead of `println!`. This patch also reduces unnecessary locks to stdout.

### version info

```
$ typst --version
typst 0.5.0
```

### Reproducer

```
$ typst fonts | true
thread 'main' panicked at 'failed printing to stdout: Broken pipe (os error 32)', library/std/src/io/stdio.rs:1019:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

### 