### PR TITLE
Watch dependencies that are outside of root

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -237,6 +237,16 @@ fn compile(mut command: CompileSettings) -> StrResult<()> {
             .map_err(|_| "failed to watch root directory")?;
     }
 
+    // Watch all the files that are used in the input file and its dependencies
+    let mut dependencies = world.dependencies();
+
+    for dep in &dependencies {
+        tracing::debug!("Watching {:?}", dep);
+        watcher
+            .watch(dep, RecursiveMode::NonRecursive)
+            .map_err(|_| format!("failed to watch {:?}", dep))?;
+    }
+
     // Handle events.
     let timeout = std::time::Duration::from_millis(100);
     loop {
@@ -261,6 +271,20 @@ fn compile(mut command: CompileSettings) -> StrResult<()> {
         if recompile {
             let ok = compile_once(&mut world, &command)?;
             comemo::evict(30);
+
+            // Unwatch all the previous dependencies before watching the new dependencies
+            for dep in &dependencies {
+                watcher
+                    .unwatch(dep)
+                    .map_err(|_| format!("failed to unwatch {:?}", dep))?;
+            }
+            dependencies = world.dependencies();
+            for dep in &dependencies {
+                tracing::debug!("Watching {:?}", dep);
+                watcher
+                    .watch(dep, RecursiveMode::NonRecursive)
+                    .map_err(|_| format!("failed to watch {:?}", dep))?;
+            }
 
             // Ipen the file if requested, this must be done on the first
             // **successful** compilation
@@ -499,6 +523,7 @@ struct SystemWorld {
     sources: FrozenVec<Box<Source>>,
     today: Cell<Option<Datetime>>,
     main: SourceId,
+    dependencies: RefCell<Vec<PathBuf>>,
 }
 
 /// Holds details about the location of a font and lazily the font itself.
@@ -530,6 +555,7 @@ impl SystemWorld {
             sources: FrozenVec::new(),
             today: Cell::new(None),
             main: SourceId::detached(),
+            dependencies: RefCell::default(),
         }
     }
 }
@@ -560,6 +586,7 @@ impl World for SystemWorld {
                     // Assume UTF-8
                     String::from_utf8(buf)?
                 };
+                self.dependencies.borrow_mut().push(path.to_owned());
                 Ok(self.insert(path, text))
             })
             .clone()
@@ -586,7 +613,10 @@ impl World for SystemWorld {
     fn file(&self, path: &Path) -> FileResult<Buffer> {
         self.slot(path)?
             .buffer
-            .get_or_init(|| read(path).map(Buffer::from))
+            .get_or_init(|| {
+                self.dependencies.borrow_mut().push(path.to_owned());
+                read(path).map(Buffer::from)
+            })
             .clone()
     }
 
@@ -668,6 +698,12 @@ impl SystemWorld {
         self.hashes.borrow_mut().clear();
         self.paths.borrow_mut().clear();
         self.today.set(None);
+        self.dependencies.borrow_mut().clear();
+    }
+
+    // Return a list of files the document depends on
+    fn dependencies(&self) -> Vec<PathBuf> {
+        self.dependencies.borrow().clone()
     }
 }
 


### PR DESCRIPTION
Closes #1508 

This is a naive way of adding the dependencies of the input file to the file watcher when using the `watch` command. It uses the `resolve` and `file` methods on the world to add the loaded files to a list of dependencies. 

I say it is a naive solution because:

- It adds the files in the working directory again if they are used in the document. The impact might be negligible if the watcher doesn't do anything if the file is already watched, but I have not checked.
- It adds loaded fonts even if they are system fonts. I'm not sure if that is a problem?
- On every recompilation it unwatches all the "dependencies" from the old compilation and then watches all the ones from the new one. We can certainly make it smarter if this has a performance impact.

This seems to work for my use case, but I haven't thoroughly tested in different situations. Let me know if something needs to be changed.