### PR TITLE
More consistent empty set signs

### DIFF
--- a/library/src/symbols/sym.rs
+++ b/library/src/symbols/sym.rs
@@ -298,7 +298,7 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
     prop: '∝',
 
     // Set theory.
-    nothing: ['∅', rev: '⦰'],
+    nothing: ['⌀', rev: '⦰', alt: '∅'],
     without: '∖',
     complement: '∁',
     in: [


### PR DESCRIPTION
Typst uses `nothing` sign that in default math font produces thin sign (like crossed zero). It is used rarer than "wide" sign (eg. see Wiki, it is primzry used on most languages I looked). Moreover, `nothing.rev` produces reversed _wide_ sign.

I moved old `nothing` to `nothing.alt`, and replaced default nothing with wide sign, so now it looks like:

![image](https://github.com/typst/typst/assets/60141933/085554c7-9504-4783-86a3-6d8035b5842e)

It is breaking change, but seems to touch not that much people as no one hadn't reported that before.

Notice: these symbols behave different on different fonts, but I think we should look at *default math font* first of all.