### PR TITLE
Few backslash in math fixes

### DIFF
--- a/library/src/math/row.rs
+++ b/library/src/math/row.rs
@@ -85,8 +85,16 @@ impl MathRow {
         self.0.iter()
     }
 
-    pub fn width(&self) -> Abs {
-        self.iter().map(MathFragment::width).sum()
+    /// It is very unintuitive, but in current state of things
+    /// `MathRow` can contain several actual rows.
+    /// That function deconstructs it to "single" rows.
+    ///
+    /// Hopefully that cloner is only a temporary hack
+    pub fn rows(&self) -> Vec<Self> {
+        self.0
+            .split(|frag| matches!(frag, MathFragment::Linebreak))
+            .map(|slice| Self(slice.to_vec()))
+            .collect()
     }
 
     pub fn ascent(&self) -> Abs {
@@ -126,23 +134,19 @@ impl MathRow {
     }
 
     pub fn into_aligned_frame(
-        mut self,
+        self,
         ctx: &MathContext,
         points: &[Abs],
         align: Align,
     ) -> Frame {
         if self.iter().any(|frag| matches!(frag, MathFragment::Linebreak)) {
-            let fragments: Vec<_> = std::mem::take(&mut self.0);
             let leading = if ctx.style.size >= MathSize::Text {
                 ParElem::leading_in(ctx.styles())
             } else {
                 TIGHT_LEADING.scaled(ctx)
             };
 
-            let mut rows: Vec<_> = fragments
-                .split(|frag| matches!(frag, MathFragment::Linebreak))
-                .map(|slice| Self(slice.to_vec()))
-                .collect();
+            let mut rows: Vec<_> = self.rows();
 
             if matches!(rows.last(), Some(row) if row.0.is_empty()) {
                 rows.pop();

--- a/library/src/math/underover.rs
+++ b/library/src/math/underover.rs
@@ -203,8 +203,10 @@ fn layout(
     let gap = gap.scaled(ctx);
     let body = ctx.layout_row(body)?;
     let body_class = body.class();
+    let body = body.into_fragment(ctx);
     let glyph = GlyphFragment::new(ctx, c, span);
     let stretched = glyph.stretch_horizontal(ctx, body.width(), Abs::zero());
+    let body = MathRow::new(vec![body]);
 
     let mut rows = vec![body, stretched.into()];
     ctx.style(if reverse {
@@ -243,6 +245,7 @@ pub(super) fn stack(
     gap: Abs,
     baseline: usize,
 ) -> Frame {
+    let rows: Vec<_> = rows.into_iter().flat_map(|r| r.rows()).collect();
     let AlignmentResult { points, width } = alignments(&rows);
     let rows: Vec<_> = rows
         .into_iter()


### PR DESCRIPTION
Fixes #1196.

# Overview

Current math stacking blocks (`cases`, `vec`, `mat`) _allow_ using "\" instead of commas in arguments and produce almost desired result. However, the spacing around them is broken (see #1196), since `rust` code assumes the arguments are single-lined. The result may be extremely confusing.

There are two general options: either fix it or forbid it. I tried fixing. I'm not sure that is the best strategy, but I thought in future there may appear reasons of using `\` instead of `,` in some rare cases (like uniting cells when styling with `show` rules).

I thought that a tiny fix for a bit more adequate behaviour will not be bad.

# Fixes
There are two simple fixes inside:
- One is fixing bad spacing for `cases`-like things. The simpliest way I found was expanding multiple rows into "single" ones before calculating new width for frame.
- Other is fixing width of `over/under`-things. Before fix, it had calculated width with method of `MathRow`, that just _sumed up_ widths of fragments inside. That's senseless in case of multiple lines or alignment inside (and doesn't take in account smaller things), so I completly removed that method. I fixed it with converting it to fragment and measuring its width.

These fixes don't touch the "right" way of using multiple lines and alignments (maybe a few more allocations&cloning, but that was already an issue for multiline equations).

# Architecture problems 

The main problem that caused that meaningless behaviour was `MathRow` class representing _both single and multiple rows_, while some code outside assumes that rows are _single only_.

I think that some new entitity could be introduced to manage _multiple rows and their alignment_. Currently alignment is realised differently for multiline equations, stacking things (cases, vecs), matrices… Some of them behave in a non-obvious way. I suppose it would be good to have good alignment management in one place.

# Gallery
Old:

![Old](https://github.com/typst/typst/assets/60141933/2d667211-6410-4660-a1af-733725ad71a5)

New:

![New](https://github.com/typst/typst/assets/60141933/0bf80bcc-fc76-4273-901a-c9ad508f8cea)

# Tests

Behaviour of `\` in multiline things other that on equation-level is quite uncertain, so I decided to avoid writing "solid" tests yet.
