### PR TITLE
Add heading `bookmarked` toggle

### DIFF
--- a/crates/typst-library/src/meta/heading.rs
+++ b/crates/typst-library/src/meta/heading.rs
@@ -80,9 +80,9 @@ pub struct HeadingElem {
 
     /// Whether the heading should appear in the [outline]($func/outline).
     ///
-    /// Note that this property does not affect whether or not headings are
-    /// shown as a bookmark in the exported PDF's outline (when exporting to
-    /// PDF). To change that behavior, use the `bookmarked` property.
+    /// Note that this property, if set to `{true}`, ensures the heading is
+    /// also shown as a bookmark in the exported PDF's outline (when exporting
+    /// to PDF). To change that behavior, use the `bookmarked` property.
     ///
     /// ```example
     /// #outline()
@@ -100,6 +100,13 @@ pub struct HeadingElem {
     /// Whether the heading should appear as a bookmark in the exported PDF's
     /// outline. Doesn't affect other export formats, such as PNG.
     ///
+    /// The default value of `{auto}` indicates that the heading will only
+    /// appear in the exported PDF's outline if its `outlined` property is set
+    /// to `{true}`, that is, if it would also be listed in Typst's
+    /// [outline]($func/outline). Setting this property to either
+    /// `{true}` (bookmark) or `{false}` (don't bookmark) bypasses that
+    /// behavior.
+    ///
     /// ```example
     /// #heading[Normal heading]
     /// This heading will be shown in
@@ -110,8 +117,8 @@ pub struct HeadingElem {
     /// bookmarked in the resulting
     /// PDF.
     /// ```
-    #[default(true)]
-    pub bookmarked: bool,
+    #[default(Smart::Auto)]
+    pub bookmarked: Smart<bool>,
 
     /// The heading's title.
     #[required]

--- a/crates/typst-library/src/meta/heading.rs
+++ b/crates/typst-library/src/meta/heading.rs
@@ -78,7 +78,11 @@ pub struct HeadingElem {
     /// ```
     pub supplement: Smart<Option<Supplement>>,
 
-    /// Whether the heading should appear in the outline.
+    /// Whether the heading should appear in the [outline]($func/outline).
+    ///
+    /// Note that this property does not affect whether or not headings are
+    /// shown in the exported PDF's outline (when exporting to PDF). Such
+    /// behavior is exclusively determined by the `bookmark` property.
     ///
     /// ```example
     /// #outline()
@@ -97,28 +101,15 @@ pub struct HeadingElem {
     /// outline. Doesn't affect other export formats, such as PNG.
     ///
     /// ```example
-    /// #outline()
-    ///
     /// #heading[Normal heading]
-    /// Nothing changes here.
-    ///
-    /// #heading(outlined: false)[Still bookmarked]
-    /// This heading does not appear
-    /// in the Typst outline, but
-    /// will still appear in the
-    /// PDF's bookmark outline.
+    /// This heading will be shown in
+    /// the PDF's bookmark outline.
     ///
     /// #heading(bookmark: false)[Not bookmarked]
-    /// This heading still appears
-    /// in the Typst outline, but
-    /// won't be bookmarked in the
-    /// resulting PDF.
-    ///
-    /// #heading(outlined: false, bookmark: false)[Fully hidden]
-    /// This heading is hidden both
-    /// from the Typst outline and
-    /// from the resulting PDF's
-    /// bookmark outline.
+    /// This heading won't be
+    /// bookmarked in the resulting
+    /// PDF.
+    /// ```
     #[default(true)]
     pub bookmark: bool,
 

--- a/crates/typst-library/src/meta/heading.rs
+++ b/crates/typst-library/src/meta/heading.rs
@@ -114,7 +114,7 @@ pub struct HeadingElem {
     /// won't be bookmarked in the
     /// resulting PDF.
     ///
-    /// #heading(outlined: false, bookmarked: false)[Fully hidden]
+    /// #heading(outlined: false, bookmark: false)[Fully hidden]
     /// This heading is hidden both
     /// from the Typst outline and
     /// from the resulting PDF's

--- a/crates/typst-library/src/meta/heading.rs
+++ b/crates/typst-library/src/meta/heading.rs
@@ -82,7 +82,7 @@ pub struct HeadingElem {
     ///
     /// Note that this property does not affect whether or not headings are
     /// shown in the exported PDF's outline (when exporting to PDF). Such
-    /// behavior is exclusively determined by the `bookmark` property.
+    /// behavior is exclusively determined by the `bookmarked` property.
     ///
     /// ```example
     /// #outline()
@@ -105,13 +105,13 @@ pub struct HeadingElem {
     /// This heading will be shown in
     /// the PDF's bookmark outline.
     ///
-    /// #heading(bookmark: false)[Not bookmarked]
+    /// #heading(bookmarked: false)[Not bookmarked]
     /// This heading won't be
     /// bookmarked in the resulting
     /// PDF.
     /// ```
     #[default(true)]
-    pub bookmark: bool,
+    pub bookmarked: bool,
 
     /// The heading's title.
     #[required]
@@ -131,7 +131,7 @@ impl Synthesize for HeadingElem {
         self.push_numbering(self.numbering(styles));
         self.push_supplement(Smart::Custom(Some(Supplement::Content(supplement))));
         self.push_outlined(self.outlined(styles));
-        self.push_bookmark(self.bookmark(styles));
+        self.push_bookmarked(self.bookmarked(styles));
 
         Ok(())
     }

--- a/crates/typst-library/src/meta/heading.rs
+++ b/crates/typst-library/src/meta/heading.rs
@@ -81,8 +81,8 @@ pub struct HeadingElem {
     /// Whether the heading should appear in the [outline]($func/outline).
     ///
     /// Note that this property does not affect whether or not headings are
-    /// shown in the exported PDF's outline (when exporting to PDF). Such
-    /// behavior is exclusively determined by the `bookmarked` property.
+    /// shown as a bookmark in the exported PDF's outline (when exporting to
+    /// PDF). To change that behavior, use the `bookmarked` property.
     ///
     /// ```example
     /// #outline()

--- a/crates/typst-library/src/meta/heading.rs
+++ b/crates/typst-library/src/meta/heading.rs
@@ -93,6 +93,35 @@ pub struct HeadingElem {
     #[default(true)]
     pub outlined: bool,
 
+    /// Whether the heading should appear as a bookmark in the exported PDF's
+    /// outline. Doesn't affect other export formats, such as PNG.
+    ///
+    /// ```example
+    /// #outline()
+    ///
+    /// #heading[Normal heading]
+    /// Nothing changes here.
+    ///
+    /// #heading(outlined: false)[Still bookmarked]
+    /// This heading does not appear
+    /// in the Typst outline, but
+    /// will still appear in the
+    /// PDF's bookmark outline.
+    ///
+    /// #heading(bookmark: false)[Not bookmarked]
+    /// This heading still appears
+    /// in the Typst outline, but
+    /// won't be bookmarked in the
+    /// resulting PDF.
+    ///
+    /// #heading(outlined: false, bookmarked: false)[Fully hidden]
+    /// This heading is hidden both
+    /// from the Typst outline and
+    /// from the resulting PDF's
+    /// bookmark outline.
+    #[default(true)]
+    pub bookmark: bool,
+
     /// The heading's title.
     #[required]
     pub body: Content,
@@ -111,6 +140,7 @@ impl Synthesize for HeadingElem {
         self.push_numbering(self.numbering(styles));
         self.push_supplement(Smart::Custom(Some(Supplement::Content(supplement))));
         self.push_outlined(self.outlined(styles));
+        self.push_bookmark(self.bookmark(styles));
 
         Ok(())
     }

--- a/crates/typst/src/export/pdf/outline.rs
+++ b/crates/typst/src/export/pdf/outline.rs
@@ -62,9 +62,9 @@ pub fn write_outline(ctx: &mut PdfContext) -> Option<Ref> {
 
             // Since this heading was bookmarked, the next heading, if it is a
             // child of this one, won't have a skipped direct ancestor (indeed,
-            // this heading would be its most direct bookmarked ancestor, and
-            // wasn't skipped). Therefore, it can be added as a child of this
-            // one, if needed, following the usual rules listed above.
+            // this heading would be its most direct ancestor, and wasn't
+            // skipped). Therefore, it can be added as a child of this one, if
+            // needed, following the usual rules listed above.
             last_skipped_level = None;
             children.push(leaf);
         } else if last_skipped_level.map_or(true, |l| leaf.level < l) {

--- a/crates/typst/src/export/pdf/outline.rs
+++ b/crates/typst/src/export/pdf/outline.rs
@@ -13,7 +13,7 @@ pub fn write_outline(ctx: &mut PdfContext) -> Option<Ref> {
     for heading in ctx.introspector.query(&item!(heading_func).select()) {
         let leaf = HeadingNode::leaf((*heading).clone());
 
-        if leaf.bookmark {
+        if leaf.bookmarked {
             let mut children = &mut tree;
             while children.last().map_or(false, |last| last.level < leaf.level) {
                 children = &mut children.last_mut().unwrap().children;
@@ -50,7 +50,7 @@ pub fn write_outline(ctx: &mut PdfContext) -> Option<Ref> {
 struct HeadingNode {
     element: Content,
     level: NonZeroUsize,
-    bookmark: bool,
+    bookmarked: bool,
     children: Vec<HeadingNode>,
 }
 
@@ -58,7 +58,7 @@ impl HeadingNode {
     fn leaf(element: Content) -> Self {
         HeadingNode {
             level: element.expect_field::<NonZeroUsize>("level"),
-            bookmark: element.expect_field::<bool>("bookmark"),
+            bookmarked: element.expect_field::<bool>("bookmarked"),
             element,
             children: Vec::new(),
         }

--- a/crates/typst/src/export/pdf/outline.rs
+++ b/crates/typst/src/export/pdf/outline.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroUsize;
 use pdf_writer::{Finish, Ref, TextStr};
 
 use super::{AbsExt, PdfContext, RefExt};
-use crate::geom::Abs;
+use crate::geom::{Abs, Smart};
 use crate::model::Content;
 
 /// Construct the outline for the document.
@@ -114,7 +114,10 @@ impl HeadingNode {
     fn leaf(element: Content) -> Self {
         HeadingNode {
             level: element.expect_field::<NonZeroUsize>("level"),
-            bookmarked: element.expect_field::<bool>("bookmarked"),
+            // 'bookmarked' set to 'auto' falls back to the value of 'outlined'.
+            bookmarked: element
+                .expect_field::<Smart<bool>>("bookmarked")
+                .unwrap_or_else(|| element.expect_field::<bool>("outlined")),
             element,
             children: Vec::new(),
         }

--- a/crates/typst/src/export/pdf/outline.rs
+++ b/crates/typst/src/export/pdf/outline.rs
@@ -13,12 +13,14 @@ pub fn write_outline(ctx: &mut PdfContext) -> Option<Ref> {
     for heading in ctx.introspector.query(&item!(heading_func).select()) {
         let leaf = HeadingNode::leaf((*heading).clone());
 
-        let mut children = &mut tree;
-        while children.last().map_or(false, |last| last.level < leaf.level) {
-            children = &mut children.last_mut().unwrap().children;
-        }
+        if leaf.bookmark {
+            let mut children = &mut tree;
+            while children.last().map_or(false, |last| last.level < leaf.level) {
+                children = &mut children.last_mut().unwrap().children;
+            }
 
-        children.push(leaf);
+            children.push(leaf);
+        }
     }
 
     if tree.is_empty() {
@@ -48,6 +50,7 @@ pub fn write_outline(ctx: &mut PdfContext) -> Option<Ref> {
 struct HeadingNode {
     element: Content,
     level: NonZeroUsize,
+    bookmark: bool,
     children: Vec<HeadingNode>,
 }
 
@@ -55,6 +58,7 @@ impl HeadingNode {
     fn leaf(element: Content) -> Self {
         HeadingNode {
             level: element.expect_field::<NonZeroUsize>("level"),
+            bookmark: element.expect_field::<bool>("bookmark"),
             element,
             children: Vec::new(),
         }

--- a/crates/typst/src/export/pdf/outline.rs
+++ b/crates/typst/src/export/pdf/outline.rs
@@ -10,16 +10,72 @@ use crate::model::Content;
 #[tracing::instrument(skip_all)]
 pub fn write_outline(ctx: &mut PdfContext) -> Option<Ref> {
     let mut tree: Vec<HeadingNode> = vec![];
+
+    // Stores the level of the topmost skipped ancestor of the next bookmarked
+    // heading. A skipped heading is a heading with 'bookmarked: false', that
+    // is, it is not added to the PDF outline, and so is not in the tree.
+    // Therefore, its next descendant must be added at its level, which is
+    // enforced in the manner shown below.
+    let mut last_skipped_level = None;
     for heading in ctx.introspector.query(&item!(heading_func).select()) {
         let leaf = HeadingNode::leaf((*heading).clone());
 
         if leaf.bookmarked {
             let mut children = &mut tree;
-            while children.last().map_or(false, |last| last.level < leaf.level) {
+
+            // Descend the tree through the latest bookmarked heading of each
+            // level until either:
+            // - you reach a node whose children would be brothers of this
+            // heading (=> add the current heading as a child of this node);
+            // - you reach a node with no children (=> this heading probably
+            // skipped a few nesting levels in Typst, or one or more ancestors
+            // of this heading weren't bookmarked, so add it as a child of this
+            // node, which is its deepest bookmarked ancestor);
+            // - or, if the latest heading(s) was(/were) skipped
+            // ('bookmarked: false'), then stop if you reach a node whose
+            // children would be brothers of the latest skipped heading
+            // of lowest level (=> those skipped headings would be ancestors
+            // of the current heading, so add it as a 'brother' of the least
+            // deep skipped ancestor among them, as those ancestors weren't
+            // added to the bookmark tree, and the current heading should not
+            // be mistakenly added as a descendant of a brother of that
+            // ancestor.)
+            //
+            // That is, if you had a bookmarked heading of level N, a skipped
+            // heading of level N, a skipped heading of level N + 1, and then
+            // a bookmarked heading of level N + 2, that last one is bookmarked
+            // as a level N heading (taking the place of its topmost skipped
+            // ancestor), so that it is not mistakenly added as a descendant of
+            // the previous level N heading.
+            //
+            // In other words, a heading can be added to the bookmark tree
+            // at most as deep as its topmost skipped direct ancestor (if it
+            // exists), or at most as deep as its actual nesting level in Typst
+            // (not exceeding whichever is the most restrictive depth limit
+            // of those two).
+            while children.last().map_or(false, |last| {
+                last_skipped_level.map_or(true, |l| last.level < l)
+                    && last.level < leaf.level
+            }) {
                 children = &mut children.last_mut().unwrap().children;
             }
 
+            // Since this heading was bookmarked, the next heading, if it is a
+            // child of this one, won't have a skipped direct ancestor (indeed,
+            // this heading would be its most direct bookmarked ancestor, and
+            // wasn't skipped). Therefore, it can be added as a child of this
+            // one, if needed, following the usual rules listed above.
+            last_skipped_level = None;
             children.push(leaf);
+        } else if last_skipped_level.map_or(true, |l| leaf.level < l) {
+            // Only the topmost / lowest-level skipped heading matters when you
+            // have consecutive skipped headings (since none of them are being
+            // added to the bookmark tree), hence the condition above.
+            // This ensures the next bookmarked heading will be placed
+            // at most as deep as its topmost skipped ancestors. Deeper
+            // ancestors do not matter as the nesting structure they create
+            // won't be visible in the PDF outline.
+            last_skipped_level = Some(leaf.level);
         }
     }
 

--- a/tests/typ/meta/outline.typ
+++ b/tests/typ/meta/outline.typ
@@ -30,7 +30,8 @@ fn main() {
 ==== Deep Stuff
 Ok ...
 
-#set heading(numbering: "(I)")
+// Ensure 'bookmark' option doesn't affect the outline
+#set heading(numbering: "(I)", bookmark: false)
 
 = #text(blue)[Zusammen]fassung
 #lorem(10)

--- a/tests/typ/meta/outline.typ
+++ b/tests/typ/meta/outline.typ
@@ -30,8 +30,8 @@ fn main() {
 ==== Deep Stuff
 Ok ...
 
-// Ensure 'bookmark' option doesn't affect the outline
-#set heading(numbering: "(I)", bookmark: false)
+// Ensure 'bookmarked' option doesn't affect the outline
+#set heading(numbering: "(I)", bookmarked: false)
 
 = #text(blue)[Zusammen]fassung
 #lorem(10)


### PR DESCRIPTION
Closes #1422. This (relatively) simple PR will allow people to write `#heading(bookmarked: false)` to prevent the heading from appearing in the exported PDF's outline (doesn't affect PNG export). It does so by simply checking for the property in the PDF outline generation step of the export.

Note that the `bookmarked` option is not linked to the `outlined` option, and defaults to `true` for all headings. I thought of having a `bookmarked: auto` default which would set it to whatever `outlined` is, but I decided against it (for now) as I think it's better (and more predictable) to just disable bookmarking explicitly. Feel free to present different opinions in the replies.

Added some docs (feel free to change them as you like).
I also added `bookmarked: false` to a heading in the outline test to ensure it doesn't have any additional implications. (I also wanted to make sure we had the `bookmarked` option in _some_ test in case someone accidentally breaks it in the future, I guess.)