### PR TITLE
Reduce rebuilds for the Nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
         genAttrs
         importTOML
         optionals
-        cleanSource
+        sourceByRegex
         ;
 
       eachSystem = f: genAttrs
@@ -40,7 +40,11 @@
           pname = "typst";
           inherit ((importTOML ./Cargo.toml).workspace.package) version;
 
-          src = cleanSource ./.;
+          src = sourceByRegex ./. [
+            "(assets|cli|docs|library|macros|src|tests)(/.*)?"
+            ''Cargo\.(toml|lock)''
+            ''build\.rs''
+          ];
 
           cargoLock = {
             lockFile = ./Cargo.lock;

--- a/flake.nix
+++ b/flake.nix
@@ -25,9 +25,6 @@
         ]
         (system: f nixpkgs.legacyPackages.${system});
 
-      rev = fallback:
-        self.shortRev or fallback;
-
       packageFor = pkgs:
         let
           rust = fenix.packages.${pkgs.stdenv.hostPlatform.system}.minimal.toolchain;
@@ -36,7 +33,7 @@
             rustc = rust;
           };
         in
-        rustPlatform.buildRustPackage rec {
+        rustPlatform.buildRustPackage {
           pname = "typst";
           inherit ((importTOML ./Cargo.toml).workspace.package) version;
 
@@ -67,7 +64,6 @@
           '';
 
           GEN_ARTIFACTS = "artifacts";
-          TYPST_VERSION = "${version} (${rev "unknown hash"})";
         };
     in
     {


### PR DESCRIPTION
This is meant as a companion to #1477, so the package caches a little better across updates, see commit messages for what specifically this does. This is separated into multiple commits, since b99417ac72e289ab470277e28d5db2eab149468a makes a lot of sense even without #1477, where 0a5b00f1d17504d818fb5191710782841fa6aecb would take a bit more justification.