### PR TITLE
Feature: multi-key cite in mark mode

### DIFF
--- a/library/src/meta/reference.rs
+++ b/library/src/meta/reference.rs
@@ -167,7 +167,9 @@ impl Show for RefElem {
                 // If cannot find the whole thing in bibliography elements,
                 // try to split them
                 let mut sub_targets = target.0.split(';');
-                let mut sub_elems = sub_targets.clone().map(|t| vt.introspector.query_label(&Label(t.into())));
+                let mut sub_elems = sub_targets
+                    .clone()
+                    .map(|t| vt.introspector.query_label(&Label(t.into())));
                 if sub_targets.all(|t| BibliographyElem::has(vt, t)) {
                     if sub_elems.any(|e| e.is_ok()) {
                         bail!(span, "label occurs in the document and its bibliography");

--- a/library/src/meta/reference.rs
+++ b/library/src/meta/reference.rs
@@ -89,7 +89,7 @@ use crate::text::TextElem;
 pub struct RefElem {
     /// The target label that should be referenced.
     #[required]
-    pub target: Label,
+    pub target: Vec<Label>,
 
     /// A supplement for the reference.
     ///
@@ -132,12 +132,19 @@ impl Synthesize for RefElem {
         self.push_citation(Some(citation));
         self.push_element(None);
 
-        let target = self.target();
-        if !BibliographyElem::has(vt, &target.0) {
-            if let Ok(elem) = vt.introspector.query_label(&target) {
-                self.push_element(Some(elem.into_inner()));
-                return Ok(());
+        let targets = self.target();
+        let mut target_push_flat = true;
+        for target in targets {
+            if !BibliographyElem::has(vt, &target.0) {
+                if let Ok(elem) = vt.introspector.query_label(&target) {
+                    self.push_element(Some(elem.into_inner()));
+                } else {
+                    target_push_flat = false
+                }
             }
+        }
+        if target_push_flat == true {
+            return Ok(());
         }
 
         Ok(())
@@ -148,22 +155,25 @@ impl Show for RefElem {
     #[tracing::instrument(name = "RefElem::show", skip_all)]
     fn show(&self, vt: &mut Vt, styles: StyleChain) -> SourceResult<Content> {
         Ok(vt.delayed(|vt| {
-            let target = self.target();
-            let elem = vt.introspector.query_label(&self.target());
+            let targets = self.target();
+            let mut elems = targets.iter().map(|target| vt.introspector.query_label(target));
             let span = self.span();
 
-            if BibliographyElem::has(vt, &target.0) {
-                if elem.is_ok() {
+            if targets.iter().all(|t: &Label| BibliographyElem::has(vt, &t.0)) {
+                if elems.any(|e| e.is_ok()) {
                     bail!(span, "label occurs in the document and its bibliography");
                 }
 
-                return Ok(self.to_citation(vt, styles)?.pack().spanned(span));
+                return Ok(self.to_citation(vt, styles)?.pack().spanned(span))
             }
 
-            let elem = elem.at(span)?;
+            // If the elements are not bibliography element,
+            // only one label (the last one) is supported
+            let target = targets.last().expect("there needs at least one target");
+            let elem = elems.last().expect("there needs at least one element").at(span)?;
 
             if elem.func() == FootnoteElem::func() {
-                return Ok(FootnoteElem::with_label(target).pack().spanned(span));
+                return Ok(FootnoteElem::with_label(target.clone()).pack().spanned(span));
             }
 
             let refable = elem
@@ -220,7 +230,8 @@ impl Show for RefElem {
 impl RefElem {
     /// Turn the reference into a citation.
     pub fn to_citation(&self, vt: &mut Vt, styles: StyleChain) -> SourceResult<CiteElem> {
-        let mut elem = CiteElem::new(vec![self.target().0]);
+        let keys: Vec<EcoString> = self.target().iter().map(|t| t.0.clone()).collect();
+        let mut elem = CiteElem::new(keys);
         elem.0.set_location(self.0.location().unwrap());
         elem.synthesize(vt, styles)?;
         elem.push_supplement(match self.supplement(styles) {

--- a/library/src/meta/reference.rs
+++ b/library/src/meta/reference.rs
@@ -143,7 +143,7 @@ impl Synthesize for RefElem {
                 }
             }
         }
-        if target_push_flat == true {
+        if target_push_flat {
             return Ok(());
         }
 

--- a/library/src/meta/reference.rs
+++ b/library/src/meta/reference.rs
@@ -180,7 +180,7 @@ impl Show for RefElem {
             let elem = elem.at(span)?;
 
             if elem.func() == FootnoteElem::func() {
-                return Ok(FootnoteElem::with_label(target.clone()).pack().spanned(span));
+                return Ok(FootnoteElem::with_label(target).pack().spanned(span));
             }
 
             let refable = elem
@@ -239,7 +239,7 @@ impl RefElem {
     pub fn to_citation(&self, vt: &mut Vt, styles: StyleChain) -> SourceResult<CiteElem> {
         let target = self.target();
         let targets = target.0.split(';');
-        let keys: Vec<EcoString> = targets.map(|t| EcoString::from(t)).collect();
+        let keys: Vec<EcoString> = targets.map(EcoString::from).collect();
         let mut elem = CiteElem::new(keys);
         elem.0.set_location(self.0.location().unwrap());
         elem.synthesize(vt, styles)?;

--- a/src/eval/library.rs
+++ b/src/eval/library.rs
@@ -62,7 +62,7 @@ pub struct LangItems {
     /// A hyperlink: `https://typst.org`.
     pub link: fn(url: EcoString) -> Content,
     /// A reference: `@target`, `@target[..]`.
-    pub reference: fn(target: Vec<Label>, supplement: Option<Content>) -> Content,
+    pub reference: fn(target: Label, supplement: Option<Content>) -> Content,
     /// The keys contained in the bibliography and short descriptions of them.
     #[allow(clippy::type_complexity)]
     pub bibliography_keys:

--- a/src/eval/library.rs
+++ b/src/eval/library.rs
@@ -62,7 +62,7 @@ pub struct LangItems {
     /// A hyperlink: `https://typst.org`.
     pub link: fn(url: EcoString) -> Content,
     /// A reference: `@target`, `@target[..]`.
-    pub reference: fn(target: Label, supplement: Option<Content>) -> Content,
+    pub reference: fn(target: Vec<Label>, supplement: Option<Content>) -> Content,
     /// The keys contained in the bibliography and short descriptions of them.
     #[allow(clippy::type_complexity)]
     pub bibliography_keys:

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -626,9 +626,9 @@ impl Eval for ast::Ref {
     #[tracing::instrument(name = "Ref::eval", skip_all)]
     fn eval(&self, vm: &mut Vm) -> SourceResult<Self::Output> {
         // let label = Label(self.target().into());
-        let labels = self.target().into_iter().map(|n| Label(n.into())).collect();
+        let label = Label(self.target().into());
         let supplement = self.supplement().map(|block| block.eval(vm)).transpose()?;
-        Ok((vm.items.reference)(labels, supplement))
+        Ok((vm.items.reference)(label, supplement))
     }
 }
 

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -625,9 +625,10 @@ impl Eval for ast::Ref {
 
     #[tracing::instrument(name = "Ref::eval", skip_all)]
     fn eval(&self, vm: &mut Vm) -> SourceResult<Self::Output> {
-        let label = Label(self.target().into());
+        // let label = Label(self.target().into());
+        let labels = self.target().into_iter().map(|n| Label(n.into())).collect();
         let supplement = self.supplement().map(|block| block.eval(vm)).transpose()?;
-        Ok((vm.items.reference)(label, supplement))
+        Ok((vm.items.reference)(labels, supplement))
     }
 }
 

--- a/src/syntax/ast.rs
+++ b/src/syntax/ast.rs
@@ -642,12 +642,14 @@ node! {
 
 impl Ref {
     /// Get the target.
-    pub fn target(&self) -> &str {
+    pub fn target(&self) -> Vec<&str> {
         self.0
             .children()
             .find(|node| node.kind() == SyntaxKind::RefMarker)
             .map(|node| node.text().trim_start_matches('@'))
             .unwrap_or_default()
+            .split(';')
+            .collect()
     }
 
     /// Get the supplement.

--- a/src/syntax/ast.rs
+++ b/src/syntax/ast.rs
@@ -642,14 +642,13 @@ node! {
 
 impl Ref {
     /// Get the target.
-    pub fn target(&self) -> Vec<&str> {
-        self.0
+    pub fn target(&self) -> &str {
+        let res = self.0
             .children()
             .find(|node| node.kind() == SyntaxKind::RefMarker)
             .map(|node| node.text().trim_start_matches('@'))
-            .unwrap_or_default()
-            .split(';')
-            .collect()
+            .unwrap_or_default();
+        res
     }
 
     /// Get the supplement.

--- a/src/syntax/ast.rs
+++ b/src/syntax/ast.rs
@@ -643,7 +643,8 @@ node! {
 impl Ref {
     /// Get the target.
     pub fn target(&self) -> &str {
-        let res = self.0
+        let res = self
+            .0
             .children()
             .find(|node| node.kind() == SyntaxKind::RefMarker)
             .map(|node| node.text().trim_start_matches('@'))

--- a/src/syntax/lexer.rs
+++ b/src/syntax/lexer.rs
@@ -304,7 +304,8 @@ impl Lexer<'_> {
     }
 
     fn ref_marker(&mut self) -> SyntaxKind {
-        self.s.eat_while(|c| is_id_continue(c) || matches!(c, ':' | '.' | ';'));
+        self.s
+            .eat_while(|c| is_id_continue(c) || matches!(c, ':' | '.' | ';'));
 
         // Don't include the trailing characters likely to be part of text.
         while matches!(self.s.scout(-1), Some('.' | ':' | ';')) {

--- a/src/syntax/lexer.rs
+++ b/src/syntax/lexer.rs
@@ -304,10 +304,10 @@ impl Lexer<'_> {
     }
 
     fn ref_marker(&mut self) -> SyntaxKind {
-        self.s.eat_while(|c| is_id_continue(c) || matches!(c, ':' | '.'));
+        self.s.eat_while(|c| is_id_continue(c) || matches!(c, ':' | '.' | ';'));
 
         // Don't include the trailing characters likely to be part of text.
-        while matches!(self.s.scout(-1), Some('.' | ':')) {
+        while matches!(self.s.scout(-1), Some('.' | ':' | ';')) {
             self.s.uneat();
         }
 


### PR DESCRIPTION
Support the use of semicolons to specify multiple keys when citing. Resolve #1606.

# Usage

```
Some text @cite1;cite2
```

```
Some text @cite1;cite2[global supplement]
```

# Note

To prevent further break features, this syntax only works when all labels are citations from the bibliography. If any one of the semicolon-separated labels also appears in the document, the parser will fall with a bail "label occurs in the document and its bibliography". If not all of the labels are from the bibliography, then the parser will fall back into the original single mode and only uses the last label. 

I'm a very beginner of Rust who just learnt Rust for 1-2 days, so please forgive some insecure codes and point them out for me to fix them.

I cannot find how to start the web IDE but I did notice that there is a source file for code autocompletion. I tried to do some corresponding changes but I cannot test whether they are workable. So these changes have not been committed.