### PR TITLE
remove broken release targets: aarch64-pc-windows-msvc and riscv64gc-unknown-linux-gnu

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,6 @@ jobs:
         - target: armv7-unknown-linux-musleabi
           os: ubuntu-latest
           cross: true
-        - target: riscv64gc-unknown-linux-gnu
-          os: ubuntu-latest
-          cross: true
         - target: x86_64-apple-darwin
           os: macos-latest
           cross: false
@@ -37,9 +34,6 @@ jobs:
         - target: x86_64-pc-windows-msvc
           os: windows-latest
           cross: false
-        - target: aarch64-pc-windows-msvc
-          os: windows-latest
-          cross: true
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
With the addition of the ureq library, the release CI build for aarch64-pc-windows-msvc and riscv64gc-unknown-linux-gnu currently fails because of ureq's dependency ring. Ring has long had problems with these targets ( https://github.com/briansmith/ring/issues/1182, https://github.com/briansmith/ring/issues/1167 ), and it seems like a difficult to fix artifact of ring's c, rust, and assembly codebase / build system. This PR removes those failing targets from the release build, a decision supported by @laurmaedje ( https://discord.com/channels/1054443721975922748/1088371867913572452/1124441928688209992 ).