### PR TITLE
Clarify docs: Weak spacings eat markup space

### DIFF
--- a/crates/typst-library/src/layout/spacing.rs
+++ b/crates/typst-library/src/layout/spacing.rs
@@ -30,6 +30,8 @@ pub struct HElem {
     /// If `{true}`, the spacing collapses at the start or end of a paragraph.
     /// Moreover, from multiple adjacent weak spacings all but the largest one
     /// collapse.
+    /// Also, calling a weak spacing from markup causes all adjacent markup
+    /// spaces to be removed, regardless of the amount of spacing inserted.
     ///
     /// ```example
     /// #h(1cm, weak: true)
@@ -40,6 +42,13 @@ pub struct HElem {
     /// supported
     /// #h(8pt, weak: true) on both
     /// sides, they do show up.
+    ///
+    /// Further #h(0pt, weak: true) more,
+    /// even the smallest of them swallow
+    /// adjacent markup spaces.
+    ///
+    /// 1#h(0pt, weak: true)#{" "}2
+    /// 3#h(0pt, weak: true)~4
     /// ```
     #[default(false)]
     pub weak: bool,

--- a/crates/typst-library/src/layout/spacing.rs
+++ b/crates/typst-library/src/layout/spacing.rs
@@ -30,25 +30,27 @@ pub struct HElem {
     /// If `{true}`, the spacing collapses at the start or end of a paragraph.
     /// Moreover, from multiple adjacent weak spacings all but the largest one
     /// collapse.
-    /// Also, calling a weak spacing from markup causes all adjacent markup
-    /// spaces to be removed, regardless of the amount of spacing inserted.
+    ///
+    /// Weak spacing in markup also causes all adjacent markup spaces to be
+    /// removed, regardless of the amount of spacing inserted. To force a space
+    /// next to weak spacing, you can explicitly write `[#" "]` (for a normal
+    /// space) or `[~]` (for a non-breaking space). The latter can be useful to
+    /// create a construct that always attaches to the preceding word with one
+    /// non-breaking space, independently of wether a markup space existed in
+    /// front or not.
     ///
     /// ```example
     /// #h(1cm, weak: true)
-    /// We identified a group of
-    /// _weak_ specimens that fail to
-    /// manifest in most cases. However,
-    /// when #h(8pt, weak: true)
-    /// supported
-    /// #h(8pt, weak: true) on both
-    /// sides, they do show up.
+    /// We identified a group of _weak_
+    /// specimens that fail to manifest
+    /// in most cases. However, when
+    /// #h(8pt, weak: true) supported
+    /// #h(8pt, weak: true) on both sides,
+    /// they do show up.
     ///
     /// Further #h(0pt, weak: true) more,
     /// even the smallest of them swallow
     /// adjacent markup spaces.
-    ///
-    /// 1#h(0pt, weak: true)#{" "}2
-    /// 3#h(0pt, weak: true)~4
     /// ```
     #[default(false)]
     pub weak: bool,


### PR DESCRIPTION
I found it not immediately clear that weak spacings unconditionally eat markup spaces.