### PR TITLE
Add datetime.from-unix and as-unix

### DIFF
--- a/crates/typst-library/src/compute/construct.rs
+++ b/crates/typst-library/src/compute/construct.rs
@@ -216,6 +216,7 @@ cast! {
 #[func]
 #[scope(
     scope.define("today", datetime_today_func());
+    scope.define("from-unix", datetime_from_unix_func());
     scope
 )]
 pub fn datetime(
@@ -336,6 +337,29 @@ pub fn datetime_today(
         .world
         .today(offset.as_custom())
         .ok_or("unable to get the current date")?)
+}
+
+/// Returns the datetime corresponding to the given Unix timestamp.
+///
+/// This function always returns a full datetime in UTC.
+///
+/// Refer to the documentation of the [`display`]($type/datetime.display) method
+/// for details on how to affect the formatting of the date.
+///
+/// ## Example
+/// ```example
+/// We went to get ice cream on
+/// #datetime.from-unix(1688503678).display().
+/// ```
+///
+/// Display: From Unix
+/// Category: construct
+#[func]
+pub fn datetime_from_unix(
+    /// The Unix timestamp.
+    timestamp: i64,
+) -> StrResult<Datetime> {
+    Datetime::from_unix(timestamp)
 }
 
 /// Creates a CMYK color.

--- a/crates/typst/src/eval/methods.rs
+++ b/crates/typst/src/eval/methods.rs
@@ -196,6 +196,7 @@ pub fn call(
                     "hour" => datetime.hour().into_value(),
                     "minute" => datetime.minute().into_value(),
                     "second" => datetime.second().into_value(),
+                    "as-unix" => datetime.as_unix().into_value(),
                     _ => return missing(),
                 }
             } else {

--- a/tests/typ/compute/construct.typ
+++ b/tests/typ/compute/construct.typ
@@ -192,6 +192,12 @@
 #test(datetime.today(offset: auto).display(), "1970-01-01")
 #test(datetime.today(offset: 2).display(), "1970-01-01")
 
+// Test conversions from and to Unix timestamps
+#let timestamp-datetime = datetime.from-unix(1688503678)
+#let component-datetime = datetime(year: 2023, month: 7, day: 4, hour: 20, minute: 47, second: 58)
+#test(timestamp-datetime, component-datetime)
+#test(component-datetime.as-unix(), 1688503678)
+
 ---
 // Error: 10-12 at least one of date or time must be fully specified
 #datetime()


### PR DESCRIPTION
See #1658.

Unresolved questions:

* Should `from-unix` and `as-unix` always work with datetimes in UTC, or should they be able to specify an offset from UTC?