### PR TITLE
Fix `typst watch` not working with some text editors

### DIFF
--- a/crates/typst-cli/src/watch.rs
+++ b/crates/typst-cli/src/watch.rs
@@ -43,6 +43,10 @@ pub fn watch(mut command: CompileCommand) -> StrResult<()> {
         {
             let event = event.map_err(|_| "failed to watch directory")?;
 
+            // Workaround for notify-rs' implicit unwatch on remove/rename (triggered
+            // by some editors when saving files) with the inotify backend.
+            // By keeping track of the removed files, we can allow those we still
+            // depend on to be watched again later on.
             if matches!(
                 event.kind,
                 notify::EventKind::Remove(notify::event::RemoveKind::File)


### PR DESCRIPTION
This fixes #1651.

As stated in the issue, the modified code unwatches all files for which we received a `Remove` event, and allows these files to be watched again if they still exist and the compilation still depends on them.

Note that I was only able to test this on Linux, I'm unsure whether this fix could create issues on other platforms.