### PR TITLE
Allow spaces in dict

### DIFF
--- a/crates/typst/src/syntax/parser.rs
+++ b/crates/typst/src/syntax/parser.rs
@@ -1240,7 +1240,8 @@ fn validate_dict<'a>(children: impl Iterator<Item = &'a mut SyntaxNode>) {
             SyntaxKind::LeftParen
             | SyntaxKind::RightParen
             | SyntaxKind::Comma
-            | SyntaxKind::Colon => {}
+            | SyntaxKind::Colon
+            | SyntaxKind::Space => {}
             kind => {
                 child.convert_to_error(eco_format!(
                     "expected named or keyed pair, found {}",


### PR DESCRIPTION
This makes the test case in #1690 not have an error node.