### PR TITLE
Makes mimalloc the default allocator. (~6% faster)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,6 +1123,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ac0e912c8ef1b735e92369695618dc5b1819f5a7bf3f167301a3ba1cea515e"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1191,6 +1201,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e2894987a3459f3ffb755608bd82188f8ed00d0ae077f1edea29c068d639d98"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -2392,6 +2411,7 @@ dependencies = [
  "flate2",
  "inferno",
  "memmap2",
+ "mimalloc",
  "notify",
  "once_cell",
  "open",

--- a/crates/typst-cli/Cargo.toml
+++ b/crates/typst-cli/Cargo.toml
@@ -30,6 +30,7 @@ dirs = "5"
 flate2 = "1"
 inferno = "0.11.15"
 memmap2 = "0.5"
+mimalloc = { version = "*", default-features = false }
 notify = "5"
 once_cell = "1"
 open = "4.0.2"

--- a/crates/typst-cli/Cargo.toml
+++ b/crates/typst-cli/Cargo.toml
@@ -30,7 +30,7 @@ dirs = "5"
 flate2 = "1"
 inferno = "0.11.15"
 memmap2 = "0.5"
-mimalloc = { version = "*", default-features = false }
+mimalloc = { version = "0.1", default-features = false }
 notify = "5"
 once_cell = "1"
 open = "4.0.2"

--- a/crates/typst-cli/src/main.rs
+++ b/crates/typst-cli/src/main.rs
@@ -17,6 +17,11 @@ use termcolor::{ColorChoice, WriteColor};
 
 use crate::args::{CliArguments, Command};
 
+use mimalloc::MiMalloc;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
 thread_local! {
     /// The CLI's exit code.
     static EXIT: Cell<ExitCode> = Cell::new(ExitCode::SUCCESS);


### PR DESCRIPTION
This PR makes `mimalloc` the default allocator as it results in a speedup over the default in an long running test (see #1695)
this results in roughly `6%` faster runtime. also has the benefit of using the same allocator independent of platform.
