### PR TITLE
Add keep-sep parameter to split on strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1504,9 +1504,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.58"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]

--- a/crates/typst/src/eval/methods.rs
+++ b/crates/typst/src/eval/methods.rs
@@ -89,7 +89,9 @@ pub fn call(
                 let repeat = args.named("repeat")?.unwrap_or(true);
                 string.trim(pattern, at, repeat).into_value()
             }
-            "split" => string.split(args.eat()?).into_value(),
+            "split" => string
+                .split(args.eat()?, args.named("keep-sep")?.unwrap_or(false))
+                .into_value(),
             _ => return missing(),
         },
 

--- a/crates/typst/src/eval/str.rs
+++ b/crates/typst/src/eval/str.rs
@@ -184,8 +184,7 @@ impl Str {
                 result.push(Value::Str(sep.into()));
             }
             result.push(Value::Str(s.into()));
-            // Safety: s.as_ptr() is valid for s.len() bytes.
-            prev_ws_start = unsafe { s.as_ptr().add(s.len()) }
+            prev_ws_start = s.as_ptr().wrapping_add(s.len());
         }
     }
 

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -644,6 +644,9 @@ the resulting parts.
 
 - pattern: string or regex (positional)
   The pattern to split at. Defaults to whitespace.
+- keep-sep: boolean (named)
+  Whether to return the matches of the pattern in the result.
+  Defaults to `{false}`.
 - returns: array
 
 # Content

--- a/tests/typ/compiler/string.typ
+++ b/tests/typ/compiler/string.typ
@@ -206,10 +206,16 @@
 
 ---
 // Test the `split` method.
+#test("hello  wor\tld".split(), ("hello", "wor", "ld"));
 #test("abc".split(""), ("", "a", "b", "c", ""))
 #test("abc".split("b"), ("a", "c"))
 #test("a123c".split(regex("\d")), ("a", "", "", "c"))
 #test("a123c".split(regex("\d+")), ("a", "c"))
+
+#test("hello  wor\tld".split(keep-sep: true), ("hello", "  ", "wor", "\t", "ld"));
+#test("abc".split("b", keep-sep: true), ("a", "b", "c"))
+#test("abbc".split("b", keep-sep: true), ("a", "b", "", "b", "c"))
+#test("a123c".split(regex("\d+"), keep-sep: true), ("a", "123", "c"))
 
 ---
 // Error: 2-2:1 unclosed string


### PR DESCRIPTION
Fixes #1710.

This also updates the `proc-macro2` dependency since 1.0.58 no longer compiles on the latest nightly, and I had to use Miri to rule out an earlier implementation of `add_entries_with_separators` that constructed the separator slices out of raw pointers.