### PR TITLE
Fix content::fields() docs in types.md

### DIFF
--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -726,6 +726,8 @@ Return the fields of this content.
 ).fields()
 ```
 
+- returns: dictionary
+
 ### location()
 The location of the content. This is only available on content returned by
 [query]($func/query), for other content it will fail with an error. The


### PR DESCRIPTION
It was missing the return type (dictionary).