### PR TITLE
Customizable parts for broken blocks

### DIFF
--- a/crates/typst-library/src/layout/container.rs
+++ b/crates/typst-library/src/layout/container.rs
@@ -440,54 +440,46 @@ impl Layout for BlockElem {
                 let outset = self.outset(styles).single;
                 let radius = self.radius(styles).single;
 
-                frame.fill_and_stroke(
-                    fill.clone(),
-                    stroke.clone(),
-                    outset,
-                    radius,
+                frame.fill_and_stroke(fill, stroke, outset, radius, self.span());
+            }
+        } else if fill.iter_multiple().any(Option::is_some)
+            || stroke
+                .iter_multiple()
+                .any(|stroke| stroke.iter().any(Option::is_some))
+        {
+            let outset = self.outset(styles);
+            let radius = self.radius(styles);
+
+            let mut iter = frames_mut.iter_mut();
+
+            if let Some(first) = iter.next() {
+                first.fill_and_stroke(
+                    fill.first,
+                    stroke.first,
+                    outset.first,
+                    radius.first,
                     self.span(),
                 );
             }
-        } else {
-            if fill.iter_multiple().any(Option::is_some)
-                || stroke
-                    .iter_multiple()
-                    .any(|stroke| stroke.iter().any(Option::is_some))
-            {
-                let outset = self.outset(styles);
-                let radius = self.radius(styles);
 
-                let mut iter = frames_mut.iter_mut();
+            if let Some(first) = iter.next_back() {
+                first.fill_and_stroke(
+                    fill.last,
+                    stroke.last,
+                    outset.last,
+                    radius.last,
+                    self.span(),
+                );
+            }
 
-                if let Some(first) = iter.next() {
-                    first.fill_and_stroke(
-                        fill.first,
-                        stroke.first,
-                        outset.first,
-                        radius.first,
-                        self.span(),
-                    );
-                }
-
-                if let Some(first) = iter.next_back() {
-                    first.fill_and_stroke(
-                        fill.last,
-                        stroke.last,
-                        outset.last,
-                        radius.last,
-                        self.span(),
-                    );
-                }
-
-                for frame in iter {
-                    frame.fill_and_stroke(
-                        fill.middle.clone(),
-                        stroke.middle.clone(),
-                        outset.middle,
-                        radius.middle,
-                        self.span(),
-                    );
-                }
+            for frame in iter {
+                frame.fill_and_stroke(
+                    fill.middle.clone(),
+                    stroke.middle.clone(),
+                    outset.middle,
+                    radius.middle,
+                    self.span(),
+                );
             }
         }
 

--- a/crates/typst-library/src/layout/container.rs
+++ b/crates/typst-library/src/layout/container.rs
@@ -269,7 +269,7 @@ pub struct BlockElem {
     /// the [rectangle's documentation]($func/rect.outset) for more details.
     #[resolve]
     #[fold]
-    pub outset: Sides<Option<Rel<Length>>>,
+    pub outset: BrokenParts<Sides<Option<Rel<Length>>>>,
 
     /// The spacing around this block. This is shorthand to set `above` and
     /// `below` to the same value.
@@ -437,7 +437,7 @@ impl Layout for BlockElem {
             let stroke = stroke.single;
 
             if fill.is_some() || stroke.iter().any(Option::is_some) {
-                let outset = self.outset(styles);
+                let outset = self.outset(styles).single;
                 let radius = self.radius(styles).single;
 
                 frame.fill_and_stroke(
@@ -463,7 +463,7 @@ impl Layout for BlockElem {
                     first.fill_and_stroke(
                         fill.first,
                         stroke.first,
-                        outset,
+                        outset.first,
                         radius.first,
                         self.span(),
                     );
@@ -473,7 +473,7 @@ impl Layout for BlockElem {
                     first.fill_and_stroke(
                         fill.last,
                         stroke.last,
-                        outset,
+                        outset.last,
                         radius.last,
                         self.span(),
                     );
@@ -483,7 +483,7 @@ impl Layout for BlockElem {
                     frame.fill_and_stroke(
                         fill.middle.clone(),
                         stroke.middle.clone(),
-                        outset,
+                        outset.middle,
                         radius.middle,
                         self.span(),
                     );

--- a/crates/typst-library/src/layout/container.rs
+++ b/crates/typst-library/src/layout/container.rs
@@ -433,7 +433,6 @@ impl Layout for BlockElem {
         };
 
         if let [frame] = frames_mut {
-            // single frame
             let fill = fill.single;
             let stroke = stroke.single;
 
@@ -450,7 +449,6 @@ impl Layout for BlockElem {
                 );
             }
         } else {
-            // multiple frames
             if fill.iter_multiple().any(Option::is_some)
                 || stroke
                     .iter_multiple()

--- a/crates/typst/src/geom/broken_parts.rs
+++ b/crates/typst/src/geom/broken_parts.rs
@@ -1,0 +1,196 @@
+use crate::eval::{CastInfo, FromValue, IntoValue, Reflect};
+
+use super::*;
+
+/// A container with first, middle, last and single components.
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Hash)]
+pub struct BrokenParts<T> {
+    /// The value for the first of multiple parts.
+    pub first: T,
+    /// The value for the parts that are neither first nor last.
+    pub middle: T,
+    /// The value for the last of multiple parts.
+    pub last: T,
+    /// The value for a singular part.
+    pub single: T,
+}
+
+impl<T> BrokenParts<T> {
+    /// Create a new instance from the four components.
+    pub const fn new(first: T, middle: T, last: T, single: T) -> Self {
+        Self { first, middle, last, single }
+    }
+
+    /// Create an instance with four equal components.
+    pub fn splat(value: T) -> Self
+    where
+        T: Clone,
+    {
+        Self {
+            first: value.clone(),
+            middle: value.clone(),
+            last: value.clone(),
+            single: value,
+        }
+    }
+
+    /// Map the individual fields with `f`.
+    pub fn map<F, U>(self, mut f: F) -> BrokenParts<U>
+    where
+        F: FnMut(T) -> U,
+    {
+        BrokenParts {
+            first: f(self.first),
+            middle: f(self.middle),
+            last: f(self.last),
+            single: f(self.single),
+        }
+    }
+
+    /// Zip two instances into one.
+    pub fn zip<U>(self, other: BrokenParts<U>) -> BrokenParts<(T, U)> {
+        BrokenParts {
+            first: (self.first, other.first),
+            middle: (self.middle, other.middle),
+            last: (self.last, other.last),
+            single: (self.single, other.single),
+        }
+    }
+
+    /// An iterator over the values for multiple parts.
+    pub fn iter_multiple(&self) -> impl Iterator<Item = &T> {
+        [&self.first, &self.middle, &self.last].into_iter()
+    }
+
+    /// Whether all parts are equal.
+    pub fn is_uniform(&self) -> bool
+    where
+        T: PartialEq,
+    {
+        self.first == self.middle && self.middle == self.last && self.last == self.single
+    }
+}
+
+impl<T> Get<BrokenPart> for BrokenParts<T> {
+    type Component = T;
+
+    fn get_ref(&self, part: BrokenPart) -> &T {
+        match part {
+            BrokenPart::First => &self.first,
+            BrokenPart::Middle => &self.middle,
+            BrokenPart::Last => &self.last,
+            BrokenPart::Single => &self.single,
+        }
+    }
+
+    fn get_mut(&mut self, side: BrokenPart) -> &mut T {
+        match side {
+            BrokenPart::First => &mut self.first,
+            BrokenPart::Middle => &mut self.middle,
+            BrokenPart::Last => &mut self.last,
+            BrokenPart::Single => &mut self.single,
+        }
+    }
+}
+
+/// The four kinds of parts that can arise from breaking.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum BrokenPart {
+    /// The first of multiple parts.
+    First,
+    /// The parts that are neither first nor last.
+    Middle,
+    /// The last of multiple parts.
+    Last,
+    /// A singular part.
+    Single,
+}
+
+impl<T: Reflect> Reflect for BrokenParts<T> {
+    fn describe() -> CastInfo {
+        T::describe() + Dict::describe()
+    }
+
+    fn castable(value: &Value) -> bool {
+        Dict::castable(value) || T::castable(value)
+    }
+}
+
+impl<T> IntoValue for BrokenParts<T>
+where
+    T: PartialEq + IntoValue,
+{
+    fn into_value(self) -> Value {
+        if self.is_uniform() {
+            return self.first.into_value();
+        }
+
+        let mut dict = Dict::new();
+        let mut handle = |key: &str, component: T| {
+            let value = component.into_value();
+            if value != Value::None {
+                dict.insert(key.into(), value);
+            }
+        };
+
+        handle("first", self.first);
+        handle("middle", self.middle);
+        handle("last", self.last);
+        handle("single", self.single);
+
+        Value::Dict(dict)
+    }
+}
+
+impl<T> FromValue for BrokenParts<T>
+where
+    T: Default + FromValue + Clone,
+{
+    fn from_value(mut value: Value) -> StrResult<Self> {
+        let keys = ["first", "middle", "last", "single", "rest"];
+        if let Value::Dict(dict) = &mut value {
+            if dict.iter().any(|(key, _)| keys.contains(&key.as_str())) {
+                let mut take = |key| dict.take(key).ok().map(T::from_value).transpose();
+                let rest = take("rest")?;
+
+                // Make sure that either `rest` or all other keys have to be given.
+                let mut take_or_rest = |key| match dict.take(key) {
+                    Ok(val) => T::from_value(val),
+                    Err(e) => rest.clone().ok_or(e),
+                };
+
+                let parts = BrokenParts {
+                    first: take_or_rest("first")?,
+                    middle: take_or_rest("middle")?,
+                    last: take_or_rest("last")?,
+                    single: take_or_rest("single")?,
+                };
+
+                dict.finish(&keys)?;
+                return Ok(parts);
+            }
+        }
+
+        if T::castable(&value) {
+            Ok(Self::splat(T::from_value(value)?))
+        } else {
+            Err(Self::error(&value))
+        }
+    }
+}
+
+impl<T: Resolve> Resolve for BrokenParts<T> {
+    type Output = BrokenParts<T::Output>;
+
+    fn resolve(self, styles: StyleChain) -> Self::Output {
+        self.map(|v| v.resolve(styles))
+    }
+}
+
+impl<T: Fold> Fold for BrokenParts<T> {
+    type Output = BrokenParts<T::Output>;
+
+    fn fold(self, outer: Self::Output) -> Self::Output {
+        self.zip(outer).map(|(inner, outer)| inner.fold(outer))
+    }
+}

--- a/crates/typst/src/geom/mod.rs
+++ b/crates/typst/src/geom/mod.rs
@@ -6,6 +6,7 @@ mod abs;
 mod align;
 mod angle;
 mod axes;
+mod broken_parts;
 mod color;
 mod corners;
 mod dir;
@@ -31,6 +32,7 @@ pub use self::abs::{Abs, AbsUnit};
 pub use self::align::{Align, GenAlign, HorizontalAlign, VerticalAlign};
 pub use self::angle::{Angle, AngleUnit};
 pub use self::axes::{Axes, Axis};
+pub use self::broken_parts::{BrokenPart, BrokenParts};
 pub use self::color::{
     CmykColor, Color, ColorSpace, LumaColor, RgbaColor, WeightedColor,
 };


### PR DESCRIPTION
This PR adds support for `block.{fill, stroke, radius, outset}` to depend on which part of a broken block it is.

There are four of these parts:
- first
- middle
- last
- single
where "middle" refers to any parts of a broken block that are neither first nor last, and "single" refers to a non-broken block.

This resolves part of #735. That issue was also asking for arbitrary content or "doing any number of complex/arbitrary things" at breakpoints, which I decided to postpone for now, since it'd require more involved design work.

One thing to note is how I've handled parsing `BrokenParts`:
It's very similar to `Sides`, i.e. a dictionary or a single value that means that all are the same.
The difference is twofold:
1. For a dictionary of `BrokenParts`, all keys **have to** be present. Thinking about this now, maybe I should go back and change that again. **Any opinions on this?**
2. There is no `rest` key, as that would interfere with detection of when something is a `Sides`-dictionary (that has a `rest` value), but the same for all parts (the `rest` key would be detected as part of `BrokenParts`, which would cause it to error)

I'd also like some help writing docs for this, as I don't really know where to start with that...