### PR TITLE
Add InstanceBlock

### DIFF
--- a/crates/typst-library/src/layout/mod.rs
+++ b/crates/typst-library/src/layout/mod.rs
@@ -73,6 +73,7 @@ pub(super) fn define(global: &mut Scope) {
     global.define("h", HElem::func());
     global.define("box", BoxElem::func());
     global.define("block", BlockElem::func());
+    global.define("instance-block", InstanceBlockElem::func());
     global.define("list", ListElem::func());
     global.define("enum", EnumElem::func());
     global.define("terms", TermsElem::func());

--- a/crates/typst/src/doc.rs
+++ b/crates/typst/src/doc.rs
@@ -417,6 +417,7 @@ pub enum FrameItem {
     Image(Image, Size, Span),
     /// Meta information and the region it applies to.
     Meta(Meta, Size),
+    InstancePlaceholder
 }
 
 impl Debug for FrameItem {
@@ -427,6 +428,7 @@ impl Debug for FrameItem {
             Self::Shape(shape, _) => write!(f, "{shape:?}"),
             Self::Image(image, _, _) => write!(f, "{image:?}"),
             Self::Meta(meta, _) => write!(f, "{meta:?}"),
+            Self::InstancePlaceholder => write!(f, "InstancePlaceholder")
         }
     }
 }

--- a/crates/typst/src/doc.rs
+++ b/crates/typst/src/doc.rs
@@ -417,7 +417,7 @@ pub enum FrameItem {
     Image(Image, Size, Span),
     /// Meta information and the region it applies to.
     Meta(Meta, Size),
-    InstancePlaceholder
+    InstancePlaceholder,
 }
 
 impl Debug for FrameItem {
@@ -428,7 +428,7 @@ impl Debug for FrameItem {
             Self::Shape(shape, _) => write!(f, "{shape:?}"),
             Self::Image(image, _, _) => write!(f, "{image:?}"),
             Self::Meta(meta, _) => write!(f, "{meta:?}"),
-            Self::InstancePlaceholder => write!(f, "InstancePlaceholder")
+            Self::InstancePlaceholder => write!(f, "InstancePlaceholder"),
         }
     }
 }

--- a/crates/typst/src/export/pdf/page.rs
+++ b/crates/typst/src/export/pdf/page.rs
@@ -399,6 +399,7 @@ fn write_frame(ctx: &mut PageContext, frame: &Frame) {
                 Meta::Hide => {}
                 Meta::PageNumbering(_) => {}
             },
+            FrameItem::InstancePlaceholder => (),
         }
     }
 }

--- a/crates/typst/src/export/render.rs
+++ b/crates/typst/src/export/render.rs
@@ -109,6 +109,7 @@ fn render_frame(
                 Meta::PageNumbering(_) => {}
                 Meta::Hide => {}
             },
+            FrameItem::InstancePlaceholder => (),
         }
     }
 }

--- a/crates/typst/src/export/svg.rs
+++ b/crates/typst/src/export/svg.rs
@@ -118,7 +118,7 @@ impl SVGRenderer {
                 FrameItem::Text(text) => self.render_text(text),
                 FrameItem::Shape(shape, _) => self.render_shape(shape),
                 FrameItem::Image(image, size, _) => self.render_image(image, size),
-                FrameItem::Meta(_, _) => {}
+                FrameItem::Meta(_, _) | FrameItem::InstancePlaceholder => {}
             };
 
             self.xml.end_element();


### PR DESCRIPTION
(*Note: This PR is half-serious. I know that this is probably too cursed to actually be accepted.*)

Implement a new element, `instance-block`, that layouts like a block, but applies a function to each frame during layout instead of the block functions of stroke and fill.

This is my follow-up to #1773, as it enables the same kind of thing by using a regular block inside the instance function, but it is far more powerful as it allows arbitrary code that can depend on the frame index and length.

## Implementation Details
This PR also adds a new `InstancePlaceholder` element, which is what's actually passed to the instance function. It produces a new `FrameItem`, also called `InstancePlaceholder`, which is replaced with the actual frame content in the `InstanceBlock` layout (after calling the function).

## Cursedness
The semantics of `instance-block` are cursed, but intentional. It's probably impossible to relayout everything based on the output of the instance function (as the input to that is already layout dependent), so the layout is explicitly only based on the body alone. This is probably the main reason that this PR shouldn't be accepted, as it feels clunky and weird.

## No Documentation
I haven't written any documentation at all. Let me know if you actually want to merge this, then I'll try to write some.