### PR TITLE
Enable feature raster images for resvg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,8 +1790,11 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "142e83d8ae8c8c639f304698a5567b229ba65caba867bf4387bbc0ae158827cf"
 dependencies = [
+ "gif",
+ "jpeg-decoder",
  "log",
  "pico-args",
+ "png",
  "rgb",
  "svgtypes",
  "tiny-skia",

--- a/crates/typst/Cargo.toml
+++ b/crates/typst/Cargo.toml
@@ -34,7 +34,7 @@ once_cell = "1"
 pdf-writer = "0.7.1"
 pixglyph = "0.1"
 regex = "1"
-resvg = { version = "0.32", default-features = false }
+resvg = { version = "0.32", default-features = false, features = ["raster-images"] }
 roxmltree = "0.18"
 rustybuzz = "0.7"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Otherwise, embedded raster images won't show up in the preview. Fixes #1785 