### PR TITLE
Gardening.

### DIFF
--- a/crates/typst-library/src/math/fragment.rs
+++ b/crates/typst-library/src/math/fragment.rs
@@ -470,13 +470,13 @@ pub enum GlyphwiseSubsts<'a> {
 
 impl<'a> GlyphwiseSubsts<'a> {
     pub fn new(gsub: LayoutTable<'a>, feature: Feature) -> Option<Self> {
-        let ssty = gsub
+        let table = gsub
             .features
             .find(feature.tag)
             .and_then(|feature| feature.lookup_indices.get(0))
             .and_then(|index| gsub.lookups.get(index))?;
-        let ssty = ssty.subtables.get::<SubstitutionSubtable>(0)?;
-        match ssty {
+        let table = table.subtables.get::<SubstitutionSubtable>(0)?;
+        match table {
             SubstitutionSubtable::Single(single_glyphs) => {
                 Some(Self::Single(single_glyphs))
             }


### PR DESCRIPTION
There was a variable named `ssty` in code related to glyph substitution that had nothing to do with the  `ssty` optical size tables.  Looks like it might have been a copy/paste thing. 