### PR TITLE
Formatter for Typst

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2593,6 +2593,18 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "toml"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c226a7bba6d859b63c92c4b4fe69c5b6b72d0cb897dbc8e6012298e6154cb56e"
@@ -2600,7 +2612,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.20.0",
 ]
 
 [[package]]
@@ -2610,6 +2622,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap 2.0.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -2758,7 +2783,7 @@ dependencies = [
  "svg2pdf",
  "time",
  "tiny-skia",
- "toml",
+ "toml 0.8.0",
  "tracing",
  "ttf-parser 0.19.2",
  "typst-macros",
@@ -2812,6 +2837,7 @@ dependencies = [
  "tracing-flame",
  "tracing-subscriber",
  "typst",
+ "typst-format",
  "typst-library",
  "ureq",
  "walkdir",
@@ -2838,6 +2864,17 @@ dependencies = [
  "unicode_names2",
  "unscanny",
  "yaml-front-matter",
+]
+
+[[package]]
+name = "typst-format"
+version = "0.8.0"
+dependencies = [
+ "clap",
+ "ecow",
+ "serde",
+ "toml 0.7.8",
+ "typst-syntax",
 ]
 
 [[package]]
@@ -2880,7 +2917,7 @@ dependencies = [
  "smallvec",
  "syntect",
  "time",
- "toml",
+ "toml 0.8.0",
  "tracing",
  "ttf-parser 0.19.2",
  "typed-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = ["crates/*", "tests"]
-default-members = ["crates/typst-cli"]
+default-members = ["crates/typst-cli", "crates/typst-format"]
 resolver = "2"
 
 [workspace.package]

--- a/crates/typst-cli/Cargo.toml
+++ b/crates/typst-cli/Cargo.toml
@@ -22,7 +22,11 @@ doc = false
 [dependencies]
 typst = { path = "../typst" }
 typst-library = { path = "../typst-library" }
-chrono = { version = "0.4.24", default-features = false, features = ["clock", "std"] }
+typst-format = { path = "../typst-format" }
+chrono = { version = "0.4.24", default-features = false, features = [
+	"clock",
+	"std",
+] }
 clap = { version = "4.4", features = ["derive", "env"] }
 codespan-reporting = "0.11"
 comemo = "0.3"
@@ -63,6 +67,7 @@ clap = { version = "4.4", features = ["derive", "string"] }
 clap_complete = "4.2.1"
 clap_mangen = "0.2.10"
 semver = "1"
+typst-format = { path = "../typst-format" }
 
 [features]
 default = ["embed-fonts"]

--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -44,6 +44,9 @@ pub enum Command {
     /// Self update the Typst CLI
     #[cfg_attr(not(feature = "self-update"), doc = " (disabled)")]
     Update(UpdateCommand),
+
+    /// Formats an input file
+    Format(typst_format::Command),
 }
 
 /// Compiles an input file into a supported output format

--- a/crates/typst-cli/src/main.rs
+++ b/crates/typst-cli/src/main.rs
@@ -46,6 +46,7 @@ fn main() -> ExitCode {
         Command::Query(command) => crate::query::query(command),
         Command::Fonts(command) => crate::fonts::fonts(command),
         Command::Update(command) => crate::update::update(command),
+        Command::Format(command) => typst_format::format(command),
     };
 
     if let Err(msg) = res {

--- a/crates/typst-format/Cargo.toml
+++ b/crates/typst-format/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "typst-format"
+version.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+edition.workspace = true
+publish = false
+
+[lib]
+doctest = false
+bench = false
+
+[[bin]]
+name = "typstformat"
+path = "src/main.rs"
+test = false
+doctest = false
+bench = false
+doc = false
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+ecow = { version = "0.1.1", features = ["serde"] }
+typst-syntax = { path = "../typst-syntax" }
+clap = { version = "4.2.4", features = ["derive", "env"] }
+toml = { version = "0.7.3", default-features = false, features = ["parse", "display"] }

--- a/crates/typst-format/src/lib.rs
+++ b/crates/typst-format/src/lib.rs
@@ -1,0 +1,198 @@
+mod logic;
+mod output;
+pub mod settings;
+mod state;
+pub mod styles;
+
+use ecow::EcoString;
+use settings::Settings;
+use state::State;
+use typst_syntax::{SyntaxKind, SyntaxNode};
+type StrResult<T> = Result<T, EcoString>;
+
+use output::Output;
+
+pub use output::OutputTarget;
+use std::{
+    fs::{self, File},
+    io::{BufWriter, Read, Write},
+    path::{Path, PathBuf},
+};
+
+pub use styles::Styles;
+
+use clap::Parser;
+
+const CONFIG_NAME: &str = "typstfmt.toml";
+
+#[derive(Debug, Clone, Parser)]
+pub struct Command {
+    /// Input path for source file, used as output path if nothing else is specified
+    #[arg(default_value = None)]
+    pub path: Option<PathBuf>,
+
+    /// Output path
+    #[arg(short, long, default_value = None)]
+    pub output: Option<PathBuf>,
+
+    /// Base style for the formatting settings
+    #[arg(short, long, default_value_t = Styles::Default)]
+    pub style: Styles,
+
+    /// Search for 'typstfmt.toml' for additional formatting settings
+    #[arg(long, default_value_t = false)]
+    pub use_configuration: bool,
+
+    /// Generate file with formatting settings based on the style
+    #[arg(long, default_value_t = false)]
+    pub save_configuration: bool,
+
+    /// Use standard input as source
+    #[arg(long, default_value_t = false)]
+    pub use_std_in: bool,
+
+    /// Use standard output as target
+    #[arg(long, default_value_t = false)]
+    pub use_std_out: bool,
+
+    /// File location to search for configuration, defaults to input path if available
+    #[arg(long, default_value = None)]
+    pub file_location: Option<PathBuf>,
+}
+
+pub fn format_node(
+    node: &SyntaxNode,
+    settings: &settings::Settings,
+    target: &mut impl OutputTarget,
+) -> StrResult<()> {
+    let mut output = Output::new(target);
+    let state = State::new();
+    logic::format(node, state, settings, &mut output);
+
+    // ensure end of file is always present
+    logic::format(
+        &SyntaxNode::leaf(SyntaxKind::Eof, EcoString::new()),
+        state,
+        settings,
+        &mut output,
+    );
+    output.finish(&state, settings);
+    Ok(())
+}
+
+pub fn format_str(
+    text: &str,
+    settings: &settings::Settings,
+    target: &mut impl OutputTarget,
+) -> StrResult<()> {
+    format_node(&typst_syntax::parse(text), settings, target)
+}
+
+pub fn format(command: &Command) -> StrResult<()> {
+    let mut settings = command.style.settings();
+
+    if command.use_configuration {
+        let path = match (&command.file_location, &command.path) {
+            (Some(path), _) => {
+                if path.extension().is_some() {
+                    path.parent().ok_or("failed to get parent folder")?.to_owned()
+                } else {
+                    path.to_owned()
+                }
+            }
+            (_, Some(path)) => path.to_owned(),
+            _ => std::env::current_dir().unwrap().to_owned(),
+        };
+        let mut path = path.as_path();
+        let file = loop {
+            let mut file = PathBuf::from(path);
+            file.push(CONFIG_NAME);
+            if file.is_file() {
+                break file;
+            }
+            path = path.parent().ok_or("could not find 'typstfmt.toml'")?;
+        };
+        settings.merge(&file)?;
+    }
+
+    if command.save_configuration {
+        std::fs::write(
+            CONFIG_NAME,
+            toml::to_string_pretty(&settings).map_err(|err| err.to_string())?,
+        )
+        .map_err(|_| "could not save configuration")?;
+        return Ok(());
+    }
+
+    let (input_data, input_name) = match (&command.path, command.use_std_in) {
+        (Some(_), true) => return Err("input path and stdin are incompatible".into()),
+        (Some(path), false) => {
+            let input_data = std::fs::read_to_string(path)
+                .map_err(|_| format!("could not read '{}'", path.display()))?;
+            (input_data, path.display().to_string())
+        }
+        (None, true) => {
+            let mut data = String::new();
+            std::io::stdin()
+                .read_to_string(&mut data)
+                .map_err(|err| err.to_string())?;
+            (data, "stdin".into())
+        }
+        (None, false) => return Err("no input path or stdin specified".into()),
+    };
+
+    let root = typst_syntax::parse(&input_data);
+
+    match (&command.output, command.use_std_out) {
+        (Some(_), true) => return Err("output path and stdout are incompatible".into()),
+        (Some(out), false) => {
+            let file = File::create(&out)
+                .map_err(|_| format!("could not create '{}'", out.display()))?;
+            let mut target = FileTarget(BufWriter::new(file));
+            format_node(&root, &settings, &mut target)?;
+            drop(target);
+        }
+        (None, true) => {
+            let mut target = StdoutTarget(String::new());
+            format_node(&root, &settings, &mut target)?;
+            drop(target);
+        }
+        (None, false) => {
+            let temp_path = Path::new("typstfmt.typ-temp");
+            let file =
+                File::create(temp_path).map_err(|_| "could not create temporary file")?;
+            let mut target = FileTarget(BufWriter::new(file));
+            format_node(&root, &settings, &mut target)?;
+            drop(target);
+            fs::rename(temp_path, input_name)
+                .map_err(|_| "could not replace input file")?;
+        }
+    };
+    Ok(())
+}
+
+pub struct FileTarget(BufWriter<File>);
+
+impl OutputTarget for FileTarget {
+    fn emit(&mut self, data: &EcoString, _settings: &settings::Settings) {
+        self.0.write_all(data.as_bytes()).unwrap();
+    }
+}
+
+pub struct StdoutTarget(String);
+
+impl OutputTarget for StdoutTarget {
+    fn emit(&mut self, data: &EcoString, _settings: &Settings) {
+        self.0.push_str(data);
+        if self.0.len() > 20 {
+            print!("{}", self.0);
+            self.0.clear();
+        }
+    }
+}
+
+impl Drop for StdoutTarget {
+    fn drop(&mut self) {
+        print!("{}", self.0);
+    }
+}

--- a/crates/typst-format/src/logic/code.rs
+++ b/crates/typst-format/src/logic/code.rs
@@ -1,0 +1,348 @@
+use super::*;
+
+pub fn format_code_block(
+    node: &SyntaxNode,
+    mut state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    let single = !node
+        .children()
+        .any(|value| value.kind() == SyntaxKind::Space && value.text().contains('\n'));
+    state.mode = Mode::Code;
+    for child in node.children() {
+        match child.kind() {
+            SyntaxKind::LeftBrace => {
+                format(child, state, settings, output);
+                if single {
+                    output.set_whitespace(Whitespace::Space, Priority::Low);
+                } else {
+                    state.indent();
+                    output.set_whitespace(Whitespace::LineBreak, Priority::Normal);
+                }
+            }
+            SyntaxKind::Code => format(child, state, settings, output),
+            SyntaxKind::RightBrace => {
+                if single {
+                    output.set_whitespace(Whitespace::Space, Priority::Low);
+                } else {
+                    state.dedent();
+                    output.set_whitespace(Whitespace::LineBreak, Priority::Normal);
+                }
+                format(child, state, settings, output);
+            }
+            _ => format(child, state, settings, output),
+        }
+    }
+}
+
+pub fn format_func_call(
+    node: &SyntaxNode,
+    state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    enum Kind {
+        Normal,
+        Columns,
+    }
+    let mut kind = Kind::Normal;
+    for child in node.children() {
+        match child.kind() {
+            SyntaxKind::Ident => {
+                kind = match child.text().as_str() {
+                    "table" => Kind::Columns,
+                    "grid" => Kind::Columns,
+                    _ => Kind::Normal,
+                };
+                format(child, state, settings, output);
+            }
+            SyntaxKind::Args => match kind {
+                Kind::Normal => format_items(child, state, settings, output),
+                Kind::Columns => format_column_args(child, state, settings, output),
+            },
+            _ => format(child, state, settings, output),
+        }
+    }
+}
+
+pub fn format_unary(
+    node: &SyntaxNode,
+    state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    for child in node.children() {
+        match child.kind() {
+            SyntaxKind::Plus | SyntaxKind::Minus => {
+                format(child, state, settings, output);
+                output.set_whitespace(Whitespace::None, Priority::High);
+            }
+            _ => format(child, state, settings, output),
+        }
+    }
+}
+
+pub fn format_named_argument(
+    node: &SyntaxNode,
+    state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    for child in node.children() {
+        match child.kind() {
+            SyntaxKind::Colon => {
+                if settings.named_argument.space_before_colon {
+                    output.set_whitespace(Whitespace::Space, Priority::High);
+                } else {
+                    output.set_whitespace(Whitespace::None, Priority::High);
+                }
+                format(child, state, settings, output);
+                if settings.named_argument.space_after_colon {
+                    output.set_whitespace(Whitespace::Space, Priority::High);
+                } else {
+                    output.set_whitespace(Whitespace::None, Priority::High);
+                }
+            }
+            _ => format(child, state, settings, output),
+        }
+    }
+}
+
+pub fn format_keyed(
+    node: &SyntaxNode,
+    state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    for child in node.children() {
+        match child.kind() {
+            SyntaxKind::Colon => {
+                if settings.dictionary_entry.space_before_colon {
+                    output.set_whitespace(Whitespace::Space, Priority::High);
+                } else {
+                    output.set_whitespace(Whitespace::None, Priority::High);
+                }
+                format(child, state, settings, output);
+                if settings.dictionary_entry.space_after_colon {
+                    output.set_whitespace(Whitespace::Space, Priority::High);
+                } else {
+                    output.set_whitespace(Whitespace::None, Priority::High);
+                }
+            }
+            _ => format(child, state, settings, output),
+        }
+    }
+}
+
+pub fn format_semicolon(
+    node: &SyntaxNode,
+    state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    output.set_whitespace(Whitespace::None, Priority::Guaranteed);
+    output.raw(node, &state, settings);
+}
+
+pub fn format_items(
+    node: &SyntaxNode,
+    mut state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    let mut trailing_comma = false;
+    let mut comma_count = 0;
+    for child in node.children() {
+        match child.kind() {
+            SyntaxKind::Comma => (trailing_comma, comma_count) = (true, comma_count + 1),
+            SyntaxKind::RightParen => break,
+            SyntaxKind::Space => {}
+            _ => trailing_comma = false,
+        }
+    }
+    state.mode = Mode::Items;
+    let single = !trailing_comma || comma_count <= 1;
+    for child in node.children() {
+        match child.kind() {
+            SyntaxKind::LeftParen => {
+                format(child, state, settings, output);
+                if single {
+                    output.set_whitespace(Whitespace::None, Priority::Guaranteed);
+                } else {
+                    state.indent();
+                    output.set_whitespace(Whitespace::LineBreak, Priority::High);
+                }
+            }
+            SyntaxKind::Comma => {
+                format(child, state, settings, output);
+                if single {
+                    output.set_whitespace(Whitespace::Space, Priority::Low);
+                } else {
+                    output.set_whitespace(Whitespace::LineBreak, Priority::High);
+                }
+            }
+            SyntaxKind::RightParen => {
+                if single {
+                    output.set_whitespace(Whitespace::None, Priority::High);
+                } else {
+                    state.dedent();
+                    output.set_whitespace(Whitespace::LineBreak, Priority::High);
+                }
+                format(child, state, settings, output);
+            }
+            _ => format(child, state, settings, output),
+        }
+    }
+}
+
+pub fn format_column_args(
+    node: &SyntaxNode,
+    mut state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    let columns_count = get_column_count(node);
+    let mut lengths = Vec::new();
+    for child in node.children() {
+        match child.kind() {
+            SyntaxKind::LeftParen
+            | SyntaxKind::RightParen
+            | SyntaxKind::Comma
+            | SyntaxKind::Space
+            | SyntaxKind::LineComment
+            | SyntaxKind::BlockComment
+            | SyntaxKind::Named => {
+                continue;
+            }
+            _ => {}
+        }
+        lengths.push(get_length(child, settings));
+    }
+    let mut columns: Vec<usize> = vec![1usize; columns_count];
+    for (index, &lenght) in lengths.iter().enumerate() {
+        let c = index % columns_count;
+        columns[c] = columns[c].max(lenght.unwrap_or(0));
+    }
+
+    state.mode = Mode::Items;
+
+    let mut current = 0usize;
+    let mut index = 0;
+    let mut pad = false;
+    for child in node.children() {
+        match child.kind() {
+            SyntaxKind::LeftParen => {
+                format(child, state, settings, output);
+                state.indent();
+                output.set_whitespace(Whitespace::LineBreak, Priority::Normal);
+            }
+            SyntaxKind::Comma => {
+                if pad {
+                    match settings.columns.comma {
+                        AlignComma::EndOfContent => {
+                            output.set_whitespace(Whitespace::None, Priority::High);
+                            format(child, state, settings, output);
+                            if let Some(value) = lengths[index] {
+                                output.set_whitespace(
+                                    Whitespace::Spaces(columns[current] - value + 1),
+                                    Priority::Normal,
+                                );
+                            }
+                        }
+                        AlignComma::EndOfCell => {
+                            if let Some(value) = lengths[index] {
+                                output.set_whitespace(
+                                    Whitespace::Spaces(columns[current] - value),
+                                    Priority::High,
+                                );
+                            }
+                            format(child, state, settings, output);
+                        }
+                    }
+                    current = (current + 1) % columns_count;
+                    index += 1;
+                    if current == 0 {
+                        output.set_whitespace(Whitespace::LineBreak, Priority::High);
+                    } else {
+                        output.set_whitespace(Whitespace::Space, Priority::Low);
+                    }
+                    pad = false;
+                } else {
+                    format(child, state, settings, output);
+                    output.set_whitespace(Whitespace::LineBreak, Priority::High);
+                }
+            }
+            SyntaxKind::RightParen => {
+                state.dedent();
+                output.set_whitespace(Whitespace::LineBreak, Priority::High);
+                format(child, state, settings, output);
+            }
+            SyntaxKind::Named => {
+                format(child, state, settings, output);
+                pad = false;
+            }
+            _ => {
+                format(child, state, settings, output);
+                pad = true;
+            }
+        }
+    }
+}
+
+fn get_column_count(node: &SyntaxNode) -> usize {
+    for child in node.children() {
+        if child.kind() != SyntaxKind::Named {
+            continue;
+        }
+        enum State {
+            Start,
+            IsColumns,
+            Columns(usize),
+        }
+
+        let state = child.children().fold(State::Start, |state, sub_child| {
+            match (&state, sub_child.kind()) {
+                (State::Start, SyntaxKind::Ident) => {
+                    if sub_child.text() == "columns" {
+                        State::IsColumns
+                    } else {
+                        State::Start
+                    }
+                }
+                (State::IsColumns, SyntaxKind::Array) => {
+                    let count =
+                        sub_child.children().fold(0, |count, value| match value.kind() {
+                            SyntaxKind::Auto
+                            | SyntaxKind::Int // would be compile error, but would be strange to skip for formatting
+                            | SyntaxKind::Numeric
+                            | SyntaxKind::Float => count + 1,
+                            _ => count,
+                        });
+                    State::Columns(count)
+                }
+                (State::IsColumns, SyntaxKind::Int) => {
+                    State::Columns(sub_child.text().parse().unwrap_or(1))
+                }
+                _ => state,
+            }
+        });
+        if let State::Columns(value) = state {
+            return if value == 0 { 1 } else { value };
+        }
+    }
+    1
+}
+
+pub fn format_code_statement(
+    node: &SyntaxNode,
+    state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    format_default(node, state, settings, output);
+    match state.mode {
+        Mode::Code => {}
+        _ => output.set_whitespace(Whitespace::LineBreak, Priority::Normal),
+    }
+}

--- a/crates/typst-format/src/logic/markup.rs
+++ b/crates/typst-format/src/logic/markup.rs
@@ -1,0 +1,182 @@
+use super::*;
+
+pub fn format_markup(
+    node: &SyntaxNode,
+    state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    let mut disabled = false;
+    for child in node.children() {
+        if (child.kind() == SyntaxKind::LineComment
+            || child.kind() == SyntaxKind::BlockComment)
+            && child.text().contains("typstfmt")
+        {
+            if child.text().contains("disable") {
+                disabled = true;
+            } else if child.text().contains("enable") {
+                disabled = false;
+            }
+        }
+        if disabled {
+            skip_formatting(child, state, settings, output);
+        } else {
+            format(child, state, settings, output);
+        }
+    }
+}
+
+pub fn format_content_block(
+    node: &SyntaxNode,
+    mut state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    let mut start_space = false;
+    let mut end_space = false;
+    let mut linebreak = false;
+    for child in node.children() {
+        if child.kind() != SyntaxKind::Markup {
+            continue;
+        }
+        for (index, sub_child) in child.children().enumerate() {
+            match (index, sub_child.kind()) {
+                (0, SyntaxKind::Space) | (0, SyntaxKind::Parbreak) => {
+                    start_space = true;
+                    end_space = true;
+                    if sub_child.text().contains('\n') {
+                        linebreak = true;
+                    }
+                }
+                (_, SyntaxKind::Space) | (_, SyntaxKind::Parbreak) => {
+                    end_space = true;
+                    if sub_child.text().contains('\n') {
+                        linebreak = true;
+                    }
+                }
+                _ => end_space = false,
+            }
+        }
+    }
+    let single = !start_space || !end_space || !linebreak;
+    state.mode = Mode::Markdown;
+    for child in node.children() {
+        match child.kind() {
+            SyntaxKind::LeftBracket => {
+                format(child, state, settings, output);
+                if single {
+                    if start_space {
+                        output.set_whitespace(Whitespace::Space, Priority::Guaranteed);
+                    } else {
+                        output.set_whitespace(Whitespace::None, Priority::Guaranteed);
+                    }
+                } else {
+                    state.indent();
+                    match settings.block.long_block_style {
+                        LongBlockStyle::Compact => {
+                            output.set_whitespace(Whitespace::Space, Priority::Low)
+                        }
+                        LongBlockStyle::Seperate => {
+                            output.set_whitespace(Whitespace::LineBreak, Priority::Normal)
+                        }
+                    }
+                }
+            }
+
+            SyntaxKind::RightBracket => {
+                if single {
+                    if end_space {
+                        output.set_whitespace(Whitespace::Space, Priority::Guaranteed);
+                    } else {
+                        output.set_whitespace(Whitespace::None, Priority::Guaranteed);
+                    }
+                } else {
+                    state.dedent();
+                    match settings.block.long_block_style {
+                        LongBlockStyle::Compact => {
+                            output.set_whitespace(Whitespace::Space, Priority::Low)
+                        }
+                        LongBlockStyle::Seperate => {
+                            output.set_whitespace(Whitespace::LineBreak, Priority::Normal)
+                        }
+                    }
+                }
+                format(child, state, settings, output);
+            }
+            _ => format(child, state, settings, output),
+        }
+    }
+}
+
+pub fn format_heading(
+    settings: &Settings,
+    node: &SyntaxNode,
+    state: State,
+    output: &mut Output<impl OutputTarget>,
+) {
+    output.set_whitespace(
+        Whitespace::LineBreaks(settings.heading.blank_lines_before + 1),
+        Priority::High,
+    );
+    format_default(node, state, settings, output);
+    output.set_whitespace(
+        Whitespace::LineBreaks(settings.heading.blank_lines_after + 1),
+        Priority::High,
+    );
+}
+
+pub fn format_label(
+    node: &SyntaxNode,
+    state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    let (whitespace, priority) = output.get_whitespace();
+    if settings.seperate_label {
+        output.set_whitespace(Whitespace::Space, Priority::Guaranteed);
+    } else {
+        output.set_whitespace(Whitespace::None, Priority::High);
+    }
+    output.raw(node, &state, settings);
+    output.set_whitespace(whitespace, priority);
+}
+
+pub fn format_term(
+    node: &SyntaxNode,
+    state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    for child in node.children() {
+        match child.kind() {
+            SyntaxKind::Colon => {
+                if settings.term.space_before_colon {
+                    output.set_whitespace(Whitespace::Space, Priority::Normal);
+                } else {
+                    output.set_whitespace(Whitespace::None, Priority::Normal);
+                }
+                format(child, state, settings, output);
+                if settings.term.space_after_colon {
+                    output.set_whitespace(Whitespace::Space, Priority::Normal);
+                } else {
+                    output.set_whitespace(Whitespace::None, Priority::Normal);
+                }
+            }
+            _ => format(child, state, settings, output),
+        }
+    }
+    output.set_whitespace(Whitespace::LineBreak, Priority::High);
+}
+
+pub fn format_end_of_file(
+    _node: &SyntaxNode,
+    _state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    if settings.final_newline {
+        output.set_whitespace(Whitespace::LineBreak, Priority::Guaranteed);
+    } else {
+        output.set_whitespace(Whitespace::None, Priority::Guaranteed);
+    }
+}

--- a/crates/typst-format/src/logic/math.rs
+++ b/crates/typst-format/src/logic/math.rs
@@ -1,0 +1,208 @@
+use super::*;
+
+pub fn format_equation(
+    node: &SyntaxNode,
+    state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    let spaces = node
+        .children()
+        .fold(0, |spaces, child| spaces + (child.kind() == SyntaxKind::Space) as u32);
+    if spaces < 2 || !equation_has_aligment(node) {
+        format_inline_equation(node, state, settings, output, spaces == 2);
+    } else {
+        format_multi_line_equation(node, state, settings, output);
+    }
+}
+
+pub fn format_multi_line_equation(
+    node: &SyntaxNode,
+    mut state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    for child in node.children() {
+        match child.kind() {
+            SyntaxKind::Dollar => match (state.mode, &settings.block.long_block_style) {
+                (Mode::Math, LongBlockStyle::Compact) => {
+                    output.set_whitespace(Whitespace::Space, Priority::Guaranteed);
+                    output.raw(child, &state, settings);
+                    output.set_whitespace(Whitespace::LineBreak, Priority::Normal);
+                }
+                (_, LongBlockStyle::Compact) => {
+                    output.set_whitespace(Whitespace::LineBreak, Priority::Normal);
+                    output.raw(child, &state, settings);
+                    output.set_whitespace(Whitespace::Space, Priority::Normal);
+                    state.mode = Mode::Math;
+                }
+                (Mode::Math, LongBlockStyle::Seperate) => {
+                    state.dedent();
+                    output.set_whitespace(Whitespace::LineBreak, Priority::Normal);
+                    output.raw(child, &state, settings);
+                }
+                (_, LongBlockStyle::Seperate) => {
+                    output.raw(child, &state, settings);
+                    state.indent();
+                    output.set_whitespace(Whitespace::LineBreak, Priority::Normal);
+                    state.mode = Mode::Math;
+                }
+            },
+            SyntaxKind::Math => {
+                format_multi_line_math(child, state, settings, output);
+            }
+            _ => format(child, state, settings, output),
+        }
+    }
+}
+
+fn format_multi_line_math(
+    node: &SyntaxNode,
+    mut state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    let has_align = node
+        .children()
+        .any(|child| child.kind() == SyntaxKind::MathAlignPoint);
+    if !has_align {
+        for child in node.children() {
+            format(child, state, settings, output);
+        }
+        return;
+    }
+    let mut lengths = Vec::new();
+    lengths.push(Vec::new());
+    let mut calculator = PositionCalculator::new();
+    let mut calc = Output::new(&mut calculator);
+    for child in node.children() {
+        match child.kind() {
+            SyntaxKind::MathAlignPoint => {
+                lengths.last_mut().unwrap().push(calc.position().1);
+                calc.reset();
+            }
+            SyntaxKind::Linebreak => {
+                lengths.last_mut().unwrap().push(calc.position().1);
+                calc.reset();
+                lengths.push(Vec::new());
+            }
+            _ => {
+                format(child, state, settings, &mut calc);
+            }
+        }
+    }
+    if calc.position().1 != 0 {
+        lengths.last_mut().unwrap().push(calc.position().1);
+    }
+
+    let columns_amount = lengths.iter().map(|v| v.len()).max().unwrap_or(1);
+    let mut columns = vec![0; columns_amount];
+    for l in lengths.iter() {
+        for (index, &v) in l.iter().enumerate() {
+            columns[index] = columns[index].max(v);
+        }
+    }
+    let mut line = 0;
+    let mut index = 0;
+    if let LongBlockStyle::Compact = settings.block.long_block_style {
+        state.extra_indentation = 2;
+    }
+    for child in node.children() {
+        match child.kind() {
+            SyntaxKind::MathAlignPoint => {
+                output.set_whitespace(Whitespace::None, Priority::Normal);
+                output.emit_whitespace(&state, settings);
+                let diff = 1 + columns[index] - lengths[line][index];
+                output.set_whitespace(Whitespace::Spaces(diff), Priority::Normal);
+                format(child, state, settings, output);
+                output.set_whitespace(Whitespace::Space, Priority::Normal);
+                index += 1;
+            }
+            SyntaxKind::Linebreak => {
+                output.set_whitespace(Whitespace::None, Priority::Normal);
+                output.emit_whitespace(&state, settings);
+                let amount = 1
+                    + columns[index..].iter().sum::<usize>()
+                    + (columns_amount - index - 1) * 3;
+                let diff = amount - lengths[line][index];
+                output.set_whitespace(Whitespace::Spaces(diff), Priority::High);
+                format(child, state, settings, output);
+                output.set_whitespace(Whitespace::LineBreak, Priority::High);
+                line += 1;
+                index = 0;
+            }
+            _ => {
+                format(child, state, settings, output);
+            }
+        }
+    }
+}
+
+fn format_inline_equation(
+    node: &SyntaxNode,
+    mut state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+    needs_spaces: bool,
+) {
+    for child in node.children() {
+        match (state.mode, child.kind()) {
+            (Mode::Math, SyntaxKind::Dollar) => {
+                if needs_spaces {
+                    output.set_whitespace(Whitespace::Space, Priority::Guaranteed);
+                } else {
+                    output.set_whitespace(Whitespace::None, Priority::High);
+                }
+                output.raw(child, &state, settings);
+            }
+            (_, SyntaxKind::Dollar) => {
+                output.raw(child, &state, settings);
+                if needs_spaces {
+                    output.set_whitespace(Whitespace::Space, Priority::Guaranteed);
+                } else {
+                    output.set_whitespace(Whitespace::None, Priority::High);
+                }
+                state.indent();
+                if let LongBlockStyle::Compact = settings.block.long_block_style {
+                    state.extra_indentation = 2;
+                }
+                state.mode = Mode::Math;
+            }
+            _ => format(child, state, settings, output),
+        }
+    }
+}
+
+fn equation_has_aligment(node: &SyntaxNode) -> bool {
+    for child in node.children() {
+        if child.kind() != SyntaxKind::Math {
+            continue;
+        }
+        for sub_child in child.children() {
+            match sub_child.kind() {
+                SyntaxKind::Linebreak => return true,
+                SyntaxKind::MathAlignPoint => return true,
+                _ => {}
+            }
+        }
+    }
+    false
+}
+
+pub fn format_math_attach(
+    node: &SyntaxNode,
+    state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    for child in node.children() {
+        match child.kind() {
+            SyntaxKind::Underscore | SyntaxKind::Hat => {
+                output.set_whitespace(Whitespace::None, Priority::High);
+                format(child, state, settings, output);
+                output.set_whitespace(Whitespace::None, Priority::High);
+            }
+            _ => format(child, state, settings, output),
+        }
+    }
+}

--- a/crates/typst-format/src/logic/mod.rs
+++ b/crates/typst-format/src/logic/mod.rs
@@ -1,0 +1,319 @@
+mod code;
+mod markup;
+mod math;
+
+use code::*;
+use markup::*;
+use math::*;
+
+use typst_syntax::{SyntaxKind, SyntaxNode};
+
+use crate::{
+    output::{Output, OutputTarget, PositionCalculator, Priority, Whitespace},
+    settings::*,
+    state::{Mode, State},
+};
+
+pub fn format(
+    node: &SyntaxNode,
+    state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    if node.erroneous()
+        && node
+            .children()
+            .flat_map(|child| child.children())
+            .any(|child| child.kind() == SyntaxKind::Error)
+    {
+        return skip_formatting(node, state, settings, output);
+    }
+
+    match node.kind() {
+        SyntaxKind::Markup => format_markup(node, state, settings, output),
+        SyntaxKind::Text => format_default(node, state, settings, output),
+        SyntaxKind::Space => format_space(node, state, settings, output),
+        SyntaxKind::Linebreak => format_and_new_line(node, state, settings, output),
+        SyntaxKind::Parbreak => {
+            output.set_whitespace(Whitespace::LineBreaks(2), Priority::High)
+        }
+        SyntaxKind::Escape => format_default(node, state, settings, output),
+        SyntaxKind::Shorthand => format_default(node, state, settings, output),
+        SyntaxKind::SmartQuote => format_default(node, state, settings, output),
+        SyntaxKind::Strong => format_default(node, state, settings, output),
+        SyntaxKind::Emph => format_default(node, state, settings, output),
+        SyntaxKind::Raw => format_default(node, state, settings, output),
+        SyntaxKind::Link => format_default(node, state, settings, output),
+        SyntaxKind::Label => format_label(node, state, settings, output),
+        SyntaxKind::Ref => format_default(node, state, settings, output),
+        SyntaxKind::RefMarker => format_default(node, state, settings, output),
+        SyntaxKind::Heading => format_heading(settings, node, state, output),
+        SyntaxKind::HeadingMarker => format_default(node, state, settings, output),
+        SyntaxKind::ListItem => format_list(node, state, settings, output),
+        SyntaxKind::ListMarker => format_default(node, state, settings, output),
+        SyntaxKind::EnumItem => format_list(node, state, settings, output),
+        SyntaxKind::EnumMarker => format_default(node, state, settings, output),
+        SyntaxKind::TermItem => format_term(node, state, settings, output),
+        SyntaxKind::TermMarker => format_default(node, state, settings, output),
+        SyntaxKind::Equation => format_equation(node, state, settings, output),
+
+        SyntaxKind::Math => format_default(node, state, settings, output),
+        SyntaxKind::MathIdent => format_default(node, state, settings, output),
+        SyntaxKind::MathAlignPoint => format_default(node, state, settings, output),
+        SyntaxKind::MathDelimited => format_default(node, state, settings, output),
+        SyntaxKind::MathAttach => format_math_attach(node, state, settings, output),
+        SyntaxKind::MathPrimes => format_default(node, state, settings, output),
+        SyntaxKind::MathFrac => format_default(node, state, settings, output),
+        SyntaxKind::MathRoot => format_default(node, state, settings, output),
+
+        SyntaxKind::Hashtag => output.raw(node, &state, settings),
+        SyntaxKind::LeftBrace => output.raw(node, &state, settings),
+        SyntaxKind::RightBrace => output.raw(node, &state, settings),
+        SyntaxKind::LeftBracket => output.raw(node, &state, settings),
+        SyntaxKind::RightBracket => output.raw(node, &state, settings),
+        SyntaxKind::LeftParen => output.raw(node, &state, settings),
+        SyntaxKind::RightParen => output.raw(node, &state, settings),
+        SyntaxKind::Comma => output.raw(node, &state, settings),
+        SyntaxKind::Semicolon => format_semicolon(node, state, settings, output),
+        SyntaxKind::Colon => output.raw(node, &state, settings),
+        SyntaxKind::Star => format_star(node, state, settings, output),
+        SyntaxKind::Underscore => format_underscore(node, state, settings, output),
+        SyntaxKind::Dollar => format_default(node, state, settings, output),
+        SyntaxKind::Plus => format_padded(node, state, settings, output),
+        SyntaxKind::Minus => format_padded(node, state, settings, output),
+        SyntaxKind::Slash => format_padded(node, state, settings, output),
+        SyntaxKind::Hat => format_default(node, state, settings, output),
+        SyntaxKind::Prime => format_default(node, state, settings, output),
+        SyntaxKind::Dot => format_no_padding(node, state, settings, output),
+        SyntaxKind::Eq => format_padded(node, state, settings, output),
+        SyntaxKind::EqEq => format_padded(node, state, settings, output),
+        SyntaxKind::ExclEq => format_padded(node, state, settings, output),
+        SyntaxKind::Lt => format_padded(node, state, settings, output),
+        SyntaxKind::LtEq => format_padded(node, state, settings, output),
+        SyntaxKind::Gt => format_padded(node, state, settings, output),
+        SyntaxKind::GtEq => format_padded(node, state, settings, output),
+        SyntaxKind::PlusEq => format_padded(node, state, settings, output),
+        SyntaxKind::HyphEq => format_padded(node, state, settings, output),
+        SyntaxKind::StarEq => format_padded(node, state, settings, output),
+        SyntaxKind::SlashEq => format_padded(node, state, settings, output),
+        SyntaxKind::Dots => format_right_bound(node, state, settings, output),
+        SyntaxKind::Arrow => format_padded(node, state, settings, output),
+        SyntaxKind::Root => format_right_bound(node, state, settings, output),
+
+        SyntaxKind::Not => output.raw(node, &state, settings),
+        SyntaxKind::And => output.raw(node, &state, settings),
+        SyntaxKind::Or => output.raw(node, &state, settings),
+        SyntaxKind::None => output.raw(node, &state, settings),
+        SyntaxKind::Auto => output.raw(node, &state, settings),
+        SyntaxKind::Let => output.raw(node, &state, settings),
+        SyntaxKind::Set => output.raw(node, &state, settings),
+        SyntaxKind::Show => output.raw(node, &state, settings),
+        SyntaxKind::If => output.raw(node, &state, settings),
+        SyntaxKind::Else => output.raw(node, &state, settings),
+        SyntaxKind::For => output.raw(node, &state, settings),
+        SyntaxKind::In => output.raw(node, &state, settings),
+        SyntaxKind::While => output.raw(node, &state, settings),
+        SyntaxKind::Break => output.raw(node, &state, settings),
+        SyntaxKind::Continue => output.raw(node, &state, settings),
+        SyntaxKind::Return => output.raw(node, &state, settings),
+        SyntaxKind::Import => output.raw(node, &state, settings),
+        SyntaxKind::Include => output.raw(node, &state, settings),
+        SyntaxKind::As => output.raw(node, &state, settings),
+
+        SyntaxKind::Code => format_default(node, state, settings, output),
+        SyntaxKind::Ident => format_default(node, state, settings, output),
+        SyntaxKind::Bool => format_default(node, state, settings, output),
+        SyntaxKind::Int => format_default(node, state, settings, output),
+        SyntaxKind::Float => format_default(node, state, settings, output),
+        SyntaxKind::Numeric => format_default(node, state, settings, output),
+        SyntaxKind::Str => format_default(node, state, settings, output),
+        SyntaxKind::CodeBlock => format_code_block(node, state, settings, output),
+        SyntaxKind::ContentBlock => format_content_block(node, state, settings, output),
+        SyntaxKind::Parenthesized => format_default(node, state, settings, output),
+        SyntaxKind::Array => format_items(node, state, settings, output),
+        SyntaxKind::Dict => format_items(node, state, settings, output),
+        SyntaxKind::Named => format_named_argument(node, state, settings, output),
+        SyntaxKind::Keyed => format_keyed(node, state, settings, output),
+        SyntaxKind::Unary => format_unary(node, state, settings, output),
+        SyntaxKind::Binary => format_default(node, state, settings, output),
+        SyntaxKind::FieldAccess => format_default(node, state, settings, output),
+        SyntaxKind::FuncCall => format_func_call(node, state, settings, output),
+        SyntaxKind::Args => format_items(node, state, settings, output),
+        SyntaxKind::Spread => format_default(node, state, settings, output),
+        SyntaxKind::Closure => format_default(node, state, settings, output),
+        SyntaxKind::Params => format_items(node, state, settings, output),
+        SyntaxKind::LetBinding => format_code_statement(node, state, settings, output),
+        SyntaxKind::SetRule => format_code_statement(node, state, settings, output),
+        SyntaxKind::ShowRule => format_code_statement(node, state, settings, output),
+        SyntaxKind::Conditional => format_default(node, state, settings, output),
+        SyntaxKind::WhileLoop => format_default(node, state, settings, output),
+        SyntaxKind::ForLoop => format_default(node, state, settings, output),
+        SyntaxKind::ModuleImport => format_code_statement(node, state, settings, output),
+        SyntaxKind::ImportItems => format_default(node, state, settings, output),
+        SyntaxKind::ModuleInclude => format_code_statement(node, state, settings, output),
+        SyntaxKind::LoopBreak => format_default(node, state, settings, output),
+        SyntaxKind::LoopContinue => format_default(node, state, settings, output),
+        SyntaxKind::FuncReturn => format_default(node, state, settings, output),
+        SyntaxKind::Destructuring => format_items(node, state, settings, output),
+        SyntaxKind::DestructAssignment => format_default(node, state, settings, output),
+        SyntaxKind::RenamedImportItem => format_default(node, state, settings, output),
+
+        SyntaxKind::LineComment => format_and_new_line(node, state, settings, output),
+        SyntaxKind::BlockComment => format_default(node, state, settings, output),
+        SyntaxKind::Error => format_default(node, state, settings, output),
+        SyntaxKind::Eof => format_end_of_file(node, state, settings, output),
+    }
+}
+
+fn format_default(
+    node: &SyntaxNode,
+    state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    output.raw(node, &state, settings);
+    for child in node.children() {
+        format(child, state, settings, output);
+    }
+}
+
+fn format_no_padding(
+    node: &SyntaxNode,
+    state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    output.set_whitespace(Whitespace::None, Priority::Normal);
+    format_default(node, state, settings, output);
+    output.set_whitespace(Whitespace::None, Priority::Normal);
+}
+
+fn format_padded(
+    node: &SyntaxNode,
+    state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    output.set_whitespace(Whitespace::Space, Priority::Low);
+    format_default(node, state, settings, output);
+    output.set_whitespace(Whitespace::Space, Priority::Low);
+}
+
+fn format_and_new_line(
+    node: &SyntaxNode,
+    state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    format_default(node, state, settings, output);
+    output.set_whitespace(Whitespace::LineBreak, Priority::Normal);
+}
+
+fn format_right_bound(
+    node: &SyntaxNode,
+    state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    format_default(node, state, settings, output);
+    output.set_whitespace(Whitespace::None, Priority::Normal);
+}
+
+fn skip_formatting(
+    node: &SyntaxNode,
+    state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    output.raw(node, &state, settings);
+    for child in node.children() {
+        skip_formatting(child, state, settings, output);
+    }
+}
+
+fn get_length(node: &SyntaxNode, settings: &Settings) -> Option<usize> {
+    let mut calculator = PositionCalculator::new();
+    let mut output = Output::new(&mut calculator);
+    let state = State::new();
+    format(node, state, settings, &mut output);
+    let (line, column) = output.position();
+    if line > 1 {
+        None
+    } else {
+        Some(column)
+    }
+}
+
+fn format_list(
+    node: &SyntaxNode,
+    mut state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    output.set_whitespace(Whitespace::LineBreak, Priority::Normal);
+    for child in node.children() {
+        match child.kind() {
+            SyntaxKind::Markup => {
+                state.indent();
+                for sub_child in child.children() {
+                    match sub_child.kind() {
+                        SyntaxKind::ListItem | SyntaxKind::EnumItem => {
+                            format(sub_child, state, settings, output);
+                        }
+                        _ => format(sub_child, state, settings, output),
+                    }
+                }
+                state.dedent();
+            }
+            _ => format(child, state, settings, output),
+        }
+    }
+    output.set_whitespace(Whitespace::LineBreak, Priority::Normal);
+}
+
+fn format_space(
+    node: &SyntaxNode,
+    state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    let preserve = match state.mode {
+        Mode::Code => true,
+        Mode::Markdown => settings.preserve_newline.content,
+        Mode::Math => settings.preserve_newline.math,
+        Mode::Items => false,
+    };
+    if preserve {
+        match node.text().chars().fold(0, |acc, c| acc + (c == '\n') as usize) {
+            0 => output.set_whitespace(Whitespace::Space, Priority::Low),
+            1 => output.set_whitespace(Whitespace::LineBreak, Priority::Normal),
+            _ => output.set_whitespace(Whitespace::LineBreaks(2), Priority::Normal),
+        }
+    } else {
+        output.set_whitespace(Whitespace::Space, Priority::Low);
+    }
+}
+
+pub fn format_star(
+    node: &SyntaxNode,
+    state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    match state.mode {
+        Mode::Code => format_padded(node, state, settings, output),
+        _ => format_default(node, state, settings, output),
+    }
+}
+
+pub fn format_underscore(
+    node: &SyntaxNode,
+    state: State,
+    settings: &Settings,
+    output: &mut Output<impl OutputTarget>,
+) {
+    match state.mode {
+        Mode::Code => format_padded(node, state, settings, output),
+        _ => format_default(node, state, settings, output),
+    }
+}

--- a/crates/typst-format/src/main.rs
+++ b/crates/typst-format/src/main.rs
@@ -1,0 +1,8 @@
+use clap::Parser;
+use ecow::EcoString;
+use typst_format::{format, Command};
+
+fn main() -> Result<(), EcoString> {
+    format(&Command::parse())?;
+    Ok(())
+}

--- a/crates/typst-format/src/output.rs
+++ b/crates/typst-format/src/output.rs
@@ -1,0 +1,196 @@
+use ecow::EcoString;
+use typst_syntax::SyntaxNode;
+
+use crate::state::State;
+
+use super::settings::Settings;
+
+#[derive(Clone, Copy)]
+pub enum Whitespace {
+    None,
+    Space,
+    Spaces(usize),
+    LineBreak,
+    LineBreaks(usize),
+}
+
+#[derive(Clone, Copy, PartialEq)]
+pub enum Priority {
+    Lowest,
+    Low,
+    Normal,
+    High,
+    Guaranteed,
+}
+
+pub trait OutputTarget {
+    fn emit(&mut self, data: &EcoString, settings: &Settings);
+}
+
+pub struct Output<'a, Target: OutputTarget> {
+    target: &'a mut Target,
+    whitespace: Whitespace,
+    priority: Priority,
+}
+
+impl<'a, Target: OutputTarget> Output<'a, Target> {
+    pub fn new(target: &'a mut Target) -> Self {
+        Self {
+            target,
+            whitespace: Whitespace::None,
+            priority: Priority::Guaranteed,
+        }
+    }
+
+    fn emit_indentation(&mut self, state: &State, settings: &Settings) {
+        if state.indentation + state.extra_indentation == 0 {
+            return;
+        }
+        match settings.indentation {
+            0 => {
+                let mut data =
+                    EcoString::with_capacity(state.indentation + state.extra_indentation);
+                for _ in 0..state.indentation {
+                    data.push('\t');
+                }
+                for _ in 0..state.extra_indentation {
+                    data.push(' ');
+                }
+                self.target.emit(&data, settings);
+            }
+            amount => {
+                let length = state.indentation * amount;
+                let mut data = EcoString::with_capacity(length + state.extra_indentation);
+                for _ in 0..length {
+                    data.push(' ');
+                }
+                for _ in 0..state.extra_indentation {
+                    data.push(' ');
+                }
+                self.target.emit(&data, settings);
+            }
+        }
+    }
+
+    pub fn emit_whitespace(&mut self, state: &State, settings: &Settings) {
+        match self.whitespace {
+            Whitespace::None => {}
+            Whitespace::Space => self.target.emit(&EcoString::inline(" "), settings),
+            Whitespace::Spaces(amount) => {
+                let mut data = EcoString::with_capacity(amount);
+                for _ in 0..amount {
+                    data.push(' ');
+                }
+                self.target.emit(&data, settings);
+            }
+            Whitespace::LineBreak => {
+                self.target.emit(&EcoString::inline("\n"), settings);
+                self.emit_indentation(state, settings)
+            }
+            Whitespace::LineBreaks(amount) => {
+                let mut data = EcoString::with_capacity(amount);
+                for _ in 0..amount {
+                    data.push('\n');
+                }
+                self.target.emit(&data, settings);
+                self.emit_indentation(state, settings)
+            }
+        }
+        self.whitespace = Whitespace::None;
+        self.priority = Priority::Lowest;
+    }
+
+    pub fn raw(&mut self, node: &SyntaxNode, state: &State, settings: &Settings) {
+        if node.text().is_empty() {
+            return;
+        }
+        self.emit_whitespace(state, settings);
+        self.target.emit(node.text(), settings);
+    }
+
+    pub fn set_whitespace(&mut self, whitespace: Whitespace, priority: Priority) {
+        if self.priority == priority {
+            // use larger whitespace
+            match (self.whitespace, whitespace) {
+                (Whitespace::None, _) => {}
+                (Whitespace::Space, Whitespace::Spaces(_)) => {}
+                (Whitespace::Space, Whitespace::LineBreak) => {}
+                (Whitespace::Space, Whitespace::LineBreaks(_)) => {}
+                (Whitespace::Spaces(before), Whitespace::Spaces(after))
+                    if after > before => {}
+                (Whitespace::Spaces(_), Whitespace::LineBreak) => {}
+                (Whitespace::Spaces(_), Whitespace::LineBreaks(_)) => {}
+                (Whitespace::LineBreak, Whitespace::LineBreaks(_)) => {}
+                (Whitespace::LineBreaks(before), Whitespace::LineBreaks(after))
+                    if after > before => {}
+                _ => return,
+            }
+        } else {
+            // use higher priority
+            match (self.priority, priority) {
+                (Priority::Lowest, _) => {}
+                (Priority::Low, Priority::Normal) => {}
+                (Priority::Low, Priority::High) => {}
+                (Priority::Normal, Priority::High) => {}
+                (_, Priority::Guaranteed) => {}
+                _ => return,
+            }
+        }
+        self.whitespace = whitespace;
+        self.priority = priority;
+    }
+
+    pub fn get_whitespace(&self) -> (Whitespace, Priority) {
+        (self.whitespace, self.priority)
+    }
+
+    pub fn finish(mut self, state: &State, settings: &Settings) {
+        self.emit_whitespace(state, settings);
+    }
+}
+
+pub struct PositionCalculator {
+    line: usize,
+    column: usize,
+}
+
+impl PositionCalculator {
+    pub fn new() -> Self {
+        Self { line: 0, column: 0 }
+    }
+
+    pub fn reset(&mut self) {
+        self.line = 0;
+        self.column = 0;
+    }
+}
+
+impl OutputTarget for PositionCalculator {
+    fn emit(&mut self, data: &EcoString, settings: &Settings) {
+        for symbol in data.chars() {
+            match symbol {
+                '\t' => {
+                    let tab_size = settings.indentation.max(1);
+                    self.column += 1 + tab_size.overflowing_sub(self.column).0 % tab_size
+                }
+                '\n' => {
+                    self.line += 1;
+                    self.column = 1;
+                }
+                _ => self.column += 1,
+            }
+        }
+    }
+}
+
+impl Output<'_, PositionCalculator> {
+    pub fn position(&self) -> (usize, usize) {
+        (self.target.line, self.target.column)
+    }
+
+    pub fn reset(&mut self) {
+        self.target.reset();
+        self.whitespace = Whitespace::None;
+        self.priority = Priority::Guaranteed;
+    }
+}

--- a/crates/typst-format/src/settings.rs
+++ b/crates/typst-format/src/settings.rs
@@ -1,0 +1,123 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::StrResult;
+
+trait Merge {
+    type Partial;
+    fn merge(&mut self, other: Self::Partial);
+}
+
+macro_rules! identity_merge {
+    ($($t:ty),*$(,)?) => {
+        $(
+            impl Merge for $t {
+                type Partial = Self;
+                fn merge(&mut self, other: Self) {
+                    *self = other;
+                }
+            }
+        )*
+    };
+}
+
+macro_rules! create_normal_and_partial {
+    ($(struct $name:ident | $partial_name:ident {$(pub $member:ident: $member_type:ty,)*})*) => {
+        $(
+            #[derive(Serialize, Debug)]
+            pub struct $name {
+                $(
+                    pub $member: $member_type,
+                )*
+            }
+
+            #[derive(Deserialize, Debug)]
+            struct $partial_name {
+                $(
+                    pub $member: Option<<$member_type as Merge>::Partial>,
+                )*
+            }
+
+            impl Merge for $name {
+                type Partial = $partial_name;
+                fn merge(&mut self, other: $partial_name) {
+                    $(
+                        if let Some(value) = other.$member {
+                            self.$member.merge(value);
+                        }
+                    )*
+                }
+            }
+        )*
+    };
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub enum UseLongBlock {
+    Never,
+    HasAligment,
+    Always,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub enum LongBlockStyle {
+    Compact,
+    Seperate,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub enum AlignComma {
+    EndOfContent,
+    EndOfCell,
+}
+
+identity_merge!(usize, bool, UseLongBlock, LongBlockStyle, AlignComma);
+
+create_normal_and_partial!(
+    struct BlockSettings | PartialBlockSettings {
+        pub long_block_style: LongBlockStyle,
+    }
+
+    struct HeadingSettings | PartialHeadingSettings {
+        pub blank_lines_before: usize,
+        pub blank_lines_after: usize,
+    }
+
+    struct ColumnsSettings | PartialColumnsSettings {
+        pub comma: AlignComma,
+    }
+
+    struct ColonSettings | PartialColonSettings {
+        pub space_before_colon: bool,
+        pub space_after_colon: bool,
+    }
+
+    struct PreserveNewLine | PartialPreserveNewLine {
+        pub content: bool,
+        pub math: bool,
+    }
+
+    struct Settings | PartialSettings {
+        pub indentation: usize,
+        pub seperate_label: bool,
+        pub final_newline: bool,
+        pub preserve_newline: PreserveNewLine,
+        pub block: BlockSettings,
+        pub term: ColonSettings,
+        pub named_argument: ColonSettings,
+        pub dictionary_entry: ColonSettings,
+        pub columns: ColumnsSettings,
+        pub heading: HeadingSettings,
+    }
+);
+
+impl Settings {
+    pub fn merge(&mut self, path: &PathBuf) -> StrResult<()> {
+        let data = std::fs::read_to_string(path)
+            .map_err(|_| format!("could not read '{}'", path.display()))?;
+        let partial = toml::from_str(&data).map_err(|err| err.to_string())?;
+        <Self as Merge>::merge(self, partial);
+        Ok(())
+    }
+}

--- a/crates/typst-format/src/state.rs
+++ b/crates/typst-format/src/state.rs
@@ -1,0 +1,35 @@
+#[derive(Clone, Copy)]
+pub enum Mode {
+    /// `[...]` or top level
+    Markdown,
+    /// `{...}`
+    Code,
+    /// `$...$`
+    Math,
+    /// `(_, ...)`
+    Items,
+}
+
+#[derive(Clone, Copy)]
+pub struct State {
+    pub indentation: usize,
+    pub extra_indentation: usize,
+    pub mode: Mode,
+}
+
+impl State {
+    pub fn new() -> Self {
+        Self {
+            indentation: 0,
+            extra_indentation: 0,
+            mode: Mode::Markdown,
+        }
+    }
+    pub fn indent(&mut self) {
+        self.indentation += 1;
+    }
+
+    pub fn dedent(&mut self) {
+        self.indentation -= 1
+    }
+}

--- a/crates/typst-format/src/styles.rs
+++ b/crates/typst-format/src/styles.rs
@@ -1,0 +1,71 @@
+use std::fmt::{self, Display, Formatter};
+
+use crate::settings::*;
+
+use clap::ValueEnum;
+
+#[derive(Debug, Copy, Clone, ValueEnum)]
+pub enum Styles {
+    /// Laurmaedje's style
+    Default,
+    /// One true bracket style
+    OTBS,
+}
+
+impl Styles {
+    pub fn settings(&self) -> Settings {
+        match self {
+            Self::Default => Settings {
+                indentation: 2,
+                seperate_label: true,
+                preserve_newline: PreserveNewLine { content: true, math: true },
+                term: ColonSettings {
+                    space_before_colon: false,
+                    space_after_colon: true,
+                },
+                named_argument: ColonSettings {
+                    space_before_colon: false,
+                    space_after_colon: true,
+                },
+                dictionary_entry: ColonSettings {
+                    space_before_colon: false,
+                    space_after_colon: true,
+                },
+                columns: ColumnsSettings { comma: AlignComma::EndOfContent },
+                block: BlockSettings { long_block_style: LongBlockStyle::Compact },
+                final_newline: true,
+                heading: HeadingSettings { blank_lines_before: 1, blank_lines_after: 0 },
+            },
+            Self::OTBS => Settings {
+                indentation: 0,
+                seperate_label: true,
+                preserve_newline: PreserveNewLine { content: false, math: true },
+                term: ColonSettings {
+                    space_before_colon: false,
+                    space_after_colon: true,
+                },
+                named_argument: ColonSettings {
+                    space_before_colon: false,
+                    space_after_colon: true,
+                },
+                dictionary_entry: ColonSettings {
+                    space_before_colon: false,
+                    space_after_colon: true,
+                },
+                columns: ColumnsSettings { comma: AlignComma::EndOfContent },
+                block: BlockSettings { long_block_style: LongBlockStyle::Seperate },
+                final_newline: true,
+                heading: HeadingSettings { blank_lines_before: 2, blank_lines_after: 1 },
+            },
+        }
+    }
+}
+
+impl Display for Styles {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.to_possible_value()
+            .expect("no values are skipped")
+            .get_name()
+            .fmt(f)
+    }
+}


### PR DESCRIPTION
Updated, old version below.

## Example

![image](https://github.com/typst/typst/assets/59712243/6d0e876d-989e-4de2-81b0-6073d24f3a95)

- left: input
- middle: default style
- right: otbs style

## Overview

- format decision based on indicator symbols
  - arrays, argument, dictionaries and parametesr are multiline if a trailing comma is present
  - equations are multiline if they have `&` or `\`
  - code and content blocks are multiline if they start or end with a linebreak
- no decisions based on line lengths
- special case for grid and table to align cells

## Other

- disable and enable with `// typstfmt disable` and `// typstfmt enable` in a comment
  - only works in markdown mode
  - whitespace and order irrelevant as long as the exact words are there

## Settings

- base style `default` and `otbs`
- optional `typstfmt.toml` in same or parent to root folder to overwrite the settings
   - if a key is not present the value from the base style is used

```yaml
indentation = 0 | 1 | 2 | ... # use 0 for tabs
seperate_label = false | true
trailing_newline = false | true

[block]
long_block_style = "Compact" | "Seperate" # if long blocks are on different lines then the start and end symbol

[colon]
space_before = false | true
space_after = false | true

[columns]
comma = "EndOfContent" | "EndOfCell" # where commas are placed for tables and grids

[heading]
blank_lines_before = 0 | 1 | 2 | ...
blank_lines_after = 0 | 1 | 2 | ...
```
## Inner workings

- the syntax tree is iterated depth first
- before and after a token whitespace (none, space, spaces, linebreak, linebreaks) can be inserted with a priority
- whitespace with the higher priority is inserted between the tokens
  - larger whitespace if the priority is the same
- result is written to a stream

# Old version

Current state on https://discord.com/channels/1054443721975922748/1134511438728269905

## Example

![image](https://github.com/typst/typst/assets/59712243/c8917d85-e120-4bd9-9ae8-7708cdf4ba1d)

## Current Design

- philosophy
  - however the input is formatted the result is the same
    - as long as this is reasonable
  - only change whitespace, all text stays the same
    - probably worth changing for better output
- overview
  - invoke with `typst format` 
  - recursively traverse the syntax nodes
  - output stores next whitespace and current indentation
  - on text the whitespace and the text is saved to file

## Test data and wishes

- what input and settings should produce what outcome?
  - please provide examples

## Open Questions

- where to put the code?
  - at the moment in `typst-cli`
  - maybe move to `typst`
  - maybe create `typst-format`
- how to provide the settings?
  - on the terminal line
  - as config file
    - file format (`yaml` like Hayagriva, `toml` like rustfmt, `json`, `ron` ...)?
- should the formatter change text?
  - add or remove trailing comma from parameter lists
  - change if content as parameter is trailing or inside the brackets
  - change heading from `== Test` to `#heading(level: 2)[Test]` and inverse
- integration with `typst watch` and or `typst compile`

## Overview

- features
  - [x] tabs or spaces
  - [x] code, markdown and parameter blocks
  - [x] label
  - [x] general spaces, linebreaks and parbreaks
  - [x] math mode
  - [ ] spacing between text (no space before `.`, ...)
  - [x] linebreaks in code mode
  - [x] aligment in math mode, tables and grids
  - [x] handle errors
  - [ ] dry-mode
  - [ ] ...
- other
  - [ ] tests, documentation, examples, ...
  - [ ] clean up and organize code
  - [ ] organize comit

## Current settings

```rust
pub enum IndentationMode {
    Space(usize),
    Tabs(usize), // value is used to calculate visual indentation for max line length
}

pub enum MarkdownWrap {
    None, // [ and ] without line seperations
    Block, // [ and ] on other lines for long markdown
    Lines, // same as Block + newlines in the text (not implemented)
}

pub struct NamedArgumentSettings {
    space_before_colon: bool,
    space_after_colon: bool, 
}

pub struct Settings {
    indentation: IndentationMode,
    seperate_label: bool,
    max_length: Option<usize>,
    markdown_wrap: MarkdownWrap,
    named_argument: NamedArgumentSettings,
}
```
