### PR TITLE
Recursive show rules

### DIFF
--- a/crates/typst/src/model/content.rs
+++ b/crates/typst/src/model/content.rs
@@ -343,7 +343,13 @@ impl Content {
 
     /// Check whether a show rule recipe is disabled.
     pub fn is_guarded(&self, guard: Guard) -> bool {
-        self.attrs.contains(&Attr::Guard(guard))
+        match guard {
+            Guard::Base(_) => self.attrs.contains(&Attr::Guard(guard)),
+            Guard::Nth(n) => self.attrs.iter().any(|attr| match attr {
+                Attr::Guard(Guard::Nth(gn)) => *gn <= n,
+                _ => false,
+            }),
+        }
     }
 
     /// Whether no show rule was executed for this content so far.

--- a/crates/typst/src/model/content.rs
+++ b/crates/typst/src/model/content.rs
@@ -323,6 +323,24 @@ impl Content {
         self
     }
 
+    /// Disable a show rule recipe for self and all children.
+    pub fn deep_guard(&mut self, guard: Guard) {
+        for attr in self.attrs.make_mut().iter_mut() {
+            if let Attr::Child(ch) = attr {
+                ch.update(|ch| {
+                    ch.deep_guard(guard);
+                })
+            }
+        }
+        self.attrs.push(Attr::Guard(guard));
+    }
+
+    /// Disable a show rule recipe for self and all children.
+    pub fn deep_guarded(mut self, guard: Guard) -> Self {
+        self.deep_guard(guard);
+        self
+    }
+
     /// Check whether a show rule recipe is disabled.
     pub fn is_guarded(&self, guard: Guard) -> bool {
         self.attrs.contains(&Attr::Guard(guard))

--- a/crates/typst/src/model/realize.rs
+++ b/crates/typst/src/model/realize.rs
@@ -67,7 +67,7 @@ pub fn realize(
     for recipe in styles.recipes() {
         let guard = Guard::Nth(n);
         if recipe.applicable(target) && !target.is_guarded(guard) {
-            if let Some(content) = try_apply(vt, target, recipe, guard)? {
+            if let Some(content) = try_apply(vt, target, recipe)? {
                 realized = Some(content.deep_guarded(guard));
                 break;
             }
@@ -100,7 +100,6 @@ fn try_apply(
     vt: &mut Vt,
     target: &Content,
     recipe: &Recipe,
-    guard: Guard,
 ) -> SourceResult<Option<Content>> {
     match &recipe.selector {
         Some(Selector::Elem(element, _)) => {

--- a/crates/typst/src/model/realize.rs
+++ b/crates/typst/src/model/realize.rs
@@ -220,7 +220,7 @@ pub enum Behaviour {
 /// Guards content against being affected by the same show rule multiple times.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum Guard {
-    /// The nth recipe from the top of the chain.
+    /// The nth or a higher recipe from the top of the chain.
     Nth(usize),
     /// The [base recipe](Show) for a kind of element.
     Base(ElemFunc),

--- a/crates/typst/src/model/realize.rs
+++ b/crates/typst/src/model/realize.rs
@@ -68,7 +68,7 @@ pub fn realize(
         let guard = Guard::Nth(n);
         if recipe.applicable(target) && !target.is_guarded(guard) {
             if let Some(content) = try_apply(vt, target, recipe, guard)? {
-                realized = Some(content);
+                realized = Some(content.deep_guarded(guard));
                 break;
             }
         }
@@ -79,7 +79,7 @@ pub fn realize(
     if let Some(showable) = target.with::<dyn Show>() {
         let guard = Guard::Base(target.func());
         if realized.is_none() && !target.is_guarded(guard) {
-            realized = Some(showable.show(vt, styles)?);
+            realized = Some(showable.show(vt, styles)?.deep_guarded(guard));
         }
     }
 
@@ -108,7 +108,7 @@ fn try_apply(
                 return Ok(None);
             }
 
-            recipe.apply_vt(vt, target.clone().guarded(guard)).map(Some)
+            recipe.apply_vt(vt, target.clone()).map(Some)
         }
 
         Some(Selector::Label(label)) => {
@@ -116,7 +116,7 @@ fn try_apply(
                 return Ok(None);
             }
 
-            recipe.apply_vt(vt, target.clone().guarded(guard)).map(Some)
+            recipe.apply_vt(vt, target.clone()).map(Some)
         }
 
         Some(Selector::Regex(regex)) => {
@@ -134,7 +134,7 @@ fn try_apply(
                     result.push(make(&text[cursor..start]));
                 }
 
-                let piece = make(m.as_str()).guarded(guard);
+                let piece = make(m.as_str());
                 let transformed = recipe.apply_vt(vt, piece)?;
                 result.push(transformed);
                 cursor = m.end();


### PR DESCRIPTION
This PR makes two changes to how guards work:
1. Every element in the output of a show rule is guarded against that rule (not just the input)
2. An `Nth` guard also guards against any higher show rules

The first one should be rather uncontroversial, while the second one brings some actual semantic differences with it.
Before, if you ran
```
#show heading: "a"
#show "a": "b"
= heading
```
it would give you `b`.

With this change, it instead gives `a`.
I think this makes it more intuitive, as the output of show rules is only styled with previous, not subsequent, show rules,
so show rules "bubble up" to the top.

We can also revert the second change if the new behaviour is considered bad, but that carries with it the cost of still allowing infinite mutual recursion to occur, i.e.
```
#show "a": "b"
#show "b": "a"
b
```
(which just gives `b` with the second change)