### PR TITLE
Enum Indentation from end of symbol to start of symbol + 1

### DIFF
--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -179,8 +179,8 @@ fn heading(p: &mut Parser) {
 
 fn list_item(p: &mut Parser) {
     let m = p.marker();
+    let min_indent = p.column(p.current_start()) + 1;
     p.assert(SyntaxKind::ListMarker);
-    let min_indent = p.column(p.prev_end());
     whitespace_line(p);
     markup(p, false, min_indent, |p| p.at(SyntaxKind::RightBracket));
     p.wrap(m, SyntaxKind::ListItem);
@@ -188,8 +188,8 @@ fn list_item(p: &mut Parser) {
 
 fn enum_item(p: &mut Parser) {
     let m = p.marker();
+    let min_indent = p.column(p.current_start()) + 1;
     p.assert(SyntaxKind::EnumMarker);
-    let min_indent = p.column(p.prev_end());
     whitespace_line(p);
     markup(p, false, min_indent, |p| p.at(SyntaxKind::RightBracket));
     p.wrap(m, SyntaxKind::EnumItem);


### PR DESCRIPTION
Conversation on Discord about formatting, where the issue arised.
https://discord.com/channels/1054443721975922748/1134511438728269905/1135164686128660503

At the moment the markdown in an enumration continues only if
```
999. Atleast this
     much indentation
     1. for sub lists
     2. another item
    
```

This changes the indentation to allow
```
(spaces)
999. This
  is enough
  1. sublist
  2. another item

(tabs)
999. This
	is enough
	1. sublist
	2. another item

```
(one space is also possible, but nobody should use one space as indent)

The minimum indentation is the start of the enum symbol (+, -, 123., ...) + 1.
For + and - this changes nothing and for numbers allows more.