### PR TITLE
Function to-fixed() for int and float

### DIFF
--- a/crates/typst/src/eval/methods.rs
+++ b/crates/typst/src/eval/methods.rs
@@ -52,14 +52,14 @@ pub fn call(
         },
 
         Value::Float(float) => match method {
-            "toFixed" => {
+            "to-fixed" => {
                 format!("{:.1$}", float, &args.expect::<usize>("digits")?).into_value()
             }
             _ => return missing(),
         },
 
         Value::Int(int) => match method {
-            "toFixed" => format!("{:.1$}", int as f64, &args.expect::<usize>("digits")?)
+            "to-fixed" => format!("{:.1$}", int as f64, &args.expect::<usize>("digits")?)
                 .into_value(),
             _ => return missing(),
         },

--- a/crates/typst/src/eval/methods.rs
+++ b/crates/typst/src/eval/methods.rs
@@ -51,6 +51,16 @@ pub fn call(
             _ => return missing(),
         },
 
+        Value::Float(float) => match method {
+            "toFixed" => format!("{:.1$}", float, &args.expect::<usize>("digits")?).into_value(),
+            _ => return missing()
+        },
+
+        Value::Int(int) => match method {
+            "toFixed" => format!("{:.1$}", int as f64, &args.expect::<usize>("digits")?).into_value(),
+            _ => return missing()
+        },
+
         Value::Str(string) => match method {
             "len" => string.len().into_value(),
             "first" => string.first().at(span)?.into_value(),

--- a/crates/typst/src/eval/methods.rs
+++ b/crates/typst/src/eval/methods.rs
@@ -52,13 +52,16 @@ pub fn call(
         },
 
         Value::Float(float) => match method {
-            "toFixed" => format!("{:.1$}", float, &args.expect::<usize>("digits")?).into_value(),
-            _ => return missing()
+            "toFixed" => {
+                format!("{:.1$}", float, &args.expect::<usize>("digits")?).into_value()
+            }
+            _ => return missing(),
         },
 
         Value::Int(int) => match method {
-            "toFixed" => format!("{:.1$}", int as f64, &args.expect::<usize>("digits")?).into_value(),
-            _ => return missing()
+            "toFixed" => format!("{:.1$}", int as f64, &args.expect::<usize>("digits")?)
+                .into_value(),
+            _ => return missing(),
         },
 
         Value::Str(string) => match method {

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -58,11 +58,11 @@ with a zero followed by either `x`, `o`, or `b`.
 ```
 
 ## Methods
-### toFixed()
+### to-fixed()
 Formats the number with a fixed amount of decimal places.
 
 ```example
-  #7.toFixed(2); // "7.00"
+  #7.to-fixed(2); // "7.00"
 ```
 
 - digits: integer (positional, required) The number of decimal places to display.
@@ -83,15 +83,15 @@ store floats. Wherever a float is expected, you can also pass an
 ```
 
 ## Methods
-### toFixed()
+### to-fixed()
 Formats the number with a fixed amount of decimal places.
 
 ```example
 #{
   let a = 8.1324;
   let b = 1.4;
-  a.toFixed(2); // "8.13";
-  b.toFixed(2); // "1.40";
+  a.to-fixed(2); // "8.13";
+  b.to-fixed(2); // "1.40";
 }
 ```
 

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -57,6 +57,17 @@ with a zero followed by either `x`, `o`, or `b`.
 #0b1001
 ```
 
+## Methods
+### toFixed()
+Formats the number with a fixed amount of decimal places.
+
+```example
+  #7.toFixed(2); // "7.00"
+```
+
+- digits: integer (positional, required) The number of decimal places to display.
+- returns: string
+
 # Float
 A floating-pointer number.
 
@@ -70,6 +81,22 @@ store floats. Wherever a float is expected, you can also pass an
 #1e4 \
 #(10 / 4)
 ```
+
+## Methods
+### toFixed()
+Formats the number with a fixed amount of decimal places.
+
+```example
+#{
+  let a = 8.1324;
+  let b = 1.4;
+  a.toFixed(2); // "8.13";
+  b.toFixed(2); // "1.40";
+}
+```
+
+- digits: integer (positional, required) The number of decimal places to display.
+- returns: string
 
 # Length
 A size or distance, possibly expressed with contextual units.

--- a/tests/typ/compiler/methods.typ
+++ b/tests/typ/compiler/methods.typ
@@ -198,3 +198,17 @@
 #test(2deg.deg(), 2.0)
 #test(2.94deg.deg(), 2.94)
 #test(0rad.deg(), 0.0)
+
+---
+// Test int methods
+#test(3.toFixed(0), "3")
+#test(3.toFixed(1), "3.0")
+
+---
+// Test float methods
+#test(1.138.toFixed(0), "1")
+#test(1.138.toFixed(1), "1.1")
+#test(1.138.toFixed(2), "1.14")
+#test(1.138.toFixed(3), "1.138")
+#test(1.138.toFixed(4), "1.1380")
+#test(1.9999.toFixed(2), "2.00")

--- a/tests/typ/compiler/methods.typ
+++ b/tests/typ/compiler/methods.typ
@@ -201,14 +201,14 @@
 
 ---
 // Test int methods
-#test(3.toFixed(0), "3")
-#test(3.toFixed(1), "3.0")
+#test(3.to-fixed(0), "3")
+#test(3.to-fixed(1), "3.0")
 
 ---
 // Test float methods
-#test(1.138.toFixed(0), "1")
-#test(1.138.toFixed(1), "1.1")
-#test(1.138.toFixed(2), "1.14")
-#test(1.138.toFixed(3), "1.138")
-#test(1.138.toFixed(4), "1.1380")
-#test(1.9999.toFixed(2), "2.00")
+#test(1.138.to-fixed(0), "1")
+#test(1.138.to-fixed(1), "1.1")
+#test(1.138.to-fixed(2), "1.14")
+#test(1.138.to-fixed(3), "1.138")
+#test(1.138.to-fixed(4), "1.1380")
+#test(1.9999.to-fixed(2), "2.00")


### PR DESCRIPTION
to-fixed() formats the number with a fixed amount of decimal places, this is handy for formatting sets of measurements in an orderly fashion or when printing currency.