### PR TITLE
Add support for opacities in PDF export

### DIFF
--- a/crates/typst-library/src/compute/construct.rs
+++ b/crates/typst-library/src/compute/construct.rs
@@ -105,10 +105,6 @@ pub fn luma(
 ///
 /// The color is specified in the sRGB color space.
 ///
-/// _Note:_ While you can specify transparent colors and Typst's preview will
-/// render them correctly, the PDF export does not handle them properly at the
-/// moment. This will be fixed in the future.
-///
 /// ## Example { #example }
 /// ```example
 /// #square(fill: rgb("#b1f2eb"))

--- a/crates/typst/src/export/pdf/external_graphics_state.rs
+++ b/crates/typst/src/export/pdf/external_graphics_state.rs
@@ -1,0 +1,37 @@
+use crate::export::pdf::{PdfContext, RefExt};
+use pdf_writer::Finish;
+
+/// A PDF external graphics state.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct ExternalGraphicsState {
+    // In the range 0-255, needs to be divided before being written into the graphics state!
+    pub stroke_opacity: u8,
+    // In the range 0-255, needs to be divided before being written into the graphics state!
+    pub fill_opacity: u8,
+}
+
+impl Default for ExternalGraphicsState {
+    fn default() -> Self {
+        Self { stroke_opacity: 255, fill_opacity: 255 }
+    }
+}
+
+impl ExternalGraphicsState {
+    pub fn uses_opacities(&self) -> bool {
+        self.stroke_opacity != 255 || self.fill_opacity != 255
+    }
+}
+
+/// Embed all used external graphics states into the PDF.
+#[tracing::instrument(skip_all)]
+pub fn write_external_graphics_states(ctx: &mut PdfContext) {
+    for external_gs in ctx.ext_gs_map.items() {
+        let gs_ref = ctx.alloc.bump();
+        ctx.ext_gs_refs.push(gs_ref);
+
+        let mut gs = ctx.writer.ext_graphics(gs_ref);
+        gs.non_stroking_alpha(external_gs.fill_opacity as f32 / 255.0)
+            .stroking_alpha(external_gs.stroke_opacity as f32 / 255.0);
+        gs.finish();
+    }
+}


### PR DESCRIPTION
See the title. Here a small (and messy) Typst document I used to test whether it works as intended:
```typst
#rect(fill: rgb(255, 255, 0, 50), width: 7cm, height: 7cm)[This is a rect with transparency!]
#text(fill: green)[Some more text.] \
#text(fill: rgb(255, 0, 0, 50))[Red text with some transparency!] \
#text(fill: rgb(255, 0, 0, 255))[Red text without transparency!] \
#move(dy: -5cm)[#rect(fill: rgb(0, 255, 0, 50), width: 10cm, height: 10cm)]
#lorem(35)
#rect(stroke: rgb(0, 0, 255, 30) + 20pt, width: 7cm, height: 7cm)[A rect with a stroke with transparency]
#rect(fill: rgb(0, 0, 0, 255), width: 7cm, height: 7cm)[#text(fill: white)[This should be a normal rect.]]
#pagebreak()
No transparency group necessary for this page.
#pagebreak()
#rect(fill: rgb(255, 255, 0, 50), width: 7cm, height: 7cm)[This is another rect with transparency!]
```
So I think this should work as intended, but a thorough review would still be appreciated. :)