### PR TITLE
Search additional font paths before system/embedded

### DIFF
--- a/crates/typst-cli/src/fonts.rs
+++ b/crates/typst-cli/src/fonts.rs
@@ -68,14 +68,14 @@ impl FontSearcher {
 
     /// Search everything that is available.
     pub fn search(&mut self, font_paths: &[PathBuf]) {
+        for path in font_paths {
+            self.search_dir(path)
+        }
+
         self.search_system();
 
         #[cfg(feature = "embed-fonts")]
         self.add_embedded();
-
-        for path in font_paths {
-            self.search_dir(path)
-        }
     }
 
     /// Add fonts that are embedded in the binary.


### PR DESCRIPTION
This PR simply gives fonts from additional font paths (specified using `--font-path`) precedence over system and embedded fonts as briefly discussed in #1846. :)

System fonts still have precedence over embedded fonts like before.

Closes #1846.