### PR TITLE
Fix crashing on empty regexps

### DIFF
--- a/crates/typst/src/model/selector.rs
+++ b/crates/typst/src/model/selector.rs
@@ -166,6 +166,9 @@ cast! {
         if regex.as_str().is_empty() {
             bail!("regex selector is empty");
         }
+        if regex.is_match("") {
+            bail!("regex matches empty text");
+        }
         Self::Regex(regex)
     },
     location: Location => Self::Location(location),

--- a/crates/typst/src/model/selector.rs
+++ b/crates/typst/src/model/selector.rs
@@ -47,6 +47,17 @@ impl Selector {
         Ok(Self::Regex(Regex::new(&regex::escape(text)).unwrap()))
     }
 
+    /// Define a regex selector.
+    pub fn regex(regex: Regex) -> StrResult<Self> {
+        if regex.as_str().is_empty() {
+            bail!("regex selector is empty");
+        }
+        if regex.is_match("") {
+            bail!("regex matches empty text");
+        }
+        Ok(Self::Regex(regex))
+    }
+
     /// Define a simple [`Selector::Can`] selector.
     pub fn can<T: ?Sized + Any>() -> Self {
         Self::Can(TypeId::of::<T>())
@@ -162,15 +173,7 @@ cast! {
         .select(),
     label: Label => Self::Label(label),
     text: EcoString => Self::text(&text)?,
-    regex: Regex => {
-        if regex.as_str().is_empty() {
-            bail!("regex selector is empty");
-        }
-        if regex.is_match("") {
-            bail!("regex matches empty text");
-        }
-        Self::Regex(regex)
-    },
+    regex: Regex => Self::regex(regex)?,
     location: Location => Self::Location(location),
 }
 

--- a/crates/typst/src/model/selector.rs
+++ b/crates/typst/src/model/selector.rs
@@ -40,8 +40,11 @@ pub enum Selector {
 
 impl Selector {
     /// Define a simple text selector.
-    pub fn text(text: &str) -> Self {
-        Self::Regex(Regex::new(&regex::escape(text)).unwrap())
+    pub fn text(text: &str) -> StrResult<Self> {
+        if text.is_empty() {
+            bail!("text selector is empty");
+        }
+        Ok(Self::Regex(Regex::new(&regex::escape(text)).unwrap()))
     }
 
     /// Define a simple [`Selector::Can`] selector.
@@ -158,8 +161,13 @@ cast! {
         .ok_or("only element functions can be used as selectors")?
         .select(),
     label: Label => Self::Label(label),
-    text: EcoString => Self::text(&text),
-    regex: Regex => Self::Regex(regex),
+    text: EcoString => Self::text(&text)?,
+    regex: Regex => {
+        if regex.as_str().is_empty() {
+            bail!("regex selector is empty");
+        }
+        Self::Regex(regex)
+    },
     location: Location => Self::Location(location),
 }
 

--- a/tests/typ/compiler/show-text.typ
+++ b/tests/typ/compiler/show-text.typ
@@ -35,6 +35,10 @@ Treeworld, the World of worlds, is a world.
 #show regex(""): [AA]
 
 ---
+// Error: 1:7-1:42 regex matches empty text
+#show regex("(VAR_GLOBAL|END_VAR||BOOL)") : []
+
+---
 // This is a fun one.
 #set par(justify: true)
 #show regex("\S"): letter => box(stroke: 1pt, inset: 2pt, upper(letter))

--- a/tests/typ/compiler/show-text.typ
+++ b/tests/typ/compiler/show-text.typ
@@ -26,6 +26,15 @@ AA (8)
 Treeworld, the World of worlds, is a world.
 
 ---
+// Test there is no crashing on empty strings
+// Error: 1:7-1:9 text selector is empty
+#show "": []
+
+---
+// Error: 1:7-1:16 regex selector is empty
+#show regex(""): [AA]
+
+---
 // This is a fun one.
 #set par(justify: true)
 #show regex("\S"): letter => box(stroke: 1pt, inset: 2pt, upper(letter))


### PR DESCRIPTION
Show rules with empty strings, `regexp`s and `regexp`-s that match empty strings now panic instead of crashing.

Fixes #1790 

(note that is doesn't fully fix initial issue as it has `\b` things, so initial #1790 is mostly like more general #229, but without them it is fixed)