### PR TITLE
Show warning to user if they use double/empty underscores (italic)

### DIFF
--- a/crates/typst/src/eval/mod.rs
+++ b/crates/typst/src/eval/mod.rs
@@ -600,7 +600,18 @@ impl Eval for ast::Emph {
 
     #[tracing::instrument(name = "Emph::eval", skip_all)]
     fn eval(&self, vm: &mut Vm) -> SourceResult<Self::Output> {
-        Ok((vm.items.emph)(self.body().eval(vm)?))
+        let body = self.body();
+        if body.exprs().next().is_none() {
+            vm.vt
+                .tracer
+                .warn(warning!(self.span(), "no text within underscores").with_hint(
+                EcoString::from(
+                    "using multiple consecutive underscores (e.g. __) has no additional effect",
+                ),
+            ));
+        }
+
+        Ok((vm.items.emph)(body.eval(vm)?))
     }
 }
 

--- a/tests/typ/lint/markup.typ
+++ b/tests/typ/lint/markup.typ
@@ -5,9 +5,22 @@
 // Warning: 1-3 no text within stars
 // Hint: 1-3 using multiple consecutive stars (e.g. **) has no additional effect
 **
+
 ---
 // Warning: 1-3 no text within stars
 // Hint: 1-3 using multiple consecutive stars (e.g. **) has no additional effect
 // Warning: 11-13 no text within stars
 // Hint: 11-13 using multiple consecutive stars (e.g. **) has no additional effect
 **not bold**
+
+---
+// Warning: 1-3 no text within underscores
+// Hint: 1-3 using multiple consecutive underscores (e.g. __) has no additional effect
+__
+
+---
+// Warning: 1-3 no text within underscores
+// Hint: 1-3 using multiple consecutive underscores (e.g. __) has no additional effect
+// Warning: 11-13 no text within underscores
+// Hint: 11-13 using multiple consecutive underscores (e.g. __) has no additional effect
+__not italic__

--- a/tests/typ/lint/markup.typ
+++ b/tests/typ/lint/markup.typ
@@ -21,6 +21,6 @@ __
 ---
 // Warning: 1-3 no text within underscores
 // Hint: 1-3 using multiple consecutive underscores (e.g. __) has no additional effect
-// Warning: 11-13 no text within underscores
-// Hint: 11-13 using multiple consecutive underscores (e.g. __) has no additional effect
+// Warning: 13-15 no text within underscores
+// Hint: 13-15 using multiple consecutive underscores (e.g. __) has no additional effect
 __not italic__


### PR DESCRIPTION
Piggybacks on the already existing code (#1731) for bold (stars) and adds it for italic (underscores).

Resolves #391 (or what is left of it 😁)