### PR TITLE
Add `outline-title` and `bookmark-title` to headings

### DIFF
--- a/crates/typst-library/src/meta/heading.rs
+++ b/crates/typst-library/src/meta/heading.rs
@@ -120,6 +120,11 @@ pub struct HeadingElem {
     #[default(Smart::Auto)]
     pub bookmarked: Smart<bool>,
 
+    /// The heading's title appearing in the outline and bookmarks.
+    /// The default value of `{auto}` indicates that the title is the same as
+    /// `body` property.
+    pub outline_title: Smart<Content>,
+
     /// The heading's title.
     #[required]
     pub body: Content,
@@ -139,6 +144,7 @@ impl Synthesize for HeadingElem {
         self.push_supplement(Smart::Custom(Some(Supplement::Content(supplement))));
         self.push_outlined(self.outlined(styles));
         self.push_bookmarked(self.bookmarked(styles));
+        self.push_outline_title(self.outline_title(styles));
 
         Ok(())
     }
@@ -219,7 +225,9 @@ impl Outlinable for HeadingElem {
             return Ok(None);
         }
 
-        let mut content = self.body();
+        let mut content = self
+            .outline_title(StyleChain::default())
+            .unwrap_or_else(|| self.body());
         if let Some(numbering) = self.numbering(StyleChain::default()) {
             let numbers = Counter::of(Self::func())
                 .at(vt, self.0.location().unwrap())?

--- a/crates/typst-library/src/meta/heading.rs
+++ b/crates/typst-library/src/meta/heading.rs
@@ -120,10 +120,21 @@ pub struct HeadingElem {
     #[default(Smart::Auto)]
     pub bookmarked: Smart<bool>,
 
-    /// The heading's title appearing in the outline and bookmarks.
-    /// The default value of `{auto}` indicates that the title is the same as
-    /// `body` property.
+    /// The heading's title appearing in the outline, and maybe in the
+    /// bookmarks.
+    ///
+    /// The default value of `{auto}` indicates that the title will be the same
+    /// as `body`.
+    #[default(Smart::Auto)]
     pub outline_title: Smart<Content>,
+
+    /// The heading's title appearing in the bookmarks.
+    ///
+    /// The default value of `{auto}` indicates that the title will be the same
+    /// as `outline-title`. If `outline-title` is also `{auto}`, the title will
+    /// be the same as `body`.
+    #[default(Smart::Auto)]
+    pub bookmark_title: Smart<Content>,
 
     /// The heading's title.
     #[required]
@@ -145,6 +156,7 @@ impl Synthesize for HeadingElem {
         self.push_outlined(self.outlined(styles));
         self.push_bookmarked(self.bookmarked(styles));
         self.push_outline_title(self.outline_title(styles));
+        self.push_bookmark_title(self.bookmark_title(styles));
 
         Ok(())
     }

--- a/crates/typst/src/export/pdf/outline.rs
+++ b/crates/typst/src/export/pdf/outline.rs
@@ -158,7 +158,8 @@ fn write_outline_item(
         outline.count(-(node.children.len() as i32));
     }
 
-    let body = node.element
+    let body = node
+        .element
         .expect_field::<Smart<Content>>("outline-title")
         .unwrap_or_else(|| node.element.expect_field::<Content>("body"));
     outline.title(TextStr(body.plain_text().trim()));

--- a/crates/typst/src/export/pdf/outline.rs
+++ b/crates/typst/src/export/pdf/outline.rs
@@ -160,8 +160,9 @@ fn write_outline_item(
 
     let body = node
         .element
-        .expect_field::<Smart<Content>>("outline-title")
-        .unwrap_or_else(|| node.element.expect_field::<Content>("body"));
+        .expect_field::<Smart<Content>>("bookmark-title")
+        .or_else(|| node.element.expect_field("outline-title"))
+        .unwrap_or_else(|| node.element.expect_field("body"));
     outline.title(TextStr(body.plain_text().trim()));
 
     let loc = node.element.location().unwrap();

--- a/crates/typst/src/export/pdf/outline.rs
+++ b/crates/typst/src/export/pdf/outline.rs
@@ -158,7 +158,9 @@ fn write_outline_item(
         outline.count(-(node.children.len() as i32));
     }
 
-    let body = node.element.expect_field::<Content>("body");
+    let body = node.element
+        .expect_field::<Smart<Content>>("outline-title")
+        .unwrap_or_else(|| node.element.expect_field::<Content>("body"));
     outline.title(TextStr(body.plain_text().trim()));
 
     let loc = node.element.location().unwrap();

--- a/crates/typst/src/geom/smart.rs
+++ b/crates/typst/src/geom/smart.rs
@@ -62,6 +62,18 @@ impl<T> Smart<T> {
         }
     }
 
+    /// Keeps `self` if it contains a custom value, otherwise computes a
+    /// default value.
+    pub fn or_else<F>(self, f: F) -> Self
+    where
+        F: FnOnce() -> Smart<T>,
+    {
+        match self {
+            Self::Auto => f(),
+            Self::Custom(x) => Self::Custom(x),
+        }
+    }
+
     /// Returns the contained custom value or a provided default value.
     pub fn unwrap_or(self, default: T) -> T {
         match self {


### PR DESCRIPTION
Closes #1889

Follow-up considerations: 

1. Is it OK to use `outline-title` as the name of field?
2. Should we add something like `bookmark-title` as well to support making the bookmark text different from the outline?