### PR TITLE
Compare rasterized svg image with reference png

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,6 +624,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
+name = "dssim"
+version = "3.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ea54acfcd238d680c2c720a5eef56d210aaabc7582a48615602bcdf0c9a5894"
+dependencies = [
+ "dssim-core",
+ "getopts",
+ "imgref",
+ "load_image",
+ "lodepng",
+ "rgb",
+]
+
+[[package]]
+name = "dssim-core"
+version = "3.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1388544389475fcfd718b35a286af17cb215202af26bf2067d0e1024adbc3fe9"
+dependencies = [
+ "imgref",
+ "itertools 0.11.0",
+ "rgb",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
 name = "ecow"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,6 +732,15 @@ dependencies = [
  "rayon-core",
  "smallvec",
  "zune-inflate",
+]
+
+[[package]]
+name = "fallible_collections"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88c69768c0a15262df21899142bc6df9b9b823546d4b4b9a7bc2d6c448ec6fd"
+dependencies = [
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -795,6 +835,33 @@ dependencies = [
  "slotmap",
  "ttf-parser",
 ]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -894,6 +961,15 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1128,22 +1204,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "image-compare"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "419d59423b7202f6a2a95d3b9cf11a8cc9bf83a29cf7dda4d617a90e8c5ccfcf"
-dependencies = [
- "image",
- "itertools",
- "rayon",
- "thiserror",
-]
-
-[[package]]
 name = "imagesize"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b72ad49b554c1728b1e83254a1b1565aea4161e28dabbfa171fc15fe62299caf"
+
+[[package]]
+name = "imgref"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2cf49df1085dcfb171460e4592597b84abe50d900fb83efb6e41b20fefd6c2c"
 
 [[package]]
 name = "include_dir"
@@ -1320,6 +1390,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1386,6 +1465,28 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lcms2"
+version = "5.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d50a4d00d909da0ec023ab34ea09bf3b3b79b5a36b3e0da3a305112edaf150"
+dependencies = [
+ "foreign-types",
+ "lcms2-sys",
+]
+
+[[package]]
+name = "lcms2-sys"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abb8aac1a07fd8cdffaa25461a3873a7bf7164cd20b849d44a183a1348d682f"
+dependencies = [
+ "cc",
+ "dunce",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "lebe"
@@ -1467,6 +1568,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a04a5b2b6f54acba899926491d0a6c59d98012938ca2ab5befb281c034e8f94"
 
 [[package]]
+name = "load_image"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f87f0f354b901237de8e6d4c0f050a3aa85b83a458fea9796f993a08a67c3cc"
+dependencies = [
+ "bytemuck",
+ "imgref",
+ "jpeg-decoder",
+ "lcms2",
+ "lodepng",
+ "quick-error",
+ "rexif",
+ "rgb",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1474,6 +1591,19 @@ checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg",
  "scopeguard",
+]
+
+[[package]]
+name = "lodepng"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0ad39f75bbaa4b10bb6f2316543632a8046a5bcf9c785488d79720b21f044f8"
+dependencies = [
+ "crc32fast",
+ "fallible_collections",
+ "flate2",
+ "libc",
+ "rgb",
 ]
 
 [[package]]
@@ -1580,6 +1710,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1587,6 +1731,15 @@ checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
  "autocfg",
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
+dependencies = [
  "num-traits",
 ]
 
@@ -1611,12 +1764,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-rational"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -1695,7 +1860,7 @@ dependencies = [
  "filetime",
  "image",
  "indexmap 1.9.3",
- "itertools",
+ "itertools 0.10.5",
  "libdeflater",
  "log",
  "rayon",
@@ -1924,6 +2089,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quick-xml"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2076,6 +2247,15 @@ dependencies = [
  "svgtypes",
  "tiny-skia",
  "usvg",
+]
+
+[[package]]
+name = "rexif"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49352965b70522af9085d7a8c2a6df7494713c67ac58b9af02bcff7fb4ca1483"
+dependencies = [
+ "num",
 ]
 
 [[package]]
@@ -3036,10 +3216,9 @@ version = "0.7.0"
 dependencies = [
  "clap",
  "comemo",
+ "dssim",
  "ecow",
  "iai",
- "image",
- "image-compare",
  "once_cell",
  "oxipng",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,6 +1128,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "image-compare"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419d59423b7202f6a2a95d3b9cf11a8cc9bf83a29cf7dda4d617a90e8c5ccfcf"
+dependencies = [
+ "image",
+ "itertools",
+ "rayon",
+ "thiserror",
+]
+
+[[package]]
 name = "imagesize"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3026,14 +3038,19 @@ dependencies = [
  "comemo",
  "ecow",
  "iai",
+ "image",
+ "image-compare",
  "once_cell",
  "oxipng",
  "rayon",
+ "resvg",
+ "roxmltree",
  "tiny-skia",
  "ttf-parser",
  "typst",
  "typst-library",
  "unscanny",
+ "usvg",
  "walkdir",
 ]
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -11,11 +11,14 @@ typst = { path = "../crates/typst" }
 typst-library = { path = "../crates/typst-library" }
 comemo = "0.3"
 ecow = { version = "0.1.1", features = ["serde"] }
+dssim = { version = "3.2.4", default-features = false }
 iai = { git = "https://github.com/reknih/iai" }
-image = { version = "0.24", default-features = false, features = ["png", "jpeg", "gif"] }
-image-compare = "0.3.0"
 once_cell = "1"
-oxipng = { version = "8.0.0", default-features = false, features = ["filetime", "parallel", "zopfli"] }
+oxipng = { version = "8.0.0", default-features = false, features = [
+  "filetime",
+  "parallel",
+  "zopfli",
+] }
 rayon = "1.7.0"
 tiny-skia = "0.9.0"
 ttf-parser = "0.18.1"
@@ -24,7 +27,9 @@ walkdir = "2"
 clap = { version = "4.2.4", features = ["derive"] }
 usvg = { version = "0.32", default-features = false, features = ["text"] }
 roxmltree = "0.18"
-resvg = { version = "0.32", default-features = false, features = ["raster-images"] }
+resvg = { version = "0.32", default-features = false, features = [
+  "raster-images",
+] }
 
 [[test]]
 name = "tests"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -12,6 +12,8 @@ typst-library = { path = "../crates/typst-library" }
 comemo = "0.3"
 ecow = { version = "0.1.1", features = ["serde"] }
 iai = { git = "https://github.com/reknih/iai" }
+image = { version = "0.24", default-features = false, features = ["png", "jpeg", "gif"] }
+image-compare = "0.3.0"
 once_cell = "1"
 oxipng = { version = "8.0.0", default-features = false, features = ["filetime", "parallel", "zopfli"] }
 rayon = "1.7.0"
@@ -20,6 +22,9 @@ ttf-parser = "0.18.1"
 unscanny = "0.1"
 walkdir = "2"
 clap = { version = "4.2.4", features = ["derive"] }
+usvg = { version = "0.32", default-features = false, features = ["text"] }
+roxmltree = "0.18"
+resvg = { version = "0.32", default-features = false, features = ["raster-images"] }
 
 [[test]]
 name = "tests"

--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -13,11 +13,13 @@ use std::path::{Path, PathBuf};
 use clap::Parser;
 use comemo::{Prehashed, Track};
 use ecow::EcoString;
+use image::{ImageBuffer, RgbaImage};
 use oxipng::{InFile, Options, OutFile};
 use rayon::iter::{ParallelBridge, ParallelIterator};
 use std::cell::OnceCell;
 use tiny_skia as sk;
 use unscanny::Scanner;
+use usvg::TreeParsing;
 use walkdir::WalkDir;
 
 use typst::diag::{bail, FileError, FileResult, Severity, StrResult};
@@ -25,8 +27,9 @@ use typst::doc::{Document, Frame, FrameItem, Meta};
 use typst::eval::{eco_format, func, Bytes, Datetime, Library, NoneValue, Tracer, Value};
 use typst::font::{Font, FontBook};
 use typst::geom::{Abs, Color, RgbaColor, Smart};
-use typst::syntax::{FileId, PackageVersion, Source, Span, SyntaxNode, VirtualPath};
-use typst::{World, WorldExt};
+use typst::syntax::{FileId, Source, Span, SyntaxNode};
+use typst::util::PathExt;
+use typst::{export, World, WorldExt};
 use typst_library::layout::{Margin, PageElem};
 use typst_library::text::{TextElem, TextSize};
 
@@ -428,9 +431,9 @@ fn test(
         fs::create_dir_all(png_path.parent().unwrap()).unwrap();
         canvas.save_png(png_path).unwrap();
 
-        let svg = typst::export::svg_merged(&document.pages, Abs::pt(5.0));
+        let svg_canvas = render_svg(&document.pages);
         fs::create_dir_all(svg_path.parent().unwrap()).unwrap();
-        std::fs::write(svg_path, svg).unwrap();
+        svg_canvas.save_png(format!("{}.png", svg_path.display())).unwrap();
 
         if let Ok(ref_pixmap) = sk::Pixmap::load_png(ref_path) {
             if canvas.width() != ref_pixmap.width()
@@ -448,6 +451,28 @@ fn test(
                     writeln!(output, "  Does not match reference image.").unwrap();
                     ok = false;
                 }
+            }
+            let ref_img: RgbaImage = ImageBuffer::from_raw(
+                ref_pixmap.width(),
+                ref_pixmap.height(),
+                ref_pixmap.data().to_vec(),
+            )
+            .expect("Invalid reference image");
+            let svg_img: RgbaImage = ImageBuffer::from_raw(
+                svg_canvas.width(),
+                svg_canvas.height(),
+                svg_canvas.data().to_vec(),
+            )
+            .expect("Invalid svg image");
+            let result = image_compare::rgba_hybrid_compare(&ref_img, &svg_img)
+                .expect("Images had different dimensions");
+            if result.score < 0.95 {
+                let diff_img = result.image.to_color_map();
+                diff_img
+                    .save(format!("{}.diff.png", svg_path.display()))
+                    .expect("Could not save diff image");
+                writeln!(output, "  Svg image difference: {}", result.score).unwrap();
+                ok = false;
             }
         } else if !document.pages.is_empty() {
             if args.update {
@@ -918,6 +943,62 @@ fn render(frames: &[Frame]) -> sk::Pixmap {
     }
 
     pixmap
+}
+
+/// Draw all frames into one image with padding in between.
+fn render_svg(frames: &[Frame]) -> sk::Pixmap {
+    let pixel_per_pt: f32 = 2.0;
+    let pixmaps: Vec<_> = frames
+        .iter()
+        .map(|frame| {
+            let limit = Abs::cm(100.0);
+            if frame.width() > limit || frame.height() > limit {
+                panic!("overlarge frame: {:?}", frame.size());
+            }
+            let svg = export::svg(frame);
+            let document = roxmltree::Document::parse(&svg).unwrap();
+            let options = usvg::Options {
+                text_rendering: usvg::TextRendering::GeometricPrecision,
+                ..Default::default()
+            };
+            let tree = usvg::Tree::from_xmltree(&document, &options).unwrap();
+            let mut pixmap = sk::Pixmap::new(
+                (frame.width().to_pt() * pixel_per_pt as f64).round().max(1.0) as u32,
+                (frame.height().to_pt() * pixel_per_pt as f64).round().max(1.0) as u32,
+            )
+            .unwrap();
+            pixmap.fill(sk::Color::WHITE);
+            let ts = sk::Transform::from_scale(pixel_per_pt, pixel_per_pt);
+            resvg::render(&tree, resvg::FitTo::Original, ts, pixmap.as_mut()).unwrap();
+            pixmap
+        })
+        .collect();
+
+    let pad = (5.0 * pixel_per_pt).round() as u32;
+    let pxw = 2 * pad + pixmaps.iter().map(sk::Pixmap::width).max().unwrap_or_default();
+    let pxh = pad + pixmaps.iter().map(|pixmap| pixmap.height() + pad).sum::<u32>();
+
+    let mut canvas = sk::Pixmap::new(pxw, pxh).unwrap();
+    canvas.fill(sk::Color::BLACK);
+
+    let [x, mut y] = [pad; 2];
+    for (frame, mut pixmap) in frames.iter().zip(pixmaps) {
+        let ts = sk::Transform::from_scale(pixel_per_pt, pixel_per_pt);
+        render_links(&mut pixmap, ts, frame);
+
+        canvas.draw_pixmap(
+            x as i32,
+            y as i32,
+            pixmap.as_ref(),
+            &sk::PixmapPaint::default(),
+            sk::Transform::identity(),
+            None,
+        );
+
+        y += pixmap.height() + pad;
+    }
+
+    canvas
 }
 
 /// Draw extra boxes for links so we can see whether they are there.


### PR DESCRIPTION
Currently the lowest similarity score is 0.88 for `text/chinese.typ`. However, I have to say that these two files look identical to me and I am Chinese. Perhaps we should adjust the threshold or use a better comparison algorithm. 
```
text/chinese.typ ❌
  Svg image difference: 0.8893894203011192
```
<img width="1603" alt="image" src="https://github.com/typst/typst/assets/25521218/310aec42-09e2-4789-ba2f-16424becb467">


