### PR TITLE
Add targets

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -66,6 +66,18 @@ impl CompileCommand {
             .clone()
             .unwrap_or_else(|| self.common.input.with_extension("pdf"))
     }
+
+    /// If the target isn't specified, makes a guess off of the extension and defaults to PDF
+    pub fn guess_target_if_needed(&mut self) {
+        if self.common.target.is_none() {
+            self.common.target = Some(match self.output().extension() {
+                Some(ext) if ext.eq_ignore_ascii_case("pdf") => ArgTarget::Pdf,
+                Some(ext) if ext.eq_ignore_ascii_case("png") => ArgTarget::Png,
+                Some(ext) if ext.eq_ignore_ascii_case("svg") => ArgTarget::Svg,
+                _ => ArgTarget::Pdf,
+            });
+        }
+    }
 }
 
 /// Processes an input file to extract provided metadata
@@ -124,6 +136,17 @@ pub struct SharedArgs {
         value_parser = clap::value_parser!(DiagnosticFormat)
     )]
     pub diagnostic_format: DiagnosticFormat,
+
+    /// In which format to output
+    #[arg(long = "target")]
+    pub target: Option<ArgTarget>,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, ValueEnum)]
+pub enum ArgTarget {
+    Pdf,
+    Png,
+    Svg,
 }
 
 /// Lists all discovered fonts in system and custom font paths

--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -11,7 +11,7 @@ use typst::geom::Color;
 use typst::syntax::{FileId, Source};
 use typst::World;
 
-use crate::args::{CompileCommand, DiagnosticFormat, ArgTarget};
+use crate::args::{ArgTarget, CompileCommand, DiagnosticFormat};
 use crate::watch::Status;
 use crate::world::SystemWorld;
 use crate::{color_stream, set_failed};

--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -11,7 +11,7 @@ use typst::geom::Color;
 use typst::syntax::{FileId, Source};
 use typst::World;
 
-use crate::args::{CompileCommand, DiagnosticFormat};
+use crate::args::{CompileCommand, DiagnosticFormat, ArgTarget};
 use crate::watch::Status;
 use crate::world::SystemWorld;
 use crate::{color_stream, set_failed};
@@ -97,14 +97,14 @@ pub fn compile_once(
 
 /// Export into the target format.
 fn export(document: &Document, command: &CompileCommand) -> StrResult<()> {
-    match command.output().extension() {
-        Some(ext) if ext.eq_ignore_ascii_case("png") => {
-            export_image(document, command, ImageExportFormat::Png)
+    if let Some(x) = command.common.target {
+        match x {
+            ArgTarget::Pdf => export_pdf(document, command),
+            ArgTarget::Png => export_image(document, command, ImageExportFormat::Png),
+            ArgTarget::Svg => export_image(document, command, ImageExportFormat::Svg),
         }
-        Some(ext) if ext.eq_ignore_ascii_case("svg") => {
-            export_image(document, command, ImageExportFormat::Svg)
-        }
-        _ => export_pdf(document, command),
+    } else {
+        export_pdf(document, command)
     }
 }
 

--- a/crates/typst-cli/src/main.rs
+++ b/crates/typst-cli/src/main.rs
@@ -25,7 +25,7 @@ thread_local! {
 
 /// Entry point.
 fn main() -> ExitCode {
-    let arguments = CliArguments::parse();
+    let mut arguments = CliArguments::parse();
     let _guard = match crate::tracing::setup_tracing(&arguments) {
         Ok(guard) => guard,
         Err(err) => {
@@ -33,6 +33,10 @@ fn main() -> ExitCode {
             None
         }
     };
+
+    if let Command::Compile(command) | Command::Watch(command) = &mut arguments.command {
+        command.guess_target_if_needed(); // :/
+    }
 
     let res = match arguments.command {
         Command::Compile(command) => crate::compile::compile(command),

--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -80,7 +80,7 @@ impl SystemWorld {
                 ArgTarget::Pdf => Target::Pdf,
                 ArgTarget::Png => Target::Png,
                 ArgTarget::Svg => Target::Svg,
-            }
+            },
         );
 
         Ok(Self {

--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -78,8 +78,8 @@ impl SystemWorld {
             || Target::Query, // Queries without a specified target are the only time we haven't already guessed it.
             |x| match x {
                 ArgTarget::Pdf => Target::Pdf,
-                ArgTarget::Png => Target::Png,
-                ArgTarget::Svg => Target::Svg,
+                ArgTarget::Png => Target::Raster,
+                ArgTarget::Svg => Target::Vector,
             },
         );
 

--- a/crates/typst-docs/src/html.rs
+++ b/crates/typst-docs/src/html.rs
@@ -5,12 +5,12 @@ use pulldown_cmark as md;
 use typed_arena::Arena;
 use typst::diag::FileResult;
 use typst::eval::{Bytes, Datetime, Tracer};
+use typst::export::Target;
 use typst::font::{Font, FontBook};
 use typst::geom::{Point, Size};
 use typst::syntax::{FileId, Source};
 use typst::World;
 use yaml_front_matter::YamlFrontMatter;
-use typst::export::Target;
 
 use super::*;
 

--- a/crates/typst-docs/src/html.rs
+++ b/crates/typst-docs/src/html.rs
@@ -10,6 +10,7 @@ use typst::geom::{Point, Size};
 use typst::syntax::{FileId, Source};
 use typst::World;
 use yaml_front_matter::YamlFrontMatter;
+use typst::export::Target;
 
 use super::*;
 
@@ -510,5 +511,9 @@ impl World for DocWorld {
 
     fn today(&self, _: Option<i64>) -> Option<Datetime> {
         Some(Datetime::from_ymd(1970, 1, 1).unwrap())
+    }
+
+    fn target(&self) -> Target {
+        Target::Pdf
     }
 }

--- a/crates/typst-library/src/lib.rs
+++ b/crates/typst-library/src/lib.rs
@@ -136,6 +136,8 @@ fn items() -> LangItems {
                 counter.call_method(vm, method, args, span)
             } else if let Some(state) = dynamic.downcast::<meta::State>().cloned() {
                 state.call_method(vm, method, args, span)
+            } else if let Some(target) = dynamic.downcast::<meta::Target>().cloned() {
+                target.call_method(method, args, span)
             } else {
                 Err(format!("type {} has no method `{method}`", dynamic.type_name()))
                     .at(span)

--- a/crates/typst-library/src/meta/mod.rs
+++ b/crates/typst-library/src/meta/mod.rs
@@ -19,7 +19,6 @@ mod target;
 pub use self::bibliography::*;
 pub use self::context::*;
 pub use self::counter::*;
-pub use self::target::*;
 pub use self::document::*;
 pub use self::figure::*;
 pub use self::footnote::*;
@@ -31,6 +30,7 @@ pub use self::outline::*;
 pub use self::query::*;
 pub use self::reference::*;
 pub use self::state::*;
+pub use self::target::*;
 
 use crate::prelude::*;
 use crate::text::TextElem;

--- a/crates/typst-library/src/meta/mod.rs
+++ b/crates/typst-library/src/meta/mod.rs
@@ -14,10 +14,12 @@ mod outline;
 mod query;
 mod reference;
 mod state;
+mod target;
 
 pub use self::bibliography::*;
 pub use self::context::*;
 pub use self::counter::*;
+pub use self::target::*;
 pub use self::document::*;
 pub use self::figure::*;
 pub use self::footnote::*;
@@ -48,6 +50,7 @@ pub(super) fn define(global: &mut Scope) {
     global.define("style", style_func());
     global.define("layout", layout_func());
     global.define("counter", counter_func());
+    global.define("target", target_func());
     global.define("numbering", numbering_func());
     global.define("state", state_func());
     global.define("query", query_func());

--- a/crates/typst-library/src/meta/target.rs
+++ b/crates/typst-library/src/meta/target.rs
@@ -1,5 +1,5 @@
-use typst::export;
 use crate::prelude::*;
+use typst::export;
 
 /// Provides access to the target format, and associated information.
 ///
@@ -61,7 +61,6 @@ impl Target {
         Self(target)
     }
 
-
     /// Call a method on a target.
     pub fn call_method(
         self,
@@ -76,7 +75,10 @@ impl Target {
             "is-png" => self.0 == export::Target::Png,
             "is-query" => self.0 == export::Target::Query,
             "is-pageless" => false, // When HTML gets added, this will be true for it.
-            "is-layouted" => matches!(self.0, export::Target::Pdf | export::Target::Svg | export::Target::Png),
+            "is-layouted" => matches!(
+                self.0,
+                export::Target::Pdf | export::Target::Svg | export::Target::Png
+            ),
             _ => bail!(span, "type target has no method `{}`", method),
         };
 

--- a/crates/typst-library/src/meta/target.rs
+++ b/crates/typst-library/src/meta/target.rs
@@ -1,0 +1,85 @@
+use typst::export;
+use crate::prelude::*;
+
+/// Provides access to the target format, and associated information.
+///
+/// This allows show rules to only be applied in certain formats.
+/// ```example
+/// #set text(red) if target().is-pdf()
+/// ```
+///
+/// ### is-pdf()
+/// True when the target is a pdf, which is the default when the target is not specified and the extension isn't something else.
+///
+/// - returns: bool
+///
+/// ### is-svg()
+/// True when the target is a svg.
+///
+/// - returns: bool
+///
+/// ### is-png()
+/// True when the target is a png.
+///
+/// - returns: bool
+///
+/// ### is-query()
+/// True when the target is a query and the target isn't overridden.
+///
+/// - returns: bool
+///
+/// ### is-pageless()
+/// True when the target is a pageless format. HTML will be pageless, and queries are pageless.
+///
+/// - returns: bool
+///
+/// ### is-layouted()
+/// True when the target is a layouted format. PDF, SVG, and PNG are layouted.
+///
+/// - returns: bool
+///
+/// Display: Target
+/// Category: meta
+#[func]
+pub fn target(
+    /// The virtual machine.
+    vm: &mut Vm,
+) -> Target {
+    Target::new(vm.vt.world.target())
+}
+
+#[derive(Clone, PartialEq, Hash, Debug)]
+pub struct Target(export::Target);
+
+cast! {
+    type Target: "target",
+}
+
+impl Target {
+    /// Create a new target
+    pub fn new(target: export::Target) -> Self {
+        Self(target)
+    }
+
+
+    /// Call a method on a target.
+    pub fn call_method(
+        self,
+        method: &str,
+        args: Args,
+        span: Span,
+    ) -> SourceResult<Value> {
+        args.finish()?;
+        let output = match method {
+            "is-pdf" => self.0 == export::Target::Pdf,
+            "is-svg" => self.0 == export::Target::Svg,
+            "is-png" => self.0 == export::Target::Png,
+            "is-query" => self.0 == export::Target::Query,
+            "is-pageless" => false, // When HTML gets added, this will be true for it.
+            "is-layouted" => matches!(self.0, export::Target::Pdf | export::Target::Svg | export::Target::Png),
+            _ => bail!(span, "type target has no method `{}`", method),
+        };
+
+        Ok(Value::Bool(output))
+    }
+}

--- a/crates/typst-library/src/meta/target.rs
+++ b/crates/typst-library/src/meta/target.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use std::fmt::Write;
 use typst::export;
 
 /// Provides access to the target format, and associated information.
@@ -13,13 +14,13 @@ use typst::export;
 ///
 /// - returns: bool
 ///
-/// ### is-svg()
-/// True when the target is a svg.
+/// ### is-vector()
+/// True when the target is vectorized (SVG).
 ///
 /// - returns: bool
 ///
-/// ### is-png()
-/// True when the target is a png.
+/// ### is-raster()
+/// True when the target is rasterized (PNG, JPG, etc).
 ///
 /// - returns: bool
 ///
@@ -48,11 +49,19 @@ pub fn target(
     Target::new(vm.vt.world.target())
 }
 
-#[derive(Clone, PartialEq, Hash, Debug)]
+#[derive(Clone, PartialEq, Hash)]
 pub struct Target(export::Target);
 
 cast! {
     type Target: "target",
+}
+
+impl Debug for Target {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.write_str("target(")?;
+        self.0.fmt(f)?;
+        f.write_char(')')
+    }
 }
 
 impl Target {
@@ -71,13 +80,13 @@ impl Target {
         args.finish()?;
         let output = match method {
             "is-pdf" => self.0 == export::Target::Pdf,
-            "is-svg" => self.0 == export::Target::Svg,
-            "is-png" => self.0 == export::Target::Png,
+            "is-vector" => self.0 == export::Target::Vector,
+            "is-raster" => self.0 == export::Target::Raster,
             "is-query" => self.0 == export::Target::Query,
             "is-pageless" => false, // When HTML gets added, this will be true for it.
             "is-layouted" => matches!(
                 self.0,
-                export::Target::Pdf | export::Target::Svg | export::Target::Png
+                export::Target::Pdf | export::Target::Vector | export::Target::Raster
             ),
             _ => bail!(span, "type target has no method `{}`", method),
         };

--- a/crates/typst/src/eval/value.rs
+++ b/crates/typst/src/eval/value.rs
@@ -53,7 +53,7 @@ pub enum Value {
     Label(Label),
     /// A content value: `[*Hi* there]`.
     Content(Content),
-    // Content styles.
+    /// Content styles.
     Styles(Styles),
     /// An array of values: `(1, "hi", 12cm)`.
     Array(Array),

--- a/crates/typst/src/export/mod.rs
+++ b/crates/typst/src/export/mod.rs
@@ -7,12 +7,24 @@ mod svg;
 pub use self::pdf::pdf;
 pub use self::render::{render, render_merged};
 pub use self::svg::{svg, svg_merged};
+use std::fmt::{Debug, Formatter};
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub enum Target {
     Pdf,
-    Png,
-    Svg,
+    Raster,
+    Vector,
     Query,
     // Html, // doesn't exist yet
+}
+
+impl Debug for Target {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Pdf => "pdf",
+            Self::Raster => "raster",
+            Self::Vector => "svg",
+            Self::Query => "query",
+        })
+    }
 }

--- a/crates/typst/src/export/mod.rs
+++ b/crates/typst/src/export/mod.rs
@@ -7,3 +7,12 @@ mod svg;
 pub use self::pdf::pdf;
 pub use self::render::{render, render_merged};
 pub use self::svg::{svg, svg_merged};
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum Target {
+    Pdf,
+    Png,
+    Svg,
+    Query,
+    // Html, // doesn't exist yet
+}

--- a/crates/typst/src/lib.rs
+++ b/crates/typst/src/lib.rs
@@ -61,6 +61,7 @@ use ecow::EcoString;
 use crate::diag::{FileResult, SourceResult};
 use crate::doc::Document;
 use crate::eval::{Bytes, Datetime, Library, Route, Tracer};
+use crate::export::Target;
 use crate::font::{Font, FontBook};
 use crate::syntax::{FileId, PackageSpec, Source, Span};
 
@@ -150,4 +151,7 @@ pub trait World {
             .expect("span does not point into any source file")
             .range(span)
     }
+
+    /// Get the target format for this compilation
+    fn target(&self) -> Target;
 }

--- a/tests/src/benches.rs
+++ b/tests/src/benches.rs
@@ -7,6 +7,7 @@ use typst::geom::Color;
 use typst::syntax::{FileId, Source};
 use typst::World;
 use unscanny::Scanner;
+use typst::export::Target;
 
 const TEXT: &str = include_str!("../typ/compiler/bench.typ");
 const FONT: &[u8] = include_bytes!("../../assets/fonts/LinLibertine_R.ttf");
@@ -145,5 +146,9 @@ impl World for BenchWorld {
 
     fn today(&self, _: Option<i64>) -> Option<Datetime> {
         unimplemented!()
+    }
+
+    fn target(&self) -> Target {
+        Target::Pdf
     }
 }

--- a/tests/src/benches.rs
+++ b/tests/src/benches.rs
@@ -2,12 +2,12 @@ use comemo::{Prehashed, Track, Tracked};
 use iai::{black_box, main, Iai};
 use typst::diag::FileResult;
 use typst::eval::{Bytes, Datetime, Library, Tracer};
+use typst::export::Target;
 use typst::font::{Font, FontBook};
 use typst::geom::Color;
 use typst::syntax::{FileId, Source};
 use typst::World;
 use unscanny::Scanner;
-use typst::export::Target;
 
 const TEXT: &str = include_str!("../typ/compiler/bench.typ");
 const FONT: &[u8] = include_bytes!("../../assets/fonts/LinLibertine_R.ttf");

--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -23,6 +23,7 @@ use walkdir::WalkDir;
 use typst::diag::{bail, FileError, FileResult, Severity, StrResult};
 use typst::doc::{Document, Frame, FrameItem, Meta};
 use typst::eval::{eco_format, func, Bytes, Datetime, Library, NoneValue, Tracer, Value};
+use typst::export::Target;
 use typst::font::{Font, FontBook};
 use typst::geom::{Abs, Color, RgbaColor, Smart};
 use typst::syntax::{FileId, Source, Span, SyntaxNode};
@@ -284,6 +285,10 @@ impl World for TestWorld {
 
     fn today(&self, _: Option<i64>) -> Option<Datetime> {
         Some(Datetime::from_ymd(1970, 1, 1).unwrap())
+    }
+
+    fn target(&self) -> Target {
+        Target::Pdf
     }
 }
 


### PR DESCRIPTION
This PR adds support for targets, which allow a document to know what it's being compiled into. 

This is part of the basics that will eventually allow HTML compilation.

Currently missing:
- tests (might not be needed? They don't really work with the existing testing pipeline, since they're meta)
- clippy. So much clippy (probably)