### PR TITLE
Allow renaming imports with `as`

### DIFF
--- a/crates/typst-syntax/src/ast.rs
+++ b/crates/typst-syntax/src/ast.rs
@@ -1975,7 +1975,15 @@ impl ModuleImport {
         self.0.children().find_map(|node| match node.kind() {
             SyntaxKind::Star => Some(Imports::Wildcard),
             SyntaxKind::ImportItems => {
-                let items = node.children().filter_map(SyntaxNode::cast).collect();
+                let items = node
+                    .children()
+                    .filter_map(|child| {
+                        child
+                            .cast::<RenamedImportItem>()
+                            .map(ImportItem::Renamed)
+                            .or_else(|| child.cast::<Ident>().map(ImportItem::Simple))
+                    })
+                    .collect();
                 Some(Imports::Items(items))
             }
             _ => Option::None,
@@ -1989,7 +1997,61 @@ pub enum Imports {
     /// All items in the scope of the file should be imported.
     Wildcard,
     /// The specified items from the file should be imported.
-    Items(Vec<Ident>),
+    Items(Vec<ImportItem>),
+}
+
+/// An imported item, potentially renamed to another identifier.
+#[derive(Debug, Clone, Hash)]
+pub enum ImportItem {
+    /// A non-renamed import (the item's name in the scope is the same as its
+    /// name).
+    Simple(Ident),
+    /// A renamed import (the item was bound to a different name in the scope
+    /// than the one it was defined as).
+    Renamed(RenamedImportItem),
+}
+
+impl ImportItem {
+    /// The original name of the imported item,
+    /// at its source. This will be the equal to the
+    /// bound name if the item wasn't renamed with 'as'.
+    pub fn original_name(&self) -> Ident {
+        match self {
+            Self::Simple(name) => name.clone(),
+            Self::Renamed(renamed_item) => renamed_item.original_name(),
+        }
+    }
+
+    /// The name which this import item was bound to.
+    /// Corresponds to the new name, if it was renamed;
+    /// otherwise, it's just its original name.
+    pub fn bound_name(&self) -> Ident {
+        match self {
+            Self::Simple(name) => name.clone(),
+            Self::Renamed(renamed_item) => renamed_item.new_name(),
+        }
+    }
+}
+
+node! {
+    /// A renamed import item: `a as d`
+    RenamedImportItem
+}
+
+impl RenamedImportItem {
+    /// The original name of the imported item (`a` in `a as d`).
+    pub fn original_name(&self) -> Ident {
+        self.0.cast_first_match().unwrap_or_default()
+    }
+
+    /// The new name of the imported item (`d` in `a as d`).
+    pub fn new_name(&self) -> Ident {
+        self.0
+            .children()
+            .filter_map(SyntaxNode::cast)
+            .nth(1)
+            .unwrap_or_default()
+    }
 }
 
 node! {

--- a/crates/typst-syntax/src/ast.rs
+++ b/crates/typst-syntax/src/ast.rs
@@ -180,6 +180,8 @@ pub enum Expr {
     For(ForLoop),
     /// A module import: `import "utils.typ": a, b, c`.
     Import(ModuleImport),
+    /// A renamed module import (without items): `import "file.typ" as utils`
+    RenamedImport(RenamedModuleImport),
     /// A module include: `include "chapter1.typ"`.
     Include(ModuleInclude),
     /// A break from a loop: `break`.
@@ -253,6 +255,7 @@ impl AstNode for Expr {
             SyntaxKind::WhileLoop => node.cast().map(Self::While),
             SyntaxKind::ForLoop => node.cast().map(Self::For),
             SyntaxKind::ModuleImport => node.cast().map(Self::Import),
+            SyntaxKind::RenamedModuleImport => node.cast().map(Self::RenamedImport),
             SyntaxKind::ModuleInclude => node.cast().map(Self::Include),
             SyntaxKind::LoopBreak => node.cast().map(Self::Break),
             SyntaxKind::LoopContinue => node.cast().map(Self::Continue),
@@ -315,6 +318,7 @@ impl AstNode for Expr {
             Self::While(v) => v.as_untyped(),
             Self::For(v) => v.as_untyped(),
             Self::Import(v) => v.as_untyped(),
+            Self::RenamedImport(v) => v.as_untyped(),
             Self::Include(v) => v.as_untyped(),
             Self::Break(v) => v.as_untyped(),
             Self::Continue(v) => v.as_untyped(),
@@ -1988,6 +1992,24 @@ impl ModuleImport {
             }
             _ => Option::None,
         })
+    }
+}
+
+node! {
+    /// A renamed module import (without items): `import "file.typ" as utils`
+    RenamedModuleImport
+}
+
+impl RenamedModuleImport {
+    /// The module or path from which the items should be imported under the
+    /// desired name.
+    pub fn source(&self) -> Expr {
+        self.0.cast_first_match().unwrap_or_default()
+    }
+
+    /// The name to save the module's items under.
+    pub fn new_name(&self) -> Ident {
+        self.0.cast_last_match().unwrap_or_default()
     }
 }
 

--- a/crates/typst-syntax/src/kind.rs
+++ b/crates/typst-syntax/src/kind.rs
@@ -242,6 +242,8 @@ pub enum SyntaxKind {
     ModuleImport,
     /// Items to import from a module: `a, b, c`.
     ImportItems,
+    /// A renamed import item: `a as d`.
+    RenamedImportItem,
     /// A module include: `include "chapter1.typ"`.
     ModuleInclude,
     /// A break from a loop: `break`.
@@ -465,6 +467,7 @@ impl SyntaxKind {
             Self::ForLoop => "for-loop expression",
             Self::ModuleImport => "`import` expression",
             Self::ImportItems => "import items",
+            Self::RenamedImportItem => "renamed import item",
             Self::ModuleInclude => "`include` expression",
             Self::LoopBreak => "`break` expression",
             Self::LoopContinue => "`continue` expression",

--- a/crates/typst-syntax/src/kind.rs
+++ b/crates/typst-syntax/src/kind.rs
@@ -240,6 +240,8 @@ pub enum SyntaxKind {
     ForLoop,
     /// A module import: `import "utils.typ": a, b, c`.
     ModuleImport,
+    /// A renamed module import (without items): `import "file.typ" as utils`
+    RenamedModuleImport,
     /// Items to import from a module: `a, b, c`.
     ImportItems,
     /// A renamed import item: `a as d`.
@@ -466,6 +468,7 @@ impl SyntaxKind {
             Self::WhileLoop => "while-loop expression",
             Self::ForLoop => "for-loop expression",
             Self::ModuleImport => "`import` expression",
+            Self::RenamedModuleImport => "`import` expression with rename",
             Self::ImportItems => "import items",
             Self::RenamedImportItem => "renamed import item",
             Self::ModuleInclude => "`include` expression",

--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -1154,9 +1154,7 @@ fn import_items(p: &mut Parser) {
 
         // rename imported item
         if p.eat_if(SyntaxKind::As) {
-            if !p.eat_if(SyntaxKind::Ident) {
-                p.unexpected();
-            }
+            p.expect(SyntaxKind::Ident);
             p.wrap(item_marker, SyntaxKind::RenamedImportItem);
         }
 

--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -1138,10 +1138,16 @@ fn module_import(p: &mut Parser) {
     let m = p.marker();
     p.assert(SyntaxKind::Import);
     code_expr(p);
-    if p.eat_if(SyntaxKind::Colon) && !p.eat_if(SyntaxKind::Star) {
-        import_items(p);
+    if p.eat_if(SyntaxKind::As) {
+        // allow renaming a full module import
+        p.expect(SyntaxKind::Ident);
+        p.wrap(m, SyntaxKind::RenamedModuleImport);
+    } else {
+        if p.eat_if(SyntaxKind::Colon) && !p.eat_if(SyntaxKind::Star) {
+            import_items(p);
+        }
+        p.wrap(m, SyntaxKind::ModuleImport);
     }
-    p.wrap(m, SyntaxKind::ModuleImport);
 }
 
 fn import_items(p: &mut Parser) {

--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -1142,6 +1142,14 @@ fn module_import(p: &mut Parser) {
         // allow renaming a full module import
         p.expect(SyntaxKind::Ident);
         p.wrap(m, SyntaxKind::RenamedModuleImport);
+
+        // friendlier error if the user tries to rename and import items at the
+        // same time
+        if p.at(SyntaxKind::Colon) {
+            p.unexpected();
+            p.hint("cannot import the renamed module and its items at the same time");
+            p.hint("try importing the module's items in a separate `import` expression");
+        }
     } else {
         if p.eat_if(SyntaxKind::Colon) && !p.eat_if(SyntaxKind::Star) {
             import_items(p);

--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -1147,9 +1147,19 @@ fn module_import(p: &mut Parser) {
 fn import_items(p: &mut Parser) {
     let m = p.marker();
     while !p.eof() && !p.at(SyntaxKind::Semicolon) {
+        let item_marker = p.marker();
         if !p.eat_if(SyntaxKind::Ident) {
             p.unexpected();
         }
+
+        // rename imported item
+        if p.eat_if(SyntaxKind::As) {
+            if !p.eat_if(SyntaxKind::Ident) {
+                p.unexpected();
+            }
+            p.wrap(item_marker, SyntaxKind::RenamedImportItem);
+        }
+
         if p.current().is_terminator() {
             break;
         }

--- a/crates/typst/src/eval/func.rs
+++ b/crates/typst/src/eval/func.rs
@@ -544,7 +544,7 @@ impl<'a> CapturesVisitor<'a> {
                 self.visit(expr.source().as_untyped());
                 if let Some(ast::Imports::Items(items)) = expr.imports() {
                     for item in items {
-                        self.bind(item);
+                        self.bind(item.bound_name());
                     }
                 }
             }

--- a/crates/typst/src/eval/mod.rs
+++ b/crates/typst/src/eval/mod.rs
@@ -1710,14 +1710,15 @@ fn apply_imports<V: IntoValue>(
                 vm.scopes.top.define(var.clone(), value.clone());
             }
         }
-        Some(ast::Imports::Items(idents)) => {
+        Some(ast::Imports::Items(items)) => {
             let mut errors = vec![];
             let scope = scope(&source_value);
-            for ident in idents {
-                if let Some(value) = scope.get(&ident) {
-                    vm.define(ident, value.clone());
+            for item in items {
+                let original_ident = item.original_name();
+                if let Some(value) = scope.get(&original_ident) {
+                    vm.define(item.bound_name(), value.clone());
                 } else {
-                    errors.push(error!(ident.span(), "unresolved import"));
+                    errors.push(error!(original_ident.span(), "unresolved import"));
                 }
             }
             if !errors.is_empty() {

--- a/crates/typst/src/eval/mod.rs
+++ b/crates/typst/src/eval/mod.rs
@@ -487,6 +487,7 @@ impl Eval for ast::Expr {
             Self::While(v) => v.eval(vm),
             Self::For(v) => v.eval(vm),
             Self::Import(v) => v.eval(vm),
+            Self::RenamedImport(v) => v.eval(vm),
             Self::Include(v) => v.eval(vm).map(Value::Content),
             Self::Break(v) => v.eval(vm),
             Self::Continue(v) => v.eval(vm),
@@ -1757,6 +1758,28 @@ impl Eval for ast::ModuleImport {
                 |module| module.name().clone(),
                 |module| module.scope(),
             )?;
+        }
+
+        Ok(Value::None)
+    }
+}
+
+impl Eval for ast::RenamedModuleImport {
+    type Output = Value;
+
+    #[tracing::instrument(name = "RenamedModuleImport::eval", skip_all)]
+    fn eval(&self, vm: &mut Vm) -> SourceResult<Self::Output> {
+        let span = self.source().span();
+        let source = self.source().eval(vm)?;
+        let name: EcoString = self.new_name().as_str().into();
+        if let Value::Func(func) = source {
+            if func.info().is_none() {
+                bail!(span, "cannot import from user-defined functions");
+            }
+            vm.scopes.top.define(name, func);
+        } else {
+            let module = import(vm, source, span, true)?;
+            vm.scopes.top.define(name, module);
         }
 
         Ok(Value::None)

--- a/crates/typst/src/ide/complete.rs
+++ b/crates/typst/src/ide/complete.rs
@@ -477,7 +477,7 @@ fn complete_imports(ctx: &mut CompletionContext) -> bool {
 /// Add completions for all exports of a module.
 fn import_item_completions(
     ctx: &mut CompletionContext,
-    existing: &[ast::Ident],
+    existing: &[ast::ImportItem],
     value: &Value,
 ) {
     let module = match value {
@@ -494,7 +494,7 @@ fn import_item_completions(
     }
 
     for (name, value) in module.scope().iter() {
-        if existing.iter().all(|ident| ident.as_str() != name) {
+        if existing.iter().all(|item| item.original_name().as_str() != name) {
             ctx.value_completion(Some(name.clone()), value, false, None);
         }
     }

--- a/crates/typst/src/ide/highlight.rs
+++ b/crates/typst/src/ide/highlight.rs
@@ -245,6 +245,7 @@ pub fn highlight(node: &LinkedNode) -> Option<Tag> {
         SyntaxKind::ForLoop => None,
         SyntaxKind::ModuleImport => None,
         SyntaxKind::ImportItems => None,
+        SyntaxKind::RenamedImportItem => None,
         SyntaxKind::ModuleInclude => None,
         SyntaxKind::LoopBreak => None,
         SyntaxKind::LoopContinue => None,

--- a/crates/typst/src/ide/highlight.rs
+++ b/crates/typst/src/ide/highlight.rs
@@ -244,6 +244,7 @@ pub fn highlight(node: &LinkedNode) -> Option<Tag> {
         SyntaxKind::WhileLoop => None,
         SyntaxKind::ForLoop => None,
         SyntaxKind::ModuleImport => None,
+        SyntaxKind::RenamedModuleImport => None,
         SyntaxKind::ImportItems => None,
         SyntaxKind::RenamedImportItem => None,
         SyntaxKind::ModuleInclude => None,

--- a/tests/typ/compiler/import.typ
+++ b/tests/typ/compiler/import.typ
@@ -128,6 +128,12 @@
 #import () => {5}: x
 
 ---
+// Error: 32-33 unexpected colon
+// Hint: 32-33 cannot import the renamed module and its items at the same time
+// Hint: 32-33 try importing the module's items in a separate `import` expression
+#import "module.typ" as renamed: a, b, c
+
+---
 // Error: 9-10 expected path, module or function, found integer
 #import 5: something
 

--- a/tests/typ/compiler/import.typ
+++ b/tests/typ/compiler/import.typ
@@ -35,6 +35,16 @@
 #test(d, 3)
 
 ---
+// A renamed item import.
+#import "module.typ": item as something
+#test(something(1, 2), 3)
+
+// Mixing up renamed and not renamed items.
+#import "module.typ": fn, b as val, item as other
+#test(val, 1)
+#test(other(1, 2), 3)
+
+---
 // Test importing from function scopes.
 // Ref: true
 
@@ -54,6 +64,18 @@
 #test(module.b, 1)
 #test(module.item(1, 2), 3)
 #test(module.push(2), 3)
+
+---
+// A renamed module import without items.
+#import "module.typ" as other
+#test(other.b, 1)
+#test(other.item(1, 2), 3)
+#test(other.push(2), 3)
+
+---
+// Renamed module import with function scopes.
+#import enum as othernum
+#test(enum, othernum)
 
 ---
 // Edge case for module access that isn't fixed.

--- a/tests/typ/compiler/import.typ
+++ b/tests/typ/compiler/import.typ
@@ -100,6 +100,7 @@
 #import enum
 #let d = (e: enum)
 #import d.e
+#import d.e as renamed
 #import d.e: item
 
 #item(2)[a]
@@ -109,6 +110,12 @@
 #let f(x) = x
 // Error: 9-10 cannot import from user-defined functions
 #import f: x
+
+---
+// Can't import from closures, despite renaming.
+#let f(x) = x
+// Error: 9-10 cannot import from user-defined functions
+#import f as g
 
 ---
 // Can't import from closures, despite modifiers.
@@ -125,12 +132,24 @@
 #import 5: something
 
 ---
+// Error: 9-10 expected path, module or function, found integer
+#import 5 as x
+
+---
 // Error: 9-11 failed to load file (is a directory)
 #import "": name
 
 ---
+// Error: 9-11 failed to load file (is a directory)
+#import "" as x
+
+---
 // Error: 9-20 file not found (searched at typ/compiler/lib/0.2.1)
 #import "lib/0.2.1"
+
+---
+// Error: 9-20 file not found (searched at typ/compiler/lib/0.2.1)
+#import "lib/0.2.1" as x
 
 ---
 // Some non-text stuff.

--- a/tests/typ/compiler/import.typ
+++ b/tests/typ/compiler/import.typ
@@ -59,6 +59,11 @@
 #ne(5, 6)
 
 ---
+// Test renaming items imported from function scopes.
+#import assert: eq as aseq
+#aseq(10, 10)
+
+---
 // A module import without items.
 #import "module.typ"
 #test(module.b, 1)
@@ -76,6 +81,12 @@
 // Renamed module import with function scopes.
 #import enum as othernum
 #test(enum, othernum)
+
+---
+// Mixing renamed module import from function with renamed item import.
+#import assert as asrt
+#import asrt: ne as asne
+#asne(1, 2)
 
 ---
 // Edge case for module access that isn't fixed.


### PR DESCRIPTION
The `as` keyword has been reserved since the dawn of Typst, but never properly used. This PR implements renaming imports using the `as` keyword, thus giving it use.

# Highlights

**New syntax:**
1. `#import "module.typ" as something` (under `SyntaxKind::RenamedModuleImport`) now imports the module's entire scope under the variable name `something` instead of `module`
2. `#import "module.typ": func as dothing` (under `SyntaxKind::RenamedImport`) now imports the `func` name (defined in the module) as `dothing` in the current scope, instead of necessarily importing it as `func`

Note that, for consistency with the current behavior, I made it so you can't import the entire scope under a new name and, at the same time, import items from it (which generates the error below). This is, however, not a hard restriction and can be lifted.

```
error: unexpected colon
  ┌─ /aaa.typ:2:22
  │
2 │ #import "bbb.typ" as f: g
  │                       ^
  │
  = hint: cannot import the renamed module and its items at the same time
  = hint: try importing the module's items in a separate `import` expression
```

# Implementation details

- **New syntax node kinds:** `RenamedModuleImport` and `RenamedImport`
  - Parser changes weren't very complex
- **AST changes:**
  - Added `RenamedModuleImport` and `RenamedImport` as AST nodes
  - Added `Expr::RenamedImport` for `RenamedModuleImport` (can't have items)
  - New enum, `ImportedItem`, representing either a `Simple` item (just an `Ident`, so, no renaming), or a `Renamed` item (`RenamedImport` node, containing original name and new name definitions for later usage by eval)
    - This enum contains a `bound_name()` method which indicates the final name of the imported item in the scope it's being imported to (regardless of it being renamed or not), in contrast to `original_name()`, which will always correspond to the definition/exported name of the item.
  - In `ModuleImport` items: changed `Vec<Ident>` to `Vec<ImportedItem>`
- **Eval changes:**
  - Implemented `Eval` for ast::RenamedModuleImport (simply took the `ast::ModuleImport` code but used the new name straight away, without calling a second function, since there are no items).
  - **(Review would be a good idea here)** Changed a thing in `eval/func.rs` - apparently there's code to capture variables into a closure, so I made it capture the `bound_name()` for imported items. Please tell me if this was the wrong call, but, in principle, seems to be working
- **IDE changes:**
  - Kept the current behavior of suggesting items based on their exported names (i.e., renaming is never suggested, as that doesn't make sense).
- Added several tests.