### PR TITLE
Get Rules, but not as get rule, but as function to styles

### DIFF
--- a/crates/typst-library/src/visualize/line.rs
+++ b/crates/typst-library/src/visualize/line.rs
@@ -1,3 +1,4 @@
+use std::any::{Any, TypeId};
 use crate::prelude::*;
 
 /// A line from one point to another.

--- a/crates/typst-library/src/visualize/line.rs
+++ b/crates/typst-library/src/visualize/line.rs
@@ -1,4 +1,3 @@
-use std::any::{Any, TypeId};
 use crate::prelude::*;
 
 /// A line from one point to another.

--- a/crates/typst-macros/src/element.rs
+++ b/crates/typst-macros/src/element.rs
@@ -1,5 +1,3 @@
-use std::any::{Any, TypeId};
-use syn::Type;
 use super::*;
 
 /// Expand the `#[element]` macro.

--- a/crates/typst-macros/src/element.rs
+++ b/crates/typst-macros/src/element.rs
@@ -569,9 +569,7 @@ fn create_get_impl(element: &Elem) -> TokenStream {
                 }
             }
         }
-    }
-    else
-    {
+    } else {
         quote! {
             impl ::typst::model::Get for #ident {
                 fn get(

--- a/crates/typst/src/eval/methods.rs
+++ b/crates/typst/src/eval/methods.rs
@@ -17,7 +17,6 @@ pub fn call(
     mut args: Args,
     span: Span,
 ) -> SourceResult<Value> {
-
     let name = value.type_name();
     let missing = || Err(missing_method(name, method)).at(span);
 

--- a/crates/typst/src/eval/methods.rs
+++ b/crates/typst/src/eval/methods.rs
@@ -220,7 +220,14 @@ pub fn call(
         },
 
         Value::Styles(style) => match method {
-            "get" => style.get_style(vm, &args.expect("element")?, &args.expect("field")?,&args.all::<Str>()?).at(span)?,
+            "get" => style
+                .get_style(
+                    vm,
+                    &args.expect("element")?,
+                    &args.expect("field")?,
+                    &args.all::<Str>()?,
+                )
+                .at(span)?,
             _ => return missing(),
         },
 

--- a/crates/typst/src/eval/methods.rs
+++ b/crates/typst/src/eval/methods.rs
@@ -17,6 +17,7 @@ pub fn call(
     mut args: Args,
     span: Span,
 ) -> SourceResult<Value> {
+
     let name = value.type_name();
     let missing = || Err(missing_method(name, method)).at(span);
 
@@ -216,6 +217,11 @@ pub fn call(
         Value::Args(args) => match method {
             "pos" => args.to_pos().into_value(),
             "named" => args.to_named().into_value(),
+            _ => return missing(),
+        },
+
+        Value::Styles(style) => match method {
+            "get" => style.get_style(vm, &args.expect("element")?, &args.expect("field")?,&args.all::<Str>()?).at(span)?,
             _ => return missing(),
         },
 

--- a/crates/typst/src/geom/axes.rs
+++ b/crates/typst/src/geom/axes.rs
@@ -290,6 +290,11 @@ cast! {
     },
 }
 
+cast! {
+    Axes<Rel<Abs>>,
+    self => array![self.x, self.y].into_value(),
+}
+
 impl<T: Resolve> Resolve for Axes<T> {
     type Output = Axes<T::Output>;
 

--- a/crates/typst/src/model/element.rs
+++ b/crates/typst/src/model/element.rs
@@ -93,7 +93,7 @@ impl ElemFunc {
     }
 
     /// Execute the set rule for the element and return the resulting style map.
-    pub fn get(self, s:StyleChain, name: &str) -> StrResult<Value> {
+    pub fn get(self, s: StyleChain, name: &str) -> StrResult<Value> {
         (self.0.get)(s, name)
     }
 }

--- a/crates/typst/src/model/mod.rs
+++ b/crates/typst/src/model/mod.rs
@@ -12,7 +12,7 @@ mod styles;
 pub use typst_macros::element;
 
 pub use self::content::{Content, MetaElem, PlainText};
-pub use self::element::{Construct, ElemFunc, Element, NativeElemFunc, Set, Get};
+pub use self::element::{Construct, ElemFunc, Element, Get, NativeElemFunc, Set};
 pub use self::introspect::{Introspector, Location, Locator};
 pub use self::label::{Label, Unlabellable};
 pub use self::realize::{

--- a/crates/typst/src/model/mod.rs
+++ b/crates/typst/src/model/mod.rs
@@ -12,7 +12,7 @@ mod styles;
 pub use typst_macros::element;
 
 pub use self::content::{Content, MetaElem, PlainText};
-pub use self::element::{Construct, ElemFunc, Element, NativeElemFunc, Set};
+pub use self::element::{Construct, ElemFunc, Element, NativeElemFunc, Set, Get};
 pub use self::introspect::{Introspector, Location, Locator};
 pub use self::label::{Label, Unlabellable};
 pub use self::realize::{

--- a/crates/typst/src/model/styles.rs
+++ b/crates/typst/src/model/styles.rs
@@ -10,7 +10,9 @@ use typst::eval::EvalMode;
 
 use super::{Content, ElemFunc, Element, Selector, Vt};
 use crate::diag::{bail, SourceResult, Trace, Tracepoint};
-use crate::eval::{cast, Args, FromValue, Func, IntoValue, Value, Vm, Str, eval_string, Scope};
+use crate::eval::{
+    cast, eval_string, Args, FromValue, Func, IntoValue, Scope, Str, Value, Vm,
+};
 use crate::syntax::Span;
 
 /// A list of style properties.
@@ -81,15 +83,28 @@ impl Styles {
     }
 
     // Return styles of set rules
-    pub fn get_style(&self, vm: &Vm, element: &EcoString, field: &EcoString, path: &[Str]) -> StrResult<Value>{
-        let x = eval_string(vm.world(), element, Span::detached(), EvalMode::Code, Scope::default()).unwrap();
+    pub fn get_style(
+        &self,
+        vm: &Vm,
+        element: &EcoString,
+        field: &EcoString,
+        path: &[Str],
+    ) -> StrResult<Value> {
+        let x = eval_string(
+            vm.world(),
+            element,
+            Span::detached(),
+            EvalMode::Code,
+            Scope::default(),
+        )
+        .unwrap();
         let y = x.cast::<ElemFunc>().unwrap();
         let result = y.get(StyleChain::new(self), field)?;
 
         // Warum kommen hier keine margins? complex default during layout!
-        path.iter().try_fold(result, |acc,item| match acc{
+        path.iter().try_fold(result, |acc, item| match acc {
             Value::Dict(d) => d.at(item, None),
-            _ => bail!("attribute \"{item}\" not found")
+            _ => bail!("attribute \"{item}\" not found"),
         })
     }
 }
@@ -188,7 +203,7 @@ impl Property {
     }
 
     /// Whether this property is the given one.
-    pub fn is_name (&self, element: &str, name: &str) -> bool {
+    pub fn is_name(&self, element: &str, name: &str) -> bool {
         self.element.name() == element && self.name == name
     }
 

--- a/crates/typst/src/model/styles.rs
+++ b/crates/typst/src/model/styles.rs
@@ -6,7 +6,7 @@ use std::ptr;
 use comemo::Prehashed;
 use ecow::{eco_vec, EcoString, EcoVec};
 use typst::diag::StrResult;
-use typst::eval::{Dict, EvalMode};
+use typst::eval::EvalMode;
 
 use super::{Content, ElemFunc, Element, Selector, Vt};
 use crate::diag::{bail, SourceResult, Trace, Tracepoint};


### PR DESCRIPTION
With this function you can retrieve the styles that have been set by set rules.

```typ
#set page(margin: 5mm)

A: #style(x=>x.get("page", "width"))

B: #style(x=>x.get("page", "columns"))

C: #style(x=>x.get("page", "margin"))

C: #style(x=>x.get("page", "margin", "top"))
```