### PR TITLE
separate decode from string/bytes for all data functions; and encode for json, toml, yaml via serde

### DIFF
--- a/crates/typst-library/Cargo.toml
+++ b/crates/typst-library/Cargo.toml
@@ -41,7 +41,7 @@ serde_yaml = "0.8"
 smallvec = "1.10"
 syntect = { version = "5", default-features = false, features = ["parsing", "regex-fancy", "plist-load", "yaml-load"] }
 time = { version = "0.3.20", features = ["formatting"] }
-toml = { version = "0.7.3", default-features = false, features = ["parse"] }
+toml = { version = "0.7.3"}
 tracing = "0.1.37"
 ttf-parser = "0.18.1"
 typed-arena = "2"

--- a/crates/typst-library/src/compute/data.rs
+++ b/crates/typst-library/src/compute/data.rs
@@ -157,9 +157,8 @@ pub fn csv_decode(
     delimiter: Delimiter,
 ) -> SourceResult<Array> {
     let Spanned { v: data, span } = data;
-    let mut builder = csv::ReaderBuilder::new();
     let data: Bytes = data.into();
-
+    let mut builder = csv::ReaderBuilder::new();
     builder.has_headers(false);
     builder.delimiter(delimiter.0 as u8);
     let mut reader = builder.from_reader(data.as_slice());

--- a/crates/typst-library/src/compute/data.rs
+++ b/crates/typst-library/src/compute/data.rs
@@ -308,6 +308,8 @@ pub fn json_encode(
     /// Path to a JSON file.
     value: Spanned<Value>,
     /// Pretty print
+    #[named]
+    #[default(true)]
     pretty: bool,
 ) -> SourceResult<Str> {
     let Spanned { v: value, span } = value;
@@ -425,6 +427,8 @@ pub fn toml_encode(
     /// Path to a JSON file.
     value: Spanned<Value>,
     /// Pretty print
+    #[named]
+    #[default(true)]
     pretty: bool,
 ) -> SourceResult<Str> {
     let Spanned { v: value, span } = value;

--- a/crates/typst-library/src/compute/data.rs
+++ b/crates/typst-library/src/compute/data.rs
@@ -158,10 +158,10 @@ pub fn csv_decode(
 ) -> SourceResult<Array> {
     let Spanned { v: data, span } = data;
     let mut builder = csv::ReaderBuilder::new();
+    let data: Bytes = data.into();
+
     builder.has_headers(false);
     builder.delimiter(delimiter.0 as u8);
-
-    let data: Bytes = data.into();
     let mut reader = builder.from_reader(data.as_slice());
     let mut array = Array::new();
 

--- a/crates/typst-library/src/compute/data.rs
+++ b/crates/typst-library/src/compute/data.rs
@@ -298,6 +298,31 @@ pub fn json_decode(
     Ok(convert_json(value))
 }
 
+/// Encode structured data into a JSON string.
+///
+/// The string/bytes must contain a valid JSON object or array. JSON objects will be
+/// converted into Typst dictionaries, and JSON arrays will be converted into
+/// Typst arrays. Strings and booleans will be converted into the Typst
+/// equivalents, `null` will be converted into `{none}`, and numbers will be
+/// converted to floats or integers depending on whether they are whole numbers.
+///
+/// ```
+///
+/// Display: JSON
+/// Category: data-loading
+#[func]
+pub fn json_encode(
+    /// Path to a JSON file.
+    value: Spanned<Value>,
+) -> SourceResult<Str> {
+    let Spanned { v: value, span } = value;
+
+    let value: serde_json::Value =
+        serde_json::from_slice(&data).map_err(format_json_error).at(span)?;
+    Ok(convert_json(value))
+}
+
+
 /// Convert a JSON value to a Typst value.
 fn convert_json(value: serde_json::Value) -> Value {
     match value {


### PR DESCRIPTION
resolves #1647. This allows for data decoding also from string and bytes + encoding json, toml and yaml. The new functions are within the original scope, e.g. 
```typc
json();
json.encode();
json.decode();
```