### PR TITLE
Fix documentation on when raw text is a block.

### DIFF
--- a/crates/typst-library/src/text/raw.rs
+++ b/crates/typst-library/src/text/raw.rs
@@ -26,6 +26,11 @@ use crate::prelude::*;
 /// Adding `rbx` to `rcx` gives
 /// the desired result.
 ///
+/// What is ```rust fn main()```
+/// in Rust would be
+/// ```java public static void main(String[] args)```
+/// in Java.
+///
 /// ```rust
 /// fn main() {
 ///     println!("Hello World!");
@@ -38,8 +43,13 @@ use crate::prelude::*;
 /// backticks (`` ` ``) to make it raw. Two backticks produce empty raw text.
 /// When you use three or more backticks, you can additionally specify a
 /// language tag for syntax highlighting directly after the opening backticks.
-/// Within raw blocks, everything is rendered as is, in particular, there are no
-/// escape sequences.
+/// Within raw blocks, everything (except for the language tag, if applicable)
+/// is rendered as is, in particular, there are no escape sequences.
+///
+/// The language tag is an identifier that directly follows the three or more
+/// backticks starting the raw text. If your content starts with something that
+/// looks like an identifier, but no syntax highlighting is needed, start the
+/// content with a single space or use the single backtick syntax.
 ///
 /// Display: Raw Text / Code
 /// Category: text

--- a/crates/typst-library/src/text/raw.rs
+++ b/crates/typst-library/src/text/raw.rs
@@ -70,8 +70,9 @@ pub struct RawElem {
 
     /// Whether the raw text is displayed as a separate block.
     ///
-    /// In markup mode, using one-backtick notation makes this `{false}`,
-    /// whereas using three-backtick notation makes it `{true}`.
+    /// In markup mode, using one-backtick notation makes this `{false}`.
+    /// Using three-backtick notation makes it `{true}` if the enclosed content
+    /// contains at least one line break.
     ///
     /// ````example
     /// // Display inline code in a small box
@@ -92,6 +93,8 @@ pub struct RawElem {
     /// )
     ///
     /// With `rg`, you can search through your files quickly.
+    /// This example searches the current directory recursively
+    /// for the text ``` Hello World```:
     ///
     /// ```bash
     /// rg "Hello World"
@@ -110,6 +113,8 @@ pub struct RawElem {
     /// ```typ
     /// This is *Typst!*
     /// ```
+    ///
+    /// This is ```typ also *Typst*```, but inline!
     /// ````
     pub lang: Option<EcoString>,
 

--- a/crates/typst-library/src/text/raw.rs
+++ b/crates/typst-library/src/text/raw.rs
@@ -26,16 +26,19 @@ use crate::prelude::*;
 /// Adding `rbx` to `rcx` gives
 /// the desired result.
 ///
-/// What is ```rust fn main()```
-/// in Rust would be
-/// ```java public static void main(String[] args)```
-/// in Java.
+/// What is ```rust fn main()``` in Rust
+/// would be ```c int main()``` in C.
 ///
 /// ```rust
 /// fn main() {
 ///     println!("Hello World!");
 /// }
 /// ```
+///
+/// This has ``` `backticks` ``` in it
+/// (but the spaces are trimmed). And
+/// ``` here``` the leading space is
+/// also trimmed.
 /// ````
 ///
 /// ## Syntax { #syntax }
@@ -46,10 +49,12 @@ use crate::prelude::*;
 /// Within raw blocks, everything (except for the language tag, if applicable)
 /// is rendered as is, in particular, there are no escape sequences.
 ///
-/// The language tag is an identifier that directly follows the three or more
-/// backticks starting the raw text. If your content starts with something that
-/// looks like an identifier, but no syntax highlighting is needed, start the
-/// content with a single space or use the single backtick syntax.
+/// The language tag is an identifier that directly follows the opening
+/// backticks only if there are three or more backticks. If your text starts
+/// with something that looks like an identifier, but no syntax highlighting is
+/// needed, start the text with a single space (which will be trimmed) or use
+/// the single backtick syntax. If your text should start or end with a
+/// backtick, put a space before or after it (it will be trimmed).
 ///
 /// Display: Raw Text / Code
 /// Category: text
@@ -104,7 +109,7 @@ pub struct RawElem {
     ///
     /// With `rg`, you can search through your files quickly.
     /// This example searches the current directory recursively
-    /// for the text ``` Hello World```:
+    /// for the text `Hello World`:
     ///
     /// ```bash
     /// rg "Hello World"


### PR DESCRIPTION
The docs for the [raw function](https://typst.app/docs/reference/text/raw/#parameters-block) say "using three-backtick notation makes [`block`] `true`." However, the [implementation](https://github.com/typst/typst/blob/2f81089995c87efdbce6c94bb29647cd1f213cfd/crates/typst-syntax/src/ast.rs#L614) also requires the raw text to contain a newline. From a user's perspective, this is important because it means that inline raw text can have syntax highlighting.

I edited the description of the `Raw::block` field to fix this, and added to the examples for `Raw::block` and `Raw::lang` to highlight these capabilities.

I hope this helps and that I captured the intent & actual behavior properly in my changes!