### PR TITLE
Improve clarity regarding location parameter in counter.final()

### DIFF
--- a/crates/typst-library/src/meta/counter.rs
+++ b/crates/typst-library/src/meta/counter.rs
@@ -267,7 +267,8 @@ use crate::prelude::*;
 /// array of integers, even if the counter has just one number.
 ///
 /// - location: location (positional, required)
-///   Can be any location. Why is it required then? Typst has to evaluate parts
+///   Can be an arbitrary location, as its value is irrelevant
+///   for the methods return value. Why is it required then? Typst has to evaluate parts
 ///   of your code multiple times to determine all counter values. By only
 ///   allowing this method within [`locate`]($func/locate) calls, the amount of
 ///   code that can depend on the method's result is reduced. If you could call

--- a/crates/typst-library/src/meta/counter.rs
+++ b/crates/typst-library/src/meta/counter.rs
@@ -267,13 +267,13 @@ use crate::prelude::*;
 /// array of integers, even if the counter has just one number.
 ///
 /// - location: location (positional, required)
-///   Can be an arbitrary location, as its value is irrelevant
-///   for the methods return value. Why is it required then? Typst has to evaluate parts
-///   of your code multiple times to determine all counter values. By only
-///   allowing this method within [`locate`]($func/locate) calls, the amount of
-///   code that can depend on the method's result is reduced. If you could call
-///   `final` directly at the top level of a module, the evaluation of the whole
-///   module and its exports could depend on the counter's value.
+///   Can be an arbitrary location, as its value is irrelevant for the method's
+///   return value. Why is it required then? Typst has to evaluate parts of your
+///   code multiple times to determine all counter values. By only allowing this
+///   method within [`locate`]($func/locate) calls, the amount of code that can
+///   depend on the method's result is reduced. If you could call `final`
+///   directly at the top level of a module, the evaluation of the whole module
+///   and its exports could depend on the counter's value.
 ///
 /// - returns: array
 ///

--- a/crates/typst-library/src/meta/query.rs
+++ b/crates/typst-library/src/meta/query.rs
@@ -140,9 +140,10 @@ pub fn query(
     /// have an explicit label attached to them. This limitation will be
     /// resolved in the future.
     target: LocatableSelector,
-    /// Can be any location. Why is it required then? As noted before, Typst has
-    /// to evaluate parts of your code multiple times to determine the values of
-    /// all state. By only allowing this function within
+    /// Can be an arbitrary location, as its value is irrelevant for the
+    /// function's return value. Why is it required then? As noted before, Typst
+    /// has to evaluate parts of your code multiple times to determine the
+    /// values of all state. By only allowing this function within
     /// [`locate`]($func/locate) calls, the amount of code that can depend on
     /// the query's result is reduced. If you could call it directly at the top
     /// level of a module, the evaluation of the whole module and its exports

--- a/crates/typst-library/src/meta/state.rs
+++ b/crates/typst-library/src/meta/state.rs
@@ -222,13 +222,14 @@ use crate::prelude::*;
 /// Gets the value of the state at the end of the document.
 ///
 /// - location: location (positional, required)
-///   Can be any location. Why is it required then? As noted before, Typst has
-///   to evaluate parts of your code multiple times to determine the values of
-///   all state. By only allowing this method within [`locate`]($func/locate)
-///   calls, the amount of code that can depend on the method's result is
-///   reduced. If you could call `final` directly at the top level of a module,
-///   the evaluation of the whole module and its exports could depend on the
-///   state's value.
+///   Can be an arbitrary location, as its value is irrelevant for the method's
+///   return value. Why is it required then? As noted before, Typst has to
+///   evaluate parts of your code multiple times to determine the values of all
+///   state. By only allowing this method within [`locate`]($func/locate) calls,
+///   the amount of code that can depend on the method's result is reduced. If
+///   you could call `final` directly at the top level of a module, the
+///   evaluation of the whole module and its exports could depend on the state's
+///   value.
 ///
 /// - returns: any
 ///


### PR DESCRIPTION
In my opinion, the new wording clarifies the fact that the value of the location parameter is not relevant for the methods return value. The current wording was not quite clear to me, see #1950.