### PR TITLE
Add format arg to CLI

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -46,7 +46,7 @@ pub struct CompileCommand {
     /// Path to output file (PDF, PNG, or SVG)
     pub output: Option<PathBuf>,
 
-    /// Specify the format of the output file, normally inferred from the extension
+    /// The format of the output file, inferred from the extension by default
     #[arg(long = "format", short = 'f')]
     pub format: Option<OutputFormat>,
 
@@ -154,7 +154,7 @@ impl Display for DiagnosticFormat {
     }
 }
 
-/// Which format to use for diagnostics.
+/// Which format to use for the generated output file.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, ValueEnum)]
 pub enum OutputFormat {
     Pdf,

--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -46,6 +46,10 @@ pub struct CompileCommand {
     /// Path to output file (PDF, PNG, or SVG)
     pub output: Option<PathBuf>,
 
+    /// Specify the format of the output file, normally inferred from the extension
+    #[arg(long = "format", short = 'f')]
+    pub format: Option<OutputFormat>,
+
     /// Opens the output file using the default viewer after compilation
     #[arg(long = "open")]
     pub open: Option<Option<String>>,
@@ -57,15 +61,6 @@ pub struct CompileCommand {
     /// Produces a flamegraph of the compilation process
     #[arg(long = "flamegraph", value_name = "OUTPUT_SVG")]
     pub flamegraph: Option<Option<PathBuf>>,
-}
-
-impl CompileCommand {
-    /// The output path.
-    pub fn output(&self) -> PathBuf {
-        self.output
-            .clone()
-            .unwrap_or_else(|| self.common.input.with_extension("pdf"))
-    }
 }
 
 /// Processes an input file to extract provided metadata
@@ -151,6 +146,23 @@ pub enum DiagnosticFormat {
 }
 
 impl Display for DiagnosticFormat {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.to_possible_value()
+            .expect("no values are skipped")
+            .get_name()
+            .fmt(f)
+    }
+}
+
+/// Which format to use for diagnostics.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, ValueEnum)]
+pub enum OutputFormat {
+    Pdf,
+    Png,
+    Svg,
+}
+
+impl Display for OutputFormat {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         self.to_possible_value()
             .expect("no values are skipped")

--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use codespan_reporting::term::{self, termcolor};
@@ -11,13 +11,37 @@ use typst::geom::Color;
 use typst::syntax::{FileId, Source};
 use typst::World;
 
-use crate::args::{CompileCommand, DiagnosticFormat};
+use crate::args::{CompileCommand, DiagnosticFormat, OutputFormat};
 use crate::watch::Status;
 use crate::world::SystemWorld;
 use crate::{color_stream, set_failed};
 
 type CodespanResult<T> = Result<T, CodespanError>;
 type CodespanError = codespan_reporting::files::Error;
+
+impl CompileCommand {
+    /// The output path.
+    pub fn output(&self) -> PathBuf {
+        self.output
+            .clone()
+            .unwrap_or_else(|| self.common.input.with_extension("pdf"))
+    }
+
+    pub fn output_format(&self) -> StrResult<OutputFormat> {
+        Ok(if let Some(specified) = self.format {
+            specified
+        } else if let Some(output) = &self.output {
+            match output.extension() {
+                Some(ext) if ext.eq_ignore_ascii_case("pdf") => OutputFormat::Pdf,
+                Some(ext) if ext.eq_ignore_ascii_case("png") => OutputFormat::Png,
+                Some(ext) if ext.eq_ignore_ascii_case("svg") => OutputFormat::Svg,
+                _ => return Err(eco_format!("could not infer output format for output path {output:?}. consider providing the format manually with `--format/-f`")),
+            }
+        } else {
+            OutputFormat::Pdf
+        })
+    }
+}
 
 /// Execute a compilation command.
 pub fn compile(mut command: CompileCommand) -> StrResult<()> {
@@ -97,14 +121,10 @@ pub fn compile_once(
 
 /// Export into the target format.
 fn export(document: &Document, command: &CompileCommand) -> StrResult<()> {
-    match command.output().extension() {
-        Some(ext) if ext.eq_ignore_ascii_case("png") => {
-            export_image(document, command, ImageExportFormat::Png)
-        }
-        Some(ext) if ext.eq_ignore_ascii_case("svg") => {
-            export_image(document, command, ImageExportFormat::Svg)
-        }
-        _ => export_pdf(document, command),
+    match command.output_format()? {
+        OutputFormat::Png => export_image(document, command, ImageExportFormat::Png),
+        OutputFormat::Svg => export_image(document, command, ImageExportFormat::Svg),
+        OutputFormat::Pdf => export_pdf(document, command),
     }
 }
 

--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -27,6 +27,9 @@ impl CompileCommand {
             .unwrap_or_else(|| self.common.input.with_extension("pdf"))
     }
 
+    /// The format to use for generated output, either specified by the user or inferred from the extension.
+    ///
+    /// Will return `Err` if the format was not specified and could not be inferred.
     pub fn output_format(&self) -> StrResult<OutputFormat> {
         Ok(if let Some(specified) = self.format {
             specified
@@ -35,7 +38,7 @@ impl CompileCommand {
                 Some(ext) if ext.eq_ignore_ascii_case("pdf") => OutputFormat::Pdf,
                 Some(ext) if ext.eq_ignore_ascii_case("png") => OutputFormat::Png,
                 Some(ext) if ext.eq_ignore_ascii_case("svg") => OutputFormat::Svg,
-                _ => return Err(eco_format!("could not infer output format for output path {output:?}. consider providing the format manually with `--format/-f`")),
+                _ => bail!("could not infer output format for path {}.\nconsider providing the format manually with `--format/-f`", output.display()),
             }
         } else {
             OutputFormat::Pdf


### PR DESCRIPTION
This also moves the `impl CompileCommand` block to `src/compile.rs` because it isn't necessary for the other usage of `src/arg.rs` in `build.rs`.