### PR TITLE
Add Finnish translations

### DIFF
--- a/crates/typst-library/src/layout/table.rs
+++ b/crates/typst-library/src/layout/table.rs
@@ -313,6 +313,7 @@ impl LocalName for TableElem {
             Lang::DANISH => "Tabel",
             Lang::DUTCH => "Tabel",
             Lang::FILIPINO => "Talaan",
+            Lang::FINNISH => "Taulukko",
             Lang::FRENCH => "Tableau",
             Lang::GERMAN => "Tabelle",
             Lang::ITALIAN => "Tabella",

--- a/crates/typst-library/src/math/mod.rs
+++ b/crates/typst-library/src/math/mod.rs
@@ -329,6 +329,7 @@ impl LocalName for EquationElem {
             Lang::DANISH => "Ligning",
             Lang::DUTCH => "Vergelijking",
             Lang::FILIPINO => "Ekwasyon",
+            Lang::FINNISH => "Yhtälö",
             Lang::FRENCH => "Équation",
             Lang::GERMAN => "Gleichung",
             Lang::ITALIAN => "Equazione",

--- a/crates/typst-library/src/meta/bibliography.rs
+++ b/crates/typst-library/src/meta/bibliography.rs
@@ -234,6 +234,7 @@ impl LocalName for BibliographyElem {
             Lang::DANISH => "Bibliografi",
             Lang::DUTCH => "Bibliografie",
             Lang::FILIPINO => "Bibliograpiya",
+            Lang::FINNISH => "Viitteet",
             Lang::FRENCH => "Bibliographie",
             Lang::GERMAN => "Bibliographie",
             Lang::ITALIAN => "Bibliografia",

--- a/crates/typst-library/src/meta/heading.rs
+++ b/crates/typst-library/src/meta/heading.rs
@@ -247,6 +247,7 @@ impl LocalName for HeadingElem {
             Lang::DANISH => "Afsnit",
             Lang::DUTCH => "Hoofdstuk",
             Lang::FILIPINO => "Seksyon",
+            Lang::FINNISH => "Osio",
             Lang::FRENCH => "Chapitre",
             Lang::GERMAN => "Abschnitt",
             Lang::ITALIAN => "Sezione",

--- a/crates/typst-library/src/meta/outline.rs
+++ b/crates/typst-library/src/meta/outline.rs
@@ -268,6 +268,7 @@ impl LocalName for OutlineElem {
             Lang::DANISH => "Indhold",
             Lang::DUTCH => "Inhoudsopgave",
             Lang::FILIPINO => "Talaan ng mga Nilalaman",
+            Lang::FINNISH => "Sisällys",
             Lang::FRENCH => "Table des matières",
             Lang::GERMAN => "Inhaltsverzeichnis",
             Lang::ITALIAN => "Indice",

--- a/crates/typst-library/src/text/raw.rs
+++ b/crates/typst-library/src/text/raw.rs
@@ -352,6 +352,7 @@ impl LocalName for RawElem {
             Lang::DANISH => "Liste",
             Lang::DUTCH => "Listing",
             Lang::FILIPINO => "Listahan",
+            Lang::FINNISH => "Esimerkki",
             Lang::FRENCH => "Liste",
             Lang::GERMAN => "Listing",
             Lang::ITALIAN => "Codice",

--- a/crates/typst-library/src/visualize/image.rs
+++ b/crates/typst-library/src/visualize/image.rs
@@ -243,6 +243,7 @@ impl LocalName for ImageElem {
             Lang::DANISH => "Figur",
             Lang::DUTCH => "Figuur",
             Lang::FILIPINO => "Pigura",
+            Lang::FINNISH => "Kuva",
             Lang::FRENCH => "Figure",
             Lang::GERMAN => "Abbildung",
             Lang::ITALIAN => "Figura",

--- a/crates/typst/src/doc.rs
+++ b/crates/typst/src/doc.rs
@@ -567,6 +567,7 @@ impl Lang {
     pub const DUTCH: Self = Self(*b"nl ", 2);
     pub const ENGLISH: Self = Self(*b"en ", 2);
     pub const FILIPINO: Self = Self(*b"tl ", 2);
+    pub const FINNISH: Self = Self(*b"fi ", 2);
     pub const FRENCH: Self = Self(*b"fr ", 2);
     pub const GERMAN: Self = Self(*b"de ", 2);
     pub const ITALIAN: Self = Self(*b"it ", 2);


### PR DESCRIPTION
Added Finnish translations.

I took some liberty in translating some words, because I thought that the direct translations wouldn't match the use case that well.