### PR TITLE
Add a method to reverse strings

### DIFF
--- a/crates/typst/src/eval/methods.rs
+++ b/crates/typst/src/eval/methods.rs
@@ -82,7 +82,12 @@ pub fn call(
                 let count = args.named("count")?;
                 string.replace(vm, pattern, with, count)?.into_value()
             }
-            "rev" => string.clusters().rev().join(None, None).at(span)?.into_value(),
+            "rev" => {
+                match string.len() {
+                    0 => string.into_value(), // Required because join returns a None value for empty strings
+                    _ => string.clusters().rev().join(None, None).at(span)?.into_value()
+                }
+            },
             "trim" => {
                 let pattern = args.eat()?;
                 let at = args.named("at")?;

--- a/crates/typst/src/eval/methods.rs
+++ b/crates/typst/src/eval/methods.rs
@@ -82,6 +82,7 @@ pub fn call(
                 let count = args.named("count")?;
                 string.replace(vm, pattern, with, count)?.into_value()
             }
+            "rev" => string.clusters().rev().join(None, None).at(span)?.into_value(),
             "trim" => {
                 let pattern = args.eat()?;
                 let at = args.named("at")?;

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -689,6 +689,11 @@ string and returns the resulting string.
   If given, only the first `count` matches of the pattern are placed.
 - returns: string
 
+### rev()
+Reverses the string, keeping grapheme clusters intact.
+
+- returns: string
+
 ### trim()
 Removes matches of a pattern from one or both sides of the string, once or
 repeatedly and returns the resulting string.

--- a/tests/typ/compiler/string.typ
+++ b/tests/typ/compiler/string.typ
@@ -177,6 +177,16 @@
 #"123".replace("123", (1, 2, 3))
 
 ---
+// Test the 'rev' method
+#test("Hello".rev(), "olleH")
+#test("World!".rev(), "!dlroW")
+#test("".rev(), "")
+#test("A".rev(), "A")
+#test("AB".rev(), "BA")
+#test("123".rev(), "321")
+#test("🏳️‍🌈A🏳️‍⚧️".rev(), "🏳️‍⚧️A🏳️‍🌈")
+
+---
 // Test the `trim` method.
 #let str = "Typst, LaTeX, Word, InDesign"
 #let array = ("Typst", "LaTeX", "Word", "InDesign")


### PR DESCRIPTION
This small PR introduces the .rev() method for reversing strings, as discussed in issue #1983. I'm relatively new to Rust and very new to compiler development, so I took this as an opportunity to learn.

One challenge I encountered was handling empty strings. The .join() method on an Array returns none when the array is empty. To address this, I used a match statement to ensure that reversing an empty string would still return an empty string, rather than none.

I appreciate any feedback you may have!