### PR TITLE
Display download progress for self-updating and packages

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -33,6 +33,10 @@ The MIT License applies to:
   adapted from the colors.css project
   (https://clrs.cc/)
 
+* The `RemoteReader` defined in `crates/typst-cli/src/download.rs` which is 
+   closely modelled after the `DownloadTracker` from rustup 
+   (https://github.com/rust-lang/rustup/blob/master/src/cli/download_tracker.rs)
+
 The MIT License (MIT)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/crates/typst-cli/Cargo.toml
+++ b/crates/typst-cli/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 test = false
 doctest = false
 bench = false
+doc = false
 
 [dependencies]
 typst = { path = "../typst" }

--- a/crates/typst-cli/Cargo.toml
+++ b/crates/typst-cli/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/main.rs"
 test = false
 doctest = false
 bench = false
-doc = false
 
 [dependencies]
 typst = { path = "../typst" }

--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -160,6 +160,8 @@ impl Display for DiagnosticFormat {
     }
 }
 
+/// Self-updates the CLI and replaces it with pre-compiled binary from a Typst
+/// release.
 #[derive(Debug, Clone, Parser)]
 pub struct UpdateCommand {
     /// Which version to update to (defaults to latest)

--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -160,8 +160,7 @@ impl Display for DiagnosticFormat {
     }
 }
 
-/// Self-updates the CLI and replaces it with pre-compiled binary from a Typst
-/// release.
+/// Update the CLI using a pre-compiled binary from a Typst GitHub release.
 #[derive(Debug, Clone, Parser)]
 pub struct UpdateCommand {
     /// Which version to update to (defaults to latest)

--- a/crates/typst-cli/src/download.rs
+++ b/crates/typst-cli/src/download.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 
 use ureq::Response;
 
-/// Keep track of this many past download amounts
+/// Keep track of this many past download amounts.
 const DOWNLOAD_TRACK_COUNT: usize = 5;
 
 /// A wrapper around [`ureq::Response`] that reads the response body in chunks
@@ -71,9 +71,9 @@ impl RemoteReader {
             let read = match self.reader.read(&mut data[offset..]) {
                 Ok(0) => break,
                 Ok(n) => n,
-                // if the data is not yet ready but will be available eventually
+                // If the data is not yet ready but will be available eventually
                 // keep trying until we either get an actual error, receive data
-                // or an Ok(0)
+                // or an Ok(0).
                 Err(ref e) if e.kind() == ErrorKind::Interrupted => continue,
                 Err(e) => return Err(e),
             };

--- a/crates/typst-cli/src/download.rs
+++ b/crates/typst-cli/src/download.rs
@@ -12,6 +12,7 @@ use ureq::Response;
 const SPEED_SAMPLES: usize = 5;
 
 /// Download binary data and display its progress.
+#[allow(clippy::result_large_err)]
 pub fn download_with_progress(url: &str) -> Result<Vec<u8>, ureq::Error> {
     let response = ureq::get(url).call()?;
     Ok(RemoteReader::from_response(response).download()?)

--- a/crates/typst-cli/src/download.rs
+++ b/crates/typst-cli/src/download.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant};
 use ureq::Response;
 
 /// A wrapper around [`ureq::Response`] that reads the response body in chunks
-/// over a websocket and displays statics about its progress.
+/// over a websocket and displays statistics about its progress.
 ///
 /// Downloads will _never_ fail due to statistics failing to print, print errors
 /// are silently ignored.
@@ -50,9 +50,9 @@ impl RemoteReader {
         }
     }
 
-    /// Download the body content and return it as a raw buffer while attempting
-    /// to print download statistics to a terminal. Download progress gets
-    /// displayed and updated every second.
+    /// Download the bodies content as raw bytes while attempting to print
+    /// download statistics to standard out. Download progress gets displayed
+    /// and updated every second.
     ///
     /// These statistics will never prevent a download from completing, errors
     /// are silently ignored.
@@ -117,7 +117,7 @@ impl RemoteReader {
     }
 
     /// Compile and format several download statistics and make an attempt at
-    /// displaying them to the terminal.
+    /// displaying them on standard out.
     fn display(&mut self) {
         let percent = (self.total_downloaded as f64 / self.content_len as f64) * 100.;
         let sum: usize = self.downloaded_last_few_secs.iter().sum();
@@ -145,7 +145,7 @@ impl RemoteReader {
         self.displayed_charcount = Some(output.chars().count());
     }
 
-    /// Erases each previously printed character and adds a carriage return
+    /// Erase each previously printed character and add a carriage return
     /// character, clearing the line for the next `display()` update.
     fn erase_chars(&mut self, count: usize) {
         let _ = write!(self.terminal, "{}", " ".repeat(count));
@@ -154,7 +154,7 @@ impl RemoteReader {
     }
 }
 
-/// Appends a unit-of-time suffix.
+/// Append a unit-of-time suffix.
 fn time_suffix(duration: Duration) -> String {
     let secs = duration.as_secs();
     match format_dhms(secs) {
@@ -165,7 +165,7 @@ fn time_suffix(duration: Duration) -> String {
     }
 }
 
-/// Format the total amound of seconds into the amount of days, hours, minutes
+/// Format the total amount of seconds into the amount of days, hours, minutes
 /// and seconds.
 fn format_dhms(sec: u64) -> (u64, u8, u8, u8) {
     let (mins, sec) = (sec / 60, (sec % 60) as u8);
@@ -174,8 +174,8 @@ fn format_dhms(sec: u64) -> (u64, u8, u8, u8) {
     (days, hours, mins, sec)
 }
 
-/// Formats a given size as a unit of time. Appending a '/s' (per second) suffix
-/// is done by setting `include_suffix` to true.
+/// Format a given size as a unit of time. Setting `include_suffix` to true
+/// appends a '/s' (per second) suffix.
 fn as_time_unit(size: usize, include_suffix: bool) -> String {
     const KI: f64 = 1024.0;
     const MI: f64 = KI * KI;

--- a/crates/typst-cli/src/download.rs
+++ b/crates/typst-cli/src/download.rs
@@ -4,6 +4,13 @@ use std::time::{Duration, Instant};
 
 use ureq::Response;
 
+/// A wrapper around [`ureq::Response`] that reads the response body in chunks
+/// over a websocket and displays statics about its progress.
+///
+/// Downloads will _never_ fail due to statistics failing to print, print errors
+/// are silently ignored.
+///
+/// [`ureq::Response`]: https://docs.rs/ureq/2.7.1/ureq/struct.Response.html
 pub struct RemoteReader {
     reader: Box<dyn Read + Send + Sync + 'static>,
     content_len: usize,
@@ -17,6 +24,13 @@ pub struct RemoteReader {
 }
 
 impl RemoteReader {
+    /// Wraps a [`ureq::Response`] and prepares it for downloading.
+    ///
+    /// Downloading data in chunks requires that the content length is known
+    /// before any reads take place. The response _must_ have a 'Content-Length'
+    /// header attached, otherwise downloading will fail.
+    ///
+    /// [`ureq::Response`]: https://docs.rs/ureq/2.7.1/ureq/struct.Response.html
     pub fn from_response(response: Response) -> Self {
         let content_len = response
             .header("Content-Length")
@@ -36,6 +50,12 @@ impl RemoteReader {
         }
     }
 
+    /// Download the body content and return it as a raw buffer while attempting
+    /// to print download statistics to a terminal. Download progress gets
+    /// displayed and updated every second.
+    ///
+    /// These statistics will never prevent a download from completing, errors
+    /// are silently ignored.
     pub fn download(mut self) -> io::Result<Vec<u8>> {
         if self.content_len == 0 {
             return Err(ErrorKind::UnexpectedEof.into());
@@ -48,6 +68,9 @@ impl RemoteReader {
             let read = match self.reader.read(&mut data[offset..]) {
                 Ok(0) => break,
                 Ok(n) => n,
+                // if the data is not yet ready but will be available eventually
+                // keep trying until we either get an actual error, receive data
+                // or an Ok(0)
                 Err(ref e) if e.kind() == ErrorKind::Interrupted => continue,
                 Err(e) => return Err(e),
             };
@@ -93,6 +116,8 @@ impl RemoteReader {
         Ok(data)
     }
 
+    /// Compile and format several download statistics and make an attempt at
+    /// displaying them to the terminal.
     fn display(&mut self) {
         let percent = (self.total_downloaded as f64 / self.content_len as f64) * 100.;
         let sum: usize = self.downloaded_last_few_secs.iter().sum();
@@ -102,10 +127,10 @@ impl RemoteReader {
 
         let output = format!(
             "{} / {} ({:3.0} %) {} in {} ETA: {}",
-            format_speed(self.total_downloaded, false),
-            format_speed(self.content_len, false),
+            as_time_unit(self.total_downloaded, false),
+            as_time_unit(self.content_len, false),
             percent,
-            format_speed(speed, true),
+            as_time_unit(speed, true),
             time_suffix(Instant::now().saturating_duration_since(self.start_time)),
             time_suffix(Duration::from_secs(if speed == 0 {
                 0
@@ -120,6 +145,8 @@ impl RemoteReader {
         self.displayed_charcount = Some(output.chars().count());
     }
 
+    /// Erases each previously printed character and adds a carriage return
+    /// character, clearing the line for the next `display()` update.
     fn erase_chars(&mut self, count: usize) {
         let _ = write!(self.terminal, "{}", " ".repeat(count));
         let _ = self.terminal.flush();
@@ -127,6 +154,7 @@ impl RemoteReader {
     }
 }
 
+/// Appends a unit-of-time suffix.
 fn time_suffix(duration: Duration) -> String {
     let secs = duration.as_secs();
     match format_dhms(secs) {
@@ -137,6 +165,8 @@ fn time_suffix(duration: Duration) -> String {
     }
 }
 
+/// Format the total amound of seconds into the amount of days, hours, minutes
+/// and seconds.
 fn format_dhms(sec: u64) -> (u64, u8, u8, u8) {
     let (mins, sec) = (sec / 60, (sec % 60) as u8);
     let (hours, mins) = (mins / 60, (mins % 60) as u8);
@@ -144,7 +174,9 @@ fn format_dhms(sec: u64) -> (u64, u8, u8, u8) {
     (days, hours, mins, sec)
 }
 
-fn format_speed(size: usize, include_suffix: bool) -> String {
+/// Formats a given size as a unit of time. Appending a '/s' (per second) suffix
+/// is done by setting `include_suffix` to true.
+fn as_time_unit(size: usize, include_suffix: bool) -> String {
     const KI: f64 = 1024.0;
     const MI: f64 = KI * KI;
     const GI: f64 = KI * KI * KI;

--- a/crates/typst-cli/src/download.rs
+++ b/crates/typst-cli/src/download.rs
@@ -1,0 +1,165 @@
+use std::collections::VecDeque;
+use std::io::{self, ErrorKind, Read, Stdout, Write};
+use std::time::{Duration, Instant};
+
+use ureq::Response;
+
+pub struct RemoteReader {
+    reader: Box<dyn Read + Send + Sync + 'static>,
+    content_len: usize,
+    total_downloaded: usize,
+    downloaded_this_sec: usize,
+    downloaded_last_few_secs: VecDeque<usize>,
+    start_time: Instant,
+    last_print: Option<Instant>,
+    displayed_charcount: Option<usize>,
+    terminal: Stdout,
+}
+
+impl RemoteReader {
+    pub fn from_response(response: Response) -> Self {
+        let content_len = response
+            .header("Content-Length")
+            .and_then(|header| header.parse().ok())
+            .unwrap_or_default();
+
+        Self {
+            reader: response.into_reader(),
+            content_len,
+            total_downloaded: 0,
+            downloaded_this_sec: 0,
+            downloaded_last_few_secs: VecDeque::new(),
+            start_time: Instant::now(),
+            last_print: None,
+            displayed_charcount: None,
+            terminal: std::io::stdout(),
+        }
+    }
+
+    pub fn download(mut self) -> io::Result<Vec<u8>> {
+        if self.content_len == 0 {
+            return Err(ErrorKind::UnexpectedEof.into());
+        }
+
+        let mut data = vec![0; self.content_len];
+        let mut offset = 0;
+
+        loop {
+            let read = match self.reader.read(&mut data[offset..]) {
+                Ok(0) => break,
+                Ok(n) => n,
+                Err(ref e) if e.kind() == ErrorKind::Interrupted => continue,
+                Err(e) => return Err(e),
+            };
+            offset += read;
+
+            let last_printed = match self.last_print {
+                Some(prev) => prev,
+                None => {
+                    let current_time = Instant::now();
+                    self.last_print = Some(current_time);
+                    current_time
+                }
+            };
+            let elapsed = Instant::now().saturating_duration_since(last_printed);
+
+            self.total_downloaded += read;
+            self.downloaded_this_sec += read;
+
+            if elapsed >= Duration::from_secs(1) {
+                self.downloaded_last_few_secs.push_front(self.downloaded_this_sec);
+                self.downloaded_this_sec = 0;
+
+                if let Some(n) = self.displayed_charcount {
+                    self.erase_chars(n);
+                }
+
+                self.display();
+                let _ = write!(self.terminal, "\r");
+                self.last_print = Some(Instant::now());
+            }
+
+            if read == 0 {
+                assert_eq!(self.total_downloaded, self.content_len);
+                break;
+            }
+        }
+
+        self.display();
+        let _ = writeln!(self.terminal);
+
+        assert_eq!(self.total_downloaded, self.content_len);
+
+        Ok(data)
+    }
+
+    fn display(&mut self) {
+        let percent = (self.total_downloaded as f64 / self.content_len as f64) * 100.;
+        let sum: usize = self.downloaded_last_few_secs.iter().sum();
+        let len = self.downloaded_last_few_secs.len();
+        let speed = if len > 0 { sum / len } else { self.content_len };
+        let remaining = self.content_len - self.total_downloaded;
+
+        let output = format!(
+            "{} / {} ({:3.0} %) {} in {} ETA: {}",
+            format_speed(self.total_downloaded, false),
+            format_speed(self.content_len, false),
+            percent,
+            format_speed(speed, true),
+            time_suffix(Instant::now().saturating_duration_since(self.start_time)),
+            time_suffix(Duration::from_secs(if speed == 0 {
+                0
+            } else {
+                (remaining / speed) as u64
+            }))
+        );
+
+        let _ = write!(self.terminal, "{output}");
+        let _ = self.terminal.flush();
+
+        self.displayed_charcount = Some(output.chars().count());
+    }
+
+    fn erase_chars(&mut self, count: usize) {
+        let _ = write!(self.terminal, "{}", " ".repeat(count));
+        let _ = self.terminal.flush();
+        let _ = write!(self.terminal, "\r");
+    }
+}
+
+fn time_suffix(duration: Duration) -> String {
+    let secs = duration.as_secs();
+    match format_dhms(secs) {
+        (0, 0, 0, s) => format!("{s:2.0}s"),
+        (0, 0, m, s) => format!("{m:2.0}m {s:2.0}s"),
+        (0, h, m, s) => format!("{h:2.0}h {m:2.0}m {s:2.0}s"),
+        (d, h, m, s) => format!("{d:3.0}d {h:2.0}h {m:2.0}m {s:2.0}s"),
+    }
+}
+
+fn format_dhms(sec: u64) -> (u64, u8, u8, u8) {
+    let (mins, sec) = (sec / 60, (sec % 60) as u8);
+    let (hours, mins) = (mins / 60, (mins % 60) as u8);
+    let (days, hours) = (hours / 24, (hours % 24) as u8);
+    (days, hours, mins, sec)
+}
+
+fn format_speed(size: usize, include_suffix: bool) -> String {
+    const KI: f64 = 1024.0;
+    const MI: f64 = KI * KI;
+    const GI: f64 = KI * KI * KI;
+
+    let size = size as f64;
+
+    let suffix = if include_suffix { "/s" } else { "" };
+
+    if size >= GI {
+        format!("{:5.1} GiB{}", size / GI, suffix)
+    } else if size >= MI {
+        format!("{:5.1} MiB{}", size / MI, suffix)
+    } else if size >= KI {
+        format!("{:5.1} KiB{}", size / KI, suffix)
+    } else {
+        format!("{size:3.0} B{}", suffix)
+    }
+}

--- a/crates/typst-cli/src/main.rs
+++ b/crates/typst-cli/src/main.rs
@@ -1,5 +1,6 @@
 mod args;
 mod compile;
+mod download;
 mod fonts;
 mod package;
 mod query;

--- a/crates/typst-cli/src/package.rs
+++ b/crates/typst-cli/src/package.rs
@@ -60,9 +60,7 @@ fn download_package(spec: &PackageSpec, package_dir: &Path) -> PackageResult<()>
     };
 
     let remote = RemoteReader::from_response(response);
-    let data = remote
-        .download()
-        .map_err(|_| PackageError::NetworkFailed)?;
+    let data = remote.download().map_err(|_| PackageError::NetworkFailed)?;
 
     let decompressed = flate2::read::GzDecoder::new(data.as_slice());
     tar::Archive::new(decompressed).unpack(package_dir).map_err(|_| {

--- a/crates/typst-cli/src/package.rs
+++ b/crates/typst-cli/src/package.rs
@@ -7,9 +7,8 @@ use termcolor::WriteColor;
 use typst::diag::{PackageError, PackageResult};
 use typst::syntax::PackageSpec;
 
-use crate::download::download_with_progress;
-
 use super::color_stream;
+use crate::download::download_with_progress;
 
 /// Make a package available in the on-disk cache.
 pub fn prepare_package(spec: &PackageSpec) -> PackageResult<PathBuf> {

--- a/crates/typst-cli/src/update.rs
+++ b/crates/typst-cli/src/update.rs
@@ -11,6 +11,7 @@ use xz2::bufread::XzDecoder;
 use zip::ZipArchive;
 
 use crate::args::UpdateCommand;
+use crate::download::RemoteReader;
 
 const TYPST_GITHUB_ORG: &str = "typst";
 const TYPST_REPO: &str = "typst";
@@ -140,11 +141,10 @@ impl Release {
             Err(_) => bail!("failed to load asset (network failed)"),
         };
 
-        let mut data = Vec::new();
-        response
-            .into_reader()
-            .read_to_end(&mut data)
-            .map_err(|err| eco_format!("failed to read response buffer: {err}"))?;
+        let remote = RemoteReader::from_response(response);
+        let data = remote
+            .download()
+            .map_err(|err| eco_format!("download failed: {err}"))?;
 
         if asset_name.contains("windows") {
             extract_binary_from_zip(&data, asset_name)

--- a/crates/typst-cli/src/update.rs
+++ b/crates/typst-cli/src/update.rs
@@ -11,7 +11,7 @@ use xz2::bufread::XzDecoder;
 use zip::ZipArchive;
 
 use crate::args::UpdateCommand;
-use crate::download::RemoteReader;
+use crate::download::download_with_progress;
 
 const TYPST_GITHUB_ORG: &str = "typst";
 const TYPST_REPO: &str = "typst";
@@ -133,18 +133,13 @@ impl Release {
             .ok_or("could not find release for your target platform")?;
 
         eprintln!("Downloading release ...");
-        let response = match ureq::get(&asset.browser_download_url).call() {
-            Ok(response) => response,
+        let data = match download_with_progress(&asset.browser_download_url) {
+            Ok(data) => data,
             Err(ureq::Error::Status(404, _)) => {
                 bail!("asset not found (searched for {})", asset.name);
             }
             Err(_) => bail!("failed to load asset (network failed)"),
         };
-
-        let remote = RemoteReader::from_response(response);
-        let data = remote
-            .download()
-            .map_err(|err| eco_format!("download failed: {err}"))?;
 
         if asset_name.contains("windows") {
             extract_binary_from_zip(&data, asset_name)


### PR DESCRIPTION
This PR introduces a `RemoteReader` that takes a `ureq::Response` and reads the data over a socket connection while updating the terminal with its progress.

Writes the following to the terminal: (modeled after `rustup update`'s [`DownloadTracker`](https://github.com/rust-lang/rustup/blob/bcfac6278c7c2f16a41294f7533aeee2f7f88d07/src/cli/download_tracker.rs))
```
Downloading release ...
4.6 MiB /  12.5 MiB ( 37 %)   1.1 MiB/s in  4s ETA:  6s
```

And for package downloads:
```
downloading @preview/xarrow:0.1.1
13.7 KiB /  13.7 KiB (100 %)  13.7 KiB/s in  0s ETA:  0s
```

Improvement on #1887 as mentioned here: https://github.com/typst/typst/pull/1887#issuecomment-1694485288