### PR TITLE
Fix: ends-with

### DIFF
--- a/crates/typst/src/eval/str.rs
+++ b/crates/typst/src/eval/str.rs
@@ -116,13 +116,22 @@ impl Str {
         match pattern {
             StrPattern::Str(pat) => self.0.ends_with(pat.as_str()),
             StrPattern::Regex(re) => {
-                // Regex expressions return non-overlapping matches, adding an
-                // ending anchor forces our regex to find the end
-                let anchored = Regex::new(&format!("({})$", re.as_str())).unwrap();
-                anchored
-                    .find_iter(self)
-                    .last()
-                    .map_or(false, |m| m.end() == self.0.len())
+                let mut start_byte = 0;
+                while let Some(mat) = re.find_iter(&self[start_byte..]).last() {
+                    if start_byte + mat.end() == self.0.len() {
+                        return true;
+                    }
+
+                    // There might still be a match overlapping this one, so
+                    // restart at the next code point
+                    if let Some(c) = &self[start_byte..].chars().next() {
+                        start_byte += mat.start() + c.len_utf8();
+                    } else {
+                        break;
+                    }
+                }
+
+                false
             }
         }
     }

--- a/crates/typst/src/eval/str.rs
+++ b/crates/typst/src/eval/str.rs
@@ -116,7 +116,13 @@ impl Str {
         match pattern {
             StrPattern::Str(pat) => self.0.ends_with(pat.as_str()),
             StrPattern::Regex(re) => {
-                re.find_iter(self).last().map_or(false, |m| m.end() == self.0.len())
+                // Regex expressions return non-overlapping matches, adding an
+                // ending anchor forces our regex to find the end
+                let anchored = Regex::new(&format!("({})$", re.as_str())).unwrap();
+                anchored
+                    .find_iter(self)
+                    .last()
+                    .map_or(false, |m| m.end() == self.0.len())
             }
         }
     }

--- a/crates/typst/src/eval/str.rs
+++ b/crates/typst/src/eval/str.rs
@@ -117,15 +117,15 @@ impl Str {
             StrPattern::Str(pat) => self.0.ends_with(pat.as_str()),
             StrPattern::Regex(re) => {
                 let mut start_byte = 0;
-                while let Some(mat) = re.find_iter(&self[start_byte..]).last() {
-                    if start_byte + mat.end() == self.0.len() {
+                while let Some(mat) = re.find_at(self, start_byte) {
+                    if mat.end() == self.0.len() {
                         return true;
                     }
 
                     // There might still be a match overlapping this one, so
                     // restart at the next code point
                     if let Some(c) = &self[start_byte..].chars().next() {
-                        start_byte += mat.start() + c.len_utf8();
+                        start_byte = mat.start() + c.len_utf8();
                     } else {
                         break;
                     }

--- a/crates/typst/src/eval/str.rs
+++ b/crates/typst/src/eval/str.rs
@@ -124,7 +124,7 @@ impl Str {
 
                     // There might still be a match overlapping this one, so
                     // restart at the next code point
-                    if let Some(c) = &self[start_byte..].chars().next() {
+                    if let Some(c) = &self[mat.start()..].chars().next() {
                         start_byte = mat.start() + c.len_utf8();
                     } else {
                         break;


### PR DESCRIPTION
Closes #1914 

Just a small fix for the `ends-with` function not working with regex. As [Laurenz suspected](https://github.com/typst/typst/issues/1914#issuecomment-1685042804), `Regex::find_iter` [only reports non-overlapping matches](https://docs.rs/regex/1.9.4/regex/struct.Regex.html#method.find_iter). This PR fixes that by just adding an ending anchor to the regex (after putting it in parentheses so that alternations work as intended).

I'll note that it does feel a bit weird to directly modify a regex string, but this should be safe - as long as the original regex is valid, putting it in parentheses is valid, and then adding the anchor will be valid as well.