### PR TITLE
Remove `ManuallyDrop` usage

### DIFF
--- a/crates/typst/src/model/mod.rs
+++ b/crates/typst/src/model/mod.rs
@@ -24,8 +24,6 @@ pub use self::styles::{
     Styles, Transform,
 };
 
-use std::mem::ManuallyDrop;
-
 use comemo::{Track, Tracked, TrackedMut, Validate};
 
 use crate::diag::{warning, SourceDiagnostic, SourceResult};
@@ -51,9 +49,7 @@ pub fn typeset(
     let mut document;
     let mut delayed;
 
-    // We need `ManuallyDrop` until this lands in stable:
-    // https://github.com/rust-lang/rust/issues/70919
-    let mut introspector = ManuallyDrop::new(Introspector::new(&[]));
+    let mut introspector = Introspector::new(&[]);
 
     // Relayout until all introspections stabilize.
     // If that doesn't happen within five attempts, we give up.
@@ -75,12 +71,9 @@ pub fn typeset(
         // Layout!
         let result = (library.items.layout)(&mut vt, content, styles)?;
 
-        // Drop the old introspector.
-        ManuallyDrop::into_inner(introspector);
-
         // Only now assign the document and construct the new introspector.
         document = result;
-        introspector = ManuallyDrop::new(Introspector::new(&document.pages));
+        introspector = Introspector::new(&document.pages);
         iter += 1;
 
         if introspector.validate(&constraint) {
@@ -95,9 +88,6 @@ pub fn typeset(
             break;
         }
     }
-
-    // Drop the introspector.
-    ManuallyDrop::into_inner(introspector);
 
     // Promote delayed errors.
     if !delayed.0.is_empty() {

--- a/crates/typst/src/model/mod.rs
+++ b/crates/typst/src/model/mod.rs
@@ -69,10 +69,8 @@ pub fn typeset(
         };
 
         // Layout!
-        let result = (library.items.layout)(&mut vt, content, styles)?;
+        document = (library.items.layout)(&mut vt, content, styles)?;
 
-        // Only now assign the document and construct the new introspector.
-        document = result;
         introspector = Introspector::new(&document.pages);
         iter += 1;
 


### PR DESCRIPTION
This usage can be removed since [the issue](https://github.com/rust-lang/rust/issues/70919) was fixed