### PR TITLE
fix typo in the to-bytes convertion

### DIFF
--- a/crates/typst-library/src/compute/construct.rs
+++ b/crates/typst-library/src/compute/construct.rs
@@ -743,7 +743,7 @@ pub fn regex(
 /// Category: construct
 #[func]
 pub fn bytes(
-    /// The value that should be converted to a string.
+    /// The value that should be converted to bytes.
     value: ToBytes,
 ) -> Bytes {
     value.0


### PR DESCRIPTION
Minor typo issue regarding the `bytes` function, see https://github.com/typst/typst/issues/2066

The last word should be "bytes", the master branch says "converted to a string" which should be a typo.

(I was looking into typst and decide to start with this minor issue as labelled by `good first issue`, please let me know if my PR follows the norm of contribution to typst/typst) 