### PR TITLE
Use `git rev-parse --short` for obtaining the commit

### DIFF
--- a/crates/typst-cli/build.rs
+++ b/crates/typst-cli/build.rs
@@ -51,11 +51,11 @@ fn typst_version() -> String {
 
     let pkg = env!("CARGO_PKG_VERSION");
     let hash = Command::new("git")
-        .args(["rev-parse", "HEAD"])
+        .args(["rev-parse", "--short=8", "HEAD"])
         .output()
         .ok()
         .filter(|output| output.status.success())
-        .and_then(|output| String::from_utf8(output.stdout.get(..8)?.into()).ok())
+        .and_then(|output| String::from_utf8(output.stdout.strip_suffix(b"\n")?.into()).ok())
         .unwrap_or_else(|| "unknown hash".into());
 
     format!("{pkg} ({hash})")


### PR DESCRIPTION
This makes it a tiny bit more robust in the event that we ever get two commits in the tree that have the same 8 character hash prefix (`git rev-parse --short` automatically makes the prefix longer if it isn't unique)