### PR TITLE
Enable writing text into a file

### DIFF
--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -138,6 +138,11 @@ impl World for SystemWorld {
         self.slot(id)?.file()
     }
 
+    fn write(&self, id: FileId, data: &[u8]) -> FileResult<()> {
+        let p = id.vpath().resolve(&self.root).ok_or(FileError::AccessDenied)?;
+        fs::write(&p, data).map_err(|f| FileError::from_io(f, &p))
+    }
+
     fn font(&self, index: usize) -> Option<Font> {
         self.fonts[index].get()
     }

--- a/crates/typst-library/src/compute/data.rs
+++ b/crates/typst-library/src/compute/data.rs
@@ -93,6 +93,26 @@ impl From<Readable> for Bytes {
     }
 }
 
+/// Writes plain text to a file.
+///
+///
+/// Display: Write
+/// Category: data-loading
+#[func]
+pub fn write(
+    /// Path to a file.
+    path: Spanned<EcoString>,
+    /// Text to write.
+    text: Spanned<EcoString>,
+    /// The virtual machine.
+    vm: &mut Vm,
+) -> SourceResult<()> {
+    let Spanned { v: path, span } = path;
+    let Spanned { v: text, span: _ } = text;
+    let id = vm.resolve_path(&path).at(span)?;
+    vm.world().write(id, text.as_bytes()).at(span)
+}
+
 /// Reads structured data from a CSV file.
 ///
 /// The CSV file will be read and parsed into a 2-dimensional array of strings:

--- a/crates/typst-library/src/compute/mod.rs
+++ b/crates/typst-library/src/compute/mod.rs
@@ -34,6 +34,7 @@ pub(super) fn define(global: &mut Scope) {
     global.define("array", array_func());
     global.define("range", range_func());
     global.define("read", read_func());
+    global.define("write", write_func());
     global.define("csv", csv_func());
     global.define("json", json_func());
     global.define("toml", toml_func());

--- a/crates/typst/src/lib.rs
+++ b/crates/typst/src/lib.rs
@@ -128,6 +128,8 @@ pub trait World {
     /// Try to access the specified file.
     fn file(&self, id: FileId) -> FileResult<Bytes>;
 
+    fn write(&self, id: FileId, data: &[u8]) -> FileResult<()>;
+
     /// Try to access the font with the given index in the font book.
     fn font(&self, index: usize) -> Option<Font>;
 


### PR DESCRIPTION
This commit enables writing text into a file. We have tried to keep the code as simple as possible.

Constraints:
- Writing outside of root should be forbidden.

## Motivation
This feature broadens Typst's scope of application as it enables any Typst code to export information that would otherwise be only available at document generation time. In particular, this enables Typst to be included in complex pipelines that only generate vectorial images as a subproblem, as it enables the following parts of the pipeline to use information about how the document has been generated.

Our specific use case consists in generating multiple-choice assessments and in grading them automatically. We use Typst to generate vectorial images from well-defined JSON documents, but the other components in our pipeline need to know where our Typst code has decided to place the various document components.
Without this feature we cannot use Typst at all for our use case.

## Simple usage example

```typ
Hello, world!

#write("./output-file.txt", "hello")
```

## Advanced usage example close to our use case
(`.txt` extensions have been added due to GitHub limitation)
- User code: [advanced.typ.txt](https://github.com/typst/typst/files/12539931/advanced.typ.txt)
- Output PDF:  [advanced.pdf](https://github.com/typst/typst/files/12539976/advanced.pdf)
- Output file: [location.json.txt](https://github.com/typst/typst/files/12539983/location.json.txt)
