### PR TITLE
Gracefully handle error if field was not defined

### DIFF
--- a/crates/typst-cli/src/query.rs
+++ b/crates/typst-cli/src/query.rs
@@ -83,7 +83,7 @@ fn retrieve(
 /// Format the query result in the output format.
 fn format(elements: Vec<Content>, command: &QueryCommand) -> StrResult<String> {
     if command.one && elements.len() != 1 {
-        bail!("expected exactly one element, found {}", elements.len())
+        bail!("expected exactly one element, found {}", elements.len());
     }
 
     let mapped: Vec<_> = elements
@@ -95,7 +95,11 @@ fn format(elements: Vec<Content>, command: &QueryCommand) -> StrResult<String> {
         .collect();
 
     if command.one {
-        serialize(&mapped[0], command.format)
+        let Some(value) = mapped.get(0)
+        else {
+            bail!("no such field found for element");
+        };
+        serialize(value, command.format)
     } else {
         serialize(&mapped, command.format)
     }

--- a/crates/typst-cli/src/query.rs
+++ b/crates/typst-cli/src/query.rs
@@ -95,8 +95,7 @@ fn format(elements: Vec<Content>, command: &QueryCommand) -> StrResult<String> {
         .collect();
 
     if command.one {
-        let Some(value) = mapped.get(0)
-        else {
+        let Some(value) = mapped.get(0) else {
             bail!("no such field found for element");
         };
         serialize(value, command.format)


### PR DESCRIPTION
Prior to this commit, when running the following command, the compiler would simply panic without providing a user-readable error message.
```sh
typst query foo.typ "<bar>" --field invalid --one
```
