### PR TITLE
Add `count` method for strings

### DIFF
--- a/crates/typst/src/eval/str.rs
+++ b/crates/typst/src/eval/str.rs
@@ -298,6 +298,15 @@ impl Str {
         }
     }
 
+    /// Count all non-overlapping matches of specified pattern.
+    #[func]
+    pub fn count(&self, pattern: StrPattern) -> usize {
+        match pattern {
+            StrPattern::Str(pat) => self.0.match_indices(pat.as_str()).count(),
+            StrPattern::Regex(re) => re.find_iter(&self.0).count(),
+        }
+    }
+
     /// Whether the string starts with the specified pattern.
     #[func]
     pub fn starts_with(

--- a/tests/typ/compiler/string.typ
+++ b/tests/typ/compiler/string.typ
@@ -73,6 +73,11 @@
 #test("abc".contains(regex("^[abc]+$")), true)
 
 ---
+// Test `count` method.
+#test("It is Typst".count("t"), 2)
+#test("It is Typst".count(regex("[Tt]")), 3) 
+
+---
 // Test the `starts-with` and `ends-with` methods.
 #test("Typst".starts-with("Ty"), true)
 #test("Typst".starts-with(regex("[Tt]ys")), false)


### PR DESCRIPTION
I think it can be quite useful method. Currently the best way to achieve that is `str.matches(pattern)` which is good, but creates much unused data (and is hard to find for some foolish people like me).

I think that the purpose is quite clear, but my use-case is kind of funny, so I think I could share it. I have a large project (in webapp, with several other people) with lots of polylux presentations and other docs. To get an overview of our progress I have a Typst file with tables of "completeness". To mark presentation as done, I check if there are no `todo`-s left in source files and enough of `question`-s to auditory. To do that, I parse source code as text (using states and so on will make it too heavy, since presetations are numerous, large and complex).

I'm sure there will be more "proper" uses of that method. :)