### PR TITLE
Set a small miter limit to avoid stroke artifacts

### DIFF
--- a/crates/typst/src/geom/stroke.rs
+++ b/crates/typst/src/geom/stroke.rs
@@ -460,7 +460,7 @@ impl Default for FixedStroke {
             line_cap: LineCap::Butt,
             line_join: LineJoin::Miter,
             dash_pattern: None,
-            miter_limit: Scalar(4.0),
+            miter_limit: Scalar(0.1),
         }
     }
 }


### PR DESCRIPTION
Per #1611 , this PR is still work in progress and would need confirmations that the solution actually works in different environment.