### PR TITLE
Fix typo in svg export

### DIFF
--- a/crates/typst/src/export/svg.rs
+++ b/crates/typst/src/export/svg.rs
@@ -327,7 +327,7 @@ impl SVGRenderer {
         if let Some(pattern) = &stroke.dash_pattern {
             self.xml.write_attribute("stoken-dashoffset", &pattern.phase.to_pt());
             self.xml.write_attribute(
-                "stoken-dasharray",
+                "stoke-dasharray",
                 &pattern
                     .array
                     .iter()

--- a/crates/typst/src/export/svg.rs
+++ b/crates/typst/src/export/svg.rs
@@ -316,18 +316,18 @@ impl SVGRenderer {
             },
         );
         self.xml.write_attribute(
-            "stoke-linejoin",
+            "stroke-linejoin",
             match stroke.line_join {
                 LineJoin::Miter => "miter",
                 LineJoin::Round => "round",
                 LineJoin::Bevel => "bevel",
             },
         );
-        self.xml.write_attribute("stoke-miterlimit", &stroke.miter_limit.0);
+        self.xml.write_attribute("stroke-miterlimit", &stroke.miter_limit.0);
         if let Some(pattern) = &stroke.dash_pattern {
-            self.xml.write_attribute("stoken-dashoffset", &pattern.phase.to_pt());
+            self.xml.write_attribute("stroke-dashoffset", &pattern.phase.to_pt());
             self.xml.write_attribute(
-                "stoke-dasharray",
+                "stroke-dasharray",
                 &pattern
                     .array
                     .iter()


### PR DESCRIPTION
stroken -> stroke, should fix #2120.

![test](https://github.com/typst/typst/assets/25521218/76d32d37-299c-4f6f-ad91-3ed241f21846)

it works now

Part of these typos has been fixed in https://github.com/typst/typst/pull/1729/commits/b45a45e50ed8aec72e71c0b505e64d475868cff0 but it seems that others are missed out.

~~Test cases will be added later this day~~ Seems that dash related tests already exist. https://github.com/typst/typst/blob/6275dfd062ca4c519b908ed56feb219879116265/tests/typ/visualize/stroke.typ#L33
But I guess image comparision based test fails to report this. 