### PR TITLE
Allow typst package to compile by itself

### DIFF
--- a/crates/typst/Cargo.toml
+++ b/crates/typst/Cargo.toml
@@ -54,7 +54,7 @@ unscanny = "0.1"
 usvg = { version = "0.35", default-features = false, features = ["text"] }
 xmlwriter = "0.1.0"
 xmp-writer = "0.1"
-time = { version = "0.3.20", features = ["std", "formatting", "macros"] }
+time = { version = "0.3.20", features = ["std", "formatting", "macros", "parsing"] }
 wasmi = "0.31.0"
 xmlparser = "0.13.5"
 


### PR DESCRIPTION
This PR adds a missing feature to `time` that is necessary to compile `crates/typst`.
