### PR TITLE
Add tooltips to a closure

### DIFF
--- a/crates/typst/src/eval/func.rs
+++ b/crates/typst/src/eval/func.rs
@@ -731,7 +731,7 @@ impl<'a> CapturesVisitor<'a> {
     fn capture(
         &mut self,
         ident: &str,
-        getter: impl for<'b> FnOnce(&'b Scopes<'a>, &str) -> StrResult<&'b Value>,
+        getter: impl FnOnce(&'a Scopes<'a>, &str) -> StrResult<&'a Value>,
     ) {
         if self.internal.get(ident).is_err() {
             let Some(value) = self

--- a/crates/typst/src/eval/mod.rs
+++ b/crates/typst/src/eval/mod.rs
@@ -51,7 +51,8 @@ pub use self::datetime::Datetime;
 pub use self::dict::{dict, Dict};
 pub use self::duration::Duration;
 pub use self::func::{
-    func, Func, IdeCapturesVisitor, NativeFunc, NativeFuncData, ParamInfo,
+    func, CapturesVisitor, Func, NativeFunc, NativeFuncData, ParamInfo,
+    SyntacticalScopeVisitor,
 };
 pub use self::library::{set_lang_items, LangItems, Library};
 pub use self::module::Module;
@@ -76,7 +77,7 @@ use if_chain::if_chain;
 use serde::{Deserialize, Serialize};
 use unicode_segmentation::UnicodeSegmentation;
 
-use self::func::{CapturesVisitor, Closure};
+use self::func::Closure;
 use crate::diag::{
     bail, error, warning, At, FileError, Hint, SourceDiagnostic, SourceResult, StrResult,
     Trace, Tracepoint,

--- a/crates/typst/src/eval/mod.rs
+++ b/crates/typst/src/eval/mod.rs
@@ -50,7 +50,9 @@ pub use self::cast::{
 pub use self::datetime::Datetime;
 pub use self::dict::{dict, Dict};
 pub use self::duration::Duration;
-pub use self::func::{func, Func, NativeFunc, NativeFuncData, ParamInfo};
+pub use self::func::{
+    func, Func, IdeCapturesVisitor, NativeFunc, NativeFuncData, ParamInfo,
+};
 pub use self::library::{set_lang_items, LangItems, Library};
 pub use self::module::Module;
 pub use self::none::NoneValue;

--- a/crates/typst/src/eval/mod.rs
+++ b/crates/typst/src/eval/mod.rs
@@ -52,7 +52,6 @@ pub use self::dict::{dict, Dict};
 pub use self::duration::Duration;
 pub use self::func::{
     func, CapturesVisitor, Func, NativeFunc, NativeFuncData, ParamInfo,
-    SyntacticalScopeVisitor,
 };
 pub use self::library::{set_lang_items, LangItems, Library};
 pub use self::module::Module;
@@ -1343,7 +1342,7 @@ impl Eval for ast::Closure<'_> {
 
         // Collect captured variables.
         let captured = {
-            let mut visitor = CapturesVisitor::new(&vm.scopes);
+            let mut visitor = CapturesVisitor::<false>::new(&vm.scopes);
             visitor.visit(self.to_untyped());
             visitor.finish()
         };

--- a/crates/typst/src/eval/mod.rs
+++ b/crates/typst/src/eval/mod.rs
@@ -1342,7 +1342,7 @@ impl Eval for ast::Closure<'_> {
 
         // Collect captured variables.
         let captured = {
-            let mut visitor = CapturesVisitor::<false>::new(&vm.scopes);
+            let mut visitor = CapturesVisitor::new(Some(&vm.scopes));
             visitor.visit(self.to_untyped());
             visitor.finish()
         };

--- a/crates/typst/src/ide/tooltip.rs
+++ b/crates/typst/src/ide/tooltip.rs
@@ -30,15 +30,6 @@ pub fn tooltip(
         return None;
     }
 
-    println!("qwq leaf {:#?}", leaf.kind());
-    {
-        let mut ancestor = Some(&leaf);
-        while let Some(node) = ancestor {
-            println!("qwq ancestor {:#?}", node.kind());
-            ancestor = node.parent();
-        }
-    }
-
     named_param_tooltip(world, &leaf)
         .or_else(|| font_tooltip(world, &leaf))
         .or_else(|| ref_tooltip(world, frames, &leaf))

--- a/crates/typst/src/ide/tooltip.rs
+++ b/crates/typst/src/ide/tooltip.rs
@@ -116,7 +116,8 @@ fn closure_tooltip(leaf: &LinkedNode) -> Option<Tooltip> {
     visitor.visit(closure);
 
     let captures = visitor.finish();
-    let mut names: Vec<_> = captures.iter().map(|(k, _)| k).collect();
+    let mut names: Vec<_> =
+        captures.iter().map(|(name, _)| eco_format!("`{name}`")).collect();
     if names.is_empty() {
         return None;
     }
@@ -124,7 +125,7 @@ fn closure_tooltip(leaf: &LinkedNode) -> Option<Tooltip> {
     names.sort();
 
     let tooltip = separated_list(&names, "and");
-    Some(Tooltip::Code(eco_format!("This closure captures {tooltip}.")))
+    Some(Tooltip::Text(eco_format!("This closure captures {tooltip}.")))
 }
 
 /// Tooltip text for a hovered length.

--- a/crates/typst/src/ide/tooltip.rs
+++ b/crates/typst/src/ide/tooltip.rs
@@ -7,9 +7,7 @@ use if_chain::if_chain;
 use super::analyze::analyze_labels;
 use super::{analyze_expr, plain_docs_sentence, summarize_font_family};
 use crate::doc::Frame;
-use crate::eval::{
-    CapturesVisitor, CastInfo, Scopes, SyntacticalScopeVisitor, Tracer, Value,
-};
+use crate::eval::{CapturesVisitor, CastInfo, Scopes, Tracer, Value};
 use crate::geom::{round_2, Length, Numeric};
 use crate::syntax::{
     ast::{self, AstNode},
@@ -34,7 +32,7 @@ pub fn tooltip(
         .or_else(|| font_tooltip(world, &leaf))
         .or_else(|| ref_tooltip(world, frames, &leaf))
         .or_else(|| expr_tooltip(world, &leaf))
-        .or_else(|| closure_tooltip(world, source, &leaf))
+        .or_else(|| closure_tooltip(world, &leaf))
 }
 
 /// A hover tooltip.
@@ -107,11 +105,7 @@ fn expr_tooltip(world: &(dyn World + 'static), leaf: &LinkedNode) -> Option<Tool
 }
 
 /// Tooltip for a hovered closure.
-fn closure_tooltip(
-    world: &(dyn World + 'static),
-    source: &Source,
-    leaf: &LinkedNode,
-) -> Option<Tooltip> {
+fn closure_tooltip(world: &(dyn World + 'static), leaf: &LinkedNode) -> Option<Tooltip> {
     // Find the closure to analyze.
     let mut ancestor = leaf;
     while !ancestor.is::<ast::Closure>() {
@@ -119,13 +113,9 @@ fn closure_tooltip(
     }
     let closure = ancestor.cast::<ast::Closure>()?.to_untyped();
 
-    // Prepare the syntactical scopes.
-    let mut external_scopes = Scopes::new(Some(world.library()));
-    let mut visitor = SyntacticalScopeVisitor::new(&mut external_scopes.top, closure);
-    visitor.visit(source.root());
-
     // analyze the closure captures.
-    let mut visitor = CapturesVisitor::new(&external_scopes);
+    let external_scopes = Scopes::new(Some(world.library()));
+    let mut visitor = CapturesVisitor::<true>::new(&external_scopes);
     visitor.visit(closure);
     let captures = visitor.finish();
     let mut names: Vec<_> = captures.iter().map(|(k, _)| k).collect();

--- a/crates/typst/src/ide/tooltip.rs
+++ b/crates/typst/src/ide/tooltip.rs
@@ -13,7 +13,7 @@ use crate::syntax::{
     ast::{self, AstNode},
     LinkedNode, Source, SyntaxKind,
 };
-use crate::util::pretty_comma_list;
+use crate::util::{pretty_comma_list, separated_list};
 use crate::World;
 
 /// Describe the item under the cursor.
@@ -125,8 +125,8 @@ fn closure_tooltip(leaf: &LinkedNode) -> Option<Tooltip> {
 
     names.sort();
 
-    let tooltip = pretty_comma_list(&names, false);
-    Some(Tooltip::Code(eco_format!("captures: {tooltip}")))
+    let tooltip = separated_list(&names, "and");
+    Some(Tooltip::Code(eco_format!("This closure captures {tooltip}.")))
 }
 
 /// Tooltip text for a hovered length.

--- a/crates/typst/src/ide/tooltip.rs
+++ b/crates/typst/src/ide/tooltip.rs
@@ -9,10 +9,8 @@ use super::{analyze_expr, plain_docs_sentence, summarize_font_family};
 use crate::doc::Frame;
 use crate::eval::{CapturesVisitor, CastInfo, Tracer, Value};
 use crate::geom::{round_2, Length, Numeric};
-use crate::syntax::{
-    ast::{self, AstNode},
-    LinkedNode, Source, SyntaxKind,
-};
+use crate::syntax::ast::{self, AstNode};
+use crate::syntax::{LinkedNode, Source, SyntaxKind};
 use crate::util::{pretty_comma_list, separated_list};
 use crate::World;
 
@@ -113,12 +111,12 @@ fn closure_tooltip(leaf: &LinkedNode) -> Option<Tooltip> {
     }
     let closure = ancestor.cast::<ast::Closure>()?.to_untyped();
 
-    // analyze the closure captures.
+    // Analyze the closure's captures.
     let mut visitor = CapturesVisitor::new(None);
     visitor.visit(closure);
+
     let captures = visitor.finish();
     let mut names: Vec<_> = captures.iter().map(|(k, _)| k).collect();
-
     if names.is_empty() {
         return None;
     }


### PR DESCRIPTION
This PR provides functionality to hover up some closure function in the IDE and then see which variables are captured.

For example, the following closure produces a tooltip `captures: hidden`
```typ
#let hidden = 10;
#let c(x, y) = {
  hidden + x + y
}
```

This PR is still in draft since we have a list of todo:
+ <del>Correctly get the `Scopes` context where the closure is located: The `CapturesVisitor` helps but still requires a `Scopes` that defines all external items visible to the closure. I don't know whether there is a convenient helper to get it.</del>
+ <del>Determine the message format of tooltip. It currently uses `eco_format!("captures: {names}")`.</del>
+ <del>(Optional) exclude the closure capturing itself from tooltip: for example the closure `c(x, y) = {}` captures `c` itself.</del>
