### PR TITLE
Use specified or inferred format extension for the output path

### DIFF
--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -22,9 +22,15 @@ type CodespanError = codespan_reporting::files::Error;
 impl CompileCommand {
     /// The output path.
     pub fn output(&self) -> PathBuf {
-        self.output
-            .clone()
-            .unwrap_or_else(|| self.common.input.with_extension("pdf"))
+        self.output.clone().unwrap_or_else(|| {
+            self.common.input.with_extension(
+                match self.output_format().unwrap_or(OutputFormat::Pdf) {
+                    OutputFormat::Pdf => "pdf",
+                    OutputFormat::Png => "png",
+                    OutputFormat::Svg => "svg",
+                },
+            )
+        })
     }
 
     /// The format to use for generated output, either specified by the user or inferred from the extension.


### PR DESCRIPTION
Per #2147, use specified or inferred format in the output_path. Previously is hardcoded to be pdf.

it should handle both the case where a filename with extension is given, such as `typst compile x.typ x.svg` or only specify the format `typst compile x.typ -f svg`