### PR TITLE
Add `insert` argument for dict.at

### DIFF
--- a/crates/typst/src/eval/dict.rs
+++ b/crates/typst/src/eval/dict.rs
@@ -140,17 +140,28 @@ impl Dict {
     /// specified.
     #[func]
     pub fn at(
-        &self,
+        &mut self,
         /// The key at which to retrieve the item.
         key: Str,
         /// A default value to return if the key is not part of the dictionary.
         #[named]
         default: Option<Value>,
+        /// If true, the default value is inserted into the dictionary if there isn't already a value.
+        #[named]
+        #[default(false)]
+        insert: bool,
     ) -> StrResult<Value> {
         self.0
             .get(&key)
             .cloned()
-            .or(default)
+            .or_else(|| {
+                if let Some(x) = &default {
+                    if insert {
+                        self.insert(key.clone(), x.clone());
+                    }
+                }
+                default
+            })
             .ok_or_else(|| missing_key_no_default(&key))
     }
 

--- a/crates/typst/src/eval/methods.rs
+++ b/crates/typst/src/eval/methods.rs
@@ -6,7 +6,7 @@ use crate::syntax::Span;
 
 /// Whether a specific method is mutating.
 pub fn is_mutating(method: &str) -> bool {
-    matches!(method, "push" | "pop" | "insert" | "remove")
+    matches!(method, "push" | "pop" | "insert" | "remove" | "at")
 }
 
 /// Whether a specific method is an accessor.
@@ -56,6 +56,7 @@ pub fn call_mut(
         },
 
         Value::Dict(dict) => match method {
+            "at" => output = dict.at(args.expect::<Str>("key")?, args.named::<Value>("default")?, args.named::<bool>("insert")?.unwrap_or(false)).at(span)?,
             "insert" => dict.insert(args.expect::<Str>("key")?, args.expect("value")?),
             "remove" => output = dict.remove(args.expect::<Str>("key")?).at(span)?,
             _ => return missing(),

--- a/tests/typ/compiler/dict.typ
+++ b/tests/typ/compiler/dict.typ
@@ -112,3 +112,17 @@
   // Error: 8-15 type dictionary has no method `nonfunc`
   dict.nonfunc()
 }
+
+---
+#{
+  let dict = (:)
+  test(dict.at("A", default: 1, insert: true), 1)
+  test(dict.at("A"), 1)
+}
+
+---
+#{
+  let dict = (:)
+  // Error: 3-29 dictionary does not contain key "b" and no default value was specified
+  dict.at("b", insert: true)
+}


### PR DESCRIPTION
Fixes #1182. Also marks `at` as a mutating function, which isn't *always* the case, but I'm not sure if there's a better way.