### PR TITLE
feat: inital Hungarian language support

### DIFF
--- a/crates/typst-library/src/layout/table.rs
+++ b/crates/typst-library/src/layout/table.rs
@@ -314,6 +314,7 @@ impl LocalName for TableElem {
             Lang::FINNISH => "Taulukko",
             Lang::FRENCH => "Tableau",
             Lang::GERMAN => "Tabelle",
+            Lang::HUNGARIAN => "Táblázat",
             Lang::ITALIAN => "Tabella",
             Lang::NYNORSK => "Tabell",
             Lang::POLISH => "Tabela",

--- a/crates/typst-library/src/math/mod.rs
+++ b/crates/typst-library/src/math/mod.rs
@@ -326,6 +326,7 @@ impl LocalName for EquationElem {
             Lang::FINNISH => "Yhtälö",
             Lang::FRENCH => "Équation",
             Lang::GERMAN => "Gleichung",
+            Lang::HUNGARIAN => "Egyenlet",
             Lang::ITALIAN => "Equazione",
             Lang::NYNORSK => "Likning",
             Lang::POLISH => "Równanie",

--- a/crates/typst-library/src/meta/bibliography.rs
+++ b/crates/typst-library/src/meta/bibliography.rs
@@ -234,6 +234,7 @@ impl LocalName for BibliographyElem {
             Lang::FINNISH => "Viitteet",
             Lang::FRENCH => "Bibliographie",
             Lang::GERMAN => "Bibliographie",
+            Lang::HUNGARIAN => "Irodalomjegyzék",
             Lang::ITALIAN => "Bibliografia",
             Lang::NYNORSK => "Bibliografi",
             Lang::POLISH => "Bibliografia",

--- a/crates/typst-library/src/meta/heading.rs
+++ b/crates/typst-library/src/meta/heading.rs
@@ -245,6 +245,7 @@ impl LocalName for HeadingElem {
             Lang::FINNISH => "Osio",
             Lang::FRENCH => "Chapitre",
             Lang::GERMAN => "Abschnitt",
+            Lang::HUNGARIAN => "Fejezet",
             Lang::ITALIAN => "Sezione",
             Lang::NYNORSK => "Kapittel",
             Lang::POLISH => "Sekcja",

--- a/crates/typst-library/src/meta/outline.rs
+++ b/crates/typst-library/src/meta/outline.rs
@@ -269,6 +269,7 @@ impl LocalName for OutlineElem {
             Lang::FINNISH => "Sisällys",
             Lang::FRENCH => "Table des matières",
             Lang::GERMAN => "Inhaltsverzeichnis",
+            Lang::HUNGARIAN => "Tartalomjegyzék",
             Lang::ITALIAN => "Indice",
             Lang::NYNORSK => "Innhald",
             Lang::POLISH => "Spis treści",

--- a/crates/typst-library/src/visualize/image.rs
+++ b/crates/typst-library/src/visualize/image.rs
@@ -237,6 +237,7 @@ impl LocalName for ImageElem {
             Lang::FINNISH => "Kuva",
             Lang::FRENCH => "Figure",
             Lang::GERMAN => "Abbildung",
+            Lang::HUNGARIAN => "Ábra",
             Lang::ITALIAN => "Figura",
             Lang::NYNORSK => "Figur",
             Lang::POLISH => "Rysunek",

--- a/crates/typst/src/doc.rs
+++ b/crates/typst/src/doc.rs
@@ -584,6 +584,7 @@ impl Lang {
     pub const TURKISH: Self = Self(*b"tr ", 2);
     pub const UKRAINIAN: Self = Self(*b"ua ", 2);
     pub const VIETNAMESE: Self = Self(*b"vi ", 2);
+    pub const HUNGARIAN: Self = Self(*b"hu ", 2);
 
     /// Return the language code as an all lowercase string slice.
     pub fn as_str(&self) -> &str {


### PR DESCRIPTION
Added Hungarian names to typst functions from the babel-hungarian LaTeX package. 

> Note: The Hungarian language changes up the order of the words 
> i.e.: Table 1 to 1. táblázat, I did not reproduce this behaviour.