### PR TITLE
Add ability to set document keywords.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # General
 .vscode
 .idea
-.*.swp
 _things
 desktop.ini
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # General
 .vscode
 .idea
+.*.swp
 _things
 desktop.ini
 .DS_Store

--- a/crates/typst-library/src/meta/document.rs
+++ b/crates/typst-library/src/meta/document.rs
@@ -27,6 +27,9 @@ pub struct DocumentElem {
     /// The document's authors.
     pub author: Author,
 
+    /// The document's keywords.
+    pub keywords: Keywords,
+
     /// The page runs.
     #[internal]
     #[variadic]
@@ -77,6 +80,7 @@ impl LayoutRoot for DocumentElem {
             pages,
             title: self.title(styles),
             author: self.author(styles).0,
+            keywords: self.keywords(styles).0,
         })
     }
 }
@@ -87,6 +91,17 @@ pub struct Author(Vec<EcoString>);
 
 cast! {
     Author,
+    self => self.0.into_value(),
+    v: EcoString => Self(vec![v]),
+    v: Array => Self(v.into_iter().map(Value::cast).collect::<StrResult<_>>()?),
+}
+
+/// A list of keywords.
+#[derive(Debug, Default, Clone, Hash)]
+pub struct Keywords(Vec<EcoString>);
+
+cast! {
+    Keywords,
     self => self.0.into_value(),
     v: EcoString => Self(vec![v]),
     v: Array => Self(v.into_iter().map(Value::cast).collect::<StrResult<_>>()?),

--- a/crates/typst/src/doc.rs
+++ b/crates/typst/src/doc.rs
@@ -28,6 +28,8 @@ pub struct Document {
     pub title: Option<EcoString>,
     /// The document's author.
     pub author: Vec<EcoString>,
+    /// The document's keywords.
+    pub keywords: Vec<EcoString>,
 }
 
 /// A finished layout with items at fixed positions.

--- a/crates/typst/src/export/pdf/mod.rs
+++ b/crates/typst/src/export/pdf/mod.rs
@@ -132,6 +132,14 @@ fn write_catalog(ctx: &mut PdfContext) {
         info.author(TextStr(&authors.join(", ")));
         xmp.creator(authors.iter().map(|s| s.as_str()));
     }
+
+    let keywords = &ctx.document.keywords;
+    if !keywords.is_empty() {
+        info.keywords(TextStr(&keywords.join(", ")));
+        let kw = keywords.join(", ");
+        xmp.pdf_keywords(&kw);
+    }
+
     info.creator(TextStr("Typst"));
     info.finish();
     xmp.creator_tool("Typst");

--- a/crates/typst/src/export/pdf/mod.rs
+++ b/crates/typst/src/export/pdf/mod.rs
@@ -135,9 +135,9 @@ fn write_catalog(ctx: &mut PdfContext) {
 
     let keywords = &ctx.document.keywords;
     if !keywords.is_empty() {
-        info.keywords(TextStr(&keywords.join(", ")));
-        let kw = keywords.join(", ");
-        xmp.pdf_keywords(&kw);
+        let joined = keywords.join(", ");
+        info.keywords(TextStr(&joined));
+        xmp.pdf_keywords(&joined);
     }
 
     info.creator(TextStr("Typst"));


### PR DESCRIPTION
_Heavily_ modeled after `author`, but uses plural `keywords` because my gut feeling is that it's more common to have multiple keywords (for those who bother to use the field).

(Also ignore `.*.swp` files in `.gitignore`)