### PR TITLE
Add information on page setup guide

### DIFF
--- a/docs/guides/welcome.md
+++ b/docs/guides/welcome.md
@@ -4,8 +4,9 @@ description: Guides for Typst.
 
 # Guides
 Welcome to the Guides section! Here, you'll find helpful material for specific
-user groups or use cases. Currently, one guide is available: An introduction
-to Typst for LaTeX users. Feel free to propose other topics for guides!
+user groups or use cases. Currently, two guides are available: An introduction
+to Typst for LaTeX users, and a detailed look at page setup. Feel free to
+propose other topics for guides!
 
 ## List of Guides
 - [Guide for LaTeX users]($guides/guide-for-latex-users)


### PR DESCRIPTION
Current paragraph of `welcome.md` in `docs/guides` only mentions one guide as being available when there are, in fact, two. This PR adds mention to the second guide.