### PR TITLE
Fix Clippy lints

### DIFF
--- a/crates/typst/src/geom/scalar.rs
+++ b/crates/typst/src/geom/scalar.rs
@@ -84,29 +84,13 @@ impl PartialEq<f64> for Scalar {
 
 impl Ord for Scalar {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other).expect("float is NaN")
+        self.0.partial_cmp(&other.0).expect("float is NaN")
     }
 }
 
 impl PartialOrd for Scalar {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.0.partial_cmp(&other.0)
-    }
-
-    fn lt(&self, other: &Self) -> bool {
-        self.0 < other.0
-    }
-
-    fn le(&self, other: &Self) -> bool {
-        self.0 <= other.0
-    }
-
-    fn gt(&self, other: &Self) -> bool {
-        self.0 > other.0
-    }
-
-    fn ge(&self, other: &Self) -> bool {
-        self.0 >= other.0
+        Some(self.cmp(other))
     }
 }
 

--- a/crates/typst/src/geom/smart.rs
+++ b/crates/typst/src/geom/smart.rs
@@ -105,6 +105,8 @@ impl<T> Smart<T> {
     where
         T: Default,
     {
+        // we want to do this; the Clippy lint is not type-aware
+        #[allow(clippy::unwrap_or_default)]
         self.unwrap_or_else(T::default)
     }
 }

--- a/crates/typst/src/geom/stroke.rs
+++ b/crates/typst/src/geom/stroke.rs
@@ -141,6 +141,8 @@ impl Stroke<Abs> {
 
     /// Unpack the stroke, filling missing fields with the default values.
     pub fn unwrap_or_default(self) -> FixedStroke {
+        // we want to do this; the Clippy lint is not type-aware
+        #[allow(clippy::unwrap_or_default)]
         self.unwrap_or(FixedStroke::default())
     }
 }


### PR DESCRIPTION
* Fix `clippy::non_canonical_partial_ord_impl` lint for `Scalar`. Since `Scalar` will never store a NaN, this should not change the semantics of `PartialOrd` on `Scalar`.
* Silence two instances of `clippy::unwrap_or_default` where we use `unwrap_or` or `unwrap_or_else` to implement the `unwrap_or_default` method on a type.