### PR TITLE
Add `reverse` parameter to `cases`

### DIFF
--- a/crates/typst-library/src/math/matrix.rs
+++ b/crates/typst-library/src/math/matrix.rs
@@ -270,6 +270,15 @@ pub struct CasesElem {
     #[default(Delimiter::Brace)]
     pub delim: Delimiter,
 
+    /// Whether the direction fo cases should be reversed.
+    ///
+    /// ```example
+    /// #set math.cases(reverse: true)
+    /// $ x = cases(1, 2) $
+    /// ```
+    #[default(false)]
+    pub reverse: bool,
+
     /// The gap between branches.
     ///
     /// ```example
@@ -295,7 +304,14 @@ impl LayoutMath for CasesElem {
             FixedAlign::Start,
             self.gap(ctx.styles()),
         )?;
-        layout_delimiters(ctx, frame, Some(delim.open()), None, self.span())
+
+        let (open, close) = if self.reverse(ctx.styles()) {
+            (None, Some(delim.close()))
+        } else {
+            (Some(delim.open()), None)
+        };
+
+        layout_delimiters(ctx, frame, open, close, self.span())
     }
 }
 

--- a/crates/typst-library/src/math/matrix.rs
+++ b/crates/typst-library/src/math/matrix.rs
@@ -274,7 +274,7 @@ pub struct CasesElem {
     ///
     /// ```example
     /// #set math.cases(reverse: true)
-    /// $ x = cases(1, 2) $
+    /// $ cases(1, 2) = x $
     /// ```
     #[default(false)]
     pub reverse: bool,

--- a/crates/typst-library/src/math/matrix.rs
+++ b/crates/typst-library/src/math/matrix.rs
@@ -270,7 +270,7 @@ pub struct CasesElem {
     #[default(Delimiter::Brace)]
     pub delim: Delimiter,
 
-    /// Whether the direction fo cases should be reversed.
+    /// Whether the direction of cases should be reversed.
     ///
     /// ```example
     /// #set math.cases(reverse: true)


### PR DESCRIPTION
Adds `reverse: false` to `cases` which allows the reverse version to be displayed, resolves #2369.

This allows the following code:
```typst
$ cases(1, 2) $

#set math.cases(reverse: true)
$ cases(1, 2) $
```
to result in:
![image](https://github.com/typst/typst/assets/137803093/2496c120-b2f8-40b3-a30f-ced4fdc3a3ce)
