### PR TITLE
Add date to document

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3471,9 +3471,9 @@ checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "xmp-writer"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd742bbbb930fc972b28bf66b7546dfbc7bb9a4c7924299df0ae6a5641fcadf"
+checksum = "4543ba138f64a94b19e1e9c66c165bca7e03d470e1c066cb76ea279d9d0e1989"
 
 [[package]]
 name = "xz2"

--- a/crates/typst-library/src/meta/document.rs
+++ b/crates/typst-library/src/meta/document.rs
@@ -94,8 +94,6 @@ impl LayoutRoot for DocumentElem {
             }
         }
 
-        println!("{:?}", self.creator_tool(styles));
-
         Ok(Document {
             pages,
             title: self.title(styles),

--- a/crates/typst-library/src/meta/document.rs
+++ b/crates/typst-library/src/meta/document.rs
@@ -32,7 +32,8 @@ pub struct DocumentElem {
     /// The document's keywords.
     pub keywords: Keywords,
 
-    /// The document's creation date. Requires a positive year, month and day. If any of these aren't given, no date is written.
+    /// The document's creation date. Requires a positive year.
+    /// If no year or a negative year is given, no date is written.
     pub date: Option<Datetime>,
 
     /// The page runs.
@@ -108,17 +109,6 @@ pub struct Keywords(Vec<EcoString>);
 
 cast! {
     Keywords,
-    self => self.0.into_value(),
-    v: EcoString => Self(vec![v]),
-    v: Array => Self(v.into_iter().map(Value::cast).collect::<StrResult<_>>()?),
-}
-
-/// A list of identifiers.
-#[derive(Debug, Default, Clone, Hash)]
-pub struct Identifier(Vec<EcoString>);
-
-cast! {
-    Identifier,
     self => self.0.into_value(),
     v: EcoString => Self(vec![v]),
     v: Array => Self(v.into_iter().map(Value::cast).collect::<StrResult<_>>()?),

--- a/crates/typst-library/src/meta/document.rs
+++ b/crates/typst-library/src/meta/document.rs
@@ -33,20 +33,7 @@ pub struct DocumentElem {
     pub keywords: Keywords,
 
     /// The document's creation date. Requires a positive year, month and day. If any of these aren't given, no date is written.
-    pub creation_date: Option<Datetime>,
-
-    /// The document's identifier (a unique set of text strings for this document).
-    pub identifier: Identifier,
-
-    /// The document's rating (-1 for rejected, 0 for unrated, 1-5 otherwise).
-    /// Rarely used in practice, but usable!
-    pub rating: Option<i32>,
-
-    /// The document's nickname.
-    pub nickname: Option<EcoString>,
-
-    /// The tool used to create the document. By default, this is your Typst version.
-    pub creator_tool: Option<EcoString>,
+    pub date: Option<Datetime>,
 
     /// The page runs.
     #[internal]
@@ -99,11 +86,7 @@ impl LayoutRoot for DocumentElem {
             title: self.title(styles),
             author: self.author(styles).0,
             keywords: self.keywords(styles).0,
-            creation_date: self.creation_date(styles),
-            creator_tool: self.creator_tool(styles),
-            identifier: self.identifier(styles).0,
-            rating: self.rating(styles),
-            nickname: self.nickname(styles),
+            date: self.date(styles),
         })
     }
 }

--- a/crates/typst-library/src/meta/document.rs
+++ b/crates/typst-library/src/meta/document.rs
@@ -32,8 +32,10 @@ pub struct DocumentElem {
     /// The document's keywords.
     pub keywords: Keywords,
 
-    /// The document's creation date. Requires a positive year.
-    /// If no year or a negative year is given, no date is written.
+    /// The document's creation date.
+    ///
+    /// The year component must be at least zero in order to be embedded into
+    /// a PDF.
     pub date: Option<Datetime>,
 
     /// The page runs.

--- a/crates/typst/Cargo.toml
+++ b/crates/typst/Cargo.toml
@@ -53,7 +53,7 @@ unicode-segmentation = "1"
 unscanny = "0.1"
 usvg = { version = "0.35", default-features = false, features = ["text"] }
 xmlwriter = "0.1.0"
-xmp-writer = "0.1"
+xmp-writer = "0.2"
 time = { version = "0.3.20", features = ["std", "formatting", "macros", "parsing"] }
 wasmi = "0.31.0"
 xmlparser = "0.13.5"

--- a/crates/typst/src/doc.rs
+++ b/crates/typst/src/doc.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use ecow::{eco_format, EcoString};
 
-use crate::eval::{cast, dict, ty, Dict, Repr, Value};
+use crate::eval::{cast, dict, ty, Datetime, Dict, Repr, Value};
 use crate::export::PdfPageLabel;
 use crate::font::Font;
 use crate::geom::{
@@ -28,8 +28,18 @@ pub struct Document {
     pub title: Option<EcoString>,
     /// The document's author.
     pub author: Vec<EcoString>,
+    /// The document's identifier (a unique set of text strings for this document).
+    pub identifier: Vec<EcoString>,
+    /// The document's rating (-1 for rejected, 0 for unrated, 1-5 otherwise).
+    pub rating: Option<i32>,
+    /// The document's nickname.
+    pub nickname: Option<EcoString>,
+    /// The tool used to create the document. By default, this is your typst version.
+    pub creator_tool: Option<EcoString>,
     /// The document's keywords.
     pub keywords: Vec<EcoString>,
+    /// The document's creation date. Requires a positive year, month and day. If any of these aren't given, no date is written.
+    pub creation_date: Option<Datetime>
 }
 
 /// A finished layout with items at fixed positions.

--- a/crates/typst/src/doc.rs
+++ b/crates/typst/src/doc.rs
@@ -39,7 +39,7 @@ pub struct Document {
     /// The document's keywords.
     pub keywords: Vec<EcoString>,
     /// The document's creation date. Requires a positive year, month and day. If any of these aren't given, no date is written.
-    pub creation_date: Option<Datetime>
+    pub creation_date: Option<Datetime>,
 }
 
 /// A finished layout with items at fixed positions.

--- a/crates/typst/src/doc.rs
+++ b/crates/typst/src/doc.rs
@@ -28,18 +28,10 @@ pub struct Document {
     pub title: Option<EcoString>,
     /// The document's author.
     pub author: Vec<EcoString>,
-    /// The document's identifier (a unique set of text strings for this document).
-    pub identifier: Vec<EcoString>,
-    /// The document's rating (-1 for rejected, 0 for unrated, 1-5 otherwise).
-    pub rating: Option<i32>,
-    /// The document's nickname.
-    pub nickname: Option<EcoString>,
-    /// The tool used to create the document. By default, this is your typst version.
-    pub creator_tool: Option<EcoString>,
     /// The document's keywords.
     pub keywords: Vec<EcoString>,
     /// The document's creation date. Requires a positive year, month and day. If any of these aren't given, no date is written.
-    pub creation_date: Option<Datetime>,
+    pub date: Option<Datetime>,
 }
 
 /// A finished layout with items at fixed positions.

--- a/crates/typst/src/doc.rs
+++ b/crates/typst/src/doc.rs
@@ -30,7 +30,7 @@ pub struct Document {
     pub author: Vec<EcoString>,
     /// The document's keywords.
     pub keywords: Vec<EcoString>,
-    /// The document's creation date. Requires a positive year, month and day. If any of these aren't given, no date is written.
+    /// The document's creation date.
     pub date: Option<Datetime>,
 }
 

--- a/crates/typst/src/export/pdf/mod.rs
+++ b/crates/typst/src/export/pdf/mod.rs
@@ -172,20 +172,17 @@ fn write_catalog(ctx: &mut PdfContext) {
     }
 
     if let Some(date) = ctx.document.date {
-        if let Some(year) =
-            date.year().and_then(|y| if y < 0 { None } else { Some(y as u16) })
-        {
-            let mut pdf_writer_date = pdf_writer::Date::new(year);
+        if let Some(year) = date.year().filter(|&y| y >= 0) {
+            let mut pdf_date = pdf_writer::Date::new(year as u16);
             if let Some(month) = date.month() {
-                pdf_writer_date = pdf_writer_date.month(month);
+                pdf_date = pdf_date.month(month);
             }
             if let Some(day) = date.day() {
-                pdf_writer_date = pdf_writer_date.day(day);
+                pdf_date = pdf_date.day(day);
             }
+            info.creation_date(pdf_date);
 
-            info.creation_date(pdf_writer_date);
-
-            let mut xmp_date = xmp_writer::DateTime::year(year);
+            let mut xmp_date = xmp_writer::DateTime::year(year as u16);
             xmp_date.month = date.month();
             xmp_date.day = date.day();
             xmp.create_date(xmp_date);

--- a/crates/typst/src/export/pdf/mod.rs
+++ b/crates/typst/src/export/pdf/mod.rs
@@ -238,7 +238,7 @@ fn write_page_labels(ctx: &mut PdfContext) -> Vec<(NonZeroUsize, Ref)> {
 
     for (i, page) in ctx.pages.iter().enumerate() {
         let nr = NonZeroUsize::new(1 + i).unwrap();
-        let Some(label) = &page.label else { continue; };
+        let Some(label) = &page.label else { continue };
 
         // Don't create a label if neither style nor prefix are specified.
         if label.prefix.is_none() && label.style.is_none() {

--- a/crates/typst/src/export/pdf/mod.rs
+++ b/crates/typst/src/export/pdf/mod.rs
@@ -161,24 +161,9 @@ fn write_catalog(ctx: &mut PdfContext) {
         xmp.creator(authors.iter().map(|s| s.as_str()));
     }
 
-    let identifiers = &ctx.document.identifier;
-    if !identifiers.is_empty() {
-        xmp.identifier(&identifiers.join(", "));
-        xmp.xmp_identifier(identifiers.iter().map(|s| s.as_str()));
-    }
-
-    if let Some(rating) = ctx.document.rating {
-        xmp.rating(rating as i64);
-    }
-
-    if let Some(nickname) = &ctx.document.nickname {
-        xmp.nickname(nickname.as_str());
-    }
-
-    let typst_creator = eco_format!("Typst {}", env!("CARGO_PKG_VERSION"));
-    let creator = ctx.document.creator_tool.as_ref().unwrap_or(&typst_creator);
-    info.creator(TextStr(creator));
-    xmp.creator_tool(creator);
+    let creator = eco_format!("Typst {}", env!("CARGO_PKG_VERSION"));
+    info.creator(TextStr(creator.as_str()));
+    xmp.creator_tool(creator.as_str());
 
     let keywords = &ctx.document.keywords;
     if !keywords.is_empty() {
@@ -187,7 +172,7 @@ fn write_catalog(ctx: &mut PdfContext) {
         xmp.pdf_keywords(&joined);
     }
 
-    if let Some(date) = ctx.document.creation_date {
+    if let Some(date) = ctx.document.date {
         fn extract_date(date: Datetime) -> Option<(u16, u8, u8)> {
             Some((
                 date.year().and_then(|y| if y < 0 { None } else { Some(y as u16) })?,

--- a/tests/typ/meta/document.typ
+++ b/tests/typ/meta/document.typ
@@ -8,7 +8,11 @@ What's up?
 ---
 // This, too.
 // Ref: false
-#set document(author: ("A", "B"))
+#set document(author: ("A", "B"), date: datetime.today())
+
+---
+// Error: 21-28 expected datetime or none, found string
+#set document(date: "today")
 
 ---
 // This, too.


### PR DESCRIPTION
Fixes #2266.

Possible points of contention:
- Some of these are basically invisible (rating, nickname), and nobody really uses them.
- Some useful metadata properties are absent

Full list of metadata, for convenience:
```
    /// The document's title. This is often rendered as the title of the
    /// PDF viewer window.
    pub title: Option<EcoString>,

    /// The document's authors.
    pub author: Author,

    /// The document's keywords.
    pub keywords: Keywords,

    /// The document's creation date. Requires a positive year, month and day. If any of these aren't given, no date is written.
    pub creation_date: Option<Datetime>,

    /// The document's identifier (a unique set of text strings for this document).
    pub identifier: Identifier,

    /// The document's rating (-1 for rejected, 0 for unrated, 1-5 otherwise).
    /// Rarely used in practice, but usable!
    pub rating: Option<i32>,

    /// The document's nickname.
    pub nickname: Option<EcoString>,

    /// The tool used to create the document. By default, this is your Typst version.
    pub creator_tool: Option<EcoString>,```