### PR TITLE
Fix crash when instantiating a sub-item that is not meant to be instantiated

### DIFF
--- a/crates/typst-library/src/meta/figure.rs
+++ b/crates/typst-library/src/meta/figure.rs
@@ -406,7 +406,7 @@ impl Outlinable for FigureElem {
 ///   caption: [A rectangle],
 /// )
 /// ```
-#[elem(name = "caption", Synthesize, Show)]
+#[elem(name = "caption", Synthesize, Show, Construct)]
 pub struct FigureCaption {
     /// The caption's position in the figure. Either `{top}` or `{bottom}`.
     ///
@@ -496,6 +496,13 @@ pub struct FigureCaption {
     /// The figure's location.
     #[synthesized]
     pub location: Option<Location>,
+}
+
+impl Construct for FigureCaption {
+    fn construct(_vm: &mut Vm, args: &mut Args) -> SourceResult<Content> {
+        bail!(error!(args.span, "cannot construct a `figure.caption` element")
+            .with_hint("use the `figure` element instead"))
+    }
 }
 
 impl Synthesize for FigureCaption {

--- a/crates/typst-library/src/meta/footnote.rs
+++ b/crates/typst-library/src/meta/footnote.rs
@@ -177,7 +177,7 @@ impl Count for FootnoteElem {
 /// #footnote[It's down here]
 /// has red text!
 /// ```
-#[elem(name = "entry", title = "Footnote Entry", Show, Finalize)]
+#[elem(name = "entry", title = "Footnote Entry", Show, Finalize, Construct)]
 pub struct FootnoteEntry {
     /// The footnote for this entry. It's location can be used to determine
     /// the footnote counter state.
@@ -260,6 +260,13 @@ pub struct FootnoteEntry {
     /// ```
     #[default(Em::new(1.0).into())]
     pub indent: Length,
+}
+
+impl Construct for FootnoteEntry {
+    fn construct(_vm: &mut Vm, args: &mut Args) -> SourceResult<Content> {
+        bail!(error!(args.span, "cannot construct a `footnote.entry` element")
+            .with_hint("use the `footnote` element instead"))
+    }
 }
 
 impl Show for FootnoteEntry {

--- a/crates/typst-library/src/meta/outline.rs
+++ b/crates/typst-library/src/meta/outline.rs
@@ -413,7 +413,7 @@ cast! {
 /// = Analysis
 /// == Setup
 /// ```
-#[elem(name = "entry", title = "Outline Entry", Show)]
+#[elem(name = "entry", title = "Outline Entry", Show, Construct)]
 pub struct OutlineEntry {
     /// The nesting level of this outline entry. Starts at `{1}` for top-level
     /// entries.
@@ -447,6 +447,13 @@ pub struct OutlineEntry {
     /// numbering set for the referenced page.
     #[required]
     pub page: Content,
+}
+
+impl Construct for OutlineEntry {
+    fn construct(_vm: &mut Vm, args: &mut Args) -> SourceResult<Content> {
+        bail!(error!(args.span, "cannot construct an `outline.entry` element")
+            .with_hint("use the `outline` element instead"))
+    }
 }
 
 impl OutlineEntry {

--- a/crates/typst-library/src/text/raw.rs
+++ b/crates/typst-library/src/text/raw.rs
@@ -454,7 +454,7 @@ impl PlainText for RawElem {
 /// It allows you to access various properties of the line, such as the line
 /// number, the raw non-highlighted text, the highlighted text, and whether it
 /// is the first or last line of the raw block.
-#[elem(name = "line", title = "Raw Text / Code Line", Show, PlainText)]
+#[elem(name = "line", title = "Raw Text / Code Line", Show, PlainText, Construct)]
 pub struct RawLine {
     /// The line number of the raw line inside of the raw block, starts at 1.
     #[required]
@@ -471,6 +471,13 @@ pub struct RawLine {
     /// The highlighted raw text.
     #[required]
     pub body: Content,
+}
+
+impl Construct for RawLine {
+    fn construct(_vm: &mut Vm, args: &mut Args) -> SourceResult<Content> {
+        bail!(error!(args.span, "cannot construct a `raw.line` element")
+            .with_hint("use the `raw` element instead"))
+    }
 }
 
 impl Show for RawLine {

--- a/tests/typ/bugs/scoped-elem-crash.typ
+++ b/tests/typ/bugs/scoped-elem-crash.typ
@@ -1,0 +1,27 @@
+// Checks that scoped element such as `raw.line` cannot be constructed
+// and therefore do not cause a compiler crash.
+// Ref: false
+
+---
+
+// Hint: 10-12 use the `raw` element instead
+// Error: 10-12 cannot construct a `raw.line` element
+#raw.line()
+
+---
+
+// Hint: 16-18 use the `figure` element instead
+// Error: 16-18 cannot construct a `figure.caption` element
+#figure.caption()
+
+---
+
+// Hint: 16-18 use the `footnote` element instead
+// Error: 16-18 cannot construct a `footnote.entry` element
+#footnote.entry()
+
+---
+
+// Hint: 15-17 use the `outline` element instead
+// Error: 15-17 cannot construct an `outline.entry` element
+#outline.entry()


### PR DESCRIPTION
`raw.line`, `figure.caption`, `footnote.entry`, and `outline.entry` are not means to be instantitable by the user, this PR adds a nicer error with hint when the user tries to create these items, instead of crashing. Also adds a test for the error messages.

Closes #2328.