### PR TITLE
Add at-or-insert to dict

### DIFF
--- a/crates/typst/src/eval/dict.rs
+++ b/crates/typst/src/eval/dict.rs
@@ -167,6 +167,20 @@ impl Dict {
         Arc::make_mut(&mut self.0).insert(key, value);
     }
 
+    /// Inserts a new pair into the dictionary and return the value. If the
+    /// dictionary already contains this key, the value is not updated.
+    /// Otherwise, the given value is inserted and returned.
+    #[func]
+    pub fn at_or_insert(
+        &mut self,
+        /// The key at which to retrieve the item.
+        key: Str,
+        /// The value to insert if the key is not part of the dictionary.
+        value: Value,
+    ) -> Value {
+        Arc::make_mut(&mut self.0).entry(key).or_insert(value).clone()
+    }
+
     /// Removes a pair from the dictionary by key and return the value.
     #[func]
     pub fn remove(

--- a/crates/typst/src/eval/dict.rs
+++ b/crates/typst/src/eval/dict.rs
@@ -167,9 +167,8 @@ impl Dict {
         Arc::make_mut(&mut self.0).insert(key, value);
     }
 
-    /// Inserts a new pair into the dictionary and return the value. If the
-    /// dictionary already contains this key, the value is not updated.
-    /// Otherwise, the given value is inserted and returned.
+    /// Gets a value from the dictionary.
+    /// If the key does not exist, inserts the given value and returns it.
     #[func]
     pub fn at_or_insert(
         &mut self,

--- a/crates/typst/src/eval/methods.rs
+++ b/crates/typst/src/eval/methods.rs
@@ -6,7 +6,7 @@ use crate::syntax::Span;
 
 /// Whether a specific method is mutating.
 pub fn is_mutating(method: &str) -> bool {
-    matches!(method, "push" | "pop" | "insert" | "remove")
+    matches!(method, "push" | "pop" | "insert" | "remove" | "at-or-insert")
 }
 
 /// Whether a specific method is an accessor.
@@ -27,7 +27,7 @@ pub fn mutable_methods_on(ty: Type) -> &'static [(&'static str, bool)] {
             ("remove", true),
         ]
     } else if ty == Type::of::<Dict>() {
-        &[("at", true), ("insert", true), ("remove", true)]
+        &[("at", true), ("insert", true), ("remove", true), ("at-or-insert", true)]
     } else {
         &[]
     }
@@ -60,6 +60,10 @@ pub fn call_mut(
         },
 
         Value::Dict(dict) => match method {
+            "at-or-insert" => {
+                output =
+                    dict.at_or_insert(args.expect::<Str>("key")?, args.expect("value")?)
+            }
             "insert" => dict.insert(args.expect::<Str>("key")?, args.expect("value")?),
             "remove" => {
                 output =

--- a/tests/typ/compiler/dict.typ
+++ b/tests/typ/compiler/dict.typ
@@ -124,3 +124,9 @@
   // Error: 8-15 type dictionary has no method `nonfunc`
   dict.nonfunc()
 }
+---
+#{
+  let dict = (:)
+  test(dict.at-or-insert("A", 1), 1)
+  test(dict.at("A"), 1)
+}


### PR DESCRIPTION
Fixes #1182. Made off of the discussion in #2187. Adds "at-or-insert" to dict, which either gets the value in a dict if it exists, or inserts a given value (and returns it).