### PR TITLE
Clarified docs for `calc.perm,rem,quo`

### DIFF
--- a/crates/typst-library/src/compute/calc.rs
+++ b/crates/typst-library/src/compute/calc.rs
@@ -443,13 +443,14 @@ pub fn fact(
     Ok(fact_impl(1, number).ok_or("the result is too large")?)
 }
 
-/// Calculates the `k`-permutation of `n`.
+/// Calculates a permutation
+/// 
+/// Returns the `k`-permutation of `n`, or the number of ways to choose `k`
+/// items from a set of `n` with regard to order.
 ///
 /// ```example
-/// $
-/// "perm"(n, k) &= n!/((n - k)!) \
-/// "perm"(5, 3) &= #calc.perm(5, 3)
-/// $
+/// $ "perm"(n, k) &= n!/((n - k)!) \
+///   "perm"(5, 3) &= #calc.perm(5, 3) $
 #[func(title = "Permutation")]
 pub fn perm(
     /// The base number. Must be non-negative.
@@ -483,6 +484,9 @@ fn fact_impl(start: u64, end: u64) -> Option<i64> {
 }
 
 /// Calculates a binomial coefficient.
+///
+/// Returns the `k`-combination `n`, or the number of ways to choose `k`
+/// items from a set of `n` without regard to order.
 ///
 /// ```example
 /// #calc.binom(10, 5)
@@ -781,7 +785,8 @@ pub fn odd(
 
 /// Calculates the remainder of two numbers.
 ///
-/// The value `calc.rem(x, y)` always has the same sign as `x`, and is smaller in magnitude than `y`.
+/// The value `calc.rem(x, y)` always has the same sign as `x`, and is smaller
+/// in magnitude than `y`.
 ///
 /// ```example
 /// #calc.rem(20, 6) \

--- a/crates/typst-library/src/compute/calc.rs
+++ b/crates/typst-library/src/compute/calc.rs
@@ -443,7 +443,7 @@ pub fn fact(
     Ok(fact_impl(1, number).ok_or("the result is too large")?)
 }
 
-/// Calculates a permutation
+/// Calculates a permutation.
 ///
 /// Returns the `k`-permutation of `n`, or the number of ways to choose `k`
 /// items from a set of `n` with regard to order.
@@ -451,6 +451,7 @@ pub fn fact(
 /// ```example
 /// $ "perm"(n, k) &= n!/((n - k)!) \
 ///   "perm"(5, 3) &= #calc.perm(5, 3) $
+/// ```
 #[func(title = "Permutation")]
 pub fn perm(
     /// The base number. Must be non-negative.
@@ -807,11 +808,10 @@ pub fn rem(
 
 /// Calculates the quotient (floored division) of two numbers.
 ///
-/// $
-/// "quo"(a, b) &= floor(a/b) \
-/// "quo"(14, 5) &= #calc.quo(14, 5) \
-/// "quo"(3.46, 0.5) &= #calc.quo(3.46, 0.5)
-/// $
+/// ```example
+/// $ "quo"(a, b) &= floor(a/b) \
+///   "quo"(14, 5) &= #calc.quo(14, 5) \
+///   "quo"(3.46, 0.5) &= #calc.quo(3.46, 0.5) $
 /// ```
 #[func(title = "Quotient")]
 pub fn quo(

--- a/crates/typst-library/src/compute/calc.rs
+++ b/crates/typst-library/src/compute/calc.rs
@@ -444,7 +444,7 @@ pub fn fact(
 }
 
 /// Calculates a permutation
-/// 
+///
 /// Returns the `k`-permutation of `n`, or the number of ways to choose `k`
 /// items from a set of `n` with regard to order.
 ///
@@ -484,7 +484,7 @@ fn fact_impl(start: u64, end: u64) -> Option<i64> {
 }
 
 /// Calculates a binomial coefficient.
-/// 
+///
 /// Returns the `k`-combination `n`, or the number of ways to choose `k`
 /// items from a set of `n` without regard to order.
 ///

--- a/crates/typst-library/src/compute/calc.rs
+++ b/crates/typst-library/src/compute/calc.rs
@@ -484,7 +484,7 @@ fn fact_impl(start: u64, end: u64) -> Option<i64> {
 }
 
 /// Calculates a binomial coefficient.
-///
+/// 
 /// Returns the `k`-combination `n`, or the number of ways to choose `k`
 /// items from a set of `n` without regard to order.
 ///

--- a/crates/typst-library/src/compute/calc.rs
+++ b/crates/typst-library/src/compute/calc.rs
@@ -443,11 +443,13 @@ pub fn fact(
     Ok(fact_impl(1, number).ok_or("the result is too large")?)
 }
 
-/// Calculates a permutation.
+/// Calculates the `k`-permutation of `n`.
 ///
 /// ```example
-/// #calc.perm(10, 5)
-/// ```
+/// $
+/// "perm"(n, k) &= n!/((n - k)!) \
+/// "perm"(5, 3) &= #calc.perm(5, 3)
+/// $
 #[func(title = "Permutation")]
 pub fn perm(
     /// The base number. Must be non-negative.
@@ -779,6 +781,8 @@ pub fn odd(
 
 /// Calculates the remainder of two numbers.
 ///
+/// The value `calc.rem(x, y)` always has the same sign as `x`, and is smaller in magnitude than `y`.
+///
 /// ```example
 /// #calc.rem(20, 6) \
 /// #calc.rem(1.75, 0.5)
@@ -796,11 +800,13 @@ pub fn rem(
     Ok(dividend.apply2(divisor.v, Rem::rem, Rem::rem))
 }
 
-/// Calculates the quotient of two numbers.
+/// Calculates the quotient (floored division) of two numbers.
 ///
-/// ```example
-/// #calc.quo(14, 5) \
-/// #calc.quo(3.46, 0.5)
+/// $
+/// "quo"(a, b) &= floor(a/b) \
+/// "quo"(14, 5) &= #calc.quo(14, 5) \
+/// "quo"(3.46, 0.5) &= #calc.quo(3.46, 0.5)
+/// $
 /// ```
 #[func(title = "Quotient")]
 pub fn quo(


### PR DESCRIPTION
Tiny patch because it wasn’t clear to me what `calc.perm` was from the docs. I also wondered how `calc.rem` and `calc.quo` handled negative inputs.

Added in-line equations to the `calc.perm` and `calc.quo` docs, not sure if that's appropriate style.