### PR TITLE
Add Text Export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2754,6 +2754,7 @@ dependencies = [
  "roxmltree",
  "rustybuzz",
  "serde",
+ "serde_json",
  "siphasher",
  "stacker",
  "subsetter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2772,6 +2772,7 @@ dependencies = [
  "unicode-segmentation",
  "unscanny",
  "usvg",
+ "vlq",
  "wasmi",
  "xmlparser",
  "xmlwriter",
@@ -3183,6 +3184,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "vlq"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65dd7eed29412da847b0f78bcec0ac98588165988a8cfe41d4ea1d429f8ccfff"
 
 [[package]]
 name = "walkdir"

--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -186,6 +186,8 @@ pub enum OutputFormat {
     Pdf,
     Png,
     Svg,
+    Txt,
+    SpannedTxt,
 }
 
 impl Display for OutputFormat {

--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -13,7 +13,7 @@ use typst::diag::{FileError, FileResult, StrResult};
 use typst::eval::{eco_format, Bytes, Datetime, Library};
 use typst::font::{Font, FontBook};
 use typst::syntax::{FileId, Source, VirtualPath};
-use typst::World;
+use typst::{PathResolver, World};
 
 use crate::args::SharedArgs;
 use crate::fonts::{FontSearcher, FontSlot};
@@ -162,6 +162,12 @@ impl World for SystemWorld {
             naive.month().try_into().ok()?,
             naive.day().try_into().ok()?,
         )
+    }
+}
+
+impl PathResolver for SystemWorld {
+    fn resolve_path(&self, path: FileId) -> Option<PathBuf> {
+        self.slot(path).ok().map(|slot| slot.path.clone())
     }
 }
 

--- a/crates/typst/Cargo.toml
+++ b/crates/typst/Cargo.toml
@@ -53,6 +53,7 @@ unicode-math-class = "0.1"
 unicode-segmentation = "1"
 unscanny = "0.1"
 usvg = { version = "0.35", default-features = false, features = ["text"] }
+vlq = "0.5.1"
 xmlwriter = "0.1.0"
 xmp-writer = "0.1"
 time = { version = "0.3.20", features = ["std", "formatting", "macros", "parsing"] }

--- a/crates/typst/Cargo.toml
+++ b/crates/typst/Cargo.toml
@@ -39,6 +39,7 @@ resvg = { version = "0.35.0", default-features = false, features = ["raster-imag
 roxmltree = "0.18"
 rustybuzz = "0.7"
 serde = { version = "1.0.184", features = ["derive"] }
+serde_json = "1"
 siphasher = "0.3"
 subsetter = "0.1.1"
 svg2pdf = "0.8"

--- a/crates/typst/src/export/mod.rs
+++ b/crates/typst/src/export/mod.rs
@@ -3,7 +3,9 @@
 mod pdf;
 mod render;
 mod svg;
+mod text;
 
 pub use self::pdf::{pdf, PdfPageLabel, PdfPageLabelStyle};
 pub use self::render::{render, render_merged};
 pub use self::svg::{svg, svg_merged};
+pub use self::text::spanned_text;

--- a/crates/typst/src/export/text.rs
+++ b/crates/typst/src/export/text.rs
@@ -1,0 +1,133 @@
+use ecow::{eco_format, EcoString};
+use serde::{Deserialize, Serialize};
+
+use crate::{diag::StrResult, model::Content, PathResolver, World};
+
+/// Text content with span information
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct SpannedText {
+    /// vector of source file paths
+    pub sources: Vec<String>,
+    /// plain text content of the file
+    pub content: EcoString,
+    /// vector of mapping from content offset to source range
+    /// The source range is encoded as a tuple of 7 values:
+    /// - start of the text range (offset group)
+    /// - end of the text range (offset group)
+    /// - file id, known as the index into the sources vector
+    /// - start line of the source range (line group)
+    /// - start column of the source range (column group)
+    /// - end line of the source range (line group)
+    /// - end column of the source range (column group)
+    ///
+    /// The numbers of each group are encoded as deltas to the previous value.
+    ///
+    /// Example:
+    /// ```typ
+    /// #let txt = "Hello! world."
+    /// #txt
+    ///
+    /// #txt
+    /// ```
+    ///
+    /// Then the plain text content is:
+    /// ```text
+    /// Hello! world.Hello! world.
+    /// ```
+    ///
+    /// And the mappings are:
+    /// ```
+    /// // content offset: 0..13
+    /// // file id: 0
+    /// // source start: 2:1
+    /// // source end: 2:4
+    /// 0, 13, 0, 2, 1, 0, 3,
+    /// // content offset: 13..26
+    /// // file id: 0
+    /// // source start: 4:1
+    /// // source end: 4:4
+    /// 0, 13, 0, 2, -3, 0, 3,
+    /// // content offset: 26..27
+    /// // file id: 0
+    /// // source start: 4:4
+    /// // source end: 5:0
+    /// 0, 1, 0, 0, 0, 1, -4
+    /// ```
+    pub mappings: Vec<i64>,
+}
+
+/// Export the content as text with span information in json format
+pub fn spanned_text(
+    world: &dyn World,
+    pr: &dyn PathResolver,
+    src: &Content,
+) -> StrResult<String> {
+    let (content, mappings) = src.text_with_spans();
+    let mut text = SpannedText { content, ..SpannedText::default() };
+
+    text.mappings.reserve(mappings.len());
+
+    let mut file_mappings = indexmap::IndexSet::new();
+
+    let mut rng_diff: i64 = 0;
+    let mut line_diff: i64 = 0;
+    let mut column_diff: i64 = 0;
+
+    for (text_rng, span) in mappings {
+        // Get source information
+        let Some((id, src)) =
+            span.id().and_then(|id| Some(id).zip(world.source(id).ok()))
+        else {
+            continue;
+        };
+        let Some(rng) = src.range(span) else {
+            continue;
+        };
+
+        // Allocate file id
+        let (fid, inserted) = file_mappings.insert_full(id);
+        if inserted {
+            let Some(path) = pr.resolve_path(id) else {
+                continue;
+            };
+
+            text.sources.push(format!("{}", path.display()));
+        }
+
+        // Get line and column information
+        let sl = src.byte_to_line(rng.start);
+        let sc = src.byte_to_column(rng.start);
+        let el = src.byte_to_line(rng.end);
+        let ec = src.byte_to_column(rng.end);
+        let Some((((sl, sc), el), ec)) = sl.zip(sc).zip(el).zip(ec) else {
+            continue;
+        };
+
+        // Encode mapping
+
+        // Start and end of the text range
+        let st = text_rng.start as i64;
+        text.mappings.push(st - rng_diff);
+        rng_diff = st;
+        let ed = text_rng.end as i64;
+        text.mappings.push(ed - rng_diff);
+        rng_diff = ed;
+
+        // File id
+        text.mappings.push(fid as i64);
+
+        // Line and column of the source start
+        text.mappings.push(sl as i64 - line_diff);
+        line_diff = sl as i64;
+        text.mappings.push(sc as i64 - column_diff);
+        column_diff = sc as i64;
+
+        // Line and column of the source end
+        text.mappings.push(el as i64 - line_diff);
+        line_diff = el as i64;
+        text.mappings.push(ec as i64 - column_diff);
+        column_diff = ec as i64;
+    }
+
+    serde_json::to_string(&text).map_err(|e| eco_format!("{}", e))
+}

--- a/crates/typst/src/lib.rs
+++ b/crates/typst/src/lib.rs
@@ -53,6 +53,7 @@ pub mod model;
 pub use typst_syntax as syntax;
 
 use std::ops::Range;
+use std::path::PathBuf;
 
 use comemo::{Prehashed, Track, TrackedMut};
 use ecow::EcoString;
@@ -182,4 +183,8 @@ impl<T: World> WorldExt for T {
     fn range(&self, span: Span) -> Option<Range<usize>> {
         self.source(span.id()?).ok()?.range(span)
     }
+}
+
+pub trait PathResolver {
+    fn resolve_path(&self, path: FileId) -> Option<PathBuf>;
 }

--- a/crates/typst/src/lib.rs
+++ b/crates/typst/src/lib.rs
@@ -59,9 +59,29 @@ use ecow::EcoString;
 
 use crate::diag::{FileResult, SourceResult};
 use crate::doc::Document;
-use crate::eval::{Bytes, Datetime, Library, Route, Tracer};
+use crate::eval::{Bytes, Datetime, Library, Module, Route, Tracer};
 use crate::font::{Font, FontBook};
 use crate::syntax::{FileId, PackageSpec, Source, Span};
+
+/// Evaluate a source file into a module.
+///
+/// - Returns `Ok(module)` if there were no fatal errors.
+/// - Returns `Err(errors)` if there were fatal errors.
+///
+/// Requires a mutable reference to a tracer. Such a tracer can be created with
+/// `Tracer::new()`. Independently of whether compilation succeeded, calling
+/// `tracer.warnings()` after compilation will return all compiler warnings.
+#[tracing::instrument(skip_all)]
+pub fn evaluate(world: &dyn World, tracer: &mut Tracer) -> SourceResult<Module> {
+    let route = Route::default();
+
+    // Call `track` just once to keep comemo's ID stable.
+    let world = world.track();
+    let mut tracer = tracer.track_mut();
+
+    // Evaluate the source file into a module.
+    eval::eval(world, route.track(), TrackedMut::reborrow_mut(&mut tracer), &world.main())
+}
 
 /// Compile a source file into a fully layouted document.
 ///

--- a/crates/typst/src/model/content.rs
+++ b/crates/typst/src/model/content.rs
@@ -1,7 +1,7 @@
 use std::any::TypeId;
 use std::fmt::Debug;
 use std::iter::{self, Sum};
-use std::ops::{Add, AddAssign};
+use std::ops::{Add, AddAssign, Range};
 
 use comemo::Prehashed;
 use ecow::{eco_format, EcoString, EcoVec};
@@ -412,6 +412,20 @@ impl Content {
             }
         });
         text
+    }
+
+    /// Extracts the text with spans of this content.
+    pub fn text_with_spans(&self) -> (EcoString, Vec<(Range<usize>, Span)>) {
+        let mut text = EcoString::new();
+        let mut contents = Vec::new();
+        self.traverse(&mut |element| {
+            if let Some(textable) = element.with::<dyn PlainText>() {
+                let start = text.len();
+                textable.plain_text(&mut text);
+                contents.push((start..text.len(), element.span()));
+            }
+        });
+        (text, contents)
     }
 
     /// Traverse this content.


### PR DESCRIPTION
Motivated by https://github.com/typst/typst/issues/2401, we can export some typst document as text.

> For the cli, I'd imagine something like `typst compile file.typ --export plaintext` which could then be used for piping into other things like wordcount, grammar checkers etc.

+ Word count: we can count words by `typst compile main.typ main.txt | wc -w`.
+ Grammar checking: we can perform grammar checking and then emit warnings or errors by encoded span information.

Add text export for cli:
- Plain text: `typst compile main.typ main.txt`
- Text with span information: `typst compile main.typ --format spanned-txt`

Example:

```typst
#let txt = "Hello! world."

#txt

#txt
```

Output of plain text format:

```plain
Hello! world.Hello! world. 
```

Output of text content with additional details (source mapping), partially inspired from [source mapping](https://www.bugsnag.com/blog/source-maps/):

```json
{
    "sources": ["/home/me/work/rust/typst/hello.typ"],
    "content": "Hello! world.Hello! world. ",
    "mappings": "AaAECAGAaAEHAGACAAACJ"
}
```

## Describe the `mappings` field

A mapping from content offset to source range in Base64 VLQs format.

Here, a source range is encoded as a tuple of 7 numbers:
- start of the text range (offset group)
- end of the text range (offset group)
- file id, known as the index into the sources vector
- start line of the source range (line group)
- start column of the source range (column group)
- end line of the source range (line group)
- end column of the source range (column group)

The numbers of each group are encoded as deltas to the previous value.

Example:
```typ
#let txt = "Hello! world."
#txt

#txt
```

Then the plain text content is:
```text
Hello! world.Hello! world.
```

And the mappings are:
```
// content offset: 0..13
// file id: 0
// source start: 2:1
// source end: 2:4
0, 13, 0, 2, 1, 0, 3,
// content offset: 13..26
// file id: 0
// source start: 4:1
// source end: 4:4
0, 13, 0, 2, -3, 0, 3,
// content offset: 26..27
// file id: 0
// source start: 4:4
// source end: 5:0
0, 1, 0, 0, 0, 1, -4
```

Then we encode the array as `AaAECAGAaAEHAGACAAACJ`.

