### PR TITLE
Replace `Vec` with `EcoVec`, removed `Box`

### DIFF
--- a/crates/typst-syntax/src/node.rs
+++ b/crates/typst-syntax/src/node.rs
@@ -3,7 +3,7 @@ use std::ops::{Deref, Range};
 use std::rc::Rc;
 use std::sync::Arc;
 
-use ecow::EcoString;
+use ecow::{eco_vec, EcoString, EcoVec};
 
 use super::ast::AstNode;
 use super::{FileId, Span, SyntaxKind};
@@ -616,7 +616,7 @@ impl ErrorNode {
             error: SyntaxError {
                 span: Span::detached(),
                 message: message.into(),
-                hints: vec![],
+                hints: eco_vec![],
             },
         }
     }
@@ -652,7 +652,7 @@ pub struct SyntaxError {
     pub message: EcoString,
     /// Additonal hints to the user, indicating how this error could be avoided
     /// or worked around.
-    pub hints: Vec<EcoString>,
+    pub hints: EcoVec<EcoString>,
 }
 
 impl SyntaxError {

--- a/crates/typst/src/eval/args.rs
+++ b/crates/typst/src/eval/args.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Debug, Formatter};
 
-use ecow::{eco_format, EcoString, EcoVec};
+use ecow::{eco_format, eco_vec, EcoString, EcoVec};
 
 use super::{func, scope, ty, Array, Dict, FromValue, IntoValue, Repr, Str, Value};
 use crate::diag::{bail, At, SourceDiagnostic, SourceResult};
@@ -155,7 +155,7 @@ impl Args {
         T: FromValue<Spanned<Value>>,
     {
         let mut list = vec![];
-        let mut errors = vec![];
+        let mut errors = eco_vec![];
         self.items.retain(|item| {
             if item.name.is_some() {
                 return true;
@@ -169,7 +169,7 @@ impl Args {
             false
         });
         if !errors.is_empty() {
-            return Err(Box::new(errors));
+            return Err(errors);
         }
         Ok(list)
     }

--- a/crates/typst/src/eval/mod.rs
+++ b/crates/typst/src/eval/mod.rs
@@ -134,7 +134,7 @@ pub fn eval(
     let root = source.root();
     let errors = root.errors();
     if !errors.is_empty() && vm.inspected.is_none() {
-        return Err(Box::new(errors.into_iter().map(Into::into).collect()));
+        return Err(errors.into_iter().map(Into::into).collect());
     }
 
     // Evaluate the module.
@@ -178,7 +178,7 @@ pub fn eval_string(
 
     let errors = root.errors();
     if !errors.is_empty() {
-        return Err(Box::new(errors.into_iter().map(Into::into).collect()));
+        return Err(errors.into_iter().map(Into::into).collect());
     }
 
     // Prepare VT.
@@ -1786,7 +1786,7 @@ impl Eval for ast::ModuleImport<'_> {
                 }
             }
             Some(ast::Imports::Items(items)) => {
-                let mut errors = vec![];
+                let mut errors = eco_vec![];
                 for item in items.iter() {
                     let original_ident = item.original_name();
                     if let Some(value) = scope.get(&original_ident) {
@@ -1808,7 +1808,7 @@ impl Eval for ast::ModuleImport<'_> {
                     }
                 }
                 if !errors.is_empty() {
-                    return Err(Box::new(errors));
+                    return Err(errors);
                 }
             }
         }

--- a/crates/typst/src/model/mod.rs
+++ b/crates/typst/src/model/mod.rs
@@ -8,6 +8,7 @@ mod realize;
 mod selector;
 mod styles;
 
+use ecow::EcoVec;
 #[doc(inline)]
 pub use typst_macros::elem;
 
@@ -89,7 +90,7 @@ pub fn typeset(
 
     // Promote delayed errors.
     if !delayed.0.is_empty() {
-        return Err(Box::new(delayed.0));
+        return Err(delayed.0);
     }
 
     Ok(document)
@@ -123,7 +124,7 @@ impl Vt<'_> {
         match f(self) {
             Ok(value) => value,
             Err(errors) => {
-                for error in *errors {
+                for error in errors {
                     self.delayed.push(error);
                 }
                 T::default()
@@ -134,7 +135,7 @@ impl Vt<'_> {
 
 /// Holds delayed errors.
 #[derive(Default, Clone)]
-pub struct DelayedErrors(Vec<SourceDiagnostic>);
+pub struct DelayedErrors(EcoVec<SourceDiagnostic>);
 
 impl DelayedErrors {
     /// Create an empty list of delayed errors.

--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -545,7 +545,7 @@ fn test_part(
         Ok(document) => (document.pages, tracer.warnings()),
         Err(errors) => {
             let mut warnings = tracer.warnings();
-            warnings.extend(*errors);
+            warnings.extend(errors);
             (vec![], warnings)
         }
     };


### PR DESCRIPTION
See #2393.

As it turns out, errors are not so cheap to clone and not so rare: delayed errors can create large amounts of `SourceDiagnostic`s that are cloned in function calls and processed as delayed errors, this means that the extra level of indirection (the `Box<..>` that used to be surrounding errors in `SourceResult<T>`) and the expensive cloning (`memcpy` over the entire contents) were expensive on documents that make use of delayed errors a lot (citations/refs inside of `locate`).