### PR TITLE
Fix compiler panic for floating `place` elements with no vertical alignment

### DIFF
--- a/crates/typst-library/src/layout/place.rs
+++ b/crates/typst-library/src/layout/place.rs
@@ -95,7 +95,10 @@ impl Layout for PlaceElem {
         let float = self.float(styles);
         let alignment = self.alignment(styles);
 
-        if float && alignment.map_or(false, |align| align.y() == Some(VAlign::Horizon)) {
+        if float
+            && alignment
+                .map_or(false, |align| matches!(align.y(), None | Some(VAlign::Horizon)))
+        {
             bail!(self.span(), "floating placement must be `auto`, `top`, or `bottom`");
         } else if !float && alignment.is_auto() {
             return Err("automatic positioning is only available for floating placement")

--- a/tests/typ/layout/place-float-auto.typ
+++ b/tests/typ/layout/place-float-auto.typ
@@ -17,3 +17,15 @@
 ---
 // Error: 2-45 floating placement must be `auto`, `top`, or `bottom`
 #place(center + horizon, float: true)[Hello]
+
+---
+// Error: 2-36 floating placement must be `auto`, `top`, or `bottom`
+#place(horizon, float: true)[Hello]
+
+---
+// Error: 2-27 floating placement must be `auto`, `top`, or `bottom`
+#place(float: true)[Hello]
+
+---
+// Error: 2-34 floating placement must be `auto`, `top`, or `bottom`
+#place(right, float: true)[Hello]


### PR DESCRIPTION
The following Typst programs would previously cause a compiler panic with the message `thread 'main' panicked at 'internal error: entered unreachable code: float must be y aligned', crates\typst-library\src\layout\flow.rs:527:34`. They now show a proper error message.

```typst
#place(float: true)[…]
```

```typst
#place(left, float: true)[…]
```

```typst
#place(center, float: true)[…]
```

```typst
#place(right, float: true)[…]
```

```typst
#place(start, float: true)[…]
```

```typst
#place(end, float: true)[…]
```