### PR TITLE
Fix trailing mandatory breaks being swallowed

### DIFF
--- a/crates/typst-library/src/layout/par.rs
+++ b/crates/typst-library/src/layout/par.rs
@@ -1206,18 +1206,18 @@ impl Iterator for Breakpoints<'_> {
 
             // Fix for: https://github.com/unicode-org/icu4x/issues/4146
             if let Some(c) = self.p.bidi.text[..self.end].chars().next_back() {
-                let at_end = self.end == self.p.bidi.text.len();
+                if self.end == self.p.bidi.text.len() {
+                    self.mandatory = true;
+                    break;
+                }
+
                 self.mandatory = match lb.get(c) {
-                    LineBreak::Glue | LineBreak::WordJoiner | LineBreak::ZWJ
-                        if !at_end =>
-                    {
-                        continue
-                    }
+                    LineBreak::Glue | LineBreak::WordJoiner | LineBreak::ZWJ => continue,
                     LineBreak::MandatoryBreak
                     | LineBreak::CarriageReturn
                     | LineBreak::LineFeed
                     | LineBreak::NextLine => true,
-                    _ => at_end,
+                    _ => false,
                 };
             }
 

--- a/crates/typst-library/src/layout/par.rs
+++ b/crates/typst-library/src/layout/par.rs
@@ -1206,15 +1206,20 @@ impl Iterator for Breakpoints<'_> {
 
             // Fix for: https://github.com/unicode-org/icu4x/issues/4146
             if let Some(c) = self.p.bidi.text[..self.end].chars().next_back() {
+                let at_end = self.end == self.p.bidi.text.len();
                 self.mandatory = match lb.get(c) {
-                    LineBreak::Glue | LineBreak::WordJoiner | LineBreak::ZWJ => continue,
+                    LineBreak::Glue | LineBreak::WordJoiner | LineBreak::ZWJ
+                        if !at_end =>
+                    {
+                        continue
+                    }
                     LineBreak::MandatoryBreak
                     | LineBreak::CarriageReturn
                     | LineBreak::LineFeed
                     | LineBreak::NextLine => true,
-                    _ => self.end == self.p.bidi.text.len(),
+                    _ => at_end,
                 };
-            };
+            }
 
             break;
         }


### PR DESCRIPTION
#2376 introduced a bug that would swallow trailing mandatory breaks if they were at the end of the input by early exiting the function. This PR fixes that such that a document with `Test~` does not produce empty output.