### PR TITLE
fix: prevent Nix warning when using `lib.getExe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,106 +2,48 @@
   "nodes": {
     "crane": {
       "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "rust-overlay": "rust-overlay"
+        ]
       },
       "locked": {
-        "lastModified": 1693787605,
-        "narHash": "sha256-rwq5U8dy+a9JFny/73L0SJu1GfWwATMPMTp7D+mjHy8=",
+        "lastModified": 1698166613,
+        "narHash": "sha256-y4rdN4flxRiROqNi1waMYIZj/Fs7L2OrszFk/1ry9vU=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "8b4f7a4dab2120cf41e7957a28a853f45016bd9d",
+        "rev": "b7db46f0f1751f7b1d1911f6be7daf568ad5bc65",
         "type": "github"
       },
       "original": {
         "owner": "ipetkov",
         "repo": "crane",
-        "type": "github"
-      }
-    },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
         "type": "github"
       }
     },
     "flake-parts": {
       "inputs": {
-        "nixpkgs-lib": [
-          "nixpkgs"
-        ]
+        "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1693611461,
-        "narHash": "sha256-aPODl8vAgGQ0ZYFIRisxYG5MOGSkIczvu2Cd8Gb9+1Y=",
+        "lastModified": 1696343447,
+        "narHash": "sha256-B2xAZKLkkeRFG5XcHHSXXcP7To9Xzr59KXeZiRf4vdQ=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "7f53fdb7bdc5bb237da7fefef12d099e4fd611ca",
+        "rev": "c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4",
         "type": "github"
       },
       "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
+        "id": "flake-parts",
+        "type": "indirect"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1693985761,
-        "narHash": "sha256-K5b+7j7Tt3+AqbWkcw+wMeqOAWyCD1MH26FPZyWXpdo=",
+        "lastModified": 1698318101,
+        "narHash": "sha256-gUihHt3yPD7bVqg+k/UVHgngyaJ3DMEBchbymBMvK1E=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0bffda19b8af722f8069d09d8b6a24594c80b352",
+        "rev": "63678e9f3d3afecfeafa0acead6239cdb447574c",
         "type": "github"
       },
       "original": {
@@ -111,55 +53,33 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1696019113,
+        "narHash": "sha256-X3+DKYWJm93DRSdC5M6K5hLqzSya9BjibtBsuARoPco=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f5892ddac112a1e9b3612c39af1b72987ee5783a",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "crane": "crane",
         "flake-parts": "flake-parts",
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "flake-utils": [
-          "crane",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "crane",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1693707092,
-        "narHash": "sha256-HR1EnynBSPqbt+04/yxxqsG1E3n6uXrOl7SPco/UnYo=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "98ccb73e6eefc481da6039ee57ad8818d1ca8d56",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -2,64 +2,65 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
 
-    flake-parts = {
-      url = "github:hercules-ci/flake-parts";
-      inputs.nixpkgs-lib.follows = "nixpkgs";
-    };
-
-    flake-utils.url = "github:numtide/flake-utils";
-
     crane = {
       url = "github:ipetkov/crane";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    systems.url = "github:nix-systems/default";
   };
 
-  outputs = inputs@{ flake-parts, flake-utils, crane, nixpkgs, ... }:
-    let
-      # Generate the typst package for the given nixpkgs instance.
-      packageFor = pkgs:
-        let
-          inherit (nixpkgs.lib)
-            importTOML
-            optionals
-            sourceByRegex
-            ;
-          Cargo-toml = importTOML ./Cargo.toml;
+  outputs = inputs@{ flake-parts, crane, nixpkgs, ... }: flake-parts.lib.mkFlake { inherit inputs; } {
+    systems = import inputs.systems;
 
-          pname = "typst";
-          version = Cargo-toml.workspace.package.version;
+    imports = [
+      inputs.flake-parts.flakeModules.easyOverlay
+    ];
 
-          # Crane-based Nix flake configuration.
-          # Based on https://github.com/ipetkov/crane/blob/master/examples/trunk-workspace/flake.nix
+    perSystem = { self', pkgs, lib, ... }:
+      let
+        # Generate the typst package for the given nixpkgs instance.
+        packageFor = pkgs:
+          let
+            inherit (lib)
+              importTOML
+              optionals
+              sourceByRegex
+              ;
+            Cargo-toml = importTOML ./Cargo.toml;
 
-          craneLib = crane.mkLib pkgs;
+            pname = "typst";
+            version = Cargo-toml.workspace.package.version;
 
-          # Typst files to include in the derivation.
-          # Here we include Rust files, assets and tests.
-          src = sourceByRegex ./. [
-            "(assets|crates|tests)(/.*)?"
-            ''Cargo\.(toml|lock)''
-            ''build\.rs''
-          ];
+            # Crane-based Nix flake configuration.
+            # Based on https://github.com/ipetkov/crane/blob/master/examples/trunk-workspace/flake.nix
+            craneLib = crane.mkLib pkgs;
 
-          # Typst derivation's args, used within crane's derivation generation
-          # functions.
-          commonCraneArgs = {
-            inherit src pname version;
-
-            buildInputs = optionals pkgs.stdenv.isDarwin [
-              pkgs.darwin.apple_sdk.frameworks.CoreServices
+            # Typst files to include in the derivation.
+            # Here we include Rust files, assets and tests.
+            src = sourceByRegex ./. [
+              "(assets|crates|tests)(/.*)?"
+              ''Cargo\.(toml|lock)''
+              ''build\.rs''
             ];
 
-            nativeBuildInputs = [ pkgs.installShellFiles ];
-          };
+            # Typst derivation's args, used within crane's derivation generation
+            # functions.
+            commonCraneArgs = {
+              inherit src pname version;
 
-          # Derivation with just the dependencies, so we don't have to keep
-          # re-building them.
-          cargoArtifacts = craneLib.buildDepsOnly commonCraneArgs;
+              buildInputs = optionals pkgs.stdenv.isDarwin [
+                pkgs.darwin.apple_sdk.frameworks.CoreServices
+              ];
 
-          typst = craneLib.buildPackage (commonCraneArgs // {
+              nativeBuildInputs = [ pkgs.installShellFiles ];
+            };
+
+            # Derivation with just the dependencies, so we don't have to keep
+            # re-building them.
+            cargoArtifacts = craneLib.buildDepsOnly commonCraneArgs;
+          in
+          craneLib.buildPackage (commonCraneArgs // {
             inherit cargoArtifacts;
 
             postInstall = ''
@@ -73,46 +74,35 @@
 
             meta.mainProgram = "typst";
           });
-        in
-        typst;
-    in
-    flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = [
-        "aarch64-darwin"
-        "aarch64-linux"
-        "x86_64-darwin"
-        "x86_64-linux"
-      ];
 
-      flake = {
-        overlays.default = _: prev: {
-          typst-dev = packageFor prev;
+        typst = packageFor pkgs;
+      in
+      {
+        formatter = pkgs.nixpkgs-fmt;
+
+        packages = {
+          default = typst;
+          typst-dev = self'.packages.default;
+        };
+
+        overlayAttrs = builtins.removeAttrs self'.packages [ "default" ];
+
+        apps.default = {
+          type = "app";
+          program = lib.getExe typst;
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            rustc
+            cargo
+          ];
+
+          buildInputs = lib.optionals pkgs.stdenv.isDarwin [
+            pkgs.darwin.apple_sdk.frameworks.CoreServices
+            pkgs.libiconv
+          ];
         };
       };
-
-      perSystem = { pkgs, ... }:
-        let
-          inherit (pkgs) lib;
-          typst = packageFor pkgs;
-        in
-        {
-          packages.default = typst;
-
-          apps.default = flake-utils.lib.mkApp {
-            drv = typst;
-          };
-
-          devShells.default = pkgs.mkShell {
-            packages = with pkgs; [
-              rustc
-              cargo
-            ];
-
-            buildInputs = lib.optionals pkgs.stdenv.isDarwin [
-              pkgs.darwin.apple_sdk.frameworks.CoreServices
-              pkgs.libiconv
-            ];
-          };
-        };
-    };
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,8 @@
             '';
 
             GEN_ARTIFACTS = "artifacts";
+
+            meta.mainProgram = "typst";
           });
         in
         typst;


### PR DESCRIPTION
Hi,

This quick fix is to prevent this kind of issue when using `lib.getExe` with Typst in Nix:

![image](https://github.com/typst/typst/assets/252042/02157ef4-335e-47bb-bd1f-1be74d85c274)

See also this: https://github.com/NixOS/nixpkgs/pull/246386

Ping @PgBiel @alerque 