### PR TITLE
Format negative zero as zero

### DIFF
--- a/crates/typst/src/util/fmt.rs
+++ b/crates/typst/src/util/fmt.rs
@@ -46,10 +46,11 @@ pub fn format_float(mut value: f64, precision: Option<u8>, suffix: &str) -> EcoS
     }
     if value.is_nan() {
         "NaN".into()
-    } else if value.is_sign_negative() {
+    } else if value < 0.0 {
         eco_format!("{}{}{}", MINUS_SIGN, value.abs(), suffix)
     } else {
-        eco_format!("{}{}", value, suffix)
+        // Call abs to prevent negative zero
+        eco_format!("{}{}", value.abs(), suffix)
     }
 }
 


### PR DESCRIPTION
Typst should not format `-0.0` as `-0.0`, but without the negation sign.