### PR TITLE
Improve "Cannot apply '{+,-}'" error messages

### DIFF
--- a/crates/typst/src/eval/ops.rs
+++ b/crates/typst/src/eval/ops.rs
@@ -52,7 +52,7 @@ pub fn pos(value: Value) -> StrResult<Value> {
         Ratio(v) => Ratio(v),
         Relative(v) => Relative(v),
         Fraction(v) => Fraction(v),
-        v => mismatch!("cannot apply '+' to {}", v),
+        v => mismatch!("cannot apply unary '+' to {}", v),
     })
 }
 
@@ -67,7 +67,7 @@ pub fn neg(value: Value) -> StrResult<Value> {
         Relative(v) => Relative(-v),
         Fraction(v) => Fraction(-v),
         Duration(v) => Duration(-v),
-        v => mismatch!("cannot apply '-' to {}", v),
+        v => mismatch!("cannot apply unary '-' to {}", v),
     })
 }
 

--- a/crates/typst/src/eval/ops.rs
+++ b/crates/typst/src/eval/ops.rs
@@ -52,7 +52,17 @@ pub fn pos(value: Value) -> StrResult<Value> {
         Ratio(v) => Ratio(v),
         Relative(v) => Relative(v),
         Fraction(v) => Fraction(v),
-        v => mismatch!("cannot apply unary '+' to {}", v),
+        Symbol(_) | Str(_) | Bytes(_) | Content(_) | Array(_) | Dict(_) | Datetime(_) => {
+            mismatch!("cannot apply unary '+' to {}", value)
+        }
+        Dyn(d) => {
+            if d.is::<Align>() {
+                mismatch!("cannot apply unary '+' to {}", d)
+            } else {
+                mismatch!("cannot apply '+' to {}", d)
+            }
+        }
+        v => mismatch!("cannot apply '+' to {}", v),
     })
 }
 
@@ -67,7 +77,8 @@ pub fn neg(value: Value) -> StrResult<Value> {
         Relative(v) => Relative(-v),
         Fraction(v) => Fraction(-v),
         Duration(v) => Duration(-v),
-        v => mismatch!("cannot apply unary '-' to {}", v),
+        Datetime(_) => mismatch!("cannot apply unary '-' to {}", value),
+        v => mismatch!("cannot apply '-' to {}", v),
     })
 }
 

--- a/tests/typ/compiler/ops-invalid.typ
+++ b/tests/typ/compiler/ops-invalid.typ
@@ -14,11 +14,11 @@
 #test({2*}, 2)
 
 ---
-// Error: 3-13 cannot apply '+' to content
+// Error: 3-13 cannot apply unary '+' to content
 #(+([] + []))
 
 ---
-// Error: 3-6 cannot apply '-' to string
+// Error: 3-6 cannot apply unary '-' to string
 #(-"")
 
 ---

--- a/tests/typ/compiler/ops-invalid.typ
+++ b/tests/typ/compiler/ops-invalid.typ
@@ -18,7 +18,7 @@
 #(+([] + []))
 
 ---
-// Error: 3-6 cannot apply unary '-' to string
+// Error: 3-6 cannot apply '-' to string
 #(-"")
 
 ---

--- a/tests/typ/compiler/ops-prec.typ
+++ b/tests/typ/compiler/ops-prec.typ
@@ -20,7 +20,7 @@
 
 ---
 // Precedence doesn't matter for chained unary operators.
-// Error: 3-12 cannot apply '-' to boolean
+// Error: 3-12 cannot apply unary '-' to boolean
 #(-not true)
 
 ---

--- a/tests/typ/compiler/ops-prec.typ
+++ b/tests/typ/compiler/ops-prec.typ
@@ -20,7 +20,7 @@
 
 ---
 // Precedence doesn't matter for chained unary operators.
-// Error: 3-12 cannot apply unary '-' to boolean
+// Error: 3-12 cannot apply '-' to boolean
 #(-not true)
 
 ---


### PR DESCRIPTION
Take a look at the following piece of Typst code:
```typ
#{
  let s = "a"
    + "b"
}
```

Currently, compiling it produces the following error:
```
error: cannot apply '+' to string
```

Seeing this error message, the uninformed user might think that strings cannot be concatenated using `+`. But the actual problem here is that Typst interprets the third line as a separate expression because (afaik) you cannot have an unparenthesized expression span over multiple lines.

This PR changes the error message to
```
error: cannot apply unary '+' to string
```
This hopefully makes it a bit clearer that the problem is not that concatenating strings is impossible.

Note that I also changed the equivalent message for `-` in the same way.

Maybe there should be a hint too, but I am not really sure that to hint at...