### PR TITLE
Add constructor for `stroke`.

### DIFF
--- a/crates/typst/src/geom/stroke.rs
+++ b/crates/typst/src/geom/stroke.rs
@@ -66,7 +66,7 @@ use crate::eval::{dict, Cast, FromValue, NoneValue};
 /// On a `stroke` object, you can access any of the fields mentioned in the
 /// dictionary format above. For example, `{(2pt + blue).thickness}` is `{2pt}`.
 /// Meanwhile, `{(2pt + blue).cap}` is `{auto}` because it's unspecified.
-#[ty]
+#[ty(scope)]
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
 pub struct Stroke<T: Numeric = Length> {
     /// The stroke's paint.
@@ -249,6 +249,19 @@ impl Fold for Stroke<Abs> {
             dash_pattern: self.dash_pattern.or(outer.dash_pattern),
             miter_limit: self.miter_limit.or(outer.miter_limit),
         }
+    }
+}
+
+#[scope]
+impl Stroke {
+    /// Converts a value into a stroke.
+    ///
+    /// The value may be a length, color or dictionary with any of the keys
+    /// `paint`, `thickness`, `line_cap`, `line_join`, `dash_pattern` or
+    /// `miter_limit`.
+    #[func(constructor)]
+    pub fn construct(stroke: Stroke) -> Stroke {
+        stroke
     }
 }
 

--- a/tests/typ/visualize/stroke.typ
+++ b/tests/typ/visualize/stroke.typ
@@ -95,3 +95,13 @@
   ((0%, 50%), (4%, 4%)),
   ((50%, 0%), (4%, 4%)),
 )
+
+---
+// Converting to stroke
+#assert.eq(stroke(red).paint, red)
+#assert.eq(stroke(red).thickness, auto)
+#assert.eq(stroke(2pt).paint, auto)
+#assert.eq(stroke((cap: "round", paint: blue)).cap, "round")
+
+// Error: 9-21 unexpected key "foo", valid keys are "paint", "thickness", "cap", "join", "dash", and "miter-limit"
+#stroke((foo: "bar"))


### PR DESCRIPTION
Minimal implementation of a constructor for the `stroke` type.

This would be especially useful in package authoring when you want to convert a length/paint/dictionary provided by the user to a stroke in order to easily access its fields.

```typ
#let my-function(my-stroke) = {
    let s = stroke(my-stroke)
    (s.paint, s.thickness, s.cap)
}
The result of #my-function(5pt) is `(auto, 5pt, auto)`
```