### PR TITLE
Add missing gradient to stroke cast

### DIFF
--- a/crates/typst/src/geom/stroke.rs
+++ b/crates/typst/src/geom/stroke.rs
@@ -262,6 +262,10 @@ cast! {
         paint: Smart::Custom(color.into()),
         ..Default::default()
     },
+    gradient: Gradient => Self {
+        paint: Smart::Custom(gradient.into()),
+        ..Default::default()
+    },
     mut dict: Dict => {
         fn take<T: FromValue>(dict: &mut Dict, key: &str) -> StrResult<Smart<T>> {
             Ok(dict.take(key).ok().map(T::from_value)

--- a/tests/typ/visualize/shape-rect.typ
+++ b/tests/typ/visualize/shape-rect.typ
@@ -51,7 +51,7 @@
 #rect(radius: (left: 10pt, cake: 5pt))
 
 ---
-// Error: 15-21 expected length, color, dictionary, stroke, none, or auto, found array
+// Error: 15-21 expected length, color, gradient, dictionary, stroke, none, or auto, found array
 #rect(stroke: (1, 2))
 
 ---


### PR DESCRIPTION
Allows using just a gradient in `stroke` parameters.

See https://github.com/typst/typst/issues/2282#issuecomment-1764606056