### PR TITLE
Derive PDF instance id from content hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,9 +1750,9 @@ dependencies = [
 
 [[package]]
 name = "pdf-writer"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "690874e8cf95d36ddffbdbdaad6ef8714c88bf8085996b673559389a04e38a02"
+checksum = "644b654f2de28457bf1e25a4905a76a563d1128a33ce60cf042f721f6818feaf"
 dependencies = [
  "bitflags 1.3.2",
  "itoa",

--- a/crates/typst/Cargo.toml
+++ b/crates/typst/Cargo.toml
@@ -31,7 +31,7 @@ kurbo = "0.9"
 log = "0.4"
 miniz_oxide = "0.7"
 once_cell = "1"
-pdf-writer = "0.9.1"
+pdf-writer = "0.9.2"
 pixglyph = "0.2"
 palette = { version = "0.7.3", default-features = false, features = ["approx", "libm"] }
 regex = "1"

--- a/crates/typst/src/export/pdf/mod.rs
+++ b/crates/typst/src/export/pdf/mod.rs
@@ -207,8 +207,7 @@ fn write_catalog(ctx: &mut PdfContext, ident: Option<&str>, timestamp: Option<Da
 
     // A unique ID for this instance of the document. Changes if anything
     // changes in the frames.
-    let instance_id =
-        hash_base64(&(&ctx.document, ctx.document.date.unwrap_or(timestamp)));
+    let instance_id = hash_base64(&ctx.pdf);
 
     if let Some(ident) = ident {
         // A unique ID for the document that stays stable across compilations.

--- a/crates/typst/src/export/pdf/mod.rs
+++ b/crates/typst/src/export/pdf/mod.rs
@@ -207,7 +207,7 @@ fn write_catalog(ctx: &mut PdfContext, ident: Option<&str>, timestamp: Option<Da
 
     // A unique ID for this instance of the document. Changes if anything
     // changes in the frames.
-    let instance_id = hash_base64(&ctx.pdf);
+    let instance_id = hash_base64(&ctx.pdf.as_bytes());
 
     if let Some(ident) = ident {
         // A unique ID for the document that stays stable across compilations.


### PR DESCRIPTION
~Blocked on https://github.com/typst/pdf-writer/pull/28. This won't compile until that is merged and the dependency is updated in this repo.~

Fixes https://github.com/typst/typst/issues/2536