### PR TITLE
Implement dict key interpolation

### DIFF
--- a/crates/typst-syntax/src/ast.rs
+++ b/crates/typst-syntax/src/ast.rs
@@ -1270,11 +1270,8 @@ node! {
 
 impl<'a> Keyed<'a> {
     /// The key: `"spacy key"`.
-    pub fn key(self) -> Str<'a> {
-        self.0
-            .children()
-            .find_map(|node| node.cast::<Str>())
-            .unwrap_or_default()
+    pub fn key(self) -> Expr<'a> {
+        self.0.cast_first_match().unwrap_or_default()
     }
 
     /// The right-hand side of the pair: `true`.

--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -943,19 +943,18 @@ fn item(p: &mut Parser, keyed: bool) -> SyntaxKind {
 
     let kind = match p.node(m).map(SyntaxNode::kind) {
         Some(SyntaxKind::Ident) => SyntaxKind::Named,
-        Some(SyntaxKind::Str) if keyed => SyntaxKind::Keyed,
+        Some(_) if keyed => SyntaxKind::Keyed,
         _ => {
             for child in p.post_process(m) {
                 if child.kind() == SyntaxKind::Colon {
                     break;
                 }
 
-                let mut message = EcoString::from("expected identifier");
-                if keyed {
-                    message.push_str(" or string");
-                }
-                message.push_str(", found ");
-                message.push_str(child.kind().name());
+                let expected = if keyed { "expression" } else { "identifier" };
+                let message = eco_format!(
+                    "expected {expected}, found {found}",
+                    found = child.kind().name(),
+                );
                 child.convert_to_error(message);
             }
             SyntaxKind::Named
@@ -1235,9 +1234,12 @@ fn validate_dict<'a>(children: impl Iterator<Item = &'a mut SyntaxNode>) {
         match child.kind() {
             SyntaxKind::Named | SyntaxKind::Keyed => {
                 let Some(first) = child.children_mut().first_mut() else { continue };
-                let key = match first.cast::<ast::Str>() {
-                    Some(str) => str.get(),
-                    None => first.text().clone(),
+                let key = if let Some(str) = first.cast::<ast::Str>() {
+                    str.get()
+                } else if let Some(ident) = first.cast::<ast::Ident>() {
+                    ident.get().clone()
+                } else {
+                    continue;
                 };
 
                 if !used.insert(key.clone()) {

--- a/crates/typst/src/eval/mod.rs
+++ b/crates/typst/src/eval/mod.rs
@@ -1022,12 +1022,8 @@ impl Eval for ast::Dict<'_> {
                 ast::DictItem::Keyed(keyed) => {
                     let raw_key = keyed.key();
                     let key = raw_key.eval(vm)?;
-                    let key_ty = key.ty();
-                    let key = key.cast::<Str>().unwrap_or_else(|_| {
-                        let message = eco_format!(
-                            "key must evaluate to a string, but evaluated to {key_ty}",
-                        );
-                        let error = SourceDiagnostic::error(raw_key.span(), message);
+                    let key = key.cast::<Str>().unwrap_or_else(|error| {
+                        let error = SourceDiagnostic::error(raw_key.span(), error);
                         invalid_keys.push(error);
                         Str::default()
                     });

--- a/tests/typ/compiler/dict.typ
+++ b/tests/typ/compiler/dict.typ
@@ -92,13 +92,13 @@
 #(a: 1, b)
 
 // Identified as dictionary due to initial colon.
+// The boolean key is allowed for now since it will only cause an error at the evaluation stage.
 // Error: 4-5 expected named or keyed pair, found integer
 // Error: 5 expected comma
-// Error: 12-16 expected identifier or string, found boolean
 // Error: 17 expected expression
 #(:1 b:"", true:)
 
-// Error: 3-8 expected identifier or string, found binary expression
+// This is allowed since the key can be an expression.
 #(a + b: "hey")
 
 ---
@@ -124,3 +124,12 @@
   // Error: 8-15 type dictionary has no method `nonfunc`
   dict.nonfunc()
 }
+
+---
+#let a = "hello"
+#let b = "world"
+#let c = "value"
+#(a + b: c)
+// Error: 3-7 key must evaluate to a string, but evaluated to boolean
+// Error: 16-18 key must evaluate to a string, but evaluated to integer
+#(true: false, 42: 3)

--- a/tests/typ/compiler/dict.typ
+++ b/tests/typ/compiler/dict.typ
@@ -130,6 +130,6 @@
 #let b = "world"
 #let c = "value"
 #(a + b: c)
-// Error: 3-7 key must evaluate to a string, but evaluated to boolean
-// Error: 16-18 key must evaluate to a string, but evaluated to integer
+// Error: 3-7 expected string, found boolean
+// Error: 16-18 expected string, found integer
 #(true: false, 42: 3)

--- a/tests/typ/compiler/dict.typ
+++ b/tests/typ/compiler/dict.typ
@@ -98,9 +98,6 @@
 // Error: 17 expected expression
 #(:1 b:"", true:)
 
-// This is allowed since the key can be an expression.
-#(a + b: "hey")
-
 ---
 // Error: 3-15 cannot mutate a temporary value
 #((key: "val").other = "some")
@@ -129,7 +126,19 @@
 #let a = "hello"
 #let b = "world"
 #let c = "value"
-#(a + b: c)
+#let d = "conflict"
+
+#assert.eq(((a): b), ("hello": "world"))
+#assert.eq(((a): 1, (a): 2), ("hello": 2))
+#assert.eq((hello: 1, (a): 2), ("hello": 2))
+#assert.eq((a + b: c, (a + b): d, (a): "value2", a: "value3"), ("helloworld": "conflict", "hello": "value2", "a": "value3"))
+
+---
+// Error: 7-10 expected identifier, found group
+// Error: 12-14 expected identifier, found integer
+#let ((a): 10) = "world"
+
+---
 // Error: 3-7 expected string, found boolean
 // Error: 16-18 expected string, found integer
 #(true: false, 42: 3)


### PR DESCRIPTION
Some things to note:

- `Keyed` now refers to any item expr where the key is not a literal identifier.
- `validate_dict` does a best attempt but is not fully accurate. Dynamic conflicts or non-string eval results at runtime will be caught at the evaluation stage. **This may not be desirable. Please advise.**
- Evaluation of a dict will collect all errors about invalid keys so the error can be a bit nicer if there are multiple invalid keys. **I'm not sure if this is a good approach. Please advise.**
- Test cases added