### PR TITLE
"Key interpolation not allowed" hint

### DIFF
--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -956,6 +956,9 @@ fn item(p: &mut Parser, keyed: bool) -> SyntaxKind {
                     found = child.kind().name(),
                 );
                 child.convert_to_error(message);
+                if !keyed {
+                    child.hint("key interpolation is not allowed here");
+                }
             }
             SyntaxKind::Named
         }

--- a/tests/typ/compiler/call.typ
+++ b/tests/typ/compiler/call.typ
@@ -81,16 +81,20 @@
 #func(1 2)
 
 // Error: 7-8 expected identifier, found integer
+// Hint: 7-8 key interpolation is not allowed here
 // Error: 9 expected expression
 #func(1:)
 
 // Error: 7-8 expected identifier, found integer
+// Hint: 7-8 key interpolation is not allowed here
 #func(1:2)
 
 // Error: 7-12 expected identifier, found string
+// Hint: 7-12 key interpolation is not allowed here
 #func("abc": 2)
 
 // Error: 7-10 expected identifier, found group
+// Hint: 7-10 key interpolation is not allowed here
 #func((x):1)
 
 ---

--- a/tests/typ/compiler/closure.typ
+++ b/tests/typ/compiler/closure.typ
@@ -175,6 +175,7 @@
 #let f((a: b), (c,), a) = none
 
 // Error: 8-14 expected identifier, found array
+// Hint: 8-14 key interpolation is not allowed here
 #let f((a, b): 0) = none
 
 // Error: 10-19 expected identifier, found destructuring pattern
@@ -206,10 +207,12 @@
 
 ---
 // Error: 10-15 expected identifier, found string
+// Hint: 10-15 key interpolation is not allowed here
 #let foo("key": b) = key
 
 ---
 // Error: 10-14 expected identifier, found `none`
+// Hint: 10-14 key interpolation is not allowed here
 #let foo(none: b) = key
 
 ---

--- a/tests/typ/compiler/dict.typ
+++ b/tests/typ/compiler/dict.typ
@@ -135,6 +135,7 @@
 
 ---
 // Error: 7-10 expected identifier, found group
+// Hint: 7-10 key interpolation is not allowed here
 // Error: 12-14 expected identifier, found integer
 #let ((a): 10) = "world"
 


### PR DESCRIPTION
This hint might be helpful in some cases. In its current state it's a bit noisy. Up to you whether this makes sense.