### PR TITLE
Add hints for invalid identifier errors

### DIFF
--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -1686,7 +1686,7 @@ impl<'s> Parser<'s> {
             let found = self.current.name();
             self.expected_found(kind.name(), found);
             self.hint(eco_format!(
-                "{} is not allowed as an identifier, try `_{}`",
+                "{} is not allowed as an identifier; try `_{}` instead",
                 found,
                 found_text
             ));

--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -1686,7 +1686,7 @@ impl<'s> Parser<'s> {
             let found = self.current.name();
             self.expected_found(kind.name(), found);
             self.hint(eco_format!(
-                "{} is not allowed as an identifier; try `_{}` instead",
+                "{} is not allowed as an identifier; try `{}_` instead",
                 found,
                 found_text
             ));

--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -1682,7 +1682,14 @@ impl<'s> Parser<'s> {
         if at {
             self.eat();
         } else if kind == SyntaxKind::Ident && self.current.is_keyword() {
-            self.expected_found(kind.name(), self.current.name());
+            let found_text = self.current_text();
+            let found = self.current.name();
+            self.expected_found(kind.name(), found);
+            self.hint(eco_format!(
+                "{} is not allowed as an identifier, try `_{}`",
+                found,
+                found_text
+            ));
         } else {
             self.balanced &= !kind.is_grouping();
             self.expected(kind.name());

--- a/crates/typst/src/diag.rs
+++ b/crates/typst/src/diag.rs
@@ -225,7 +225,8 @@ impl<T> Trace<T> for SourceResult<T> {
 /// A result type with a string error message.
 pub type StrResult<T> = Result<T, EcoString>;
 
-/// Convert a [`StrResult`] to a [`SourceResult`] by adding span information.
+/// Convert a [`StrResult`] and [`HintedStrResult`] to a [`SourceResult`] by
+/// adding span information.
 pub trait At<T> {
     /// Add the span information.
     fn at(self, span: Span) -> SourceResult<T>;
@@ -259,6 +260,12 @@ pub struct HintedString {
     /// Additional hints to the user, indicating how this error could be avoided
     /// or worked around.
     pub hints: Vec<EcoString>,
+}
+
+impl From<EcoString> for HintedString {
+    fn from(value: EcoString) -> Self {
+        Self { message: value, hints: vec![] }
+    }
 }
 
 impl<T> At<T> for Result<T, HintedString> {

--- a/crates/typst/src/diag.rs
+++ b/crates/typst/src/diag.rs
@@ -225,7 +225,7 @@ impl<T> Trace<T> for SourceResult<T> {
 /// A result type with a string error message.
 pub type StrResult<T> = Result<T, EcoString>;
 
-/// Convert a [`StrResult`] and [`HintedStrResult`] to a [`SourceResult`] by
+/// Convert a [`StrResult`] or [`HintedStrResult`] to a [`SourceResult`] by
 /// adding span information.
 pub trait At<T> {
     /// Add the span information.

--- a/crates/typst/src/eval/func.rs
+++ b/crates/typst/src/eval/func.rs
@@ -9,7 +9,7 @@ use super::{
     cast, scope, ty, Args, CastInfo, Eval, FlowEvent, IntoValue, Route, Scope, Scopes,
     Tracer, Type, Value, Vm,
 };
-use crate::diag::{bail, SourceResult, StrResult};
+use crate::diag::{bail, HintedStrResult, SourceResult, StrResult};
 use crate::model::{
     Content, DelayedErrors, Element, Introspector, Locator, Selector, Vt,
 };
@@ -764,7 +764,7 @@ impl<'a> CapturesVisitor<'a> {
     fn capture(
         &mut self,
         ident: &str,
-        getter: impl FnOnce(&'a Scopes<'a>, &str) -> StrResult<&'a Value>,
+        getter: impl FnOnce(&'a Scopes<'a>, &str) -> HintedStrResult<&'a Value>,
     ) {
         if self.internal.get(ident).is_err() {
             let Some(value) = self

--- a/crates/typst/src/eval/scope.rs
+++ b/crates/typst/src/eval/scope.rs
@@ -80,8 +80,9 @@ fn unknown_variable(var: &str) -> HintedString {
     };
 
     if matches!(var, "none" | "true" | "false" | "auto") {
-        res.hints
-            .push(eco_format!("if you meant to use a literal, add a hash before it"));
+        res.hints.push(eco_format!(
+            "if you meant to use a literal, try adding a hash before it"
+        ));
     } else if var.contains('-') {
         res.hints.push(eco_format!(
             "if you meant to use subtraction, try adding spaces around the minus sign",

--- a/crates/typst/src/eval/scope.rs
+++ b/crates/typst/src/eval/scope.rs
@@ -7,7 +7,7 @@ use indexmap::IndexMap;
 use super::{
     Func, IntoValue, Library, Module, NativeFunc, NativeFuncData, NativeType, Type, Value,
 };
-use crate::diag::{bail, StrResult};
+use crate::diag::{bail, HintedStrResult, HintedString, StrResult};
 use crate::model::{Element, NativeElement};
 
 /// A stack of scopes.
@@ -40,7 +40,7 @@ impl<'a> Scopes<'a> {
     }
 
     /// Try to access a variable immutably.
-    pub fn get(&self, var: &str) -> StrResult<&Value> {
+    pub fn get(&self, var: &str) -> HintedStrResult<&Value> {
         std::iter::once(&self.top)
             .chain(self.scopes.iter().rev())
             .chain(self.base.map(|base| base.global.scope()))
@@ -49,22 +49,22 @@ impl<'a> Scopes<'a> {
     }
 
     /// Try to access a variable immutably in math.
-    pub fn get_in_math(&self, var: &str) -> StrResult<&Value> {
+    pub fn get_in_math(&self, var: &str) -> HintedStrResult<&Value> {
         std::iter::once(&self.top)
             .chain(self.scopes.iter().rev())
             .chain(self.base.map(|base| base.math.scope()))
             .find_map(|scope| scope.get(var))
-            .ok_or_else(|| eco_format!("unknown variable: {}", var))
+            .ok_or_else(|| unknown_variable(var))
     }
 
     /// Try to access a variable mutably.
-    pub fn get_mut(&mut self, var: &str) -> StrResult<&mut Value> {
+    pub fn get_mut(&mut self, var: &str) -> HintedStrResult<&mut Value> {
         std::iter::once(&mut self.top)
             .chain(&mut self.scopes.iter_mut().rev())
             .find_map(|scope| scope.get_mut(var))
             .ok_or_else(|| {
                 match self.base.and_then(|base| base.global.scope().get(var)) {
-                    Some(_) => eco_format!("cannot mutate a constant: {}", var),
+                    Some(_) => eco_format!("cannot mutate a constant: {}", var).into(),
                     _ => unknown_variable(var),
                 }
             })?
@@ -73,16 +73,22 @@ impl<'a> Scopes<'a> {
 
 /// The error message when a variable is not found.
 #[cold]
-fn unknown_variable(var: &str) -> EcoString {
-    if var.contains('-') {
-        eco_format!(
-            "unknown variable: {} - if you meant to use subtraction, \
-             try adding spaces around the minus sign.",
-            var
-        )
-    } else {
-        eco_format!("unknown variable: {}", var)
+fn unknown_variable(var: &str) -> HintedString {
+    let mut res = HintedString {
+        message: eco_format!("unknown variable: {}", var),
+        hints: vec![],
+    };
+
+    if matches!(var, "none" | "true" | "false" | "auto") {
+        res.hints
+            .push(eco_format!("if you meant to use a literal, add a hash before it"));
+    } else if var.contains('-') {
+        res.hints.push(eco_format!(
+            "if you meant to use subtraction, try adding spaces around the minus sign",
+        ));
     }
+
+    res
 }
 
 /// A map from binding names to values.
@@ -170,8 +176,11 @@ impl Scope {
     }
 
     /// Try to access a variable mutably.
-    pub fn get_mut(&mut self, var: &str) -> Option<StrResult<&mut Value>> {
-        self.map.get_mut(var).map(Slot::write)
+    pub fn get_mut(&mut self, var: &str) -> Option<HintedStrResult<&mut Value>> {
+        self.map
+            .get_mut(var)
+            .map(Slot::write)
+            .map(|res| res.map_err(HintedString::from))
     }
 
     /// Get the category of a definition.

--- a/crates/typst/src/eval/scope.rs
+++ b/crates/typst/src/eval/scope.rs
@@ -79,7 +79,7 @@ fn unknown_variable(var: &str) -> HintedString {
         hints: vec![],
     };
 
-    if matches!(var, "none" | "true" | "false" | "auto") {
+    if matches!(var, "none" | "auto" | "false" | "true") {
         res.hints.push(eco_format!(
             "if you meant to use a literal, try adding a hash before it"
         ));

--- a/tests/typ/compiler/embedded-expr.typ
+++ b/tests/typ/compiler/embedded-expr.typ
@@ -3,11 +3,13 @@
 
 ---
 // Error: 6-8 expected identifier, found keyword `as`
+// Hint: 6-8 keyword `as` is not allowed as an identifier, try `_as`
 #let as = 1 + 2
 
 ---
 #{
   // Error: 7-9 expected identifier, found keyword `as`
+  // Hint: 7-9 keyword `as` is not allowed as an identifier, try `_as`
   let as = 10
 }
 

--- a/tests/typ/compiler/embedded-expr.typ
+++ b/tests/typ/compiler/embedded-expr.typ
@@ -3,13 +3,13 @@
 
 ---
 // Error: 6-8 expected identifier, found keyword `as`
-// Hint: 6-8 keyword `as` is not allowed as an identifier, try `_as`
+// Hint: 6-8 keyword `as` is not allowed as an identifier; try `_as` instead
 #let as = 1 + 2
 
 ---
 #{
   // Error: 7-9 expected identifier, found keyword `as`
-  // Hint: 7-9 keyword `as` is not allowed as an identifier, try `_as`
+  // Hint: 7-9 keyword `as` is not allowed as an identifier; try `_as` instead
   let as = 10
 }
 

--- a/tests/typ/compiler/embedded-expr.typ
+++ b/tests/typ/compiler/embedded-expr.typ
@@ -3,13 +3,13 @@
 
 ---
 // Error: 6-8 expected identifier, found keyword `as`
-// Hint: 6-8 keyword `as` is not allowed as an identifier; try `_as` instead
+// Hint: 6-8 keyword `as` is not allowed as an identifier; try `as_` instead
 #let as = 1 + 2
 
 ---
 #{
   // Error: 7-9 expected identifier, found keyword `as`
-  // Hint: 7-9 keyword `as` is not allowed as an identifier; try `_as` instead
+  // Hint: 7-9 keyword `as` is not allowed as an identifier; try `as_` instead
   let as = 10
 }
 

--- a/tests/typ/compiler/hint.typ
+++ b/tests/typ/compiler/hint.typ
@@ -11,13 +11,15 @@
   a = 1-a
   a = a -1
 
-  // Error: 7-10 unknown variable: a-1 - if you meant to use subtraction, try adding spaces around the minus sign.
+  // Error: 7-10 unknown variable: a-1
+  // Hint: 7-10 if you meant to use subtraction, try adding spaces around the minus sign
   a = a-1
 }
 
 ---
 #{
-  // Error: 3-6 unknown variable: a-1 - if you meant to use subtraction, try adding spaces around the minus sign.
+  // Error: 3-6 unknown variable: a-1
+  // Hint: 3-6 if you meant to use subtraction, try adding spaces around the minus sign
   a-1 = 2
 }
 


### PR DESCRIPTION
## Invalid identifiers
```typst
#let none = none
```

Will add a hint why this specific node is not expected here:
```
error: expected identifier, found `none`
  ┌─ test/test.typ:1:5
  │
1 │ #let none = none
  │      ^^^^
  │
  = hint: `none` is not allowed as an identifier; try `_none` instead
```

This previously hinted within the error message itself:
```typst
#let a = 1
#{a = a-1}
```

Now uses a hint to suggest adding spaces around the minus if the var is unknown:
```
error: unknown variable: a-1
  ┌─ test/test.typ:2:6
  │
2 │ #{a = a-1}
  │       ^^^
  │
  = hint: if you meant to use subtraction, try adding spaces around the minus sign
```

## Unknown variable in math mode
```typst
#let bbox(stroke: 0pt) = box(stroke: stroke)[$b o x$]
$ bbox(stroke: none) $
```

Will now for some literals hint that a has must be used:
```
error: unknown variable: none
  ┌─ test/test.typ:2:15
  │
2 │ $ bbox(stroke: none) $
  │                ^^^^
  │
  = hint: if you meant to use a literal, add a hash before it
```

Because `bbox(stroke: 12pt)` will create 2 tokens, `[12, pt]` the node would only get `pt` which is a valid identifier, so not all cases are easily caught with this.

I opted to keep it simple (only triggers on `false`, `true`, `none` and `auto`) to avoid false positives.