### PR TITLE
Make reference to spreading in arguments of `grid`

### DIFF
--- a/crates/typst-library/src/layout/grid.rs
+++ b/crates/typst-library/src/layout/grid.rs
@@ -36,26 +36,30 @@ use super::Sizing;
 ///
 /// # Example
 /// ```example
-/// #set text(10pt, style: "italic")
-/// #let cell = rect.with(
+/// // We use `rect` to emphasize the area of cells
+/// #set rect(
 ///   inset: 8pt,
 ///   fill: rgb("e4e5ea"),
 ///   width: 100%,
-///   radius: 6pt
 /// )
+/// 
 /// #grid(
-///   columns: (60pt, 1fr, 60pt),
-///   rows: (60pt, auto),
+///   columns: (60pt, 1fr, 2fr),
+///   rows: (auto, 60pt),
 ///   gutter: 3pt,
-///   cell(height: 100%)[Easy to learn],
-///   cell(height: 100%)[Great output],
-///   cell(height: 100%)[Intuitive],
-///   cell[Our best Typst yet],
-///   cell[
-///     Responsive design in print
-///     for everyone
-///   ],
-///   cell[One more thing...],
+///   rect[Fixed width, auto height],
+///   rect[1/3 of the remains],
+///   rect[2/3 of the remains],
+///   rect(height: 100%)[Fixed height],
+///   image("tiger.jpg", height: 100%),
+///   image("tiger.jpg", height: 100%),
+/// )
+/// 
+/// // We can also "spread" an array of content or strings
+/// #grid(
+///   columns: 5,
+///   gutter: 5pt,
+///   ..range(25).map(str)
 /// )
 /// ```
 #[elem(Layout)]
@@ -94,8 +98,6 @@ pub struct GridElem {
     /// The contents of the grid cells.
     ///
     /// The cells are populated in row-major order.
-    ///
-    /// You can also [spread](https://typst.app/docs/reference/foundations/arguments/#spreading) an array of content.
     #[variadic]
     pub children: Vec<Content>,
 }

--- a/crates/typst-library/src/layout/grid.rs
+++ b/crates/typst-library/src/layout/grid.rs
@@ -34,9 +34,12 @@ use super::Sizing;
 /// instead of an array. For example, `columns:` `{3}` is equivalent to
 /// `columns:` `{(auto, auto, auto)}`.
 ///
-/// # Example
+/// # Examples
+/// The example below demonstrates the different track sizing options.
+///
 /// ```example
-/// // We use `rect` to emphasize the area of cells
+/// // We use `rect` to emphasize the
+/// // area of cells.
 /// #set rect(
 ///   inset: 8pt,
 ///   fill: rgb("e4e5ea"),
@@ -54,8 +57,12 @@ use super::Sizing;
 ///   image("tiger.jpg", height: 100%),
 ///   image("tiger.jpg", height: 100%),
 /// )
+/// ```
 ///
-/// // We can also "spread" an array of content or strings
+/// You can also [spread]($arguments/#spreading) an array of strings or content
+/// into a grid to populate its cells.
+///
+/// ```example
 /// #grid(
 ///   columns: 5,
 ///   gutter: 5pt,

--- a/crates/typst-library/src/layout/grid.rs
+++ b/crates/typst-library/src/layout/grid.rs
@@ -94,6 +94,8 @@ pub struct GridElem {
     /// The contents of the grid cells.
     ///
     /// The cells are populated in row-major order.
+    ///
+    /// You can also [spread](https://typst.app/docs/reference/foundations/arguments/#spreading) an array of content.
     #[variadic]
     pub children: Vec<Content>,
 }

--- a/crates/typst-library/src/layout/grid.rs
+++ b/crates/typst-library/src/layout/grid.rs
@@ -42,7 +42,7 @@ use super::Sizing;
 ///   fill: rgb("e4e5ea"),
 ///   width: 100%,
 /// )
-/// 
+///
 /// #grid(
 ///   columns: (60pt, 1fr, 2fr),
 ///   rows: (auto, 60pt),
@@ -54,7 +54,7 @@ use super::Sizing;
 ///   image("tiger.jpg", height: 100%),
 ///   image("tiger.jpg", height: 100%),
 /// )
-/// 
+///
 /// // We can also "spread" an array of content or strings
 /// #grid(
 ///   columns: 5,


### PR DESCRIPTION
This PR makes a reference on "spreading" in the description of the `childen` argument of a grid. Note that in the original PR, I inserted a direct/manual/hard link to https://typst.app/docs/reference/foundations/arguments/#spreading. I am not sure about how to use internal links (like `[grid documentation]($grid)` from https://github.com/typst/typst/blob/main/crates/typst-library/src/layout/table.rs), but that should be done before this is merged.

This PR spawned from [this](https://github.com/typst/typst/issues/2339) issue