### PR TITLE
Fix OkLab color negation

### DIFF
--- a/crates/typst/src/geom/color.rs
+++ b/crates/typst/src/geom/color.rs
@@ -906,7 +906,7 @@ impl Color {
     pub fn negate(self) -> Color {
         match self {
             Self::Luma(c) => Self::Luma(Luma::new(1.0 - c.luma)),
-            Self::Oklab(c) => Self::Oklab(Oklab::new(c.l, 1.0 - c.a, 1.0 - c.b, c.alpha)),
+            Self::Oklab(c) => Self::Oklab(Oklab::new(c.l, -c.a, -c.b, c.alpha)),
             Self::LinearRgb(c) => Self::LinearRgb(LinearRgba::new(
                 1.0 - c.red,
                 1.0 - c.green,


### PR DESCRIPTION
This changes negation to effectively rotate hue by 180deg.
Previously, negation failed in certain cases and produced unexpected results.
