### PR TITLE
Fix color export for SVG

### DIFF
--- a/crates/typst/src/export/svg.rs
+++ b/crates/typst/src/export/svg.rs
@@ -1243,7 +1243,7 @@ impl ColorEncode for Color {
             Color::LinearRgb(rgb) => {
                 if rgb.alpha != 1.0 {
                     eco_format!(
-                        "color(srgb-linear {:.3} {:.3} {:.3} / {:.3})",
+                        "color(srgb-linear {:.5} {:.5} {:.5} / {:.5})",
                         rgb.red,
                         rgb.green,
                         rgb.blue,
@@ -1251,7 +1251,7 @@ impl ColorEncode for Color {
                     )
                 } else {
                     eco_format!(
-                        "color(srgb-linear {:.3} {:.3} {:.3})",
+                        "color(srgb-linear {:.5} {:.5} {:.5})",
                         rgb.red,
                         rgb.green,
                         rgb.blue,
@@ -1261,16 +1261,16 @@ impl ColorEncode for Color {
             Color::Oklab(oklab) => {
                 if oklab.alpha != 1.0 {
                     eco_format!(
-                        "oklab({:?} {:.3} {:.3} / {:.3})",
-                        Ratio::new(oklab.l as f64),
+                        "oklab({:.3}% {:.5} {:.5} / {:.5})",
+                        Ratio::new(oklab.l as f64).get() * 100.0,
                         oklab.a,
                         oklab.b,
                         oklab.alpha
                     )
                 } else {
                     eco_format!(
-                        "oklab({:?} {:.3} {:.3})",
-                        Ratio::new(oklab.l as f64),
+                        "oklab({:.3}% {:.5} {:.5})",
+                        Ratio::new(oklab.l as f64).get() * 100.0,
                         oklab.a,
                         oklab.b,
                     )
@@ -1279,18 +1279,18 @@ impl ColorEncode for Color {
             Color::Hsl(hsl) => {
                 if hsl.alpha != 1.0 {
                     eco_format!(
-                        "hsla({:?} {:?} {:?} / {:.3})",
-                        Angle::deg(hsl.hue.into_degrees() as f64),
-                        Ratio::new(hsl.saturation as f64),
-                        Ratio::new(hsl.lightness as f64),
+                        "hsla({:.3}deg {:.3}% {:.3}% / {:.5})",
+                        Angle::deg(hsl.hue.into_degrees() as f64).to_deg(),
+                        Ratio::new(hsl.saturation as f64).get() * 100.0,
+                        Ratio::new(hsl.lightness as f64).get() * 100.0,
                         hsl.alpha,
                     )
                 } else {
                     eco_format!(
-                        "hsl({:?} {:?} {:?})",
-                        Angle::deg(hsl.hue.into_degrees() as f64),
-                        Ratio::new(hsl.saturation as f64),
-                        Ratio::new(hsl.lightness as f64),
+                        "hsl({:.3}deg {:.3}% {:.3}%)",
+                        Angle::deg(hsl.hue.into_degrees() as f64).to_deg(),
+                        Ratio::new(hsl.saturation as f64).get() * 100.0,
+                        Ratio::new(hsl.lightness as f64).get() * 100.0,
                     )
                 }
             }

--- a/crates/typst/src/export/svg.rs
+++ b/crates/typst/src/export/svg.rs
@@ -1262,7 +1262,7 @@ impl ColorEncode for Color {
                 if oklab.alpha != 1.0 {
                     eco_format!(
                         "oklab({:.3}% {:.5} {:.5} / {:.5})",
-                        oklab.l as f64 * 100.0,
+                        oklab.l * 100.0,
                         oklab.a,
                         oklab.b,
                         oklab.alpha
@@ -1270,7 +1270,7 @@ impl ColorEncode for Color {
                 } else {
                     eco_format!(
                         "oklab({:.3}% {:.5} {:.5})",
-                        oklab.l as f64 * 100.0,
+                        oklab.l * 100.0,
                         oklab.a,
                         oklab.b,
                     )
@@ -1280,17 +1280,17 @@ impl ColorEncode for Color {
                 if hsl.alpha != 1.0 {
                     eco_format!(
                         "hsla({:.3}deg {:.3}% {:.3}% / {:.5})",
-                        hsl.hue.into_degrees() as f64,
-                        hsl.saturation as f64 * 100.0,
-                        hsl.lightness as f64 * 100.0,
+                        hsl.hue.into_degrees(),
+                        hsl.saturation * 100.0,
+                        hsl.lightness * 100.0,
                         hsl.alpha,
                     )
                 } else {
                     eco_format!(
                         "hsl({:.3}deg {:.3}% {:.3}%)",
-                        hsl.hue.into_degrees() as f64,
-                        hsl.saturation as f64 * 100.0,
-                        hsl.lightness as f64 * 100.0,
+                        hsl.hue.into_degrees(),
+                        hsl.saturation * 100.0,
+                        hsl.lightness * 100.0,
                     )
                 }
             }

--- a/crates/typst/src/export/svg.rs
+++ b/crates/typst/src/export/svg.rs
@@ -1262,7 +1262,7 @@ impl ColorEncode for Color {
                 if oklab.alpha != 1.0 {
                     eco_format!(
                         "oklab({:.3}% {:.5} {:.5} / {:.5})",
-                        Ratio::new(oklab.l as f64).get() * 100.0,
+                        oklab.l as f64 * 100.0,
                         oklab.a,
                         oklab.b,
                         oklab.alpha
@@ -1270,7 +1270,7 @@ impl ColorEncode for Color {
                 } else {
                     eco_format!(
                         "oklab({:.3}% {:.5} {:.5})",
-                        Ratio::new(oklab.l as f64).get() * 100.0,
+                        oklab.l as f64 * 100.0,
                         oklab.a,
                         oklab.b,
                     )
@@ -1280,17 +1280,17 @@ impl ColorEncode for Color {
                 if hsl.alpha != 1.0 {
                     eco_format!(
                         "hsla({:.3}deg {:.3}% {:.3}% / {:.5})",
-                        Angle::deg(hsl.hue.into_degrees() as f64).to_deg(),
-                        Ratio::new(hsl.saturation as f64).get() * 100.0,
-                        Ratio::new(hsl.lightness as f64).get() * 100.0,
+                        hsl.hue.into_degrees() as f64,
+                        hsl.saturation as f64 * 100.0,
+                        hsl.lightness as f64 * 100.0,
                         hsl.alpha,
                     )
                 } else {
                     eco_format!(
                         "hsl({:.3}deg {:.3}% {:.3}%)",
-                        Angle::deg(hsl.hue.into_degrees() as f64).to_deg(),
-                        Ratio::new(hsl.saturation as f64).get() * 100.0,
-                        Ratio::new(hsl.lightness as f64).get() * 100.0,
+                        hsl.hue.into_degrees() as f64,
+                        hsl.saturation as f64 * 100.0,
+                        hsl.lightness as f64 * 100.0,
                     )
                 }
             }


### PR DESCRIPTION
Before this change (including 0.9.0), colors were exported incorrectly in SVGs.
This PR resolves this issue.

You can verify that it works by rendering the following typst code.
It should display yellow and red bars with and without transparency.
```typ
#rect(
  width: 100%,
  height: 20pt,
  fill: color.linear-rgb(100%, 50%, 0%, 50%),
)
#rect(
  width: 100%,
  height: 20pt,
  fill: oklab(60%, 40%, 40%, 50%),
)
#rect(
  width: 100%,
  height: 20pt,
  fill: color.hsl(0deg, 40%, 60%, 50%),
)
#rect(
  width: 100%,
  height: 20pt,
  fill: color.linear-rgb(100%, 50%, 0%),
)
#rect(
  width: 100%,
  height: 20pt,
  fill: oklab(60%, 40%, 40%),
)
#rect(
  width: 100%,
  height: 20pt,
  fill: color.hsl(0deg, 40%, 60%),
)
```
