### PR TITLE
Implement csv file header rows support. 

### DIFF
--- a/crates/typst-library/src/compute/data.rs
+++ b/crates/typst-library/src/compute/data.rs
@@ -131,7 +131,9 @@ pub fn csv(
     #[default]
     delimiter: Delimiter,
     /// Whether the CSV file has a header row.
-    /// Defaults to `{true}`.
+    /// When using this option, each row in the CSV file will be represented as an dictionary, where the header field is the key and the row field is the value.
+    /// All rows will be collected into a single array. Header rows will be stripped.
+    /// Defaults to `{false}`.
     #[named]
     #[default(false)]
     has_headers: bool,
@@ -155,7 +157,7 @@ impl csv {
         #[default]
         delimiter: Delimiter,
         /// Whether the CSV file has a header row.
-        /// Defaults to `{true}`.
+        /// Defaults to `{false}`.
         #[named]
         #[default(false)]
         has_headers: bool,

--- a/crates/typst-library/src/compute/data.rs
+++ b/crates/typst-library/src/compute/data.rs
@@ -167,7 +167,10 @@ impl csv {
         let mut reader = builder.from_reader(data.as_slice());
         let mut headers: Option<::csv::StringRecord> = None;
 
+        let mut line_offset: usize = 1; // Counting lines from 1
+
         if has_headers {
+            line_offset = 2; // Counting lines from 2 (1 is header)
             let headers_result = reader.headers();
             headers = Some(headers_result.map_err(|err| format_csv_error(err, 1)).at(span)?.clone());
         }
@@ -177,8 +180,8 @@ impl csv {
         for (line, result) in reader.records().enumerate() {
             // Original solution use line from error, but that is incorrect with
             // `has_headers` set to `false`. See issue:
-            // https://github.com/BurntSushi/rust-csv/issues/184
-            let line = line + 1; // Counting lines from 1
+            // https://github.com/BurntSushi/rust-csv/issues/184            
+            let line = line + line_offset; 
             let row = result.map_err(|err| format_csv_error(err, line)).at(span)?;
             if let Some(headers) = headers.clone() {
                 let mut dict = Dict::new();

--- a/crates/typst-library/src/compute/data.rs
+++ b/crates/typst-library/src/compute/data.rs
@@ -180,12 +180,12 @@ impl csv {
         for (line, result) in reader.records().enumerate() {
             // Original solution use line from error, but that is incorrect with
             // `has_headers` set to `false`. See issue:
-            // https://github.com/BurntSushi/rust-csv/issues/184            
-            let line = line + line_offset; 
+            // https://github.com/BurntSushi/rust-csv/issues/184
+            let line = line + line_offset;
             let row = result.map_err(|err| format_csv_error(err, line)).at(span)?;
             if let Some(headers) = headers.clone() {
                 let mut dict = Dict::new();
-                for (header_field, field) in headers.into_iter().zip(row.into_iter()) { 
+                for (header_field, field) in headers.into_iter().zip(row.into_iter()) {
                     let value = field.into_value();
                     dict.insert(header_field.into(), value)
                 }
@@ -196,7 +196,7 @@ impl csv {
             }
         }
 
-        Ok(array)       
+        Ok(array)
     }
 }
 

--- a/tests/typ/compute/data.typ
+++ b/tests/typ/compute/data.typ
@@ -23,12 +23,25 @@
 #table(columns: data.at(0).len(), ..cells)
 
 ---
+// Test reading CSV data with headers enabled.
+#let data = csv("/files/zoo.csv", has-headers: true)
+#test(data.len(), 3)
+#test(data.at(0).Name, "Debby")
+#test(data.at(2).Weight, "150kg")
+#test(data.at(1).Species, "Tiger")
+
+---
 // Error: 6-16 file not found (searched at typ/compute/nope.csv)
 #csv("nope.csv")
 
 ---
 // Error: 6-22 failed to parse CSV (found 3 instead of 2 fields in line 3)
 #csv("/files/bad.csv")
+
+---
+// Test error numbering with headers enabled.
+// Error: 6-22 failed to parse CSV (found 3 instead of 2 fields in line 3)
+#csv("/files/bad.csv", has-headers: true)
 
 ---
 // Test reading JSON data.


### PR DESCRIPTION
This would close #2618.

I am not completely sure about the `has_headers` naming, an argument could be made to use `use_headers`, since you might not want to use the flag even if your csv file has headers (for example when building a table as shown in the example in the documentation).

Is it possible to add an example to a parameter? I think one example with `has-headers` enabled might be helpful.