### PR TITLE
Make Oklab and Oklch chroma ratios relative to 0.4

### DIFF
--- a/tests/typ/compiler/methods.typ
+++ b/tests/typ/compiler/methods.typ
@@ -109,6 +109,8 @@
 #test-repr(cmyk(4%, 5%, 6%, 7%).components(), (4%, 5%, 6%, 7%))
 #test-repr(oklab(10%, 0.2, 0.3).components(), (10%, 0.2, 0.3, 100%))
 #test-repr(oklch(10%, 0.2, 90deg).components(), (10%, 0.2, 90deg, 100%))
+#test-repr(oklab(10%, 50%, 75%).components(), (10%, 0.2, 0.3, 100%))
+#test-repr(oklch(10%, 50%, 90deg).components(), (10%, 0.2, 90deg, 100%))
 #test-repr(color.linear-rgb(10%, 20%, 30%).components(), (10%, 20%, 30%, 100%))
 #test-repr(color.hsv(10deg, 20%, 30%).components(), (10deg, 20%, 30%, 100%))
 #test-repr(color.hsl(10deg, 20%, 30%).components(), (10deg, 20%, 30%, 100%))


### PR DESCRIPTION
In CSS, `oklab(50% 100% 50%)` produces the same color as `oklab(50% 0.4 0.2)`.
The same is true with oklch's chroma parameter: `oklch(50% 100% 0deg) = oklch(50% 0.4 0deg)`.
This PR changes Typst's behavior to be in line with CSS's, which IMO is more intuitive overall.
It also adds increased compatibility with any color pickers that output CSS oklch calls.
