### PR TITLE
Draft to add numberings to counters

### DIFF
--- a/crates/typst-library/src/layout/page.rs
+++ b/crates/typst-library/src/layout/page.rs
@@ -258,10 +258,11 @@ pub struct PageElem {
     ///   footer: [
     ///     #set align(right)
     ///     #set text(8pt)
-    ///     #counter(page).display(
-    ///       "1 of I",
-    ///       both: true,
-    ///     )
+    ///     #counter(
+    ///        page,
+    ///        "1 of I",
+    ///        both: true
+    ///     ).display()
     ///   ]
     /// )
     ///
@@ -413,7 +414,7 @@ impl PageElem {
             };
 
             let mut counter =
-                Counter::new(CounterKey::Page).display(Some(numbering.clone()), both);
+                Counter::new(CounterKey::Page, Some(numbering.clone()), both).display();
 
             // We interpret the Y alignment as selecting header or footer
             // and then ignore it for aligning the actual number.

--- a/crates/typst-library/src/math/mod.rs
+++ b/crates/typst-library/src/math/mod.rs
@@ -252,8 +252,8 @@ impl Layout for EquationElem {
         if block {
             if let Some(numbering) = self.numbering(styles) {
                 let pod = Regions::one(regions.base(), Axes::splat(false));
-                let counter = Counter::of(Self::elem())
-                    .display(Some(numbering), false)
+                let counter = Counter::of(Self::elem(), Some(numbering), false)
+                    .display()
                     .layout(vt, styles, pod)?
                     .into_frame();
 
@@ -357,7 +357,7 @@ impl Refable for EquationElem {
     }
 
     fn counter(&self) -> Counter {
-        Counter::of(Self::elem())
+        Counter::of(Self::elem(), None, false)
     }
 
     fn numbering(&self) -> Option<Numbering> {

--- a/crates/typst-library/src/meta/figure.rs
+++ b/crates/typst-library/src/meta/figure.rs
@@ -253,15 +253,18 @@ impl Synthesize for FigureElem {
         };
 
         // Construct the figure's counter.
-        let counter =
-            Counter::new(CounterKey::Selector(select_where!(Self, Kind => kind.clone())));
+        let counter = Counter::new(
+            CounterKey::Selector(select_where!(Self, Kind => kind.clone())),
+            numbering.clone(),
+            false,
+        );
 
         // Fill the figure's caption.
         let mut caption = self.caption(styles);
         if let Some(caption) = &mut caption {
             caption.push_kind(kind.clone());
             caption.push_supplement(supplement.clone());
-            caption.push_numbering(numbering.clone());
+            caption.push_numbering(numbering.clone()); // TODO: remove
             caption.push_counter(Some(counter.clone()));
             caption.push_figure_location(self.location());
         }
@@ -339,7 +342,9 @@ impl Refable for FigureElem {
     }
 
     fn counter(&self) -> Counter {
-        self.counter().clone().unwrap_or_else(|| Counter::of(Self::elem()))
+        self.counter()
+            .clone()
+            .unwrap_or_else(|| Counter::of(Self::elem(), None, false))
     }
 
     fn numbering(&self) -> Option<Numbering> {
@@ -462,7 +467,7 @@ pub struct FigureCaption {
     /// ```example
     /// #show figure.caption: it => [
     ///   #underline(it.body) |
-    ///   #it.supplement #it.counter.display(it.numbering)
+    ///   #it.supplement #it.counter.display()
     /// ]
     ///
     /// #figure(

--- a/crates/typst-library/src/meta/footnote.rs
+++ b/crates/typst-library/src/meta/footnote.rs
@@ -127,7 +127,7 @@ impl Show for FootnoteElem {
         Ok(vt.delayed(|vt| {
             let loc = self.declaration_location(vt).at(self.span())?;
             let numbering = self.numbering(styles);
-            let counter = Counter::of(Self::elem());
+            let counter = Counter::of(Self::elem(), Some(numbering.clone()), false);
             let num = counter.at(vt, loc)?.display(vt, numbering)?;
             let sup = SuperElem::new(num).pack();
             let loc = loc.variant(1);
@@ -269,7 +269,7 @@ impl Show for FootnoteEntry {
         let number_gap = Em::new(0.05);
         let default = StyleChain::default();
         let numbering = note.numbering(default);
-        let counter = Counter::of(FootnoteElem::elem());
+        let counter = Counter::of(FootnoteElem::elem(), Some(numbering.clone()), false);
         let loc = note.location().unwrap();
         let num = counter.at(vt, loc)?.display(vt, numbering)?;
         let sup = SuperElem::new(num)

--- a/crates/typst-library/src/meta/heading.rs
+++ b/crates/typst-library/src/meta/heading.rs
@@ -145,8 +145,8 @@ impl Show for HeadingElem {
     fn show(&self, _: &mut Vt, styles: StyleChain) -> SourceResult<Content> {
         let mut realized = self.body().clone();
         if let Some(numbering) = self.numbering(styles).as_ref() {
-            realized = Counter::of(Self::elem())
-                .display(Some(numbering.clone()), false)
+            realized = Counter::of(Self::elem(), Some(numbering.clone()), false)
+                .display()
                 .spanned(self.span())
                 + HElem::new(Em::new(0.3).into()).with_weak(true).pack()
                 + realized;
@@ -201,7 +201,7 @@ impl Refable for HeadingElem {
     }
 
     fn counter(&self) -> Counter {
-        Counter::of(Self::elem())
+        Counter::of(Self::elem(), None, false)
     }
 
     fn numbering(&self) -> Option<Numbering> {
@@ -218,7 +218,7 @@ impl Outlinable for HeadingElem {
         let mut content = self.body().clone();
         let default = StyleChain::default();
         if let Some(numbering) = self.numbering(default).as_ref() {
-            let numbers = Counter::of(Self::elem())
+            let numbers = Counter::of(Self::elem(), Some(numbering.clone()), false)
                 .at(vt, self.location().unwrap())?
                 .display(vt, numbering)?;
             content = numbers + SpaceElem::new().pack() + content;

--- a/crates/typst-library/src/meta/outline.rs
+++ b/crates/typst-library/src/meta/outline.rs
@@ -473,7 +473,7 @@ impl OutlineEntry {
                 Numbering::Pattern(NumberingPattern::from_str("1").unwrap())
             });
 
-        let page = Counter::new(CounterKey::Page)
+        let page = Counter::new(CounterKey::Page, Some(page_numbering.clone()), false)
             .at(vt, location)?
             .display(vt, &page_numbering)?;
 

--- a/docs/guides/page-setup.md
+++ b/docs/guides/page-setup.md
@@ -294,10 +294,10 @@ a custom footer with page numbers and more.
 #set page(footer: [
   *American Society of Proceedings*
   #h(1fr)
-  #counter(page).display(
-    "1/1",
-    both: true,
-  )
+  #counter(
+    page, "1/1",
+    both: true
+  ).display()
 ])
 
 This page has a custom footer.
@@ -317,7 +317,7 @@ circle for each page.
 #set page(footer: [
   *Fun Typography Club*
   #h(1fr)
-  #counter(page).display(num => {
+  #counter(page, num => {
     let circles = num * (
       box(circle(
         radius: 2pt,
@@ -328,7 +328,7 @@ circle for each page.
       inset: (bottom: 1pt),
       circles.join(h(1pt))
     )
-  })
+  }).display()
 ])
 
 This page has a custom footer.

--- a/tests/typ/layout/page-marginals.typ
+++ b/tests/typ/layout/page-marginals.typ
@@ -7,9 +7,9 @@
     text(0.8em)[_Chapter 1_]
   },
   footer: align(center)[\~ #counter(page).display() \~],
-  background: counter(page).display(n => if n <= 2 {
+  background: counter(page, n => if n <= 2 {
     place(center + horizon, circle(radius: 1cm, fill: luma(90%)))
-  })
+  }).display()
 )
 
 But, soft! what light through yonder window breaks? It is the east, and Juliet

--- a/tests/typ/meta/counter.typ
+++ b/tests/typ/meta/counter.typ
@@ -8,10 +8,10 @@ Final: #locate(loc => mine.final(loc).at(0)) \
 #mine.step()
 First: #mine.display() \
 #mine.update(7)
-#mine.display("1 of 1", both: true) \
+#counter("mine!", "1 of 1", both: true).display() \
 #mine.step()
 #mine.step()
-Second: #mine.display("I")
+Second: #counter("mine!", "I").display()
 #mine.update(n => n * 2)
 #mine.step()
 

--- a/tests/typ/meta/figure-caption.typ
+++ b/tests/typ/meta/figure-caption.typ
@@ -45,7 +45,7 @@
 #show figure.caption: it => emph[
   #it.body
   (#it.supplement
-   #it.counter.display(it.numbering))
+   #it.counter.display())
 ]
 
 #figure(

--- a/tests/typ/meta/figure.typ
+++ b/tests/typ/meta/figure.typ
@@ -50,7 +50,7 @@ We can clearly see that @fig-cylinder and
   if not it.numbering == none {
     title = it.supplement
     if not it.numbering == none {
-      title += " " +  it.counter.display(it.numbering)
+      title += " " +  it.counter.display()
     }
   }
   title = strong(title)


### PR DESCRIPTION
This change would allow dependent numberings to be implemented #2652.

For now I tried to keep the changes to examples / documentation minimal as I'm not sure if this is the right way to do this.
The biggest change to the usage is for user-defined counters, which now requires knowing the key in order to display it with a different numbering. This is should probably be changed, by allowing to construct counters from other counters. For internally created counters the difference should not be that noticeable since the set-rules are the same as before.