### PR TITLE
Add `arguments` constructor & fix equality

### DIFF
--- a/crates/typst/src/eval/args.rs
+++ b/crates/typst/src/eval/args.rs
@@ -38,7 +38,8 @@ use crate::util::pretty_array_like;
 /// #text(..dict)[Hello]
 /// ```
 #[ty(scope, name = "arguments")]
-#[derive(Clone, PartialEq, Hash)]
+#[derive(Clone, Hash)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 pub struct Args {
     /// The span of the whole argument list.
     pub span: Span,
@@ -47,7 +48,8 @@ pub struct Args {
 }
 
 /// An argument to a function call: `12` or `draw: false`.
-#[derive(Debug, Clone, PartialEq, Hash)]
+#[derive(Debug, Clone, Hash)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 pub struct Arg {
     /// The span of the whole argument.
     pub span: Span,
@@ -271,6 +273,12 @@ impl Args {
     }
 }
 
+impl PartialEq for Args {
+    fn eq(&self, other: &Self) -> bool {
+        self.to_pos() == other.to_pos() && self.to_named() == other.to_named()
+    }
+}
+
 impl Debug for Args {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         f.debug_list().entries(&self.items).finish()
@@ -281,6 +289,12 @@ impl Repr for Args {
     fn repr(&self) -> EcoString {
         let pieces = self.items.iter().map(Arg::repr).collect::<Vec<_>>();
         pretty_array_like(&pieces, false).into()
+    }
+}
+
+impl PartialEq for Arg {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.value.v == other.value.v
     }
 }
 

--- a/crates/typst/src/eval/args.rs
+++ b/crates/typst/src/eval/args.rs
@@ -230,6 +230,27 @@ impl Args {
 
 #[scope]
 impl Args {
+    /// Construct an argument sink in place.
+    ///
+    /// This function behaves like `{#let args(..sink) = sink}`.
+    ///
+    /// ```example
+    /// #let args = arguments(stroke: red, inset: 1em, [Body])
+    /// #box(..args)
+    /// ```
+    #[func(constructor)]
+    pub fn construct(
+        /// The real arguments (the other argument is just for the docs).
+        /// The docs argument cannot be called `args`.
+        args: &mut Args,
+        /// The arguments to construct.
+        #[external]
+        #[variadic]
+        arguments: Vec<Args>,
+    ) -> Args {
+        args.take()
+    }
+
     /// Returns the captured positional arguments as an array.
     #[func(name = "pos", title = "Positional")]
     pub fn to_pos(&self) -> Array {


### PR DESCRIPTION
I think, I had numerous times, where I wrote `#let args(..sink) = sink` to construct `arguments` because they have no constructor. Particularly in debugging scenarios of functions.

This PR adds the aforementioned constructor, I thought about making it strictly take one array and one dict, but the identity function solves all use cases.

This PR also fixes the equality for `arguments`, such that it no longer includes its spans and works regardless of argument order.

```typst
#let named = (a: 1, b: 2)
#let pos = ([First], [Second])

#let a = arguments(..named, ..pos)
#let b = arguments(a: 1, b: 2, [First], [Second])
#let c = arguments(b: 2, a: 1)[First][Second]

#assert(a == b and b == c)
```