### PR TITLE
Implement JPEG XL support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,6 +1379,125 @@ dependencies = [
 ]
 
 [[package]]
+name = "jxl-bitstream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c3205d18cf6229b3f694de66e592886ff7afb0740bc0e85594e3b28d6f6622"
+dependencies = [
+ "tracing",
+]
+
+[[package]]
+name = "jxl-coding"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7075600c762c1ce9e2dd1fbc3fa8ded2af1401fe2221449eca943977742dd0b4"
+dependencies = [
+ "jxl-bitstream",
+]
+
+[[package]]
+name = "jxl-color"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9084bc33b6d01e26b1db6c187514a51a57f4e3780335f3120ab55ee0b08f6e73"
+dependencies = [
+ "jxl-bitstream",
+ "jxl-coding",
+ "jxl-grid",
+]
+
+[[package]]
+name = "jxl-frame"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d63bdd104e3746669a123de86f940aa5d59fdc9c5a65f16a4f867dde75e45e1"
+dependencies = [
+ "jxl-bitstream",
+ "jxl-coding",
+ "jxl-grid",
+ "jxl-image",
+ "jxl-modular",
+ "jxl-vardct",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-grid"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48800b21ed6bb3bbc2f818ae9cd40530bdfb1a211f57d5a7a49b8b10f62145e8"
+
+[[package]]
+name = "jxl-image"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86f7f74acc9c9e66604c8d030e00cdef5a0c455ea3d7d26bd9ddbb9160be59"
+dependencies = [
+ "jxl-bitstream",
+ "jxl-color",
+ "jxl-grid",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-modular"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504e6b55db362568592be81993c772fc6786c56fb67ae769ff62dc514c3e6748"
+dependencies = [
+ "jxl-bitstream",
+ "jxl-coding",
+ "jxl-grid",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-oxide"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e3b7e459d823979c4ca0c9584f391581db154437f34596ea443b082e9b6064"
+dependencies = [
+ "jxl-bitstream",
+ "jxl-color",
+ "jxl-frame",
+ "jxl-grid",
+ "jxl-image",
+ "jxl-render",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-render"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7157d1c6c4896ddc800cb0cc8ba545ba7417ab9afc51f39e69484e6607c8707e"
+dependencies = [
+ "jxl-bitstream",
+ "jxl-coding",
+ "jxl-color",
+ "jxl-frame",
+ "jxl-grid",
+ "jxl-image",
+ "jxl-modular",
+ "jxl-vardct",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-vardct"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb4a2d9ba8c48a52f6143ba01c38aac67d1309c9b939a9f84cd60f650d15053e"
+dependencies = [
+ "jxl-bitstream",
+ "jxl-coding",
+ "jxl-grid",
+ "jxl-modular",
+ "tracing",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2898,6 +3017,7 @@ dependencies = [
  "fontdb",
  "image",
  "indexmap 2.0.2",
+ "jxl-oxide",
  "kurbo",
  "lasso",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ image = { version = "0.24", default-features = false, features = ["png", "jpeg",
 include_dir = "0.7"
 indexmap = { version = "2", features = ["serde"] }
 inferno = "0.11.15"
+jxl-oxide = "0.4.0"
 kurbo = "0.9"
 lasso = { version = "0.7.2", features = ["ahasher", "multi-threaded"] }
 lipsum = "0.9"

--- a/crates/typst-library/src/visualize/image.rs
+++ b/crates/typst-library/src/visualize/image.rs
@@ -142,6 +142,7 @@ impl Layout for ImageElem {
                 match ext.as_str() {
                     "png" => ImageFormat::Raster(RasterFormat::Png),
                     "jpg" | "jpeg" => ImageFormat::Raster(RasterFormat::Jpg),
+                    "jxl" => ImageFormat::Raster(RasterFormat::Jxl),
                     "gif" => ImageFormat::Raster(RasterFormat::Gif),
                     "svg" | "svgz" => ImageFormat::Vector(VectorFormat::Svg),
                     _ => match &data {

--- a/crates/typst-svg/src/lib.rs
+++ b/crates/typst-svg/src/lib.rs
@@ -1079,6 +1079,7 @@ fn convert_image_to_base64_url(image: &Image) -> EcoString {
         ImageFormat::Raster(f) => match f {
             RasterFormat::Png => "png",
             RasterFormat::Jpg => "jpeg",
+            RasterFormat::Jxl => "jxl",
             RasterFormat::Gif => "gif",
         },
         ImageFormat::Vector(f) => match f {

--- a/crates/typst/Cargo.toml
+++ b/crates/typst/Cargo.toml
@@ -24,6 +24,7 @@ ecow = { workspace = true}
 fontdb = { workspace = true }
 image = { workspace = true }
 indexmap = { workspace = true }
+jxl-oxide = { workspace = true }
 kurbo = { workspace = true }
 lasso = { workspace = true }
 log = { workspace = true }

--- a/crates/typst/src/image/raster.rs
+++ b/crates/typst/src/image/raster.rs
@@ -1,5 +1,5 @@
 use std::hash::{Hash, Hasher};
-use std::io;
+use std::io::{self, Read};
 use std::sync::Arc;
 
 use ecow::{eco_format, EcoString};
@@ -7,7 +7,8 @@ use image::codecs::gif::GifDecoder;
 use image::codecs::jpeg::JpegDecoder;
 use image::codecs::png::PngDecoder;
 use image::io::Limits;
-use image::{guess_format, ImageDecoder, ImageResult};
+use image::{guess_format, DynamicImage, ImageBuffer, ImageDecoder, ImageResult};
+use jxl_oxide::JxlImage;
 use typst_macros::Cast;
 
 use crate::diag::{bail, StrResult};
@@ -21,7 +22,7 @@ pub struct RasterImage(Arc<Repr>);
 struct Repr {
     data: Bytes,
     format: RasterFormat,
-    dynamic: image::DynamicImage,
+    dynamic: DynamicImage,
     icc: Option<Vec<u8>>,
 }
 
@@ -29,23 +30,20 @@ impl RasterImage {
     /// Decode a raster image.
     #[comemo::memoize]
     pub fn new(data: Bytes, format: RasterFormat) -> StrResult<Self> {
-        fn decode_with<'a, T: ImageDecoder<'a>>(
-            decoder: ImageResult<T>,
-        ) -> ImageResult<(image::DynamicImage, Option<Vec<u8>>)> {
-            let mut decoder = decoder?;
-            let icc = decoder.icc_profile().filter(|icc| !icc.is_empty());
-            decoder.set_limits(Limits::default())?;
-            let dynamic = image::DynamicImage::from_decoder(decoder)?;
-            Ok((dynamic, icc))
-        }
-
         let cursor = io::Cursor::new(&data);
         let (dynamic, icc) = match format {
-            RasterFormat::Jpg => decode_with(JpegDecoder::new(cursor)),
-            RasterFormat::Png => decode_with(PngDecoder::new(cursor)),
-            RasterFormat::Gif => decode_with(GifDecoder::new(cursor)),
-        }
-        .map_err(format_image_error)?;
+            RasterFormat::Jpg => {
+                decode_with(JpegDecoder::new(cursor)).map_err(format_image_error)?
+            }
+            RasterFormat::Png => {
+                decode_with(PngDecoder::new(cursor)).map_err(format_image_error)?
+            }
+            RasterFormat::Gif => {
+                decode_with(GifDecoder::new(cursor)).map_err(format_image_error)?
+            }
+            RasterFormat::Jxl => decode_jxl(cursor)
+                .map_err(|err| eco_format!("failed to decode jpeg xl image ({err})"))?,
+        };
 
         Ok(Self(Arc::new(Repr { data, format, dynamic, icc })))
     }
@@ -71,7 +69,7 @@ impl RasterImage {
     }
 
     /// Access the underlying dynamic image.
-    pub fn dynamic(&self) -> &image::DynamicImage {
+    pub fn dynamic(&self) -> &DynamicImage {
         &self.0.dynamic
     }
 
@@ -89,6 +87,140 @@ impl Hash for Repr {
     }
 }
 
+/// Decode an image using a decoder from the `image` crate.
+///
+/// Returns a decoded image and optionally an ICC profile.
+fn decode_with<'a, T: ImageDecoder<'a>>(
+    decoder: ImageResult<T>,
+) -> ImageResult<(DynamicImage, Option<Vec<u8>>)> {
+    let mut decoder = decoder?;
+    let icc = decoder.icc_profile().filter(|icc| !icc.is_empty());
+    decoder.set_limits(Limits::default())?;
+    let dynamic = DynamicImage::from_decoder(decoder)?;
+    Ok((dynamic, icc))
+}
+
+/// Decode a JPEG XL image using `jxl-oxide`.
+///
+/// Returns a decoded image and optionally an ICC profile.
+fn decode_jxl<R: Read>(reader: R) -> StrResult<(DynamicImage, Option<Vec<u8>>)> {
+    use jxl_oxide::{PixelFormat, RenderResult};
+
+    let mut image = JxlImage::from_reader(reader)
+        .map_err(|err| eco_format!("failed to decode JPEG XL image ({err})"))?;
+    let width = image.width();
+    let height = image.height();
+    let bit_depth = image.image_header().metadata.bit_depth.bits_per_sample();
+    let render = match image
+        .render_next_frame()
+        .map_err(|err| eco_format!("failed to decode JPEG XL image ({err})"))?
+    {
+        RenderResult::Done(render) => render,
+        RenderResult::NeedMoreData => {
+            return Err(eco_format!("JPEG XL frame is incomplete."))
+        }
+        RenderResult::NoMoreFrames => {
+            return Err(eco_format!("Not enough frames are present in JPEG XL file."))
+        }
+    };
+    let dynamic = match image.pixel_format() {
+        PixelFormat::Gray => {
+            if bit_depth <= 8 {
+                let buf = render.color_channels()[0]
+                    .buf()
+                    .iter()
+                    .map(|&f| (f * (u8::MAX as f32)) as u8)
+                    .collect();
+                let image_buffer = ImageBuffer::from_vec(width, height, buf).unwrap();
+                DynamicImage::ImageLuma8(image_buffer)
+            } else {
+                let buf = render.color_channels()[0]
+                    .buf()
+                    .iter()
+                    .map(|&f| (f * (u16::MAX as f32)) as u16)
+                    .collect();
+                let image_buffer = ImageBuffer::from_vec(width, height, buf).unwrap();
+                DynamicImage::ImageLuma16(image_buffer)
+            }
+        }
+        PixelFormat::Graya => {
+            if bit_depth <= 8 {
+                let buf = render
+                    .image()
+                    .buf()
+                    .iter()
+                    .map(|&f| (f * (u8::MAX as f32)) as u8)
+                    .collect();
+                let image_buffer = ImageBuffer::from_vec(width, height, buf).unwrap();
+                DynamicImage::ImageLumaA8(image_buffer)
+            } else {
+                let buf = render
+                    .image()
+                    .buf()
+                    .iter()
+                    .map(|&f| (f * (u16::MAX as f32)) as u16)
+                    .collect();
+                let image_buffer = ImageBuffer::from_vec(width, height, buf).unwrap();
+                DynamicImage::ImageLumaA16(image_buffer)
+            }
+        }
+        PixelFormat::Rgb => {
+            if bit_depth <= 8 {
+                let buf = render
+                    .image()
+                    .buf()
+                    .iter()
+                    .map(|&f| (f * (u8::MAX as f32)) as u8)
+                    .collect();
+                let image_buffer = ImageBuffer::from_vec(width, height, buf).unwrap();
+                DynamicImage::ImageRgb8(image_buffer)
+            } else if bit_depth <= 16 {
+                let buf = render
+                    .image()
+                    .buf()
+                    .iter()
+                    .map(|&f| (f * (u16::MAX as f32)) as u16)
+                    .collect();
+                let image_buffer = ImageBuffer::from_vec(width, height, buf).unwrap();
+                DynamicImage::ImageRgb16(image_buffer)
+            } else {
+                let buf = render.image().buf().to_vec();
+                let image_buffer = ImageBuffer::from_vec(width, height, buf).unwrap();
+                DynamicImage::ImageRgb32F(image_buffer)
+            }
+        }
+        PixelFormat::Rgba => {
+            if bit_depth <= 8 {
+                let buf = render
+                    .image()
+                    .buf()
+                    .iter()
+                    .map(|&f| (f / (u8::MAX as f32)) as u8)
+                    .collect();
+                let image_buffer = ImageBuffer::from_vec(width, height, buf).unwrap();
+                DynamicImage::ImageRgba8(image_buffer)
+            } else if bit_depth <= 16 {
+                let buf = render
+                    .image()
+                    .buf()
+                    .iter()
+                    .map(|&f| (f / (u16::MAX as f32)) as u16)
+                    .collect();
+                let image_buffer = ImageBuffer::from_vec(width, height, buf).unwrap();
+                DynamicImage::ImageRgba16(image_buffer)
+            } else {
+                let buf = render.image().buf().to_vec();
+                let image_buffer = ImageBuffer::from_vec(width, height, buf).unwrap();
+                DynamicImage::ImageRgba32F(image_buffer)
+            }
+        }
+        PixelFormat::Cmyk => todo!(),
+        PixelFormat::Cmyka => todo!(),
+    };
+    let icc = image.embedded_icc().map(|icc| icc.to_vec());
+    Ok((dynamic, icc))
+}
+
 /// A raster graphics format.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Cast)]
 pub enum RasterFormat {
@@ -98,6 +230,8 @@ pub enum RasterFormat {
     Jpg,
     /// Raster format that is typically used for short animated clips.
     Gif,
+    /// Universal and modern raster format with great compression.
+    Jxl,
 }
 
 impl RasterFormat {
@@ -107,13 +241,16 @@ impl RasterFormat {
     }
 }
 
-impl From<RasterFormat> for image::ImageFormat {
-    fn from(format: RasterFormat) -> Self {
-        match format {
+impl TryFrom<RasterFormat> for image::ImageFormat {
+    type Error = EcoString;
+
+    fn try_from(format: RasterFormat) -> StrResult<Self> {
+        Ok(match format {
             RasterFormat::Png => image::ImageFormat::Png,
             RasterFormat::Jpg => image::ImageFormat::Jpeg,
             RasterFormat::Gif => image::ImageFormat::Gif,
-        }
+            RasterFormat::Jxl => bail!("Format not supported by the image crate."),
+        })
     }
 }
 


### PR DESCRIPTION
This PR implements JPEG XL support.
JPEG XL images can be imported and they do display correctly.

However, I wrote this code mostly as a PoC.
That means, the code isn't _great_ and CMYK images can't be imported yet.
Also, tests are missing.
I also didn't check if `jxl-oxide` was the best library to use and how complete it actually is. EDIT: seems pretty good (https://github.com/web-platform-tests/interop/issues/430#issuecomment-1811972676)

If we decide that this feature is one we want, I'll gladly finish this work.
For now though, I'll keep it a draft PR.