### PR TITLE
Watching fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2935,7 +2935,6 @@ dependencies = [
  "dirs",
  "ecow",
  "env_proxy",
- "filetime",
  "flate2",
  "fontdb",
  "inferno",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ csv = "1"
 dirs = "5"
 ecow = { version = "0.2", features = ["serde"] }
 env_proxy = "0.4"
-filetime = "0.2"
 flate2 = "1"
 fontdb = { version = "0.15", default-features = false }
 hayagriva = "0.4"

--- a/crates/typst-cli/Cargo.toml
+++ b/crates/typst-cli/Cargo.toml
@@ -32,7 +32,6 @@ comemo = { workspace = true }
 dirs = { workspace = true }
 ecow = { workspace = true }
 env_proxy = { workspace = true }
-filetime = { workspace = true }
 flate2 = { workspace = true }
 fontdb = { workspace = true, features = ["memmap", "fontconfig"] }
 inferno = { workspace = true }

--- a/crates/typst-cli/src/watch.rs
+++ b/crates/typst-cli/src/watch.rs
@@ -64,11 +64,8 @@ pub fn watch(mut command: CompileCommand) -> StrResult<()> {
 
         if recompile {
             // Retrieve the dependencies of the last compilation.
-            let previous: HashSet<PathBuf> = world
-                .dependencies()
-                .filter(|path| !removed.contains(*path))
-                .map(ToOwned::to_owned)
-                .collect();
+            let previous: HashSet<PathBuf> =
+                world.dependencies().filter(|path| !removed.contains(path)).collect();
 
             // Reset all dependencies.
             world.reset();
@@ -93,11 +90,11 @@ fn watch_dependencies(
 ) -> StrResult<()> {
     // Watch new paths that weren't watched yet.
     for path in world.dependencies() {
-        let watched = previous.remove(path);
+        let watched = previous.remove(&path);
         if path.exists() && !watched {
             tracing::info!("Watching {}", path.display());
             watcher
-                .watch(path, RecursiveMode::NonRecursive)
+                .watch(&path, RecursiveMode::NonRecursive)
                 .map_err(|err| eco_format!("failed to watch {path:?} ({err})"))?;
         }
     }

--- a/crates/typst-cli/src/watch.rs
+++ b/crates/typst-cli/src/watch.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 
@@ -28,13 +28,13 @@ pub fn watch(mut command: CompileCommand) -> StrResult<()> {
         .map_err(|err| eco_format!("failed to setup file watching ({err})"))?;
 
     // Watch all the files that are used by the input file and its dependencies.
-    watch_dependencies(&mut world, &mut watcher, HashSet::new())?;
+    let mut watched = HashMap::new();
+    watch_dependencies(&mut world, &mut watcher, &mut watched)?;
 
     // Handle events.
     let timeout = std::time::Duration::from_millis(100);
     let output = command.output();
     loop {
-        let mut removed = HashSet::new();
         let mut recompile = false;
         for event in rx
             .recv()
@@ -46,16 +46,16 @@ pub fn watch(mut command: CompileCommand) -> StrResult<()> {
 
             // Workaround for notify-rs' implicit unwatch on remove/rename
             // (triggered by some editors when saving files) with the inotify
-            // backend. By keeping track of the removed files, we can allow
-            // those we still depend on to be watched again later on.
+            // backend. By keeping track of the potentially unwatched files, we
+            // can allow those we still depend on to be watched again later on.
             if matches!(
                 event.kind,
                 notify::EventKind::Remove(notify::event::RemoveKind::File)
             ) {
+                // Mark the file as unwatched and remove the watch in case it
+                // still exists.
                 let path = &event.paths[0];
-                removed.insert(path.clone());
-
-                // Remove the watch in case it still exists.
+                watched.remove(path);
                 watcher.unwatch(path).ok();
             }
 
@@ -63,10 +63,6 @@ pub fn watch(mut command: CompileCommand) -> StrResult<()> {
         }
 
         if recompile {
-            // Retrieve the dependencies of the last compilation.
-            let previous: HashSet<PathBuf> =
-                world.dependencies().filter(|path| !removed.contains(path)).collect();
-
             // Reset all dependencies.
             world.reset();
 
@@ -74,36 +70,48 @@ pub fn watch(mut command: CompileCommand) -> StrResult<()> {
             compile_once(&mut world, &mut command, true)?;
             comemo::evict(10);
 
-            // Adjust the watching.
-            watch_dependencies(&mut world, &mut watcher, previous)?;
+            // Adjust the file watching.
+            watch_dependencies(&mut world, &mut watcher, &mut watched)?;
         }
     }
 }
 
 /// Adjust the file watching. Watches all new dependencies and unwatches
-/// all `previous` dependencies that are not relevant anymore.
+/// all previously `watched` files that are no relevant anymore.
 #[tracing::instrument(skip_all)]
 fn watch_dependencies(
     world: &mut SystemWorld,
     watcher: &mut dyn Watcher,
-    mut previous: HashSet<PathBuf>,
+    watched: &mut HashMap<PathBuf, bool>,
 ) -> StrResult<()> {
-    // Watch new paths that weren't watched yet.
+    // Mark all files as not "seen" so that we may unwatch them if they aren't
+    // in the dependency list.
+    for seen in watched.values_mut() {
+        *seen = false;
+    }
+
+    // Retrieve the dependencies of the last compilation and watch new paths
+    // that weren't watched yet.
     for path in world.dependencies() {
-        let watched = previous.remove(&path);
-        if path.exists() && !watched {
+        if path.exists() && !watched.contains_key(&path) {
             tracing::info!("Watching {}", path.display());
             watcher
                 .watch(&path, RecursiveMode::NonRecursive)
                 .map_err(|err| eco_format!("failed to watch {path:?} ({err})"))?;
         }
+
+        // Mark the file as "seen" so that we don't unwatch it.
+        watched.insert(path, true);
     }
 
     // Unwatch old paths that don't need to be watched anymore.
-    for path in previous {
-        tracing::info!("Unwatching {}", path.display());
-        watcher.unwatch(&path).ok();
-    }
+    watched.retain(|path, &mut seen| {
+        if !seen {
+            tracing::info!("Unwatching {}", path.display());
+            watcher.unwatch(path).ok();
+        }
+        seen
+    });
 
     Ok(())
 }

--- a/crates/typst-cli/src/watch.rs
+++ b/crates/typst-cli/src/watch.rs
@@ -91,9 +91,10 @@ fn watch_dependencies(
     }
 
     // Retrieve the dependencies of the last compilation and watch new paths
-    // that weren't watched yet.
-    for path in world.dependencies() {
-        if path.exists() && !watched.contains_key(&path) {
+    // that weren't watched yet. We can't watch paths that don't exist yet
+    // unfortunately, so we filter those out.
+    for path in world.dependencies().filter(|path| path.exists()) {
+        if !watched.contains_key(&path) {
             tracing::info!("Watching {}", path.display());
             watcher
                 .watch(&path, RecursiveMode::NonRecursive)

--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -1,13 +1,10 @@
 use std::cell::{Cell, OnceCell, RefCell, RefMut};
 use std::collections::HashMap;
 use std::fs;
-use std::hash::Hash;
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Datelike, Local};
 use comemo::Prehashed;
-use same_file::Handle;
-use siphasher::sip128::{Hasher128, SipHasher13};
 use typst::diag::{FileError, FileResult, StrResult};
 use typst::doc::Frame;
 use typst::eval::{eco_format, Bytes, Datetime, Library};
@@ -36,12 +33,8 @@ pub struct SystemWorld {
     book: Prehashed<FontBook>,
     /// Locations of and storage for lazily loaded fonts.
     fonts: Vec<FontSlot>,
-    /// Maps package-path combinations to canonical hashes. All package-path
-    /// combinations that point to the same file are mapped to the same hash. To
-    /// be used in conjunction with `paths`.
-    hashes: RefCell<HashMap<FileId, FileResult<PathHash>>>,
-    /// Maps canonical path hashes to source files and buffers.
-    slots: RefCell<HashMap<PathHash, PathSlot>>,
+    /// Maps file ids to source files and buffers.
+    slots: RefCell<HashMap<FileId, FileSlot>>,
     /// The current datetime if requested. This is stored here to ensure it is
     /// always the same within one compilation. Reset between compilations.
     now: OnceCell<DateTime<Local>>,
@@ -85,7 +78,6 @@ impl SystemWorld {
             library: Prehashed::new(typst_library::build()),
             book: Prehashed::new(searcher.book),
             fonts: searcher.fonts,
-            hashes: RefCell::default(),
             slots: RefCell::default(),
             now: OnceCell::new(),
             export_cache: ExportCache::new(),
@@ -108,17 +100,16 @@ impl SystemWorld {
     }
 
     /// Return all paths the last compilation depended on.
-    pub fn dependencies(&mut self) -> impl Iterator<Item = &Path> {
+    pub fn dependencies(&mut self) -> impl Iterator<Item = PathBuf> + '_ {
         self.slots
             .get_mut()
             .values()
             .filter(|slot| slot.accessed())
-            .map(|slot| slot.path.as_path())
+            .filter_map(|slot| slot.system_path(&self.root).ok())
     }
 
     /// Reset the compilation state in preparation of a new compilation.
     pub fn reset(&mut self) {
-        self.hashes.borrow_mut().clear();
         for slot in self.slots.borrow_mut().values_mut() {
             slot.reset();
         }
@@ -156,11 +147,11 @@ impl World for SystemWorld {
     }
 
     fn source(&self, id: FileId) -> FileResult<Source> {
-        self.slot(id)?.source()
+        self.slot(id)?.source(&self.root)
     }
 
     fn file(&self, id: FileId) -> FileResult<Bytes> {
-        self.slot(id)?.file()
+        self.slot(id)?.file(&self.root)
     }
 
     fn font(&self, index: usize) -> Option<Font> {
@@ -186,59 +177,29 @@ impl World for SystemWorld {
 impl SystemWorld {
     /// Access the canonical slot for the given file id.
     #[tracing::instrument(skip_all)]
-    fn slot(&self, id: FileId) -> FileResult<RefMut<PathSlot>> {
-        let mut system_path = PathBuf::new();
-        let hash = self
-            .hashes
-            .borrow_mut()
-            .entry(id)
-            .or_insert_with(|| {
-                // Determine the root path relative to which the file path
-                // will be resolved.
-                let buf;
-                let mut root = &self.root;
-                if let Some(spec) = id.package() {
-                    buf = prepare_package(spec)?;
-                    root = &buf;
-                }
-
-                // Join the path to the root. If it tries to escape, deny
-                // access. Note: It can still escape via symlinks.
-                system_path = id.vpath().resolve(root).ok_or(FileError::AccessDenied)?;
-
-                PathHash::new(&system_path)
-            })
-            .clone()?;
-
-        Ok(RefMut::map(self.slots.borrow_mut(), |paths| {
-            paths.entry(hash).or_insert_with(|| PathSlot::new(id, system_path))
+    fn slot(&self, id: FileId) -> FileResult<RefMut<FileSlot>> {
+        Ok(RefMut::map(self.slots.borrow_mut(), |slots| {
+            slots.entry(id).or_insert_with(|| FileSlot::new(id))
         }))
     }
 }
 
-/// Holds canonical data for all paths pointing to the same entity.
+/// Holds the processed data for a file ID.
 ///
 /// Both fields can be populated if the file is both imported and read().
-struct PathSlot {
-    /// The slot's canonical file id.
+struct FileSlot {
+    /// The slot's file id.
     id: FileId,
-    /// The slot's path on the system.
-    path: PathBuf,
     /// The lazily loaded and incrementally updated source file.
     source: SlotCell<Source>,
     /// The lazily loaded raw byte buffer.
     file: SlotCell<Bytes>,
 }
 
-impl PathSlot {
+impl FileSlot {
     /// Create a new path slot.
-    fn new(id: FileId, path: PathBuf) -> Self {
-        Self {
-            id,
-            path,
-            file: SlotCell::new(),
-            source: SlotCell::new(),
-        }
+    fn new(id: FileId) -> Self {
+        Self { id, file: SlotCell::new(), source: SlotCell::new() }
     }
 
     /// Whether the file was accessed in the ongoing compilation.
@@ -254,28 +215,51 @@ impl PathSlot {
     }
 
     /// Retrieve the source for this file.
-    fn source(&self) -> FileResult<Source> {
-        self.source.get_or_init(&self.path, |data, prev| {
-            let text = decode_utf8(&data)?;
-            if let Some(mut prev) = prev {
-                prev.replace(text);
-                Ok(prev)
-            } else {
-                Ok(Source::new(self.id, text.into()))
-            }
-        })
+    fn source(&self, root: &Path) -> FileResult<Source> {
+        self.source.get_or_init(
+            || self.system_path(root),
+            |data, prev| {
+                let text = decode_utf8(&data)?;
+                if let Some(mut prev) = prev {
+                    prev.replace(text);
+                    Ok(prev)
+                } else {
+                    Ok(Source::new(self.id, text.into()))
+                }
+            },
+        )
     }
 
     /// Retrieve the file's bytes.
-    fn file(&self) -> FileResult<Bytes> {
-        self.file.get_or_init(&self.path, |data, _| Ok(data.into()))
+    fn file(&self, root: &Path) -> FileResult<Bytes> {
+        self.file
+            .get_or_init(|| self.system_path(root), |data, _| Ok(data.into()))
+    }
+
+    /// The path of the slot on the system.
+    fn system_path(&self, root: &Path) -> FileResult<PathBuf> {
+        // Determine the root path relative to which the file path
+        // will be resolved.
+        let buf;
+        let mut root = root;
+        if let Some(spec) = self.id.package() {
+            buf = prepare_package(spec)?;
+            root = &buf;
+        }
+
+        // Join the path to the root. If it tries to escape, deny
+        // access. Note: It can still escape via symlinks.
+        self.id.vpath().resolve(root).ok_or(FileError::AccessDenied)
     }
 }
 
 /// Lazily processes data for a file.
 struct SlotCell<T> {
+    /// The processed data.
     data: RefCell<Option<FileResult<T>>>,
+    /// A hash of the raw file contents / access error.
     fingerprint: Cell<u128>,
+    /// Whether the slot has been accessed in the current compilation.
     accessed: Cell<bool>,
 }
 
@@ -303,12 +287,12 @@ impl<T: Clone> SlotCell<T> {
     /// Gets the contents of the cell or initialize them.
     fn get_or_init(
         &self,
-        path: &Path,
+        path: impl FnOnce() -> FileResult<PathBuf>,
         f: impl FnOnce(Vec<u8>, Option<T>) -> FileResult<T>,
     ) -> FileResult<T> {
         let mut borrow = self.data.borrow_mut();
 
-        // If we retrieved the file already in this compilation, retrieve it.
+        // If we accessed the file already in this compilation, retrieve it.
         if self.accessed.replace(true) {
             if let Some(data) = &*borrow {
                 return data.clone();
@@ -316,10 +300,10 @@ impl<T: Clone> SlotCell<T> {
         }
 
         // Read and hash the file.
-        let result = read(path);
+        let result = path().and_then(|p| read(&p));
         let fingerprint = typst::util::hash128(&result);
 
-        // If the file contents didn't change, yield the old data.
+        // If the file contents didn't change, yield the old processed data.
         if self.fingerprint.replace(fingerprint) == fingerprint {
             if let Some(data) = &*borrow {
                 return data.clone();
@@ -331,20 +315,6 @@ impl<T: Clone> SlotCell<T> {
         *borrow = Some(value.clone());
 
         value
-    }
-}
-
-/// A hash that is the same for all paths pointing to the same entity.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-struct PathHash(u128);
-
-impl PathHash {
-    fn new(path: &Path) -> FileResult<Self> {
-        let f = |e| FileError::from_io(e, path);
-        let handle = Handle::from_path(path).map_err(f)?;
-        let mut state = SipHasher13::new();
-        handle.hash(&mut state);
-        Ok(Self(state.finish128().as_u128()))
     }
 }
 


### PR DESCRIPTION
This PR addresses #2601 and #2685 by making some fundamental changes to the file handling in the CLI:

1. The CLI now uses file content hashes instead of file modification times to determine whether a file changed. While this is unfortunately a bit slower, the timestamps are unreliable on Windows: Replacing an existing file doesn't change the creation date and retains the modification date of the original file there. This means neither of the timestamps is up to date and Typst thinks the file didn't change.

2. As [pointed out](https://github.com/typst/typst/issues/2601#issuecomment-1808377689) by @Myriad-Dreamin, the `PathHash` was an unreliable construct throughout multiple compilations. Before 0.9, this wasn't a problem because the resources were all cleared between compilations. The intent of the path hashes was to canonicalize the parsed data for a file if two different paths point to the same file. This was originally important for things like `/file.typ` and `/dir/../file.typ`. However, we've since added lexical path normalization which covers most of the cases. For the remaining ones (e.g. symlinks), the duplication is bearable. As a result, the `hashes` and `slots` hash maps were replaced with a single HashMap from `FileId` to `FileSlot`, which simplifies things quite a lot.

3. The watching logic was simplified to retrieve the dependencies just once and switched to a single, persistent `watched` hashmap instead of multiple ad-hoc hashmaps.

I have tested this on macOS and Windows. I would appreciate if people would further test it (especially on Linux) to ensure it works before merging.