### PR TITLE
Make `color.components`' alpha parameter named

### DIFF
--- a/crates/typst/src/geom/color.rs
+++ b/crates/typst/src/geom/color.rs
@@ -702,6 +702,7 @@ impl Color {
     pub fn components(
         self,
         /// Whether to include the alpha component.
+        #[named]
         #[default(true)]
         alpha: bool,
     ) -> Array {

--- a/tests/typ/compiler/methods.typ
+++ b/tests/typ/compiler/methods.typ
@@ -122,7 +122,7 @@
 #test(luma(40).to-hex(), "#282828")
 #test-repr(cmyk(4%, 5%, 6%, 7%).to-hex(), "#e4e1df")
 #test-repr(rgb(cmyk(4%, 5%, 6%, 7%)).components(), (89.28%, 88.35%, 87.42%, 100%))
-#test-repr(rgb(luma(40%)).components(false), (40%, 40%, 40%))
+#test-repr(rgb(luma(40%)).components(alpha: false), (40%, 40%, 40%))
 #test-repr(cmyk(luma(40)).components(), (11.76%, 10.67%, 10.51%, 14.12%))
 #test-repr(cmyk(rgb(1, 2, 3)), cmyk(66.67%, 33.33%, 0%, 98.82%))
 #test-repr(luma(rgb(1, 2, 3)), luma(0.73%))


### PR DESCRIPTION
This is a rather small change, but until the parameter rework is a thing, an improvement in readability still.
It changes the `alpha` parameter of `color.components` to be named.
Compare these two lines, for example:
```typ
#let (r, g, b) = col.components(false)
#let (r, g, b) = col.components(alpha: false)
```
I think in the latter it is more obvious what the argument does.
It also is a bit more consistent with how user-defined functions work, where you can't _really_ specify whether a positional argument should be optional.

An issue with this change, however, is that it does break some code making use of the optional parameter.
