### PR TITLE
Update test-helper doc for the easiest installation instruction

### DIFF
--- a/tools/test-helper/README.md
+++ b/tools/test-helper/README.md
@@ -14,6 +14,8 @@ For the test helper to work correctly, you also need to install `oxipng`, for
 example with `cargo install oxipng`.
 
 ## Installation
-The simplest way to install this extension (and keep it up-to-date) is to add a
-symlink from `~/.vscode/extensions/typst-test-helper` to
-`path/to/typst/tools/test-helper`.
+The simplest way to install this extension (and keep it up-to-date) is to use VSCode's UI:
+* Go to View > Command Palette,
+* In the drop down list, pick command "Developer: Install extension from location",
+* Select this `test-helper` directory in the file explorer dialogue box. VSCode will add
+the extension's path to `~/.vscode/extensions/extensions.json`.


### PR DESCRIPTION
Hi - the easiest way of installation now is using this command from the Command Palette in VSCode:

<img width="697" alt="Screenshot 2023-11-22 at 12 14 26" src="https://github.com/typst/typst/assets/18319900/00e4d15c-8829-4bdf-8256-f57479c70abd">

I believe it can greatly help new contributors.