### PR TITLE
Allow multiple font paths in `TYPST_FONT_PATHS`

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -5,7 +5,7 @@ use semver::Version;
 
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 
-/// The character used by the operating system to separate path components
+/// The character typically used to separate path components
 /// in environment variables.
 const ENV_PATH_SEP: char = if cfg!(windows) { ';' } else { ':' };
 

--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -118,7 +118,7 @@ pub struct SharedArgs {
         long = "font-path",
         env = "TYPST_FONT_PATHS",
         value_name = "DIR",
-        action = ArgAction::Append,
+        value_delimiter = ','
     )]
     pub font_paths: Vec<PathBuf>,
 
@@ -139,7 +139,7 @@ pub struct FontsCommand {
         long = "font-path",
         env = "TYPST_FONT_PATHS",
         value_name = "DIR",
-        action = ArgAction::Append,
+        value_delimiter = ','
     )]
     pub font_paths: Vec<PathBuf>,
 

--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -5,6 +5,10 @@ use semver::Version;
 
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 
+/// The character used by the operating system to separate path components
+/// in environment variables.
+const ENV_PATH_SEP: char = if cfg!(windows) { ';' } else { ':' };
+
 /// The Typst compiler.
 #[derive(Debug, Clone, Parser)]
 #[clap(name = "typst", version = crate::typst_version(), author)]
@@ -118,7 +122,7 @@ pub struct SharedArgs {
         long = "font-path",
         env = "TYPST_FONT_PATHS",
         value_name = "DIR",
-        value_delimiter = ','
+        value_delimiter = ENV_PATH_SEP,
     )]
     pub font_paths: Vec<PathBuf>,
 
@@ -139,7 +143,7 @@ pub struct FontsCommand {
         long = "font-path",
         env = "TYPST_FONT_PATHS",
         value_name = "DIR",
-        value_delimiter = ','
+        value_delimiter = ENV_PATH_SEP,
     )]
     pub font_paths: Vec<PathBuf>,
 


### PR DESCRIPTION
This PR changes the behavior of `TYPST_FONT_PATHS` to allow a colon- or semicolon-separated list of paths.
Semicolons are used on windows, while on all other operating systems, colons are used. This appears to be [consistent with Python](https://docs.python.org/3/library/os.html#os.pathsep), at least for the major operating systems.

The following searches `my-fonts/` and `company-fonts/`:
```sh
TYPST_FONT_PATHS=my-fonts/:company-fonts/ typst fonts
```

This searches `my-fonts/` and `test-fonts/`, overwriting the environment variable:
```sh
TYPST_FONT_PATHS=my-fonts/:company-fonts/ typst fonts \
  --font-path my-fonts --font-path test-fonts
```

From what I can tell, the behavior is actually the same as before, just with commas being treated differently.
