### PR TITLE
Upgrade open package to v5.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,9 +1527,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "open"
-version = "5.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfabf1927dce4d6fdf563d63328a0a506101ced3ec780ca2135747336c98cef8"
+checksum = "90878fb664448b54c4e592455ad02831e23a3f7e157374a8b95654731aac7349"
 dependencies = [
  "is-wsl",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ log = "0.4"
 miniz_oxide = "0.7"
 notify = "6"
 once_cell = "1"
-open = "5"
+open = "5.0.1"
 oxipng = { git = "https://github.com/typst/oxipng", rev = "b8ec65b", default-features = false, features = ["filetime", "parallel", "zopfli"] }
 palette = { version = "0.7.3", default-features = false, features = ["approx", "libm"] }
 pathdiff = "0.2"


### PR DESCRIPTION
This fixes #2724 by updating the `open` package to the latest version, which handles spaces in paths to apps properly on Windows.