### PR TITLE
Add method for setting the alpha component of a color

### DIFF
--- a/crates/typst/src/layout/frame.rs
+++ b/crates/typst/src/layout/frame.rs
@@ -372,16 +372,11 @@ impl Frame {
 
     /// Debug in place.
     pub fn debug_in_place(&mut self) {
-        let Color::Rgb(mut transparent_teal) = Color::TEAL.to_rgb() else {
-            unreachable!();
-        };
-        transparent_teal.alpha = 0.5;
-
         self.insert(
             0,
             Point::zero(),
             FrameItem::Shape(
-                Geometry::Rect(self.size).filled(transparent_teal.into()),
+                Geometry::Rect(self.size).filled(Color::TEAL.with_alpha(0.5).into()),
                 Span::detached(),
             ),
         );

--- a/crates/typst/src/layout/frame.rs
+++ b/crates/typst/src/layout/frame.rs
@@ -372,11 +372,16 @@ impl Frame {
 
     /// Debug in place.
     pub fn debug_in_place(&mut self) {
+        let Color::Rgb(mut transparent_teal) = Color::TEAL.to_rgb() else {
+            unreachable!();
+        };
+        transparent_teal.alpha = 0.5;
+
         self.insert(
             0,
             Point::zero(),
             FrameItem::Shape(
-                Geometry::Rect(self.size).filled(Color::TEAL.with_alpha(0.5).into()),
+                Geometry::Rect(self.size).filled(transparent_teal.into()),
                 Span::detached(),
             ),
         );

--- a/crates/typst/src/visualize/color.rs
+++ b/crates/typst/src/visualize/color.rs
@@ -912,7 +912,14 @@ impl Color {
         }
     }
 
-    /// Sets the alpha component of a color, if it has one.
+    /// Returns a new color with the specified alpha value.
+    ///
+    /// This function fails when the color space does not support transparency.
+    ///
+    /// ```example
+    /// #square(fill: teal)
+    /// #square(fill: teal.with-alpha(50%))
+    /// ```
     #[func]
     pub fn with_alpha(
         self,

--- a/crates/typst/src/visualize/color.rs
+++ b/crates/typst/src/visualize/color.rs
@@ -8,6 +8,7 @@ use palette::convert::FromColorUnclamped;
 use palette::encoding::{self, Linear};
 use palette::{
     Darken, Desaturate, FromColor, Lighten, Okhsva, OklabHue, RgbHue, Saturate, ShiftHue,
+    WithAlpha,
 };
 
 use crate::diag::{bail, error, At, SourceResult, StrResult};
@@ -911,6 +912,30 @@ impl Color {
         }
     }
 
+    /// Sets the alpha component of a color, if it has one.
+    #[func]
+    pub fn with_alpha(
+        self,
+        /// The call span
+        span: Span,
+        /// The new alpha value.
+        alpha: Component,
+    ) -> SourceResult<Color> {
+        let alpha = alpha.0.get() as f32;
+        Ok(match self {
+            Self::Oklab(c) => Self::Oklab(c.with_alpha(alpha)),
+            Self::Oklch(c) => Self::Oklch(c.with_alpha(alpha)),
+            Self::LinearRgb(c) => Self::LinearRgb(c.with_alpha(alpha)),
+            Self::Rgb(c) => Self::Rgb(c.with_alpha(alpha)),
+            Self::Hsl(c) => Self::Hsl(c.with_alpha(alpha)),
+            Self::Hsv(c) => Self::Hsv(c.with_alpha(alpha)),
+            Self::Luma(_) | Self::Cmyk(_) => {
+                bail!(error!(span, "cannot set alpha component of this color space")
+                    .with_hint("try converting your color to RGB first"))
+            }
+        })
+    }
+
     /// Increases the saturation of a color by a given factor.
     #[func]
     pub fn saturate(
@@ -1138,21 +1163,6 @@ impl Color {
             Color::Hsl(c) => Some(c.alpha),
             Color::Hsv(c) => Some(c.alpha),
         }
-    }
-
-    /// Sets the alpha channel of the color, if it has one.
-    pub fn with_alpha(mut self, alpha: f32) -> Self {
-        match &mut self {
-            Color::Luma(_) | Color::Cmyk(_) => {}
-            Color::Oklab(c) => c.alpha = alpha,
-            Color::Oklch(c) => c.alpha = alpha,
-            Color::Rgb(c) => c.alpha = alpha,
-            Color::LinearRgb(c) => c.alpha = alpha,
-            Color::Hsl(c) => c.alpha = alpha,
-            Color::Hsv(c) => c.alpha = alpha,
-        }
-
-        self
     }
 
     /// Converts the color to a vec of four floats.

--- a/tests/typ/compiler/color.typ
+++ b/tests/typ/compiler/color.typ
@@ -78,6 +78,24 @@
 }
 
 ---
+/// Test alpha modification.
+// Ref: false
+#let orig = rgb(80%, 50%, 0%, 75%)
+#let target = rgb(80%, 50%, 0%, 50%)
+#test-repr(orig.with-alpha(50%), target)
+#test-repr(orig.with-alpha(128), target)
+#test-repr(oklab(orig).with-alpha(50%), oklab(target))
+#test-repr(oklch(orig).with-alpha(50%), oklch(target))
+#test-repr(color.linear-rgb(orig).with-alpha(50%), color.linear-rgb(target))
+#test-repr(color.hsl(orig).with-alpha(50%), color.hsl(target))
+#test-repr(color.hsv(orig).with-alpha(50%), color.hsv(target))
+
+---
+// Error: 2-26 cannot set alpha component of this color space
+// Hint: 2-26 try converting your color to RGB first
+#luma(50%).with-alpha(50)
+
+---
 // Test gray color modification.
 // Ref: false
 #test-repr(luma(20%).lighten(50%), luma(60%))


### PR DESCRIPTION
With this PR users can easily modify the alpha value of a color:
```typ
square(fill: teal.with-alpha(50%))
```
