### PR TITLE
Check actions with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  ignore:
+    - dependency-name: dtolnay/rust-toolchain


### PR DESCRIPTION
adds a dependabot config file for keeping github actions up to date