### PR TITLE
avoid single variant match blocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,3 +132,6 @@ codegen-units = 1
 
 [profile.release.package."typst-cli"]
 strip = true
+
+[workspace.lints.clippy]
+single_match_else = "warn"

--- a/crates/typst-cli/Cargo.toml
+++ b/crates/typst-cli/Cargo.toml
@@ -74,3 +74,6 @@ embed-fonts = []
 
 # Permits the CLI to update itself without a package manager
 self-update = ["dep:self-replace", "dep:xz2", "dep:zip", "ureq/json"]
+
+[lints]
+workspace = true

--- a/crates/typst-docs/Cargo.toml
+++ b/crates/typst-docs/Cargo.toml
@@ -25,3 +25,6 @@ typed-arena = { workspace = true }
 unicode_names2 = { workspace = true }
 unscanny = { workspace = true }
 yaml-front-matter = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/typst-ide/Cargo.toml
+++ b/crates/typst-ide/Cargo.toml
@@ -24,3 +24,6 @@ if_chain = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
 unscanny = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/typst-macros/Cargo.toml
+++ b/crates/typst-macros/Cargo.toml
@@ -22,3 +22,6 @@ heck = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/typst-pdf/Cargo.toml
+++ b/crates/typst-pdf/Cargo.toml
@@ -32,3 +32,6 @@ ttf-parser = { workspace = true }
 unicode-properties = { workspace = true }
 unscanny = { workspace = true }
 xmp-writer = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/typst-render/Cargo.toml
+++ b/crates/typst-render/Cargo.toml
@@ -27,3 +27,6 @@ roxmltree = { workspace = true }
 tiny-skia = { workspace = true }
 ttf-parser = { workspace = true }
 usvg = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/typst-svg/Cargo.toml
+++ b/crates/typst-svg/Cargo.toml
@@ -25,3 +25,6 @@ tracing = { workspace = true }
 ttf-parser = { workspace = true }
 xmlparser = { workspace = true }
 xmlwriter = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/typst-syntax/Cargo.toml
+++ b/crates/typst-syntax/Cargo.toml
@@ -26,3 +26,6 @@ unicode-math-class = { workspace = true }
 unicode-script = { workspace = true }
 unicode-segmentation = { workspace = true }
 unscanny = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/typst/Cargo.toml
+++ b/crates/typst/Cargo.toml
@@ -65,3 +65,6 @@ wasmi = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 stacker = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/typst/src/engine.rs
+++ b/crates/typst/src/engine.rs
@@ -35,13 +35,10 @@ impl Engine<'_> {
         F: FnOnce(&mut Self) -> SourceResult<T>,
         T: Default,
     {
-        match f(self) {
-            Ok(value) => value,
-            Err(errors) => {
-                self.tracer.delay(errors);
-                T::default()
-            }
-        }
+        f(self).unwrap_or_else(|errors| {
+            self.tracer.delay(errors);
+            T::default()
+        })
     }
 }
 

--- a/crates/typst/src/introspection/counter.rs
+++ b/crates/typst/src/introspection/counter.rs
@@ -550,10 +550,11 @@ pub struct CounterState(pub SmallVec<[usize; 3]>);
 impl CounterState {
     /// Get the initial counter state for the key.
     pub fn init(key: &CounterKey) -> Self {
-        Self(match key {
+        Self(if key == &CounterKey::Page {
             // special case, because pages always start at one.
-            CounterKey::Page => smallvec![1],
-            _ => smallvec![0],
+            smallvec![1]
+        } else {
+            smallvec![0]
         })
     }
 

--- a/crates/typst/src/layout/grid.rs
+++ b/crates/typst/src/layout/grid.rs
@@ -478,13 +478,13 @@ impl<'a> GridLayouter<'a> {
     fn layout_auto_row(&mut self, engine: &mut Engine, y: usize) -> SourceResult<()> {
         // Determine the size for each region of the row. If the first region
         // ends up empty for some column, skip the region and remeasure.
-        let mut resolved = match self.measure_auto_row(engine, y, true)? {
-            Some(resolved) => resolved,
-            None => {
+        let mut resolved =
+            if let Some(resolved) = self.measure_auto_row(engine, y, true)? {
+                resolved
+            } else {
                 self.finish_region(engine)?;
                 self.measure_auto_row(engine, y, false)?.unwrap()
-            }
-        };
+            };
 
         // Nothing to layout.
         if resolved.is_empty() {

--- a/crates/typst/src/text/smartquote.rs
+++ b/crates/typst/src/text/smartquote.rs
@@ -308,15 +308,14 @@ cast! {
 
 fn str_to_set(value: &str) -> StrResult<[EcoString; 2]> {
     let mut iter = value.graphemes(true);
-    match (iter.next(), iter.next(), iter.next()) {
-        (Some(open), Some(close), None) => Ok([open.into(), close.into()]),
-        _ => {
-            let count = value.graphemes(true).count();
-            bail!(
-                "expected 2 characters, found {count} character{}",
-                if count > 1 { "s" } else { "" }
-            );
-        }
+    if let (Some(open), Some(close), None) = (iter.next(), iter.next(), iter.next()) {
+        Ok([open.into(), close.into()])
+    } else {
+        let count = value.graphemes(true).count();
+        bail!(
+            "expected 2 characters, found {count} character{}",
+            if count > 1 { "s" } else { "" }
+        );
     }
 }
 


### PR DESCRIPTION
prefer 'if let` to single variant match blocks.

the lint itself is a small win which improves readability *slightly*, and reduces indentation/nesting.

Perhaps more usefully, this PR also introduces the `[workspace.lints]` boiler plate needed to support gradually adding of workspace-level lints (if desirable)