### PR TITLE
Demo mid() with a new example showing a friction point with auto-scaling

### DIFF
--- a/crates/typst/src/math/lr.rs
+++ b/crates/typst/src/math/lr.rs
@@ -86,7 +86,7 @@ impl LayoutMath for LrElem {
 /// Scales contents vertically to the nearest surrounding `{lr()}` group.
 ///
 /// ```example
-/// $ { x mid(|) sum_(i=1)^oo phi_i (x) < 1 } $
+/// $ { x mid(|) a|A|sum_(i=1)^oo phi_i (x) < 1 } $
 /// ```
 #[elem(LayoutMath)]
 pub struct MidElem {

--- a/crates/typst/src/math/lr.rs
+++ b/crates/typst/src/math/lr.rs
@@ -83,10 +83,10 @@ impl LayoutMath for LrElem {
     }
 }
 
-/// Scales contents vertically to the nearest surrounding `{lr()}` group.
+/// Scales delimiters vertically to the nearest surrounding `{lr()}` group.
 ///
 /// ```example
-/// $ { x mid(|) a|A|sum_(i=1)^oo phi_i (x) < 1 } $
+/// $ { x mid(|) sum_(i=1)^oo phi_i (x,y)|_(y=0) < 1 } $
 /// ```
 #[elem(LayoutMath)]
 pub struct MidElem {

--- a/crates/typst/src/math/lr.rs
+++ b/crates/typst/src/math/lr.rs
@@ -86,7 +86,7 @@ impl LayoutMath for LrElem {
 /// Scales delimiters vertically to the nearest surrounding `{lr()}` group.
 ///
 /// ```example
-/// $ { x mid(|) sum_(i=1)^oo phi_i (x,y)|_(y=0) < 1 } $
+/// $ { x mid(|) sum_(i=1)^n w_i|f_i (x)| < 1 } $
 /// ```
 #[elem(LayoutMath)]
 pub struct MidElem {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -69,7 +69,7 @@ description: |
     and footnote entries
 
 - Math
-  - Added [`mid`]($math.mid) function for scaling a character up to the height
+  - Added [`mid`]($math.mid) function for scaling a delimiter up to the height
     of the surrounding [`lr`]($math.lr) group
   - The [`op`]($math.op) function can now take any content, not just strings
   - Improved documentation for [math alignment]($category/math/#alignment)


### PR DESCRIPTION
One common suggestion regarding the `lr()`/`mid()` function is that Typst should auto-scale vertical bars (`|`) in an `lr()` call, instead of having to manually trigger it with a `mid()` call.

This new example, which is made obvious by being incorporated into the online reference doc, shows a case of false positive that may ensue, thus nudging contributors to think about what to do before opening an Issue or PR.