### PR TITLE
Don't exit watcher on invalid utf-8

### DIFF
--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -78,7 +78,7 @@ pub fn compile_once(
         Status::Compiling.print(command).unwrap();
     }
 
-    // Check the encoding of main file.
+    // Check if main file can be read and opened.
     if let Err(errors) = world.source(world.main()).at(Span::detached()) {
         tracing::info!("Failed to open and decode main file");
 
@@ -86,7 +86,7 @@ pub fn compile_once(
             Status::Error.print(command).unwrap();
         }
 
-        // Create diagnostics for invalid utf-8 instead of an error.
+        // Create diagnostics instead of return Err.
         print_diagnostics(world, &errors, &[], command.common.diagnostic_format)
             .map_err(|err| eco_format!("failed to print diagnostics ({err})"))?;
 

--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -80,13 +80,13 @@ pub fn compile_once(
 
     // Check if main file can be read and opened.
     if let Err(errors) = world.source(world.main()).at(Span::detached()) {
+        set_failed();
         tracing::info!("Failed to open and decode main file");
 
         if watching {
             Status::Error.print(command).unwrap();
         }
 
-        // Create diagnostics instead of return Err.
         print_diagnostics(world, &errors, &[], command.common.diagnostic_format)
             .map_err(|err| eco_format!("failed to print diagnostics ({err})"))?;
 


### PR DESCRIPTION
Refer to Issue #2632. Modified `typst-cli`. 
Make the watcher not exiting when invalid utf-8 is encountered.
