### PR TITLE
Optimized labels & introspector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2644,6 +2644,7 @@ dependencies = [
  "ciborium",
  "comemo",
  "csv",
+ "dashmap",
  "ecow",
  "fontdb",
  "hayagriva",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ clap_mangen = "0.2.10"
 codespan-reporting = "0.11"
 comemo = "0.3.1"
 csv = "1"
+dashmap = "5.5"
 dirs = "5"
 ecow = { version = "0.2", features = ["serde"] }
 env_proxy = "0.4"

--- a/crates/typst-cli/src/query.rs
+++ b/crates/typst-cli/src/query.rs
@@ -4,7 +4,6 @@ use serde::Serialize;
 use typst::diag::{bail, StrResult};
 use typst::eval::{eval_string, EvalMode, Tracer};
 use typst::foundations::{Content, IntoValue, LocatableSelector, Scope};
-use typst::introspection::Introspector;
 use typst::model::Document;
 use typst::syntax::Span;
 use typst::World;
@@ -76,7 +75,8 @@ fn retrieve(
     })?
     .cast::<LocatableSelector>()?;
 
-    Ok(Introspector::new(&document.pages)
+    Ok(document
+        .introspector
         .query(&selector.0)
         .into_iter()
         .map(|x| x.into_inner())

--- a/crates/typst-ide/src/analyze.rs
+++ b/crates/typst-ide/src/analyze.rs
@@ -4,8 +4,7 @@ use typst::engine::{Engine, Route};
 use typst::eval::{Tracer, Vm};
 use typst::foundations::{Label, Scopes, Value};
 use typst::introspection::{Introspector, Locator};
-use typst::layout::Frame;
-use typst::model::BibliographyElem;
+use typst::model::{BibliographyElem, Document};
 use typst::syntax::{ast, LinkedNode, Span, SyntaxKind};
 use typst::World;
 
@@ -75,12 +74,11 @@ pub fn analyze_import(world: &dyn World, source: &LinkedNode) -> Option<Value> {
 /// - All labels and descriptions for them, if available
 /// - A split offset: All labels before this offset belong to nodes, all after
 ///   belong to a bibliography.
-pub fn analyze_labels(frames: &[Frame]) -> (Vec<(Label, Option<EcoString>)>, usize) {
+pub fn analyze_labels(document: &Document) -> (Vec<(Label, Option<EcoString>)>, usize) {
     let mut output = vec![];
-    let introspector = Introspector::new(frames);
 
     // Labels in the document.
-    for elem in introspector.all() {
+    for elem in document.introspector.all() {
         let Some(label) = elem.label() else { continue };
         let details = elem
             .get_by_name("caption")
@@ -98,7 +96,7 @@ pub fn analyze_labels(frames: &[Frame]) -> (Vec<(Label, Option<EcoString>)>, usi
     let split = output.len();
 
     // Bibliography keys.
-    for (key, detail) in BibliographyElem::keys(introspector.track()) {
+    for (key, detail) in BibliographyElem::keys(document.introspector.track()) {
         output.push((Label::new(&key), detail));
     }
 

--- a/crates/typst-pdf/src/lib.rs
+++ b/crates/typst-pdf/src/lib.rs
@@ -19,7 +19,6 @@ use ecow::{eco_format, EcoString};
 use pdf_writer::types::Direction;
 use pdf_writer::{Finish, Name, Pdf, Ref, TextStr};
 use typst::foundations::Datetime;
-use typst::introspection::Introspector;
 use typst::layout::{Abs, Dir, Em, Transform};
 use typst::model::Document;
 use typst::text::{Font, Lang};
@@ -144,14 +143,6 @@ impl<'a> PdfContext<'a> {
             pattern_map: Remapper::new(),
             extg_map: Remapper::new(),
         }
-    }
-
-    /// Gets a reference to the document's introspector.
-    ///
-    /// # Panics
-    /// Panics if the document has no introspector.
-    pub fn introspector(&self) -> &'a Introspector {
-        self.document.introspector.as_ref().unwrap()
     }
 }
 

--- a/crates/typst-pdf/src/lib.rs
+++ b/crates/typst-pdf/src/lib.rs
@@ -70,10 +70,6 @@ pub fn pdf(
 struct PdfContext<'a> {
     /// The document that we're currently exporting.
     document: &'a Document,
-    /// An introspector for the document, used to resolve locations links and
-    /// the document outline.
-    introspector: Introspector,
-
     /// The writer we are writing the PDF into.
     pdf: Pdf,
     /// Content of exported pages.
@@ -128,7 +124,6 @@ impl<'a> PdfContext<'a> {
         let page_tree_ref = alloc.bump();
         Self {
             document,
-            introspector: Introspector::new(&document.pages),
             pdf: Pdf::new(),
             pages: vec![],
             glyph_sets: HashMap::new(),
@@ -149,6 +144,14 @@ impl<'a> PdfContext<'a> {
             pattern_map: Remapper::new(),
             extg_map: Remapper::new(),
         }
+    }
+
+    /// Gets a reference to the document's introspector.
+    ///
+    /// # Panics
+    /// Panics if the document has no introspector.
+    pub fn introspector(&self) -> &'a Introspector {
+        self.document.introspector.as_ref().unwrap()
     }
 }
 

--- a/crates/typst-pdf/src/outline.rs
+++ b/crates/typst-pdf/src/outline.rs
@@ -18,7 +18,7 @@ pub(crate) fn write_outline(ctx: &mut PdfContext) -> Option<Ref> {
     // Therefore, its next descendant must be added at its level, which is
     // enforced in the manner shown below.
     let mut last_skipped_level = None;
-    for heading in ctx.introspector().query(&HeadingElem::elem().select()).iter() {
+    for heading in ctx.document.introspector.query(&HeadingElem::elem().select()).iter() {
         let leaf = HeadingNode::leaf((**heading).clone());
 
         if leaf.bookmarked {
@@ -140,7 +140,6 @@ fn write_outline_item(
 ) -> Ref {
     let id = ctx.alloc.bump();
     let next_ref = Ref::new(id.get() + node.len() as i32);
-    let introspector = ctx.introspector();
 
     let mut outline = ctx.pdf.outline_item(id);
     outline.parent(parent_ref);
@@ -164,7 +163,7 @@ fn write_outline_item(
     outline.title(TextStr(body.plain_text().trim()));
 
     let loc = node.element.location().unwrap();
-    let pos = introspector.position(loc);
+    let pos = ctx.document.introspector.position(loc);
     let index = pos.page.get() - 1;
     if let Some(page) = ctx.pages.get(index) {
         let y = (pos.point.y - Abs::pt(10.0)).max(Abs::zero());

--- a/crates/typst-pdf/src/outline.rs
+++ b/crates/typst-pdf/src/outline.rs
@@ -18,7 +18,7 @@ pub(crate) fn write_outline(ctx: &mut PdfContext) -> Option<Ref> {
     // Therefore, its next descendant must be added at its level, which is
     // enforced in the manner shown below.
     let mut last_skipped_level = None;
-    for heading in ctx.introspector.query(&HeadingElem::elem().select()).iter() {
+    for heading in ctx.introspector().query(&HeadingElem::elem().select()).iter() {
         let leaf = HeadingNode::leaf((**heading).clone());
 
         if leaf.bookmarked {
@@ -140,6 +140,7 @@ fn write_outline_item(
 ) -> Ref {
     let id = ctx.alloc.bump();
     let next_ref = Ref::new(id.get() + node.len() as i32);
+    let introspector = ctx.introspector();
 
     let mut outline = ctx.pdf.outline_item(id);
     outline.parent(parent_ref);
@@ -163,7 +164,7 @@ fn write_outline_item(
     outline.title(TextStr(body.plain_text().trim()));
 
     let loc = node.element.location().unwrap();
-    let pos = ctx.introspector.position(loc);
+    let pos = introspector.position(loc);
     let index = pos.page.get() - 1;
     if let Some(page) = ctx.pages.get(index) {
         let y = (pos.point.y - Abs::pt(10.0)).max(Abs::zero());

--- a/crates/typst-pdf/src/page.rs
+++ b/crates/typst-pdf/src/page.rs
@@ -145,7 +145,6 @@ pub(crate) fn write_page_tree(ctx: &mut PdfContext) {
 #[tracing::instrument(skip_all)]
 fn write_page(ctx: &mut PdfContext, i: usize) {
     let page = &ctx.pages[i];
-    let introspector = ctx.introspector();
     let content_id = ctx.alloc.bump();
 
     let mut page_writer = ctx.pdf.page(page.id);
@@ -181,7 +180,7 @@ fn write_page(ctx: &mut PdfContext, i: usize) {
                 continue;
             }
             Destination::Position(pos) => *pos,
-            Destination::Location(loc) => introspector.position(*loc),
+            Destination::Location(loc) => ctx.document.introspector.position(*loc),
         };
 
         let index = pos.page.get() - 1;

--- a/crates/typst-pdf/src/page.rs
+++ b/crates/typst-pdf/src/page.rs
@@ -145,6 +145,7 @@ pub(crate) fn write_page_tree(ctx: &mut PdfContext) {
 #[tracing::instrument(skip_all)]
 fn write_page(ctx: &mut PdfContext, i: usize) {
     let page = &ctx.pages[i];
+    let introspector = ctx.introspector();
     let content_id = ctx.alloc.bump();
 
     let mut page_writer = ctx.pdf.page(page.id);
@@ -180,7 +181,7 @@ fn write_page(ctx: &mut PdfContext, i: usize) {
                 continue;
             }
             Destination::Position(pos) => *pos,
-            Destination::Location(loc) => ctx.introspector.position(*loc),
+            Destination::Location(loc) => introspector.position(*loc),
         };
 
         let index = pos.page.get() - 1;

--- a/crates/typst/Cargo.toml
+++ b/crates/typst/Cargo.toml
@@ -24,6 +24,7 @@ chinese-number = { workspace = true }
 ciborium = { workspace = true }
 comemo = { workspace = true }
 csv = { workspace = true }
+dashmap = { workspace = true }
 ecow = { workspace = true}
 fontdb = { workspace = true }
 hayagriva = { workspace = true }

--- a/crates/typst/src/introspection/introspector.rs
+++ b/crates/typst/src/introspection/introspector.rs
@@ -90,7 +90,7 @@ impl Introspector {
                     if let Some(label) = content.label() {
                         self.label_cache
                             .entry(label)
-                            .or_insert_with(SmallVec::new)
+                            .or_default()
                             .push(self.elems.len() - 1);
                     }
                 }
@@ -110,11 +110,6 @@ impl Introspector {
     /// Get an element by its location.
     fn get(&self, location: &Location) -> Option<&Prehashed<Content>> {
         self.elems.get(location).map(|(elem, _)| elem)
-    }
-
-    /// Get the number of elements.
-    pub fn len(&self) -> usize {
-        self.elems.len()
     }
 
     /// Get the index of this element among all.

--- a/crates/typst/src/introspection/introspector.rs
+++ b/crates/typst/src/introspection/introspector.rs
@@ -41,7 +41,7 @@ impl Introspector {
         Self::with_parent(frames, None)
     }
 
-    /// Create a new introspector with a given capacity.
+    /// Create a new introspector with a parent from which capacities are inferred.
     #[tracing::instrument(skip_all)]
     pub fn with_parent(frames: &[Frame], parent: Option<&Introspector>) -> Self {
         let mut introspector = Self {

--- a/crates/typst/src/lib.rs
+++ b/crates/typst/src/lib.rs
@@ -135,7 +135,7 @@ fn typeset(
         // Layout!
         document = content.layout_root(&mut engine, styles)?;
 
-        introspector = Introspector::with_capacity(&document.pages, introspector.len());
+        introspector = Introspector::with_parent(&document.pages, Some(&introspector));
         iter += 1;
 
         if introspector.validate(&constraint) {

--- a/crates/typst/src/lib.rs
+++ b/crates/typst/src/lib.rs
@@ -135,7 +135,7 @@ fn typeset(
         // Layout!
         document = content.layout_root(&mut engine, styles)?;
 
-        introspector = Introspector::new(&document.pages);
+        introspector = Introspector::with_capacity(&document.pages, introspector.len());
         iter += 1;
 
         if introspector.validate(&constraint) {
@@ -157,6 +157,8 @@ fn typeset(
         return Err(delayed);
     }
 
+    // Set the introspector.
+    document.introspector = Some(introspector);
     Ok(document)
 }
 

--- a/crates/typst/src/lib.rs
+++ b/crates/typst/src/lib.rs
@@ -111,8 +111,7 @@ fn typeset(
     let styles = StyleChain::new(&library.styles);
 
     let mut iter = 0;
-    let mut document;
-    let mut introspector = Introspector::new(&[]);
+    let mut document = Document::default();
 
     // Relayout until all introspections stabilize.
     // If that doesn't happen within five attempts, we give up.
@@ -129,16 +128,15 @@ fn typeset(
             route: Route::default(),
             tracer: tracer.track_mut(),
             locator: &mut locator,
-            introspector: introspector.track_with(&constraint),
+            introspector: document.introspector.track_with(&constraint),
         };
 
         // Layout!
         document = content.layout_root(&mut engine, styles)?;
-
-        introspector = Introspector::with_parent(&document.pages, Some(&introspector));
+        document.introspector.rebuild(&document.pages);
         iter += 1;
 
-        if introspector.validate(&constraint) {
+        if document.introspector.validate(&constraint) {
             break;
         }
 
@@ -157,8 +155,6 @@ fn typeset(
         return Err(delayed);
     }
 
-    // Set the introspector.
-    document.introspector = Some(introspector);
     Ok(document)
 }
 

--- a/crates/typst/src/model/document.rs
+++ b/crates/typst/src/model/document.rs
@@ -110,7 +110,7 @@ impl LayoutRoot for DocumentElem {
             author: self.author(styles).0,
             keywords: self.keywords(styles).0,
             date: self.date(styles),
-            introspector: None,
+            introspector: Introspector::default(),
         })
     }
 }
@@ -138,7 +138,7 @@ cast! {
 }
 
 /// A finished document with metadata and page frames.
-#[derive(Clone, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Document {
     /// The page frames.
     pub pages: Vec<Frame>,
@@ -150,8 +150,8 @@ pub struct Document {
     pub keywords: Vec<EcoString>,
     /// The document's creation date.
     pub date: Smart<Option<Datetime>>,
-    /// The document's introspector.
-    pub introspector: Option<Introspector>,
+    /// Provides the ability to execute queries on the document.
+    pub introspector: Introspector,
 }
 
 #[cfg(test)]
@@ -159,8 +159,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_document_is_send() {
-        fn ensure_send<T: Send>() {}
-        ensure_send::<Document>();
+    fn test_document_is_send_and_sync() {
+        fn ensure_send_and_sync<T: Send + Sync>() {}
+        ensure_send_and_sync::<Document>();
     }
 }

--- a/crates/typst/src/model/document.rs
+++ b/crates/typst/src/model/document.rs
@@ -5,7 +5,7 @@ use crate::engine::Engine;
 use crate::foundations::{
     cast, elem, Args, Array, Construct, Content, Datetime, Smart, StyleChain, Value,
 };
-use crate::introspection::ManualPageCounter;
+use crate::introspection::{Introspector, ManualPageCounter};
 use crate::layout::{Frame, LayoutRoot, PageElem};
 
 /// The root element of a document and its metadata.
@@ -110,6 +110,7 @@ impl LayoutRoot for DocumentElem {
             author: self.author(styles).0,
             keywords: self.keywords(styles).0,
             date: self.date(styles),
+            introspector: None,
         })
     }
 }
@@ -137,7 +138,7 @@ cast! {
 }
 
 /// A finished document with metadata and page frames.
-#[derive(Debug, Default, Clone, Hash)]
+#[derive(Clone, Default)]
 pub struct Document {
     /// The page frames.
     pub pages: Vec<Frame>,
@@ -149,6 +150,8 @@ pub struct Document {
     pub keywords: Vec<EcoString>,
     /// The document's creation date.
     pub date: Smart<Option<Datetime>>,
+    /// The document's introspector.
+    pub introspector: Option<Introspector>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
As the title says, this is (yet another) round of optimizations this time focused on queries. It allows labels to be cached in the `Introspector` and used more efficiently for queries and `query_label`. Overall this gives us a small but measurable performance gain of 15-30% depending on the scenario. Cold gains (as always) are a little lower but it brings us down to (almost) the ~5s compile times.

This also improves the allocation pattern of `Introspector` to allow it to pre-allocate larger structures from the previous `Introspector`'s sizes. Also moves `Introspector` into `Document` allowing the PDF export code to re-use the existing introspector instead of creating its own. These two changes might seem esoteric and undeeded, but their impact is measurable at around a ~50ms reduction in compile time across both incremental and cold.
