### PR TITLE
Fix chinese numbers being limited to 255

### DIFF
--- a/crates/typst/src/model/numbering.rs
+++ b/crates/typst/src/model/numbering.rs
@@ -482,7 +482,7 @@ impl NumberingKind {
                     Case::Upper => ChineseCase::Upper,
                 };
 
-                match (n as u8).to_chinese(
+                match (n as u64).to_chinese(
                     match l {
                         Self::SimplifiedChinese => ChineseVariant::Simple,
                         Self::TraditionalChinese => ChineseVariant::Traditional,


### PR DESCRIPTION
Prior to this PR, 1 and 257 were formatted the same way.
This PR fixes that behavior.
