### PR TITLE
Optimize element queries using `Block`

### DIFF
--- a/crates/typst/src/foundations/content.rs
+++ b/crates/typst/src/foundations/content.rs
@@ -12,7 +12,7 @@ use smallvec::smallvec;
 use crate::diag::{SourceResult, StrResult};
 use crate::engine::Engine;
 use crate::foundations::{
-    elem, func, scope, ty, Dict, Element, FromValue, Guard, IntoValue, Label,
+    elem, func, scope, ty, Block, Dict, Element, FromValue, Guard, IntoValue, Label,
     NativeElement, Recipe, Repr, Selector, Str, Style, Styles, Value,
 };
 use crate::introspection::{Location, Meta, MetaElem};
@@ -177,6 +177,12 @@ impl Content {
     pub fn field(&self, id: u8) -> StrResult<Value> {
         self.get(id)
             .ok_or_else(|| missing_field(self.elem().field_name(id).unwrap()))
+    }
+
+    /// Checks whether the field with the given ID is equal to the given value.
+    #[inline]
+    pub fn field_eq(&self, id: u8, value: &Block) -> bool {
+        self.0.field_eq(id, value)
     }
 
     /// Get a field by name, returning a missing field error if it does not

--- a/crates/typst/src/foundations/func.rs
+++ b/crates/typst/src/foundations/func.rs
@@ -349,13 +349,19 @@ impl Func {
         let fields = fields
             .into_iter()
             .map(|(key, value)| {
-                element.field_id(&key).map(|id| (id, value)).ok_or_else(|| {
+                let id = element.field_id(&key).ok_or_else(|| {
                     eco_format!(
                         "element `{}` does not have field `{}`",
                         element.name(),
                         key
                     )
-                })
+                })?;
+
+                let block = element.parse_field(id, value).map_err(|e| {
+                    eco_format!("cannot parse value for field `{}`: {}", key, e)
+                })?;
+
+                Ok((id, block))
             })
             .collect::<StrResult<smallvec::SmallVec<_>>>()?;
 

--- a/crates/typst/src/foundations/styles.rs
+++ b/crates/typst/src/foundations/styles.rs
@@ -260,6 +260,7 @@ impl Debug for Property {
 /// therefore already on the heap or they will be small enough that we can just
 /// clone them.
 #[derive(Hash)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 pub struct Block(Box<dyn Blockable>);
 
 impl Block {

--- a/crates/typst/src/text/raw.rs
+++ b/crates/typst/src/text/raw.rs
@@ -507,6 +507,14 @@ impl PlainText for RawLine {
     }
 }
 
+cast! {
+    RawLine,
+    v: Content => (*v
+        .unpack::<RawLine>()
+        .ok_or_else(|| eco_format!("expected a raw.line"))?
+    ).clone(),
+}
+
 /// Wrapper struct for the state required to highlight typst code.
 struct ThemedHighlighter<'a> {
     /// The code being highlighted.


### PR DESCRIPTION
Instead of using `Value` to perform queries on elements (which causes an allocation for every single value check), this pre-parses all of the values into `Block`s that are part of the query and elements can now take these blocks to do checking. This moves the allocations into the `where` call and lightens the load of the queries themselves.

The gains are smaller than I was expecting but measurable. I would expect it to be more significant on lower end hardware.

Due to the complexity, I'll let you decide whether it's worth it.