### PR TITLE
Let test.rs --exact also accept file path of a typ file

### DIFF
--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -120,9 +120,7 @@ fn main() {
                 return None;
             }
 
-            let src_whole_path =
-                Path::new(&std::env::current_dir().unwrap()).join(src_path.clone());
-            if args.matches(&src_whole_path) {
+            if args.matches(&src_path.canonicalize().unwrap()) {
                 Some(src_path)
             } else {
                 None

--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -87,7 +87,7 @@ impl Args {
         for i in 0..components_len {
             path_endings.insert(
                 components[(components_len - i - 1)..]
-                    .join(&std::path::MAIN_SEPARATOR.to_string()),
+                    .join(std::path::MAIN_SEPARATOR_STR),
             );
         }
 

--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -31,6 +31,7 @@ use typst::{Library, World, WorldExt};
 use unscanny::Scanner;
 use walkdir::WalkDir;
 
+// These directories are all relative to the tests/ directory.
 const TYP_DIR: &str = "typ";
 const REF_DIR: &str = "ref";
 const PNG_DIR: &str = "png";
@@ -102,7 +103,7 @@ fn main() {
     let world = TestWorld::new(args.print);
 
     println!("Running tests...");
-    let results = WalkDir::new("typ")
+    let results = WalkDir::new(TYP_DIR)
         .into_iter()
         .par_bridge()
         .filter_map(|entry| {
@@ -115,7 +116,7 @@ fn main() {
                 return None;
             }
 
-            let src_path = entry.into_path();
+            let src_path = entry.into_path(); // Relative to TYP_DIR.
             if src_path.extension() != Some(OsStr::new("typ")) {
                 return None;
             }
@@ -148,10 +149,10 @@ fn main() {
 
     let len = results.len();
     let ok = results.iter().sum::<usize>();
-    if len > 1 {
+    if len >= 2 {
         println!("{ok} / {len} tests passed.");
     } else if len == 0 {
-        println!("No test ran. Did you spell paths correctly?");
+        println!("No test ran.");
     }
 
     if ok != len {


### PR DESCRIPTION
Originally, if `--exact` is provided then the path filter only matches with a test file's final filename, so that e.g. `cargo test --all --test tests -- --exact footnote.typ
` only runs `meta/footnote.typ`, and `meta/cite-footnote.typ` is excluded. This is reasonable, because when users give `footnote.typ` to `--exact` they only want the former to run.

However, with the original behavior, `cargo test --all --test tests -- --exact meta/footnote.typ`
won't pick up any test. This is often surprising to users, because "exact" seems to mean the exact path. Users usually don't know they should only provide the final filename to `--exact`, and they often just paste the path string copied with the IDE's handy UI/command.

This patch allows users to provide path from the tests directory, so _all_ commands below will pick up `meta/footnote.typ` (and `meta/cite-footnote.typ` is still excluded):
```
cargo test --all --test tests -- --exact footnote.typ                # status quo
cargo test --all --test tests -- --exact meta/footnote.typ
cargo test --all --test tests -- --exact typ/meta/footnote.typ
cargo test --all --test tests -- --exact tests/typ/meta/footnote.typ # path copied from VSCode
```