### PR TITLE
Let test-helper use the same commands as the CLI-only workflow

### DIFF
--- a/tools/test-helper/README.md
+++ b/tools/test-helper/README.md
@@ -1,17 +1,16 @@
 # Test helper
 
 This is a small VS Code extension that helps with managing Typst's test suite.
-When installed, three new buttons appear in the menubar for all `.typ` files in
+When installed, a few new buttons appear in the menubar for all `.typ` files in
 the `tests` folder.
 
 - Open: Opens the output and reference images of a test to the side.
 - Refresh: Refreshes the preview.
 - Rerun: Re-runs the test.
-- Update: Copies the output into the reference folder and optimizes
-  it with `oxipng`.
+- Update: Update the reference image.
 
-For the test helper to work correctly, you also need to install `oxipng`, for
-example with `cargo install oxipng`.
+Under the hood, the extension uses the [same CLI command](../../tests/README.md) to run
+the tests and to update the reference images.
 
 ## Installation
 The simplest way to install this extension (and keep it up-to-date) is to use VSCode's UI:

--- a/tools/test-helper/extension.js
+++ b/tools/test-helper/extension.js
@@ -53,14 +53,17 @@ function activate(context) {
 
     const updateCmd = vscode.commands.registerCommand("ShortcutMenuBar.testUpdate", () => {
         const uri = vscode.window.activeTextEditor.document.uri
-        const { pngPath, refPath } = getPaths(uri)
+        const components = uri.fsPath.split(/tests[\/\\]/)
+        const dir = components[0]
+        const subPath = components[1]
 
-        vscode.workspace.fs.copy(pngPath, refPath, { overwrite: true }).then(() => {
-            console.log('Copied to reference file')
-            cp.exec(`oxipng -o max -a ${refPath.fsPath}`, (err, stdout, stderr) => {
+        cp.exec(
+            `cargo test --manifest-path ${dir}/Cargo.toml --all --test tests -- ${subPath} --update`,
+            (err, stdout, stderr) => {
+                console.log('Update tests')
                 refreshPanel(stdout, stderr)
-            })
-        })
+            }
+        )
     })
 
     context.subscriptions.push(openCmd)

--- a/tools/test-helper/extension.js
+++ b/tools/test-helper/extension.js
@@ -39,11 +39,10 @@ function activate(context) {
     const rerunCmd = vscode.commands.registerCommand("ShortcutMenuBar.testRerun", () => {
         const uri = vscode.window.activeTextEditor.document.uri
         const components = uri.fsPath.split(/tests[\/\\]/)
-        const dir = components[0]
-        const subPath = components[1]
+        const [repoRoot, subPath] = components
 
         cp.exec(
-            `cargo test --manifest-path ${dir}/Cargo.toml --all --test tests -- ${subPath}`,
+            `cargo test --manifest-path ${repoRoot}/Cargo.toml --all --test tests -- ${subPath}`,
             (err, stdout, stderr) => {
                 console.log('Ran tests')
                 refreshPanel(stdout, stderr)
@@ -54,11 +53,10 @@ function activate(context) {
     const updateCmd = vscode.commands.registerCommand("ShortcutMenuBar.testUpdate", () => {
         const uri = vscode.window.activeTextEditor.document.uri
         const components = uri.fsPath.split(/tests[\/\\]/)
-        const dir = components[0]
-        const subPath = components[1]
+        const [repoRoot, subPath] = components
 
         cp.exec(
-            `cargo test --manifest-path ${dir}/Cargo.toml --all --test tests -- ${subPath} --update`,
+            `cargo test --manifest-path ${repoRoot}/Cargo.toml --all --test tests -- ${subPath} --update`,
             (err, stdout, stderr) => {
                 console.log('Update tests')
                 refreshPanel(stdout, stderr)


### PR DESCRIPTION
As mentioned in Discord, it seems there's something wrong with the original `test-helper`:

1. In a fresh checkout of the repo (HEAD is 9926a594e7 "Disable dependabot"), build typst. Ensure you have followed test-helper/README.md 's instruction: ran `cargo install oxipng` and installed the test_helper extension in VSCode.
2. Open footnote.typ and its reference image via the test_helper extension, click the "Rerun test" botton to run the test.
3. Verify currently the repo is clean i.e. no file changed.
4. In footnote.typ, click "Update reference image" button
5. One file changed: tests/ref/meta/footnote.png UNEXPECTED!

Since oxipng is locked by the project's lock file and is compiled from source, the extension should no longer require users to separately install oxipng.