### PR TITLE
Fix #2821: defaults on `#[synthesized]` fields

### DIFF
--- a/crates/typst-macros/src/elem.rs
+++ b/crates/typst-macros/src/elem.rs
@@ -732,7 +732,7 @@ fn create_native_elem_impl(element: &Elem) -> TokenStream {
         } else {
             quote! {
                 <#elem as #foundations::ElementFields>::Fields::#name => {
-                    Some(self.#field_ident.clone()?.into_value())
+                    self.#field_ident.clone().map(#foundations::IntoValue::into_value)
                 }
             }
         }
@@ -1052,7 +1052,6 @@ fn create_native_elem_impl(element: &Elem) -> TokenStream {
             }
 
             fn field(&self, id: u8) -> Option<#foundations::Value> {
-                use #foundations::IntoValue;
                 let id = <#ident as #foundations::ElementFields>::Fields::try_from(id).ok()?;
                 match id {
                     <#ident as #foundations::ElementFields>::Fields::Label => #label_field,

--- a/tests/typ/bugs/2821-missing-fields.typ
+++ b/tests/typ/bugs/2821-missing-fields.typ
@@ -1,0 +1,9 @@
+// Issue #2821: Setting a figure's supplement to none removes the field
+// Ref: false
+
+---
+#show figure.caption: it => {
+  assert(it.has("supplement"))
+  assert(it.supplement == none)
+}
+#figure([], caption: [], supplement: none)


### PR DESCRIPTION
Fixes #2821.

While adding the ability for synthesized fields to take default values in #2687 a bug was introduced in several methods for field accesses on `Content`, since those are only used in scripting and only on those specific elements that make use of this feature it wasn't caught before. It's now fixed with changes to the `#[elem]` macro.