### PR TITLE
Implement lexicographic array comparison

### DIFF
--- a/tests/typ/compiler/ops-invalid.typ
+++ b/tests/typ/compiler/ops-invalid.typ
@@ -38,6 +38,14 @@
 #(2.2 <= float("nan"))
 
 ---
+// Error: 3-26 cannot compare integer and string
+#((0, 1, 3) > (0, 1, "a"))
+
+---
+// Error: 3-42 cannot compare 3.5 with NaN
+#((0, "a", 3.5) <= (0, "a", float("nan")))
+
+---
 // Error: 3-12 cannot divide by zero
 #(1.2 / 0.0)
 

--- a/tests/typ/compiler/ops.typ
+++ b/tests/typ/compiler/ops.typ
@@ -206,6 +206,14 @@
 #test(50% < 40% + 0pt, false)
 #test(40% + 0pt < 50% + 0pt, true)
 #test(1em < 2em, true)
+#test((0, 1, 2, 4) < (0, 1, 2, 5), true)
+#test((0, 1, 2, 4) < (0, 1, 2, 3), false)
+#test((0, 1, 2, 3.3) > (0, 1, 2, 4), false)
+#test((0, 1, 2) < (0, 1, 2, 3), true)
+#test((0, 1, "b") > (0, 1, "a", 3), true)
+#test((0, 1.1, 3) >= (0, 1.1, 3), true)
+#test((0, 1, datetime(day: 1, month: 12, year: 2023)) <= (0, 1, datetime(day: 1, month: 12, year: 2023), 3), true)
+#test(("a", 23, 40, "b") > ("a", 23, 40), true)
 
 ---
 // Test assignment operators.

--- a/tests/typ/compiler/ops.typ
+++ b/tests/typ/compiler/ops.typ
@@ -214,6 +214,10 @@
 #test((0, 1.1, 3) >= (0, 1.1, 3), true)
 #test((0, 1, datetime(day: 1, month: 12, year: 2023)) <= (0, 1, datetime(day: 1, month: 12, year: 2023), 3), true)
 #test(("a", 23, 40, "b") > ("a", 23, 40), true)
+#test(() <= (), true)
+#test(() >= (), true)
+#test(() <= (1,), true)
+#test((1,) <= (), false)
 
 ---
 // Test assignment operators.


### PR DESCRIPTION
Closes #2711

## Algorithm
- Zip both arrays and fold to compare element-wise from the start
- Keep comparing while the elements are equal (or until there's an error)
- As soon as a pair of elements of same index isn't equal, that (the first non-equal comparison) will become the result of the operation
- If the result of the operation is that the two arrays are equal, then compare their lengths (since zip stops at the shortest one). A larger array will compare as "greater" than a smaller array when they have the same prefixes. (Consistent with how Python [and Rust](https://doc.rust-lang.org/std/cmp/trait.Ord.html#lexicographical-comparison) do it.)

## Possible improvements
- [x] Could leverage `try_fold`'s stop-on-`Err(...)` optimization to stop folding when a non-equal result is found. This would require having the `cmp_result` variable be a `Result<Ordering, StrResult<Ordering>>`, which is why it felt a bit weird to me at first, but it would probably be faster (right now, from the first non-equal result onwards, it keeps folding on the remaining elements and just returning the accumulator each time). Please tell me if this would be desirable.
   - **Done:** switched to `find_map` instead of `try_fold`.
- [ ] This could lead to a stack overflow on arrays of arrays if they nest too deeply. Is there a sane way we can prevent this? Should we care?

## Tests
Added some tests for the expected behavior; feel free to suggest more.