### PR TITLE
Code diff/patch syntax highlighting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,9 +1527,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "open"
-version = "5.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfabf1927dce4d6fdf563d63328a0a506101ced3ec780ca2135747336c98cef8"
+checksum = "90878fb664448b54c4e592455ad02831e23a3f7e157374a8b95654731aac7349"
 dependencies = [
  "is-wsl",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ log = "0.4"
 miniz_oxide = "0.7"
 notify = "6"
 once_cell = "1"
-open = "5"
+open = "5.0.1"
 oxipng = { git = "https://github.com/typst/oxipng", rev = "b8ec65b", default-features = false, features = ["filetime", "parallel", "zopfli"] }
 palette = { version = "0.7.3", default-features = false, features = ["approx", "libm"] }
 pathdiff = "0.2"

--- a/crates/typst-library/src/text/raw.rs
+++ b/crates/typst-library/src/text/raw.rs
@@ -785,6 +785,9 @@ pub static THEME: Lazy<synt::Theme> = Lazy::new(|| synt::Theme {
         item("support.macro", Some("#16718d"), None),
         item("meta.annotation", Some("#301414"), None),
         item("entity.other, meta.interpolation", Some("#8b41b1"), None),
+        item("meta.diff.range", Some("#8b41b1"), None),
+        item("markup.inserted, meta.diff.header.to-file", Some("#298e0d"), None),
+        item("markup.deleted, meta.diff.header.from-file", Some("#d73a49"), None),
     ],
 });
 


### PR DESCRIPTION
This PR adds rudimentary support for highlighting diffs/patches and solves #2727. A sample of the highlighting is attached below.

<img width="418" alt="Screenshot 2023-11-23 at 9 11 53 PM" src="https://github.com/typst/typst/assets/119540449/146897f5-64c0-4543-9668-ab15d07678b1">