### PR TITLE
Add theming for scopes required by diff/patch format

### DIFF
--- a/crates/typst/src/text/raw.rs
+++ b/crates/typst/src/text/raw.rs
@@ -792,6 +792,9 @@ pub static RAW_THEME: Lazy<synt::Theme> = Lazy::new(|| synt::Theme {
         item("support.macro", Some("#16718d"), None),
         item("meta.annotation", Some("#301414"), None),
         item("entity.other, meta.interpolation", Some("#8b41b1"), None),
+        item("meta.diff.range", Some("#8b41b1"), None),
+        item("markup.inserted, meta.diff.header.to-file", Some("#298e0d"), None),
+        item("markup.deleted, meta.diff.header.from-file", Some("#d73a49"), None),
     ],
 });
 


### PR DESCRIPTION
This PR adds rudimentary support for highlighting diffs/patches and solves #2727. A sample of the highlighting is attached below.

<img width="418" alt="Screenshot 2023-11-23 at 9 11 53 PM" src="https://github.com/typst/typst/assets/119540449/146897f5-64c0-4543-9668-ab15d07678b1">