### PR TITLE
Add delay to fix compile + open not opening a PDF-reader

### DIFF
--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -117,6 +117,9 @@ pub fn compile_once(
 
             if let Some(open) = command.open.take() {
                 open_file(open.as_deref(), &command.output())?;
+
+                // keeps the process alive long enough for the editor command to fire
+                std::thread::sleep(std::time::Duration::from_millis(10));
             }
         }
 


### PR DESCRIPTION
It seems that the main process quit before the PDF-reader command had fully gone through. Since the watch command keeps the process open, the issue didn't happen then. A  lower duration might be possible, 1 ms delay worked ~90% of the time for me but it's probably best to have some margin