### PR TITLE
Moved `auto` note above example (figure > caption > separator)

### DIFF
--- a/crates/typst/src/model/figure.rs
+++ b/crates/typst/src/model/figure.rs
@@ -462,6 +462,9 @@ pub struct FigureCaption {
 
     /// The separator which will appear between the number and body.
     ///
+    /// If set to `{auto}`, the separator will be adapted to the current
+    /// [language]($text.lang) and [region]($text.region).
+    ///
     /// ```example
     /// #set figure.caption(separator: [ --- ])
     ///
@@ -470,9 +473,6 @@ pub struct FigureCaption {
     ///   caption: [A rectangle],
     /// )
     /// ```
-    ///
-    /// If set to `{auto}`, the separator will be adapted to the current
-    /// [language]($text.lang) and [region]($text.region).
     pub separator: Smart<Content>,
 
     /// The caption's body.


### PR DESCRIPTION
Previously `auto` note was only visible when example is shown.

https://typst.app/docs/reference/model/figure/#definitions-caption-separator
