### PR TITLE
Rephrased documentation about pattern > relativeness

### DIFF
--- a/crates/typst/src/visualize/gradient.rs
+++ b/crates/typst/src/visualize/gradient.rs
@@ -72,12 +72,13 @@ use crate::visualize::{Color, ColorSpace, WeightedColor};
 /// stops evenly.
 ///
 /// # Relativeness
-/// The location of the `{0%}` and `{100%}` stops is dependant on the dimensions
-/// of a container. This container can either be the shape they are painted on,
-/// or the closest surrounding container. This is controlled by the `relative`
-/// argument of a gradient constructor. By default, gradients are relative to
-/// the shape they are painted on, unless the gradient is applied on text, in
-/// which case they are relative to the closest ancestor container.
+/// The location of the `{0%}` and `{100%}` stops depends on the dimensions
+/// of a container. This container can either be the shape that it is being
+/// painted on, or the closest surrounding container. This is controlled by the
+/// `relative` argument of a gradient constructor. By default, gradients are
+/// relative to the shape they are being painted on, unless the gradient is
+/// applied on text, in which case they are relative to the closest ancestor
+/// container.
 ///
 /// Typst determines the ancestor container as follows:
 /// - For shapes that are placed at the root/top level of the document, the

--- a/crates/typst/src/visualize/pattern.rs
+++ b/crates/typst/src/visualize/pattern.rs
@@ -80,11 +80,12 @@ use crate::World;
 ///
 /// # Relativeness
 /// The location of the starting point of the pattern is dependent on the
-/// dimensions of a container. This container can either be the shape they
-/// are painted on, or the closest surrounding container. This is controlled by
-/// the `relative` argument of a pattern constructor. By default, patterns are
-/// relative to the shape they are painted on, unless the pattern is applied on
-/// text, in which case they are relative to the closest ancestor container.
+/// dimensions of a container. This container can either be the shape that it is
+/// being painted on, or the closest surrounding container. This is controlled
+/// by the `relative` argument of a pattern constructor. By default, patterns
+/// are relative to the shape they are being painted on, unless the pattern is
+/// applied on text, in which case they are relative to the closest ancestor
+/// container.
 ///
 /// Typst determines the ancestor container as follows:
 /// - For shapes that are placed at the root/top level of the document, the


### PR DESCRIPTION
https://typst.app/docs/reference/visualize/pattern/#relativeness:

> The location of the starting point of the pattern is dependent on the dimensions of a container. This container can either be the shape *they are* painted on, or the closest surrounding container.

"They are" is not applicable in this context and doesn't make sense in English. You can't understand what "they" is referring to.
