### PR TITLE
docs: move spaces between badges out of link texts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,20 @@
 
 <p align="center">
   <a href="https://typst.app/docs/">
-    <img alt="Documentation" src="https://img.shields.io/website?down_message=offline&label=docs&up_color=007aff&up_message=online&url=https%3A%2F%2Ftypst.app%2Fdocs"/>
-  </a>
+    <img alt="Documentation" src="https://img.shields.io/website?down_message=offline&label=docs&up_color=007aff&up_message=online&url=https%3A%2F%2Ftypst.app%2Fdocs"
+  /></a>
   <a href="https://typst.app/">
-    <img alt="Typst App" src="https://img.shields.io/website?down_message=offline&label=typst.app&up_color=239dad&up_message=online&url=https%3A%2F%2Ftypst.app"/>
-  </a>
+    <img alt="Typst App" src="https://img.shields.io/website?down_message=offline&label=typst.app&up_color=239dad&up_message=online&url=https%3A%2F%2Ftypst.app"
+  /></a>
   <a href="https://discord.gg/2uDybryKPe">
-    <img alt="Discord Server" src="https://img.shields.io/discord/1054443721975922748?color=5865F2&label=discord&labelColor=555"/>
-  </a>
+    <img alt="Discord Server" src="https://img.shields.io/discord/1054443721975922748?color=5865F2&label=discord&labelColor=555"
+  /></a>
   <a href="https://github.com/typst/typst/blob/main/LICENSE">
-    <img alt="Apache-2 License" src="https://img.shields.io/badge/license-Apache%202-brightgreen"/>
-  </a>
+    <img alt="Apache-2 License" src="https://img.shields.io/badge/license-Apache%202-brightgreen"
+  /></a>
   <a href="https://typst.app/jobs/">
-    <img alt="Jobs at Typst" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Ftypst.app%2Fassets%2Fdata%2Fshields.json&query=%24.jobs.text&label=jobs&color=%23A561FF&cacheSeconds=1800">
-  </a>
+    <img alt="Jobs at Typst" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Ftypst.app%2Fassets%2Fdata%2Fshields.json&query=%24.jobs.text&label=jobs&color=%23A561FF&cacheSeconds=1800"
+  /></a>
 </p>
 
 Typst is a new markup-based typesetting system that is designed to be as powerful


### PR DESCRIPTION
**Before**

![image](https://github.com/typst/typst/assets/6376638/f42e22d0-5d51-418d-a620-43e9fc853685)
https://github.com/typst/typst/blob/70ca0d257bb4ba927f63260e20443f244e0bb58c/README.md

Note the wired short underlines in between badges.

**After**

![image](https://github.com/typst/typst/assets/6376638/82805148-3e4e-4d88-bcd3-0edb51f0bfc3)

https://github.com/muzimuzhi/typst/blob/ad343110ef83b68dc48b7208c11b56b10307f2ab/README.md

**More info**

In short, according to [CSS Text Module Level 3](https://www.w3.org/TR/css-text-3/#white-space-processing), sec. 4. "White Space Processing & Control Characters",

```html
<p>
  <a href="...">
    <img .../>
  </a>
  <a href="...">
    <img .../>
  </a>
</p>
```
is equivalent to
```html
<p><a href="..."><img .../> </a><a href="..."><img .../> </a></p>
```
Thus the white space characters between `/>` of `img` tag and `</a>` are collapsed to a single space that is reserved. See a similar discussion [here](https://gitlab.com/islandoftex/arara/-/issues/95#note_1190288409).
