### PR TITLE
Shape plan caching

### DIFF
--- a/crates/typst/src/layout/inline/shaping.rs
+++ b/crates/typst/src/layout/inline/shaping.rs
@@ -2,10 +2,11 @@ use std::borrow::Cow;
 use std::fmt::{self, Debug, Formatter};
 use std::ops::Range;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use az::SaturatingAs;
 use ecow::EcoString;
-use rustybuzz::{Tag, UnicodeBuffer};
+use rustybuzz::{ShapePlan, Tag, UnicodeBuffer};
 use unicode_script::{Script, UnicodeScript};
 
 use super::SpanMapper;
@@ -690,9 +691,21 @@ fn shape_segment<'a>(
         Dir::RTL => rustybuzz::Direction::RightToLeft,
         _ => unimplemented!("vertical text layout"),
     });
+    buffer.guess_segment_properties();
+
+    // Prepare the shape plan. This plan depends on direction, script, language,
+    // and features, but is independent from the text and can thus be
+    // memoized.
+    let plan = create_shape_plan(
+        &font,
+        buffer.direction(),
+        buffer.script(),
+        buffer.language().as_ref(),
+        &ctx.features,
+    );
 
     // Shape!
-    let buffer = rustybuzz::shape(font.rusty(), &ctx.features, buffer);
+    let buffer = rustybuzz::shape_with_plan(font.rusty(), &plan, buffer);
     let infos = buffer.glyph_infos();
     let pos = buffer.glyph_positions();
     let ltr = ctx.dir.is_positive();
@@ -781,6 +794,24 @@ fn shape_segment<'a>(
     }
 
     ctx.used.pop();
+}
+
+/// Create a shape plan.
+#[comemo::memoize]
+fn create_shape_plan(
+    font: &Font,
+    direction: rustybuzz::Direction,
+    script: rustybuzz::Script,
+    language: Option<&rustybuzz::Language>,
+    features: &[rustybuzz::Feature],
+) -> Arc<ShapePlan> {
+    Arc::new(rustybuzz::ShapePlan::new(
+        font.rusty(),
+        direction,
+        Some(script),
+        language,
+        features,
+    ))
 }
 
 /// Shape the text with tofus from the given font.


### PR DESCRIPTION
This caches the shape plan, which is required for shaping a run of text. This doesn't give as big wins as I'd have hoped, but in my testing it did give a few percent of speedup.

Before merging, this should be switched to a released version of rustybuzz (once that's available, I had to land some adjustments in rustybuzz.) 