### PR TITLE
Ignore *.pdf for typ files in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ tests/png
 tests/pdf
 tests/svg
 tests/target
+tests/typ/**/*.pdf
 tests/fuzz/target
 tests/fuzz/corpus
 tests/fuzz/artifacts


### PR DESCRIPTION
Sometimes this *.pdf file appears (and is an untracked file in `git status`) -- for instance, `tests/typ/text/deco.pdf` appeared in my working directory after I ran test deco.typ. It's likely saved by the [Typst LSP](https://github.com/nvarner/typst-lsp).

Let's ignore it in case developers didn't notice its existence and blindly commits it.

Or, maintainers could configure some hooks to reject PRs with these files. It's up to you the maintainers :)