### PR TITLE
Mention `str(<label>)` feature in documentation for `label`

### DIFF
--- a/crates/typst/src/foundations/label.rs
+++ b/crates/typst/src/foundations/label.rs
@@ -1,6 +1,6 @@
 use ecow::{eco_format, EcoString};
 
-use crate::foundations::{func, scope, ty, Repr};
+use crate::foundations::{func, scope, ty, Repr, Str};
 use crate::util::PicoStr;
 
 /// A label for an element.
@@ -59,6 +59,12 @@ impl Label {
         name: PicoStr,
     ) -> Label {
         Self(name)
+    }
+
+    /// The name with which this label was constructed.
+    #[func]
+    pub fn name(&self) -> Str {
+        self.0.resolve().into()
     }
 }
 

--- a/crates/typst/src/foundations/label.rs
+++ b/crates/typst/src/foundations/label.rs
@@ -1,6 +1,6 @@
 use ecow::{eco_format, EcoString};
 
-use crate::foundations::{func, scope, ty, Repr, Str};
+use crate::foundations::{func, scope, ty, Repr};
 use crate::util::PicoStr;
 
 /// A label for an element.
@@ -11,6 +11,9 @@ use crate::util::PicoStr;
 ///
 /// A labelled element can be [referenced]($ref), [queried]($query) for, and
 /// [styled]($styling) through its label.
+///
+/// Once constructed, you can get the name of a label using
+/// [`str`]($str/#constructor).
 ///
 /// # Example
 /// ```example
@@ -59,12 +62,6 @@ impl Label {
         name: PicoStr,
     ) -> Label {
         Self(name)
-    }
-
-    /// The name with which this label was constructed.
-    #[func]
-    pub fn name(&self) -> Str {
-        self.0.resolve().into()
     }
 }
 

--- a/tests/typ/compiler/label.typ
+++ b/tests/typ/compiler/label.typ
@@ -67,5 +67,6 @@ _Visible_
 ---
 // Test getting the name of a label.
 // Ref: false
-#test(label("hey").name(), "hey")
-#test([Hmm<hey>].label.name(), "hey")
+#test(str(<hey>), "hey")
+#test(str(label("hey")), "hey")
+#test(str([Hmm<hey>].label), "hey")

--- a/tests/typ/compiler/label.typ
+++ b/tests/typ/compiler/label.typ
@@ -63,3 +63,9 @@ _Visible_
 #test([Hello<hi>].label, <hi>)
 #test([#[A *B* C]<hi>].label, <hi>)
 #test([#text(red)[Hello]<hi>].label, <hi>)
+
+---
+// Test getting the name of a label.
+// Ref: false
+#test(label("hey").name(), "hey")
+#test([Hmm<hey>].label.name(), "hey")


### PR DESCRIPTION
This PR mentions the `str(<label>)` feature in the documentation for [`label`](https://typst.app/docs/reference/foundations/label/).