### PR TITLE
Docs: Mention `color.map` module, give example

### DIFF
--- a/crates/typst/src/visualize/color.rs
+++ b/crates/typst/src/visualize/color.rs
@@ -105,7 +105,12 @@ const ANGLE_EPSILON: f32 = 1e-5;
 ///
 /// # Predefined color maps
 /// Typst also includes a number of preset color maps that can be used for
-/// gradients. Most of these color maps are chosen to be color blind friendly.
+/// [gradients]($gradient.linear). These are simply arrays of colors defined in
+/// the module `color.map`.
+///
+/// ```example
+/// #circle(fill: gradient.linear(..color.map.crest))
+/// ```
 ///
 /// | Map        | Details                                                     |
 /// |------------|:------------------------------------------------------------|


### PR DESCRIPTION
The `color.map` module is already mentioned on the gradients page; this adds it to the color maps section. That section lists all the preset color maps, so it should probably say how to access them, too.