### PR TITLE
docs: Clarify code mode in "Writing in Typst"

### DIFF
--- a/docs/tutorial/1-writing.md
+++ b/docs/tutorial/1-writing.md
@@ -121,7 +121,7 @@ default. It's also lacking a caption. Let's fix that by using the
 positional argument and an optional caption as a named argument.
 
 Within the argument list of the `figure` function, Typst is already in code
-mode. This means, you can now remove the hash before the image function call.
+mode. This means, you now have to remove the hash before the image function call.
 The hash is only needed directly in markup (to disambiguate text from function
 calls).
 


### PR DESCRIPTION
It is not optional to remove "#".
You have to remove it in order to compile the document.