### PR TITLE
Remove mentions of the fact that Typst makes specifically 5 attempts to stabilize layout in user-facing documentation

### DIFF
--- a/crates/typst/src/introspection/query.rs
+++ b/crates/typst/src/introspection/query.rs
@@ -72,8 +72,8 @@ use crate::introspection::Location;
 /// titled `Real`. Thus, `count` is `1` and one `Fake` heading is generated.
 /// Typst sees that the query's result has changed and processes it again. This
 /// time, `count` is `2` and two `Fake` headings are generated. This goes on and
-/// on. As we can see, the output has five headings. This is because Typst
-/// simply gives up after five attempts.
+/// on. As we can see, the output has a finite amount of headings. This is
+/// because Typst simply gives up after a few attempts.
 ///
 /// In general, you should try not to write queries that affect themselves. The
 /// same words of caution also apply to other introspection features like

--- a/crates/typst/src/introspection/state.rs
+++ b/crates/typst/src/introspection/state.rs
@@ -170,8 +170,8 @@ use crate::World;
 /// a state, the results might never converge. The example below illustrates
 /// this. We initialize our state with `1` and then update it to its own final
 /// value plus 1. So it should be `2`, but then its final value is `2`, so it
-/// should be `3`, and so on. This example display `4` because Typst simply
-/// gives up after a few attempts.
+/// should be `3`, and so on. This example displays a finite value because
+/// Typst simply gives up after a few attempts.
 ///
 /// ```example
 /// #let s = state("x", 1)


### PR DESCRIPTION
[The documentation for `state`](https://typst.app/docs/reference/introspection/state/#caution) used to explain that Typst makes four attempts to stabilize layout. This is wrong.

Rather than simply replacing "4" with "5", I removed all mentions of the fact that Typst makes specifically five attempts to stabilize layout in user-facing documentation. That way, this value can be changed later without having to update multiple pages in the documentation.

Another solution would be to add a comment in the last test of `meta/state` to remind contributors who change this value to update the documentation in multiple places.

Note that I have kept it in [`architecture.md`](https://github.com/typst/typst/blob/main/docs/dev/architecture.md#layout) because this is not user-facing, and intended for contributors, who might need to know the exact value.