### PR TITLE
Fix unnamed sinks not capturing named args

### DIFF
--- a/crates/typst/src/eval/call.rs
+++ b/crates/typst/src/eval/call.rs
@@ -306,7 +306,7 @@ pub(crate) fn call_closure(
                 }
             },
             ast::Param::Sink(ident) => {
-                sink = ident.name();
+                sink = Some(ident.name());
                 if let Some(sink_size) = sink_size {
                     sink_pos_values = Some(args.consume(sink_size)?);
                 }
@@ -321,12 +321,15 @@ pub(crate) fn call_closure(
         }
     }
 
-    if let Some(sink) = sink {
+    if let Some(sink_name) = sink {
+        // Remaining args are captured regardless of whether the sink is named.
         let mut remaining_args = args.take();
-        if let Some(sink_pos_values) = sink_pos_values {
-            remaining_args.items.extend(sink_pos_values);
+        if let Some(sink_name) = sink_name {
+            if let Some(sink_pos_values) = sink_pos_values {
+                remaining_args.items.extend(sink_pos_values);
+            }
+            vm.define(sink_name, remaining_args);
         }
-        vm.define(sink, remaining_args);
     }
 
     // Ensure all arguments have been used.

--- a/tests/typ/compiler/spread.typ
+++ b/tests/typ/compiler/spread.typ
@@ -115,6 +115,16 @@
 }
 
 ---
+// Unnamed sink should just ignore any extra arguments.
+#{
+  let f(a, b: 5, ..) = (a, b)
+  test(f(4), (4, 5))
+  test(f(10, b: 11), (10, 11))
+  test(f(13, 20, b: 12), (13, 12))
+  test(f(15, b: 16, c: 13), (15, 16))
+}
+
+---
 #{
   let f(..a, b, c, d) = none
 


### PR DESCRIPTION
Fixes #2983

The problem was a tiny oopsie in the `eval::call_closure` code, where `sink` was an `Option<Ident<'a>>` (it would be `Some`, and thus the named arg capturing code would execute, only if the sink were named) while it should have been `Option<Option<Ident<'a>>` (`Some(None)` when the sink is unnamed and `Some(Some(ident))` when the sink is named - in both cases, the remaining named args should be captured).