### PR TITLE
Fix pattern offset in PDF

### DIFF
--- a/crates/typst-pdf/src/pattern.rs
+++ b/crates/typst-pdf/src/pattern.rs
@@ -74,7 +74,7 @@ pub(crate) fn write_patterns(ctx: &mut PdfContext) {
         resources_map.finish();
         tiling_pattern
             .matrix(transform_to_array(
-                transform.post_concat(Transform::scale(Ratio::one(), -Ratio::one())),
+                transform.pre_concat(Transform::scale(Ratio::one(), -Ratio::one())),
             ))
             .filter(Filter::FlateDecode);
     }


### PR DESCRIPTION
Fixes #2900

I don't really know how the transforms come into place, but it seems to work.

---
(left: relative to self, right: relative to parent (stack))

*Before:*

![image](https://github.com/typst/typst/assets/7191192/174c612e-117e-4a1e-b625-4b90c7a23c98)


*After:*

![image](https://github.com/typst/typst/assets/7191192/1e1910aa-8d5a-4127-bcac-52605aa8675c)
