### PR TITLE
Explain how to get the location of an element returned by `query`

### DIFF
--- a/crates/typst/src/introspection/query.rs
+++ b/crates/typst/src/introspection/query.rs
@@ -9,6 +9,9 @@ use crate::introspection::Location;
 /// retrieve the current document location with the [`locate`]($locate)
 /// function.
 ///
+/// You can get the location of the elements returned by `query` with
+/// [`location`]($content.location).
+///
 /// # Finding elements
 /// In the example below, we create a custom page header that displays the text
 /// "Typst Academy" in small capitals and the current section title. On the


### PR DESCRIPTION
This small PR improves the documentation for `query` by explaining how to get the location of an element.

This is a useful addition, as illustrated by [this person on Discord not knowing this is possible](https://discord.com/channels/1054443721975922748/1184906131550769242).