### PR TITLE
Show which test reference image was updated

### DIFF
--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -498,7 +498,9 @@ fn test(
         stdout.write_all(name.to_string_lossy().as_bytes()).unwrap();
         if ok {
             writeln!(stdout, " ✔").unwrap();
-            if stdout.is_terminal() {
+            // Don't clear the line when the reference image was updated, to
+            // show in the output which test had its image updated.
+            if !updated && stdout.is_terminal() {
                 // ANSI escape codes: cursor moves up and clears the line.
                 write!(stdout, "\x1b[1A\x1b[2K").unwrap();
             }


### PR DESCRIPTION
Fixes #3007

Before:
!["Updated reference image" shown, but not the name of the test](https://github.com/typst/typst/assets/9021226/bdd2f526-3710-48c5-ada6-87626e506138)

After:
![The name of the test is now shown as well](https://github.com/typst/typst/assets/9021226/b073c445-ab67-433b-aab8-7452e43ce584)
