### PR TITLE
add current numbering way of hiragana and katakana (#3005)

### DIFF
--- a/crates/typst/src/model/numbering.rs
+++ b/crates/typst/src/model/numbering.rs
@@ -39,7 +39,7 @@ pub fn numbering(
     engine: &mut Engine,
     /// Defines how the numbering works.
     ///
-    /// **Counting symbols** are `1`, `a`, `A`, `i`, `I`, `い`, `イ`, `א`, `가`,
+    /// **Counting symbols** are `1`, `a`, `A`, `i`, `I`, `あ`, `い`, `ア`, `イ`, `א`, `가`,
     /// `ㄱ`, and `*`. They are replaced by the number in the sequence, in the
     /// given case.
     ///
@@ -160,7 +160,7 @@ cast! {
 /// How to turn a number into text.
 ///
 /// A pattern consists of a prefix, followed by one of `1`, `a`, `A`, `i`,
-/// `I`, `い`, `イ`, `א`, `가`, `ㄱ`, or `*`, and then a suffix.
+/// `I`, `あ`, `い`, `ア`, `イ`, `א`, `가`, `ㄱ`, or `*`, and then a suffix.
 ///
 /// Examples of valid patterns:
 /// - `1)`
@@ -292,7 +292,9 @@ pub enum NumberingKind {
     // character.
     #[allow(unused)]
     TraditionalChinese,
+    HiraganaAiueo,
     HiraganaIroha,
+    KatakanaAiueo,
     KatakanaIroha,
     KoreanJamo,
     KoreanSyllable,
@@ -308,7 +310,9 @@ impl NumberingKind {
             '*' => NumberingKind::Symbol,
             'א' => NumberingKind::Hebrew,
             '一' | '壹' => NumberingKind::SimplifiedChinese,
+            'あ' => NumberingKind::HiraganaAiueo,
             'い' => NumberingKind::HiraganaIroha,
+            'ア' => NumberingKind::KatakanaAiueo,
             'イ' => NumberingKind::KatakanaIroha,
             'ㄱ' => NumberingKind::KoreanJamo,
             '가' => NumberingKind::KoreanSyllable,
@@ -326,7 +330,9 @@ impl NumberingKind {
             Self::Hebrew => 'א',
             Self::SimplifiedChinese => '一',
             Self::TraditionalChinese => '一',
+            Self::HiraganaAiueo => 'あ',
             Self::HiraganaIroha => 'い',
+            Self::KatakanaAiueo => 'ア',
             Self::KatakanaIroha => 'イ',
             Self::KoreanJamo => 'ㄱ',
             Self::KoreanSyllable => '가',
@@ -346,6 +352,18 @@ impl NumberingKind {
                 },
                 n,
             ),
+            Self::HiraganaAiueo => zeroless::<46>(
+                |x| {
+                    [
+                        'あ', 'い', 'う', 'え', 'お', 'か', 'き', 'く', 'け', 'こ', 'さ',
+                        'し', 'す', 'せ', 'そ', 'た', 'ち', 'つ', 'て', 'と', 'な', 'に',
+                        'ぬ', 'ね', 'の', 'は', 'ひ', 'ふ', 'へ', 'ほ', 'ま', 'み', 'む',
+                        'め', 'も', 'や', 'ゆ', 'よ', 'ら', 'り', 'る', 'れ', 'ろ', 'わ',
+                        'を', 'ん',
+                    ][x]
+                },
+                n,
+            ),
             Self::HiraganaIroha => zeroless::<47>(
                 |x| {
                     [
@@ -354,6 +372,18 @@ impl NumberingKind {
                         'む', 'う', 'ゐ', 'の', 'お', 'く', 'や', 'ま', 'け', 'ふ', 'こ',
                         'え', 'て', 'あ', 'さ', 'き', 'ゆ', 'め', 'み', 'し', 'ゑ', 'ひ',
                         'も', 'せ', 'す',
+                    ][x]
+                },
+                n,
+            ),
+            Self::KatakanaAiueo => zeroless::<46>(
+                |x| {
+                    [
+                        'ア', 'イ', 'ウ', 'エ', 'オ', 'カ', 'キ', 'ク', 'ケ', 'コ', 'サ',
+                        'シ', 'ス', 'セ', 'ソ', 'タ', 'チ', 'ツ', 'テ', 'ト', 'ナ', 'ニ',
+                        'ヌ', 'ネ', 'ノ', 'ハ', 'ヒ', 'フ', 'ヘ', 'ホ', 'マ', 'ミ', 'ム',
+                        'メ', 'モ', 'ヤ', 'ユ', 'ヨ', 'ラ', 'リ', 'ル', 'レ', 'ロ', 'ワ',
+                        'ヲ', 'ン',
                     ][x]
                 },
                 n,

--- a/tests/typ/meta/numbering.typ
+++ b/tests/typ/meta/numbering.typ
@@ -85,20 +85,3 @@
 ---
 // Error: 17-19 number must be at least zero
 #numbering("1", -1) 
-
----
-#for i in range(0, 9) {
-  numbering("あ", i)
-  [ and ]
-  numbering("I.あ", i, i)
-  [ for #i \ ]
-}
-
-#for i in range(0, 9) {
-  numbering("ア", i)
-  [ and ]
-  numbering("I.ア", i, i)
-  [ for #i \ ]
-}
-
----

--- a/tests/typ/meta/numbering.typ
+++ b/tests/typ/meta/numbering.typ
@@ -84,4 +84,21 @@
 
 ---
 // Error: 17-19 number must be at least zero
-#numbering("1", -1)
+#numbering("1", -1) 
+
+---
+#for i in range(0, 9) {
+  numbering("あ", i)
+  [ and ]
+  numbering("I.あ", i, i)
+  [ for #i \ ]
+}
+
+#for i in range(0, 9) {
+  numbering("ア", i)
+  [ and ]
+  numbering("I.ア", i, i)
+  [ for #i \ ]
+}
+
+---

--- a/tests/typ/meta/numbering.typ
+++ b/tests/typ/meta/numbering.typ
@@ -83,5 +83,21 @@
 }
 
 ---
+#set text(lang: "jp", font: ("Linux Libertine", "Noto Serif CJK JP"))
+#for i in range(0, 9) {
+  numbering("あ", i)
+  [ and ]
+  numbering("I.あ", i, i)
+  [ for #i \ ]
+}
+
+#for i in range(0, 9) {
+  numbering("ア", i)
+  [ and ]
+  numbering("I.ア", i, i)
+  [ for #i \ ]
+}
+---
 // Error: 17-19 number must be at least zero
 #numbering("1", -1) 
+


### PR DESCRIPTION
As I mentioned at #3005, Japanese numbering method of typst, "iroha",  is old ones. 
Today most of Japanese people use "aiueo" as a numbering way of hiragana and katakana, so I add a current Japanese numbering way.

Users can use this "aiueo" numbering like you use other numbering method.  Only users should do is set "あ" or ”ア" as a counting symbols.  Then, users use numbering with Japanese current counting way, "あいうえお…" or "アイウエオ".

What I changed is adding some code in the file of numbering.rs.
I add two NumberingKind, "HiraganaAiueo" and "KatakanaAiueo", as it looks similar to "HiraganaIroha" and "KatakanaIroha".