### PR TITLE
Don't allow nested line comment inside block comment

### DIFF
--- a/crates/typst-syntax/src/lexer.rs
+++ b/crates/typst-syntax/src/lexer.rs
@@ -145,10 +145,6 @@ impl Lexer<'_> {
                     depth += 1;
                     '_'
                 }
-                ('/', '/') => {
-                    self.line_comment();
-                    '_'
-                }
                 _ => c,
             }
         }

--- a/tests/typ/compiler/comment.typ
+++ b/tests/typ/compiler/comment.typ
@@ -17,12 +17,13 @@ C/*
 // End of block comment in line comment.
 // Hello */
 
-// Nested line comment.
-/*//*/
-Still comment.
-*/
-
+// Nested "//" doesn't count as line comment.
+/* // */
 E
+
+/*//*/
+This is a comment.
+*/*/
 
 ---
 // End should not appear without start.


### PR DESCRIPTION
Fixes #1113.
A corresponding test existed already, I edited it to match the new behavior.

Although the behavior was the same before this pull request, I added a test that ensures that `/*//*/` parses as the start of two nested block comments (and not as a single block comment with matching ending delimiter).
