### PR TITLE
Removed unnecessary uppercase in the Tutorial welcome page

### DIFF
--- a/docs/tutorial/welcome.md
+++ b/docs/tutorial/welcome.md
@@ -6,7 +6,7 @@ description: Typst's tutorial.
 Welcome to Typst's tutorial! In this tutorial, you will learn how to write and
 format documents in Typst. We will start with everyday tasks and gradually
 introduce more advanced features. This tutorial does not assume prior knowledge
-of Typst, other Markup languages, or programming. We do assume that you know how
+of Typst, other markup languages, or programming. We do assume that you know how
 to edit a text file.
 
 The best way to start is to sign up to the Typst app for free and follow along


### PR DESCRIPTION
A tiny typo PR that changes "Markup languages" in favor of "markup languages" in the [Tutorial's welcome page](https://typst.app/docs/tutorial/). It looks weird and every other instance of the word in the documentation is lowercase (except for HTML - HyperText Markup Language, which makes sence since it's an acronym).