### PR TITLE
Clarify label name's pattern in doc

### DIFF
--- a/crates/typst/src/foundations/label.rs
+++ b/crates/typst/src/foundations/label.rs
@@ -26,7 +26,8 @@ use crate::util::PicoStr;
 ///
 /// # Syntax
 /// This function also has dedicated syntax: You can create a label by enclosing
-/// its name in angle brackets. This works both in markup and code.
+/// its name in angle brackets. This works both in markup and code. A label's
+/// name can be Unicode identifiers optionally joined by "_", "-", ":", and ".".
 ///
 /// Currently, labels can only be attached to elements in markup mode, not in
 /// code mode. This might change in the future.


### PR DESCRIPTION
When using labels one sometimes wonder "can I insert a dot or a colon in the name?"

The answer is yes, as confirmed by
https://github.com/typst/typst/blob/b1256283da047fd4e2c0ba24d981759c745661bb/crates/typst-syntax/src/lexer.rs#L293
and subsequently by
https://github.com/typst/typst/blob/b1256283da047fd4e2c0ba24d981759c745661bb/crates/typst-syntax/src/lexer.rs#L745-L747
and function `is_xid_continue` is implemented by crate [unicode-ident](https://crates.io/crates/unicode-ident) that follows the [Unicode Standard Annex #31](https://www.unicode.org/reports/tr31/) standard.