### PR TITLE
Fix `#[internal]` fields needing `IntoValue` impl

### DIFF
--- a/crates/typst-macros/src/elem.rs
+++ b/crates/typst-macros/src/elem.rs
@@ -834,17 +834,21 @@ fn create_native_elem_impl(element: &Elem) -> TokenStream {
         });
 
     // Creation of the fields dictionary for inherent fields.
-    let field_dict = element.inherent_fields().clone().map(|field| {
-        let name = &field.name;
-        let field_ident = &field.ident;
-        let field_call = quote! { ::ecow::EcoString::from(#name).into() };
-        quote! {
-            fields.insert(
-                #field_call,
-                #foundations::IntoValue::into_value(self.#field_ident.clone())
-            );
-        }
-    });
+    let field_dict = element
+        .inherent_fields()
+        .filter(|field| !field.internal)
+        .clone()
+        .map(|field| {
+            let name = &field.name;
+            let field_ident = &field.ident;
+            let field_call = quote! { ::ecow::EcoString::from(#name).into() };
+            quote! {
+                fields.insert(
+                    #field_call,
+                    #foundations::IntoValue::into_value(self.#field_ident.clone())
+                );
+            }
+        });
 
     // Creation of the fields dictionary for optional fields.
     let field_opt_dict = element


### PR DESCRIPTION
This was due to appearing in the `.fields()` dict which they should not!