### PR TITLE
Add indent_all to par

### DIFF
--- a/crates/typst/src/layout/inline/mod.rs
+++ b/crates/typst/src/layout/inline/mod.rs
@@ -410,8 +410,9 @@ fn collect<'a>(
     let mut iter = children.iter().map(|c| &**c).peekable();
 
     let first_line_indent = ParElem::first_line_indent_in(*styles);
+    let indent_all = ParElem::indent_all_in(*styles);
     if !first_line_indent.is_zero()
-        && consecutive
+        && (indent_all || consecutive)
         && AlignElem::alignment_in(*styles).resolve(*styles).x
             == TextElem::dir_in(*styles).start().into()
     {

--- a/crates/typst/src/model/par.rs
+++ b/crates/typst/src/model/par.rs
@@ -80,9 +80,6 @@ pub struct ParElem {
 
     /// The indent the first line of a paragraph should have.
     ///
-    /// Only the first line of a consecutive paragraph will be indented (not
-    /// the first one in a block or on the page).
-    ///
     /// By typographic convention, paragraph breaks are indicated either by some
     /// space between paragraphs or by indented first lines. Consider reducing
     /// the [paragraph spacing]($block.spacing) to the [`leading`] when
@@ -90,6 +87,16 @@ pub struct ParElem {
     /// `[#show par: set block(spacing: 0.65em)]`).
     #[ghost]
     pub first_line_indent: Length,
+
+    /// Whether to apply `first-line-indent` to all paragraphs.
+    ///
+    /// If it sets to `true`, `first-line-indent` will be applied to all
+    /// paragraphs. If it sets to `false`, only the first line of a consecutive
+    /// paragraph will be indented (not the first one in a block or on the
+    /// page). `false` is the only behavior prior to version `0.10.0`.
+    #[ghost]
+    #[default(false)]
+    pub indent_all: bool,
 
     /// The indent all but the first line of a paragraph should have.
     #[ghost]


### PR DESCRIPTION
This parameter will allow user to apply `first-line-indent` to all paragraphs including first paragraph. I am still unsure whether `indent-all` is the correct variable for this. I would also like to request for review regarding the comment/description of the variable.

Before:

```typst
#set par(
  first-line-indent: 2em,
  // indent-all: true,
)

#lorem(30)

#lorem(30)

#lorem(30)
```

![image](https://github.com/typst/typst/assets/57625126/ed244d18-e984-466f-8696-8382b54afacc)

After:

```typst
#set par(
  first-line-indent: 2em,
  indent-all: true,
)

#lorem(30)

#lorem(30)

#lorem(30)
```

![image](https://github.com/typst/typst/assets/57625126/4359b215-fd9a-4b2d-8968-86d592afaf0b)


Fixes #311 