### PR TITLE
Add `#float.to-bits()`

### DIFF
--- a/crates/typst/src/foundations/float.rs
+++ b/crates/typst/src/foundations/float.rs
@@ -47,6 +47,19 @@ impl f64 {
     ) -> f64 {
         value.0
     }
+
+    /// Converts the bit pattern to a signed 64-bit integer.
+    ///
+    /// ```example
+    /// #float.to-bits(0.0)
+    /// #float.to-bits(-0.0)
+    /// ```
+    #[func]
+    pub fn to_bits(value: f64) -> i64 {
+        // Typst doesn't have unsigned 64-bit integers, so we represent
+        // the bit pattern as a signed 64-bit integer.
+        value.to_bits() as i64
+    }
 }
 
 impl Repr for f64 {

--- a/tests/typ/compute/construct.typ
+++ b/tests/typ/compute/construct.typ
@@ -185,6 +185,12 @@
 #symbol()
 
 ---
+// Test conversion of floats to bits (held by a signed integer).
+#test(float.to-bits(0.0), 0)
+#test(float.to-bits(-0.0), -9223372036854775808)
+#test(float.to-bits(12306.233), 4667991037467273724)
+
+---
 // Test conversion to string.
 #test(str(123), "123")
 #test(str(123, base: 3), "11120")


### PR DESCRIPTION
Fixing #3119 (see design discussions there).

Confirmed by
```rust
fn main() {
    let a: f64 = 12306.0;
    println!("{}", a.to_bits());
    println!("{:x}", a.to_bits());
    println!("{}", a.to_bits() as i64);
}
```
