### PR TITLE
Let type constructor/field access error report the name correctly

### DIFF
--- a/crates/typst/src/foundations/ty.rs
+++ b/crates/typst/src/foundations/ty.rs
@@ -94,25 +94,27 @@ impl Type {
             .constructor
             .as_ref()
             .map(|lazy| Func::from(*lazy))
-            .ok_or_else(|| eco_format!("type self does not have a constructor"))
+            .ok_or_else(|| {
+                eco_format!("type `{}` does not have a constructor", self.short_name())
+            })
     }
 
-    /// The type's associated scope of sub-definition.
+    /// The type's associated scope that holds sub-definitions.
     pub fn scope(&self) -> &'static Scope {
         &(self.0).0.scope
     }
 
     /// Get a field from this type's scope, if possible.
     pub fn field(&self, field: &str) -> StrResult<&'static Value> {
-        self.scope()
-            .get(field)
-            .ok_or_else(|| eco_format!("type self does not contain field `{}`", field))
+        self.scope().get(field).ok_or_else(|| {
+            eco_format!("type `{}` does not contain field `{}`", self.short_name(), field)
+        })
     }
 }
 
 // Type compatibility.
 impl Type {
-    /// The type's backwards-compatible name.
+    /// The type's backward-compatible name.
     pub fn compat_name(&self) -> &str {
         self.long_name()
     }

--- a/crates/typst/src/foundations/ty.rs
+++ b/crates/typst/src/foundations/ty.rs
@@ -107,7 +107,7 @@ impl Type {
     /// Get a field from this type's scope, if possible.
     pub fn field(&self, field: &str) -> StrResult<&'static Value> {
         self.scope().get(field).ok_or_else(|| {
-            eco_format!("type `{}` does not contain field `{}`", self.short_name(), field)
+            eco_format!("type {self} does not contain field `{field}`")
         })
     }
 }

--- a/crates/typst/src/foundations/ty.rs
+++ b/crates/typst/src/foundations/ty.rs
@@ -95,7 +95,7 @@ impl Type {
             .as_ref()
             .map(|lazy| Func::from(*lazy))
             .ok_or_else(|| {
-                eco_format!("type `{}` does not have a constructor", self.short_name())
+                eco_format!("type {self} does not have a constructor")
             })
     }
 

--- a/crates/typst/src/foundations/ty.rs
+++ b/crates/typst/src/foundations/ty.rs
@@ -94,9 +94,7 @@ impl Type {
             .constructor
             .as_ref()
             .map(|lazy| Func::from(*lazy))
-            .ok_or_else(|| {
-                eco_format!("type {self} does not have a constructor")
-            })
+            .ok_or_else(|| eco_format!("type {self} does not have a constructor"))
     }
 
     /// The type's associated scope that holds sub-definitions.
@@ -106,9 +104,9 @@ impl Type {
 
     /// Get a field from this type's scope, if possible.
     pub fn field(&self, field: &str) -> StrResult<&'static Value> {
-        self.scope().get(field).ok_or_else(|| {
-            eco_format!("type {self} does not contain field `{field}`")
-        })
+        self.scope()
+            .get(field)
+            .ok_or_else(|| eco_format!("type {self} does not contain field `{field}`"))
     }
 }
 

--- a/tests/typ/bugs/3110-no-type-ctor-or-field.typ
+++ b/tests/typ/bugs/3110-no-type-ctor-or-field.typ
@@ -1,0 +1,15 @@
+// Issue #3110: let the error message report the type name.
+// https://github.com/typst/typst/issues/3110
+// Ref: false
+
+---
+// Error: 2-9 type `content` does not have a constructor
+#content()
+
+---
+// Error: 6-12 type `int` does not contain field `MAXVAL`
+#int.MAXVAL
+
+---
+// Error: 6-18 type `str` does not contain field `from-unïcode`
+#str.from-unïcode(97)

--- a/tests/typ/bugs/3110-no-type-ctor-or-field.typ
+++ b/tests/typ/bugs/3110-no-type-ctor-or-field.typ
@@ -3,13 +3,13 @@
 // Ref: false
 
 ---
-// Error: 2-9 type `content` does not have a constructor
+// Error: 2-9 type content does not have a constructor
 #content()
 
 ---
-// Error: 6-12 type `int` does not contain field `MAXVAL`
+// Error: 6-12 type integer does not contain field `MAXVAL`
 #int.MAXVAL
 
 ---
-// Error: 6-18 type `str` does not contain field `from-unïcode`
+// Error: 6-18 type string does not contain field `from-unïcode`
 #str.from-unïcode(97)


### PR DESCRIPTION
Fix #3110 

I agree it's kinda confusing. Maybe the `self` was caused by a search-and-replace operation? If the name is deliberately omitted, maybe it should write `itself`.

The `short_name()` (which returns `self.0.name`) of the type is set by https://github.com/typst/typst/blob/7eebafa7837ec173a7b2064ae60fd45b5413d17c/crates/typst-macros/src/ty.rs#L62 and then by https://github.com/typst/typst/blob/46053b62e5d87118f33476d3c7f6ddf794fbafeb/crates/typst-macros/src/util.rs#L168

The location of the test is debatable (how about a new file in `tests/typ/compiler/`?), though.