### PR TITLE
Add Catalan translations

### DIFF
--- a/crates/typst/src/math/equation.rs
+++ b/crates/typst/src/math/equation.rs
@@ -272,6 +272,7 @@ impl LocalName for EquationElem {
             Lang::ALBANIAN => "Ekuacion",
             Lang::ARABIC => "معادلة",
             Lang::BOKMÅL => "Ligning",
+            Lang::CATALAN => "Equació",
             Lang::CHINESE if option_eq(region, "TW") => "方程式",
             Lang::CHINESE => "公式",
             Lang::CZECH => "Rovnice",

--- a/crates/typst/src/model/bibliography.rs
+++ b/crates/typst/src/model/bibliography.rs
@@ -284,6 +284,7 @@ impl LocalName for BibliographyElem {
             Lang::ALBANIAN => "Bibliografi",
             Lang::ARABIC => "المراجع",
             Lang::BOKMÅL => "Bibliografi",
+            Lang::CATALAN => "Bibliografia",
             Lang::CHINESE if option_eq(region, "TW") => "書目",
             Lang::CHINESE => "参考文献",
             Lang::CZECH => "Bibliografie",

--- a/crates/typst/src/model/heading.rs
+++ b/crates/typst/src/model/heading.rs
@@ -253,6 +253,7 @@ impl LocalName for HeadingElem {
             Lang::ALBANIAN => "Kapitull",
             Lang::ARABIC => "الفصل",
             Lang::BOKMÅL => "Kapittel",
+            Lang::CATALAN => "Capítol",
             Lang::CHINESE if option_eq(region, "TW") => "小節",
             Lang::CHINESE => "小节",
             Lang::CZECH => "Kapitola",

--- a/crates/typst/src/model/outline.rs
+++ b/crates/typst/src/model/outline.rs
@@ -264,6 +264,7 @@ impl LocalName for OutlineElem {
             Lang::ALBANIAN => "Përmbajtja",
             Lang::ARABIC => "المحتويات",
             Lang::BOKMÅL => "Innhold",
+            Lang::CATALAN => "Índex",
             Lang::CHINESE if option_eq(region, "TW") => "目錄",
             Lang::CHINESE => "目录",
             Lang::CZECH => "Obsah",

--- a/crates/typst/src/model/table.rs
+++ b/crates/typst/src/model/table.rs
@@ -208,6 +208,7 @@ impl LocalName for TableElem {
             Lang::ALBANIAN => "Tabel",
             Lang::ARABIC => "جدول",
             Lang::BOKMÅL => "Tabell",
+            Lang::CATALAN => "Taula",
             Lang::CHINESE => "表",
             Lang::CZECH => "Tabulka",
             Lang::DANISH => "Tabel",

--- a/crates/typst/src/text/lang.rs
+++ b/crates/typst/src/text/lang.rs
@@ -14,6 +14,7 @@ impl Lang {
     pub const ALBANIAN: Self = Self(*b"sq ", 2);
     pub const ARABIC: Self = Self(*b"ar ", 2);
     pub const BOKMÅL: Self = Self(*b"nb ", 2);
+    pub const CATALAN: Self = Self(*b"ca ", 2);
     pub const CHINESE: Self = Self(*b"zh ", 2);
     pub const CZECH: Self = Self(*b"cs ", 2);
     pub const DANISH: Self = Self(*b"da ", 2);

--- a/crates/typst/src/text/raw.rs
+++ b/crates/typst/src/text/raw.rs
@@ -434,6 +434,7 @@ impl LocalName for RawElem {
             Lang::ALBANIAN => "List",
             Lang::ARABIC => "قائمة",
             Lang::BOKMÅL => "Utskrift",
+            Lang::CATALAN => "Llistat",
             Lang::CHINESE if option_eq(region, "TW") => "程式",
             Lang::CHINESE => "代码",
             Lang::CZECH => "Seznam",

--- a/crates/typst/src/visualize/image/mod.rs
+++ b/crates/typst/src/visualize/image/mod.rs
@@ -253,6 +253,7 @@ impl LocalName for ImageElem {
             Lang::ALBANIAN => "Figurë",
             Lang::ARABIC => "شكل",
             Lang::BOKMÅL => "Figur",
+            Lang::CATALAN => "Figura",
             Lang::CHINESE if option_eq(region, "TW") => "圖",
             Lang::CHINESE => "图",
             Lang::CZECH => "Obrázek",


### PR DESCRIPTION
Translations courtesy of Guillem Vidal

This PR is the result of a support email thread. I have checked for Catalan hyphenation patterns, but have only found a GPL-3 licensed repo. Guillem has the following input on hyphenation:

> And for the hyphenation, Catalan is close enough to Spanish. With the extra character l·l, which can be hyphenated as l-l (I don't know if you can add special cases).
> 
> Beyond this, there are certain rules which are different, so it won't be 100% accurate, but I think it'll do for now.
> 
> Is there any way to disable hyphenation for a word? In case someone reaches the scenario that the Spanish hyphenation pattern is wrong for Catalan.
>
> if there's a way to do this, I would add hyphenation, if not, I would leave it without.

Given that we cannot add extra rules, I would leave it disabled for now. Any input?