### PR TITLE
Add explanation of show rule scope in footnote

### DIFF
--- a/crates/typst/src/model/footnote.rs
+++ b/crates/typst/src/model/footnote.rs
@@ -24,7 +24,8 @@ use crate::visualize::{LineElem, Stroke};
 /// To customize the appearance of the entry in the footnote listing, see
 /// [`footnote.entry`]($footnote.entry). The footnote itself is realized as a
 /// normal superscript, so you can use a set rule on the [`super`]($super)
-/// function to customize it.
+/// function to customize it. You can also apply a show rule to customize
+/// only the footnote marker (superscript number) in the running text.
 ///
 /// # Example
 /// ```example


### PR DESCRIPTION
This is initialized by this discussion in Discord, where I felt that there are not enough examples to give a glance of how `show` rules works for different elements.
https://discord.com/channels/1054443721975922748/1088371919725793360/1195341868272205945

In documentation of footnote, there are only examples of how to customize each entry of the footnote list, but lacks how  it would work when show rules applied to footnote itself. So I wanted to add an example at first, but other disscusant suggested that this example is less used so instead I added only one setence to explain the scope of show rule for footnote.