### PR TITLE
Added gradient alias for nabla symbol

### DIFF
--- a/crates/typst/src/symbols/sym.rs
+++ b/crates/typst/src/symbols/sym.rs
@@ -393,6 +393,7 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
     infinity: '∞',
     oo: '∞',
     diff: '∂',
+    gradient: '∇',
     nabla: '∇',
     sum: ['∑', integral: '⨋'],
     product: ['∏', co: '∐'],


### PR DESCRIPTION
Personally, I really need a grad/gradient alias for `nabla` symbol, because it describes a gradient (∇f(...) is a gradient). I never heard nabla outside of searching "what is the symbol for gradient?". IMHO, a lot of folks will agree.

I'm not sure about the placement of the alias. We can change it, but I think it's in a good spot already.
