### PR TITLE
Renamed `diff` symbol to `partial`

### DIFF
--- a/crates/typst/src/symbols/sym.rs
+++ b/crates/typst/src/symbols/sym.rs
@@ -394,7 +394,8 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
     // Calculus.
     infinity: '∞',
     oo: '∞',
-    diff: '∂',
+    diff: '∂', // deprecated (don't forget to delete later)
+    partial: '∂',
     gradient: '∇',
     nabla: '∇',
     sum: ['∑', integral: '⨋'],


### PR DESCRIPTION
Note that this saves the `diff` symbol for backward compatibility (with
a comment to easily find it). It should be deleted after a few versions.
This deprecation should be mentioned in the next release notes.

Linking related opened issues: #3099, #2188.
Closes #3210.
