### PR TITLE
fix(FontInfo): extract black weight from full name

### DIFF
--- a/crates/typst/src/text/font/book.rs
+++ b/crates/typst/src/text/font/book.rs
@@ -257,6 +257,9 @@ impl FontInfo {
                 {
                     number += 50;
                 }
+                if full.ends_with("black") {
+                    number = 900;
+                }
                 FontWeight::from_number(number)
             };
 


### PR DESCRIPTION
Fixes https://github.com/typst/typst/issues/3213

This overrides the font weight number to 900 (black) if the font's full name contains `"black"`. This lets Typst correctly identify the weight of Arial Black, resulting in correct use of the default Arial font when appropriate.