### PR TITLE
Include units in top-level SVG element

### DIFF
--- a/crates/typst-svg/src/lib.rs
+++ b/crates/typst-svg/src/lib.rs
@@ -247,8 +247,10 @@ impl SVGRenderer {
             "viewBox",
             format_args!("0 0 {} {}", size.x.to_pt(), size.y.to_pt()),
         );
-        self.xml.write_attribute("width", &size.x.to_pt());
-        self.xml.write_attribute("height", &size.y.to_pt());
+        self.xml
+            .write_attribute_fmt("width", format_args!("{}pt", size.x.to_pt()));
+        self.xml
+            .write_attribute_fmt("height", format_args!("{}pt", size.y.to_pt()));
         self.xml.write_attribute("xmlns", "http://www.w3.org/2000/svg");
         self.xml
             .write_attribute("xmlns:xlink", "http://www.w3.org/1999/xlink");


### PR DESCRIPTION
While exporting SVGs from typst for a pen-plotter, I noticed that the root SVG element did not have units in the "width" and "height" fields. Without these, the SVG size will be interpreted in the [initial coordinate system](https://www.w3.org/TR/SVG11/coords.html#InitialCoordinateSystem), which varies by environment but is usually wrong. e.g.
* Adobe Illustrator interprets it correctly as points (1/72 in, ≈ 352µm)
* Inkscape interprets it as CSS pixels (1/96in ≈ 265µm), scaling the image down to 75% size
* Renderers of a parent SVG interpret it as user units

This PR always sets the unit to "pt" on the root element.
