### PR TITLE
Jump from click for raw text

### DIFF
--- a/crates/typst-syntax/src/ast.rs
+++ b/crates/typst-syntax/src/ast.rs
@@ -631,6 +631,25 @@ impl<'a> Raw<'a> {
         let text = self.0.text();
         text.starts_with("```") && text.chars().any(is_newline)
     }
+
+    /// Tries to map an offset in the resulting `text()` to a corresponding
+    /// offset in the syntax node.
+    pub fn map_offset_back(self, text_offset: usize) -> Option<usize> {
+        // TODO: This doesn't respect indent.
+        let text = self.0.text().as_str();
+        let mut s = Scanner::new(text);
+        s.eat_while('`');
+
+        if text.starts_with("```") {
+            if s.eat_if(is_id_start) {
+                s.eat_while(is_id_continue);
+            }
+            s.eat_if(' ');
+            s.eat_if(is_newline);
+        }
+
+        Some(s.cursor() + text_offset)
+    }
 }
 
 node! {

--- a/crates/typst/src/text/item.rs
+++ b/crates/typst/src/text/item.rs
@@ -56,6 +56,10 @@ pub struct Glyph {
     /// be more than one due to multi-byte UTF-8 encoding or ligatures.
     pub range: Range<u16>,
     /// The source code location of the text.
+    ///
+    /// The u16 describes the offset of the glyph in the shaped text among all
+    /// consecutive text with this span (in the paragraph). It can, but does not
+    /// necessarily make sense to use as an offset directly into an AST node.
     pub span: (Span, u16),
 }
 


### PR DESCRIPTION
This adds support for precise jump-from-click (preview to source) for raw blocks. This required:
- Adding spans to the text elements generated by the raw block.
- Assigning span offsets in paragraph layout relative to clusters of segments with the same span
- Adding supporting for mapping back a text offset for a raw block to an AST offset in the node. This is actually surprisingly tricky. I added code to adjust the offset by the backticks and language tag, but dedent isn't properly handled yet. The AST code that handles raw blocks also some unfortunate code duplication. It should probably be rewritten from scratch to support all uses properly.