### PR TITLE
doc: remove inaccurate statement in eval

### DIFF
--- a/crates/typst/src/foundations/mod.rs
+++ b/crates/typst/src/foundations/mod.rs
@@ -256,8 +256,6 @@ pub fn eval(
     /// The engine.
     engine: &mut Engine,
     /// A string of Typst code to evaluate.
-    ///
-    /// The code in the string cannot interact with the file system.
     source: Spanned<String>,
     /// The syntactical mode in which the string is parsed.
     ///


### PR DESCRIPTION
actually it can read fs. Given that normal typst code can also read fs, there is no much difference between them.

```
#set page(height: auto, width: auto)

#eval("json(\"test.json\")")
```

reading from fs shouldnt be a big deal IMO. because we already isolate fs access inside the directory. so i just remove the line in doc