### PR TITLE
Link to `datetime` from `datetime.display` docs

### DIFF
--- a/crates/typst/src/foundations/datetime.rs
+++ b/crates/typst/src/foundations/datetime.rs
@@ -317,6 +317,8 @@ impl Datetime {
     /// `[[year]-[month]-[day]]`. If you specified a time, it will be
     /// `[[hour]:[minute]:[second]]`. In the case of a datetime, it will be
     /// `[[year]-[month]-[day] [hour]:[minute]:[second]]`.
+    ///
+    /// See the [format syntax]($datetime/#format) for more information.
     #[func]
     pub fn display(
         &self,


### PR DESCRIPTION
When looking at the documentation for the datetime.display method. It is not immediately obvious what the format syntax is. To improve that, I added a link to the datetime type where the format syntax is explained.

I hope I got the syntax for the documentation right. I couldn't find a way to easily generate the documentation locally to check whether it works. If you could explain how I could do that, I'd be happy to check.