### PR TITLE
Refactor folding

### DIFF
--- a/crates/typst/src/foundations/auto.rs
+++ b/crates/typst/src/foundations/auto.rs
@@ -239,14 +239,14 @@ impl<T: Resolve> Resolve for Smart<T> {
     }
 }
 
-impl<T> Fold for Smart<T>
-where
-    T: Fold,
-    T::Output: Default,
-{
-    type Output = Smart<T::Output>;
-
-    fn fold(self, outer: Self::Output) -> Self::Output {
-        self.map(|inner| inner.fold(outer.unwrap_or_default()))
+impl<T: Fold> Fold for Smart<T> {
+    fn fold(self, outer: Self) -> Self {
+        use Smart::Custom;
+        match (self, outer) {
+            (Custom(inner), Custom(outer)) => Custom(inner.fold(outer)),
+            // An explicit `auto` should be respected, thus we don't do
+            // `inner.or(outer)`.
+            (inner, _) => inner,
+        }
     }
 }

--- a/crates/typst/src/foundations/dict.rs
+++ b/crates/typst/src/foundations/dict.rs
@@ -138,7 +138,6 @@ impl Dict {
         };
 
         let mut msg = String::from(match unexpected.len() {
-            0 => unreachable!(),
             1 => "unexpected key ",
             _ => "unexpected keys ",
         });

--- a/crates/typst/src/foundations/styles.rs
+++ b/crates/typst/src/foundations/styles.rs
@@ -6,7 +6,6 @@ use std::{iter, mem, ptr};
 
 use comemo::Prehashed;
 use ecow::{eco_vec, EcoString, EcoVec};
-use once_cell::sync::Lazy;
 use smallvec::SmallVec;
 
 use crate::diag::{SourceResult, Trace, Tracepoint};
@@ -457,90 +456,53 @@ impl<'a> StyleChain<'a> {
         Chainable::chain(local, self)
     }
 
+    /// Cast the first value for the given property in the chain.
+    pub fn get<T: Clone + 'static>(
+        self,
+        func: Element,
+        id: u8,
+        inherent: Option<&T>,
+        default: impl Fn() -> T,
+    ) -> T {
+        self.properties::<T>(func, id, inherent)
+            .next()
+            .cloned()
+            .unwrap_or_else(default)
+    }
+
     /// Cast the first value for the given property in the chain,
-    /// returning a borrowed value if possible.
-    pub fn get_borrowed<T: Clone>(
+    /// returning a borrowed value.
+    pub fn get_ref<T: 'static>(
         self,
         func: Element,
         id: u8,
         inherent: Option<&'a T>,
-        default: &'static Lazy<T>,
+        default: impl Fn() -> &'a T,
     ) -> &'a T {
         self.properties::<T>(func, id, inherent)
             .next()
-            .unwrap_or_else(|| default)
+            .unwrap_or_else(default)
     }
 
-    /// Cast the first value for the given property in the chain.
-    pub fn get<T: Clone>(
+    /// Cast the first value for the given property in the chain, taking
+    /// `Fold` implementations into account.
+    pub fn get_folded<T: Fold + Clone + 'static>(
         self,
         func: Element,
         id: u8,
         inherent: Option<&T>,
-        default: &'static Lazy<T>,
+        default: impl Fn() -> T,
     ) -> T {
-        self.get_borrowed(func, id, inherent, default).clone()
-    }
-
-    /// Cast the first value for the given property in the chain.
-    pub fn get_resolve<T: Clone + Resolve>(
-        self,
-        func: Element,
-        id: u8,
-        inherent: Option<&T>,
-        default: &'static Lazy<T>,
-    ) -> T::Output {
-        self.get(func, id, inherent, default).resolve(self)
-    }
-
-    /// Cast the first value for the given property in the chain.
-    pub fn get_fold<T: Clone + Fold + 'static>(
-        self,
-        func: Element,
-        id: u8,
-        inherent: Option<&T>,
-        default: impl Fn() -> T::Output,
-    ) -> T::Output {
         fn next<T: Fold>(
             mut values: impl Iterator<Item = T>,
-            default: &impl Fn() -> T::Output,
-        ) -> T::Output {
+            default: &impl Fn() -> T,
+        ) -> T {
             values
                 .next()
                 .map(|value| value.fold(next(values, default)))
                 .unwrap_or_else(default)
         }
         next(self.properties::<T>(func, id, inherent).cloned(), &default)
-    }
-
-    /// Cast the first value for the given property in the chain.
-    pub fn get_resolve_fold<T>(
-        self,
-        func: Element,
-        id: u8,
-        inherent: Option<&T>,
-        default: impl Fn() -> <T::Output as Fold>::Output,
-    ) -> <T::Output as Fold>::Output
-    where
-        T: Resolve + Clone + 'static,
-        T::Output: Fold,
-    {
-        fn next<T>(
-            mut values: impl Iterator<Item = T>,
-            styles: StyleChain,
-            default: &impl Fn() -> <T::Output as Fold>::Output,
-        ) -> <T::Output as Fold>::Output
-        where
-            T: Resolve + 'static,
-            T::Output: Fold,
-        {
-            values
-                .next()
-                .map(|value| value.resolve(styles).fold(next(values, styles, default)))
-                .unwrap_or_else(default)
-        }
-
-        next(self.properties::<T>(func, id, inherent).cloned(), self, &default)
     }
 
     /// Iterate over all style recipes in the chain.
@@ -925,38 +887,36 @@ impl<T: Resolve> Resolve for Option<T> {
 /// #rect()
 /// ```
 pub trait Fold {
-    /// The type of the folded output.
-    type Output;
-
     /// Fold this inner value with an outer folded value.
-    fn fold(self, outer: Self::Output) -> Self::Output;
+    fn fold(self, outer: Self) -> Self;
 }
 
-impl<T> Fold for Option<T>
-where
-    T: Fold,
-    T::Output: Default,
-{
-    type Output = Option<T::Output>;
+impl Fold for bool {
+    fn fold(self, _: Self) -> Self {
+        self
+    }
+}
 
-    fn fold(self, outer: Self::Output) -> Self::Output {
-        self.map(|inner| inner.fold(outer.unwrap_or_default()))
+impl<T: Fold> Fold for Option<T> {
+    fn fold(self, outer: Self) -> Self {
+        match (self, outer) {
+            (Some(inner), Some(outer)) => Some(inner.fold(outer)),
+            // An explicit `None` should be respected, thus we don't do
+            // `inner.or(outer)`.
+            (inner, _) => inner,
+        }
     }
 }
 
 impl<T> Fold for Vec<T> {
-    type Output = Vec<T>;
-
-    fn fold(mut self, outer: Self::Output) -> Self::Output {
+    fn fold(mut self, outer: Self) -> Self {
         self.extend(outer);
         self
     }
 }
 
 impl<T, const N: usize> Fold for SmallVec<[T; N]> {
-    type Output = SmallVec<[T; N]>;
-
-    fn fold(mut self, outer: Self::Output) -> Self::Output {
+    fn fold(mut self, outer: Self) -> Self {
         self.extend(outer);
         self
     }

--- a/crates/typst/src/layout/align.rs
+++ b/crates/typst/src/layout/align.rs
@@ -215,9 +215,7 @@ impl Repr for Alignment {
 }
 
 impl Fold for Alignment {
-    type Output = Self;
-
-    fn fold(self, outer: Self::Output) -> Self::Output {
+    fn fold(self, outer: Self) -> Self {
         match (self, outer) {
             (Self::H(x), Self::V(y) | Self::Both(_, y)) => Self::Both(x, y),
             (Self::V(y), Self::H(x) | Self::Both(x, _)) => Self::Both(x, y),

--- a/crates/typst/src/layout/axes.rs
+++ b/crates/typst/src/layout/axes.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Debug, Formatter};
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, Deref, Not};
 
 use crate::diag::bail;
-use crate::foundations::{array, cast, Array, Fold, Resolve, Smart, StyleChain};
+use crate::foundations::{array, cast, Array, Resolve, Smart, StyleChain};
 use crate::layout::{Abs, Dir, Length, Ratio, Rel};
 use crate::util::Get;
 
@@ -83,14 +83,6 @@ impl<T> Axes<T> {
         F: FnMut(&T) -> bool,
     {
         f(&self.x) && f(&self.y)
-    }
-
-    /// Filter the individual fields with a mask.
-    pub fn filter(self, mask: Axes<bool>) -> Axes<Option<T>> {
-        Axes {
-            x: if mask.x { Some(self.x) } else { None },
-            y: if mask.y { Some(self.y) } else { None },
-        }
     }
 }
 
@@ -196,16 +188,6 @@ cast! {
     },
     "horizontal" => Self::X,
     "vertical" => Self::Y,
-}
-
-impl<T> Axes<Option<T>> {
-    /// Unwrap the individual fields.
-    pub fn unwrap_or(self, other: Axes<T>) -> Axes<T> {
-        Axes {
-            x: self.x.unwrap_or(other.x),
-            y: self.y.unwrap_or(other.y),
-        }
-    }
 }
 
 impl<T> Axes<Smart<T>> {
@@ -323,16 +305,5 @@ impl<T: Resolve> Resolve for Axes<T> {
 
     fn resolve(self, styles: StyleChain) -> Self::Output {
         self.map(|v| v.resolve(styles))
-    }
-}
-
-impl<T: Fold> Fold for Axes<Option<T>> {
-    type Output = Axes<T::Output>;
-
-    fn fold(self, outer: Self::Output) -> Self::Output {
-        self.zip_map(outer, |inner, outer| match inner {
-            Some(value) => value.fold(outer),
-            None => outer,
-        })
     }
 }

--- a/crates/typst/src/layout/container.rs
+++ b/crates/typst/src/layout/container.rs
@@ -133,7 +133,7 @@ impl Packed<BoxElem> {
 
         // Apply inset.
         let mut body = self.body(styles).unwrap_or_default();
-        let inset = self.inset(styles);
+        let inset = self.inset(styles).unwrap_or_default();
         if inset.iter().any(|v| !v.is_zero()) {
             body = body.padded(inset.map(|side| side.map(Length::from)));
         }
@@ -154,20 +154,24 @@ impl Packed<BoxElem> {
 
         // Prepare fill and stroke.
         let fill = self.fill(styles);
-        let stroke = self.stroke(styles).map(|s| s.map(Stroke::unwrap_or_default));
+        let stroke = self
+            .stroke(styles)
+            .unwrap_or_default()
+            .map(|s| s.map(Stroke::unwrap_or_default));
 
         // Clip the contents
         if self.clip(styles) {
-            let outset = self.outset(styles).relative_to(frame.size());
+            let outset =
+                self.outset(styles).unwrap_or_default().relative_to(frame.size());
             let size = frame.size() + outset.sum_by_axis();
-            let radius = self.radius(styles);
+            let radius = self.radius(styles).unwrap_or_default();
             frame.clip(clip_rect(size, radius, &stroke));
         }
 
         // Add fill and/or stroke.
         if fill.is_some() || stroke.iter().any(Option::is_some) {
-            let outset = self.outset(styles);
-            let radius = self.radius(styles);
+            let outset = self.outset(styles).unwrap_or_default();
+            let radius = self.radius(styles).unwrap_or_default();
             frame.fill_and_stroke(fill, stroke, outset, radius, self.span());
         }
 
@@ -350,7 +354,7 @@ impl LayoutMultiple for Packed<BlockElem> {
     ) -> SourceResult<Fragment> {
         // Apply inset.
         let mut body = self.body(styles).unwrap_or_default();
-        let inset = self.inset(styles);
+        let inset = self.inset(styles).unwrap_or_default();
         if inset.iter().any(|v| !v.is_zero()) {
             body = body.clone().padded(inset.map(|side| side.map(Length::from)));
         }
@@ -418,14 +422,18 @@ impl LayoutMultiple for Packed<BlockElem> {
 
         // Prepare fill and stroke.
         let fill = self.fill(styles);
-        let stroke = self.stroke(styles).map(|s| s.map(Stroke::unwrap_or_default));
+        let stroke = self
+            .stroke(styles)
+            .unwrap_or_default()
+            .map(|s| s.map(Stroke::unwrap_or_default));
 
         // Clip the contents
         if self.clip(styles) {
             for frame in frames.iter_mut() {
-                let outset = self.outset(styles).relative_to(frame.size());
+                let outset =
+                    self.outset(styles).unwrap_or_default().relative_to(frame.size());
                 let size = frame.size() + outset.sum_by_axis();
-                let radius = self.radius(styles);
+                let radius = self.radius(styles).unwrap_or_default();
                 frame.clip(clip_rect(size, radius, &stroke));
             }
         }
@@ -437,8 +445,8 @@ impl LayoutMultiple for Packed<BlockElem> {
                 skip = first.is_empty() && rest.iter().any(|frame| !frame.is_empty());
             }
 
-            let outset = self.outset(styles);
-            let radius = self.radius(styles);
+            let outset = self.outset(styles).unwrap_or_default();
+            let radius = self.radius(styles).unwrap_or_default();
             for frame in frames.iter_mut().skip(skip as usize) {
                 frame.fill_and_stroke(
                     fill.clone(),

--- a/crates/typst/src/layout/corners.rs
+++ b/crates/typst/src/layout/corners.rs
@@ -80,6 +80,16 @@ impl<T> Corners<T> {
     }
 }
 
+impl<T> Corners<Option<T>> {
+    /// Unwrap-or-default the individual corners.
+    pub fn unwrap_or_default(self) -> Corners<T>
+    where
+        T: Default,
+    {
+        self.map(Option::unwrap_or_default)
+    }
+}
+
 impl<T> Get<Corner> for Corners<T> {
     type Component = T;
 
@@ -133,20 +143,21 @@ impl<T: Reflect> Reflect for Corners<Option<T>> {
     }
 }
 
-impl<T> IntoValue for Corners<T>
+impl<T> IntoValue for Corners<Option<T>>
 where
     T: PartialEq + IntoValue,
 {
     fn into_value(self) -> Value {
         if self.is_uniform() {
-            return self.top_left.into_value();
+            if let Some(top_left) = self.top_left {
+                return top_left.into_value();
+            }
         }
 
         let mut dict = Dict::new();
-        let mut handle = |key: &str, component: T| {
-            let value = component.into_value();
-            if value != Value::None {
-                dict.insert(key.into(), value);
+        let mut handle = |key: &str, component: Option<T>| {
+            if let Some(c) = component {
+                dict.insert(key.into(), c.into_value());
             }
         };
 
@@ -221,12 +232,13 @@ impl<T: Resolve> Resolve for Corners<T> {
 }
 
 impl<T: Fold> Fold for Corners<Option<T>> {
-    type Output = Corners<T::Output>;
-
-    fn fold(self, outer: Self::Output) -> Self::Output {
-        self.zip(outer).map(|(inner, outer)| match inner {
-            Some(value) => value.fold(outer),
-            None => outer,
+    fn fold(self, outer: Self) -> Self {
+        self.zip(outer).map(|(inner, outer)| match (inner, outer) {
+            (Some(inner), Some(outer)) => Some(inner.fold(outer)),
+            // Usually, folding an inner `None` with an `outer` preferres the
+            // explicit `None`. However, here `None` means unspecified and thus
+            // we want `outer`.
+            (inner, outer) => inner.or(outer),
         })
     }
 }

--- a/crates/typst/src/layout/grid/layout.rs
+++ b/crates/typst/src/layout/grid/layout.rs
@@ -151,7 +151,7 @@ pub trait ResolvableCell {
         y: usize,
         fill: &Option<Paint>,
         align: Smart<Alignment>,
-        inset: Sides<Rel<Length>>,
+        inset: Sides<Option<Rel<Length>>>,
         styles: StyleChain,
     ) -> Cell;
 
@@ -204,7 +204,7 @@ impl CellGrid {
         cells: &[T],
         fill: &Celled<Option<Paint>>,
         align: &Celled<Smart<Alignment>>,
-        inset: Sides<Rel<Length>>,
+        inset: Sides<Option<Rel<Length>>>,
         engine: &mut Engine,
         styles: StyleChain,
         span: Span,

--- a/crates/typst/src/layout/grid/mod.rs
+++ b/crates/typst/src/layout/grid/mod.rs
@@ -13,8 +13,8 @@ use crate::foundations::{
     cast, elem, scope, Array, Content, Fold, Packed, Show, Smart, StyleChain, Value,
 };
 use crate::layout::{
-    Abs, AlignElem, Alignment, Axes, Fragment, LayoutMultiple, Length, Regions, Rel,
-    Sides, Sizing,
+    AlignElem, Alignment, Axes, Fragment, LayoutMultiple, Length, Regions, Rel, Sides,
+    Sizing,
 };
 use crate::syntax::Span;
 use crate::util::NonZeroExt;
@@ -264,7 +264,6 @@ pub struct GridElem {
     /// )
     /// ```
     #[fold]
-    #[default(Sides::splat(Abs::pt(0.0).into()))]
     pub inset: Sides<Option<Rel<Length>>>,
 
     /// The contents of the grid cells.
@@ -462,7 +461,7 @@ impl ResolvableCell for Packed<GridCell> {
         y: usize,
         fill: &Option<Paint>,
         align: Smart<Alignment>,
-        inset: Sides<Rel<Length>>,
+        inset: Sides<Option<Rel<Length>>>,
         styles: StyleChain,
     ) -> Cell {
         let cell = &mut *self;
@@ -481,9 +480,8 @@ impl ResolvableCell for Packed<GridCell> {
             Smart::Auto => cell.align(styles),
         });
         cell.push_inset(Smart::Custom(
-            cell.inset(styles).map_or(inset, |inner| inner.fold(inset)).map(Some),
+            cell.inset(styles).map_or(inset, |inner| inner.fold(inset)),
         ));
-
         Cell { body: self.pack(), fill, colspan }
     }
 

--- a/crates/typst/src/layout/length.rs
+++ b/crates/typst/src/layout/length.rs
@@ -5,7 +5,7 @@ use std::ops::{Add, Div, Mul, Neg};
 use ecow::{eco_format, EcoString};
 
 use crate::diag::{At, Hint, SourceResult};
-use crate::foundations::{func, scope, ty, Repr, Resolve, StyleChain, Styles};
+use crate::foundations::{func, scope, ty, Fold, Repr, Resolve, StyleChain, Styles};
 use crate::layout::{Abs, Em};
 use crate::syntax::Span;
 use crate::util::Numeric;
@@ -272,5 +272,11 @@ impl Resolve for Length {
 
     fn resolve(self, styles: StyleChain) -> Self::Output {
         self.abs + self.em.resolve(styles)
+    }
+}
+
+impl Fold for Length {
+    fn fold(self, _: Self) -> Self {
+        self
     }
 }

--- a/crates/typst/src/layout/page.rs
+++ b/crates/typst/src/layout/page.rs
@@ -549,18 +549,11 @@ impl Margin {
 }
 
 impl Fold for Margin {
-    type Output = Margin;
-
-    fn fold(self, outer: Self::Output) -> Self::Output {
-        let sides =
-            self.sides
-                .zip(outer.sides)
-                .map(|(inner, outer)| match (inner, outer) {
-                    (Some(value), Some(outer)) => Some(value.fold(outer)),
-                    _ => inner.or(outer),
-                });
-        let two_sided = self.two_sided.or(outer.two_sided);
-        Margin { sides, two_sided }
+    fn fold(self, outer: Self) -> Self {
+        Margin {
+            sides: self.sides.fold(outer.sides),
+            two_sided: self.two_sided.fold(outer.two_sided),
+        }
     }
 }
 

--- a/crates/typst/src/layout/rel.rs
+++ b/crates/typst/src/layout/rel.rs
@@ -259,19 +259,12 @@ where
     }
 }
 
-impl Fold for Rel<Abs> {
-    type Output = Self;
-
-    fn fold(self, _: Self::Output) -> Self::Output {
-        self
-    }
-}
-
-impl Fold for Rel<Length> {
-    type Output = Self;
-
-    fn fold(self, _: Self::Output) -> Self::Output {
-        self
+impl<T> Fold for Rel<T>
+where
+    T: Numeric + Fold,
+{
+    fn fold(self, outer: Self) -> Self {
+        Self { rel: self.rel, abs: self.abs.fold(outer.abs) }
     }
 }
 

--- a/crates/typst/src/layout/sides.rs
+++ b/crates/typst/src/layout/sides.rs
@@ -94,6 +94,16 @@ impl<T: Add> Sides<T> {
     }
 }
 
+impl<T> Sides<Option<T>> {
+    /// Unwrap-or-default the individual sides.
+    pub fn unwrap_or_default(self) -> Sides<T>
+    where
+        T: Default,
+    {
+        self.map(Option::unwrap_or_default)
+    }
+}
+
 impl Sides<Rel<Abs>> {
     /// Evaluate the sides relative to the given `size`.
     pub fn relative_to(self, size: Size) -> Sides<Abs> {
@@ -159,20 +169,21 @@ impl<T: Reflect> Reflect for Sides<Option<T>> {
     }
 }
 
-impl<T> IntoValue for Sides<T>
+impl<T> IntoValue for Sides<Option<T>>
 where
     T: PartialEq + IntoValue,
 {
     fn into_value(self) -> Value {
         if self.is_uniform() {
-            return self.left.into_value();
+            if let Some(left) = self.left {
+                return left.into_value();
+            }
         }
 
         let mut dict = Dict::new();
-        let mut handle = |key: &str, component: T| {
-            let value = component.into_value();
-            if value != Value::None {
-                dict.insert(key.into(), value);
+        let mut handle = |key: &str, component: Option<T>| {
+            if let Some(c) = component {
+                dict.insert(key.into(), c.into_value());
             }
         };
 
@@ -226,12 +237,13 @@ impl<T: Resolve> Resolve for Sides<T> {
 }
 
 impl<T: Fold> Fold for Sides<Option<T>> {
-    type Output = Sides<T::Output>;
-
-    fn fold(self, outer: Self::Output) -> Self::Output {
-        self.zip(outer).map(|(inner, outer)| match inner {
-            Some(value) => value.fold(outer),
-            None => outer,
+    fn fold(self, outer: Self) -> Self {
+        self.zip(outer).map(|(inner, outer)| match (inner, outer) {
+            (Some(inner), Some(outer)) => Some(inner.fold(outer)),
+            // Usually, folding an inner `None` with an `outer` preferres the
+            // explicit `None`. However, here `None` means unspecified and thus
+            // we want `outer`.
+            (inner, outer) => inner.or(outer),
         })
     }
 }

--- a/crates/typst/src/math/cancel.rs
+++ b/crates/typst/src/math/cancel.rs
@@ -97,7 +97,7 @@ pub struct CancelElem {
     #[fold]
     #[default(Stroke {
         // Default stroke has 0.5pt for better visuals.
-        thickness: Smart::Custom(Abs::pt(0.5)),
+        thickness: Smart::Custom(Abs::pt(0.5).into()),
         ..Default::default()
     })]
     pub stroke: Stroke,

--- a/crates/typst/src/math/matrix.rs
+++ b/crates/typst/src/math/matrix.rs
@@ -425,11 +425,10 @@ fn layout_mat_body(
     };
 
     let (hline, vline, stroke) = match augment {
-        Some(v) => {
-            // need to get stroke here for ownership
-            let stroke = v.stroke_or(default_stroke);
-
-            (v.hline, v.vline, stroke)
+        Some(augment) => {
+            // We need to get stroke here for ownership.
+            let stroke = augment.stroke.unwrap_or_default().unwrap_or(default_stroke);
+            (augment.hline, augment.vline, stroke)
         }
         _ => (AugmentOffsets::default(), AugmentOffsets::default(), default_stroke),
     };
@@ -593,11 +592,19 @@ pub struct Augment<T: Numeric = Length> {
     pub stroke: Smart<Stroke<T>>,
 }
 
-impl Augment<Abs> {
-    fn stroke_or(&self, fallback: FixedStroke) -> FixedStroke {
-        match &self.stroke {
-            Smart::Custom(v) => v.clone().unwrap_or(fallback),
-            Smart::Auto => fallback,
+impl<T: Numeric + Fold> Fold for Augment<T> {
+    fn fold(self, outer: Self) -> Self {
+        Self {
+            stroke: match (self.stroke, outer.stroke) {
+                (Smart::Custom(inner), Smart::Custom(outer)) => {
+                    Smart::Custom(inner.fold(outer))
+                }
+                // Usually, folding an inner `auto` with an `outer` preferres
+                // the explicit `auto`. However, here `auto` means unspecified
+                // and thus we want `outer`.
+                (inner, outer) => inner.or(outer),
+            },
+            ..self
         }
     }
 }
@@ -614,21 +621,6 @@ impl Resolve for Augment {
     }
 }
 
-impl Fold for Augment<Abs> {
-    type Output = Augment<Abs>;
-
-    fn fold(mut self, outer: Self::Output) -> Self::Output {
-        // Special case for handling `auto` strokes in subsequent `Augment`.
-        if self.stroke.is_auto() && outer.stroke.is_custom() {
-            self.stroke = outer.stroke;
-        } else {
-            self.stroke = self.stroke.fold(outer.stroke);
-        }
-
-        self
-    }
-}
-
 cast! {
     Augment,
     self => {
@@ -637,13 +629,11 @@ cast! {
             return self.vline.0[0].into_value();
         }
 
-        let d = dict! {
-            "hline" => self.hline.into_value(),
-            "vline" => self.vline.into_value(),
-            "stroke" => self.stroke.into_value()
-        };
-
-        d.into_value()
+        dict! {
+            "hline" => self.hline,
+            "vline" => self.vline,
+            "stroke" => self.stroke,
+        }.into_value()
     },
     v: isize => Augment {
         hline: AugmentOffsets::default(),
@@ -651,15 +641,15 @@ cast! {
         stroke: Smart::Auto,
     },
     mut dict: Dict => {
-        // need the transpose for the defaults to work
-        let hline = dict.take("hline").ok().map(AugmentOffsets::from_value)
-            .transpose().unwrap_or_default().unwrap_or_default();
-        let vline = dict.take("vline").ok().map(AugmentOffsets::from_value)
-            .transpose().unwrap_or_default().unwrap_or_default();
-
-        let stroke = dict.take("stroke").ok().map(Stroke::from_value)
-            .transpose()?.map(Smart::Custom).unwrap_or(Smart::Auto);
-
+        let mut take = |key| dict.take(key).ok().map(AugmentOffsets::from_value).transpose();
+        let hline = take("hline")?.unwrap_or_default();
+        let vline = take("vline")?.unwrap_or_default();
+        let stroke = dict.take("stroke")
+            .ok()
+            .map(Stroke::from_value)
+            .transpose()?
+            .map(Smart::Custom)
+            .unwrap_or(Smart::Auto);
         Augment { hline, vline, stroke }
     },
 }

--- a/crates/typst/src/model/bibliography.rs
+++ b/crates/typst/src/model/bibliography.rs
@@ -323,7 +323,6 @@ impl LocalName for Packed<BibliographyElem> {
 }
 
 /// A loaded bibliography.
-#[ty]
 #[derive(Clone, PartialEq)]
 pub struct Bibliography {
     map: Arc<IndexMap<PicoStr, hayagriva::Entry>>,
@@ -419,12 +418,6 @@ impl Debug for Bibliography {
 impl Hash for Bibliography {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.hash.hash(state);
-    }
-}
-
-impl Repr for Bibliography {
-    fn repr(&self) -> EcoString {
-        "..".into()
     }
 }
 

--- a/crates/typst/src/model/emph.rs
+++ b/crates/typst/src/model/emph.rs
@@ -36,6 +36,6 @@ pub struct EmphElem {
 impl Show for Packed<EmphElem> {
     #[typst_macros::time(name = "emph", span = self.span())]
     fn show(&self, _: &mut Engine, _: StyleChain) -> SourceResult<Content> {
-        Ok(self.body().clone().styled(TextElem::set_emph(ItalicToggle)))
+        Ok(self.body().clone().styled(TextElem::set_emph(ItalicToggle(true))))
     }
 }

--- a/crates/typst/src/model/list.rs
+++ b/crates/typst/src/model/list.rs
@@ -150,7 +150,7 @@ impl LayoutMultiple for Packed<ListElem> {
                 .unwrap_or_else(|| *BlockElem::below_in(styles).amount())
         };
 
-        let depth = self.depth(styles);
+        let Depth(depth) = self.depth(styles);
         let marker = self
             .marker(styles)
             .resolve(engine, depth)?
@@ -162,8 +162,9 @@ impl LayoutMultiple for Packed<ListElem> {
             cells.push(Cell::from(Content::empty()));
             cells.push(Cell::from(marker.clone()));
             cells.push(Cell::from(Content::empty()));
-            cells
-                .push(Cell::from(item.body().clone().styled(ListElem::set_depth(Depth))));
+            cells.push(Cell::from(
+                item.body().clone().styled(ListElem::set_depth(Depth(1))),
+            ));
         }
 
         let stroke = None;
@@ -235,19 +236,11 @@ cast! {
     v: Func => Self::Func(v),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Hash)]
-struct Depth;
-
-cast! {
-    Depth,
-    self => Value::None,
-    _: Value => Self,
-}
+#[derive(Debug, Default, Clone, Copy, PartialEq, Hash)]
+struct Depth(usize);
 
 impl Fold for Depth {
-    type Output = usize;
-
-    fn fold(self, outer: Self::Output) -> Self::Output {
-        outer + 1
+    fn fold(self, outer: Self) -> Self {
+        Self(outer.0 + self.0)
     }
 }

--- a/crates/typst/src/model/table.rs
+++ b/crates/typst/src/model/table.rs
@@ -194,7 +194,7 @@ pub struct TableElem {
     /// )
     /// ```
     #[fold]
-    #[default(Sides::splat(Abs::pt(5.0).into()))]
+    #[default(Sides::splat(Some(Abs::pt(5.0).into())))]
     pub inset: Sides<Option<Rel<Length>>>,
 
     /// The contents of the table cells.
@@ -378,7 +378,7 @@ impl ResolvableCell for Packed<TableCell> {
         y: usize,
         fill: &Option<Paint>,
         align: Smart<Alignment>,
-        inset: Sides<Rel<Length>>,
+        inset: Sides<Option<Rel<Length>>>,
         styles: StyleChain,
     ) -> Cell {
         let cell = &mut *self;
@@ -397,9 +397,8 @@ impl ResolvableCell for Packed<TableCell> {
             Smart::Auto => cell.align(styles),
         });
         cell.push_inset(Smart::Custom(
-            cell.inset(styles).map_or(inset, |inner| inner.fold(inset)).map(Some),
+            cell.inset(styles).map_or(inset, |inner| inner.fold(inset)),
         ));
-
         Cell { body: self.pack(), fill, colspan }
     }
 

--- a/crates/typst/src/text/deco.rs
+++ b/crates/typst/src/text/deco.rs
@@ -1,13 +1,10 @@
 use kurbo::{BezPath, Line, ParamCurve};
+use smallvec::smallvec;
 use ttf_parser::{GlyphId, OutlineBuilder};
-
-use ecow::{eco_format, EcoString};
 
 use crate::diag::SourceResult;
 use crate::engine::Engine;
-use crate::foundations::{
-    elem, ty, Content, Fold, Packed, Repr, Show, Smart, StyleChain,
-};
+use crate::foundations::{elem, Content, Packed, Show, Smart, StyleChain};
 use crate::layout::{Abs, Em, Frame, FrameItem, Length, Point, Size};
 use crate::syntax::Span;
 use crate::text::{
@@ -89,7 +86,7 @@ pub struct UnderlineElem {
 impl Show for Packed<UnderlineElem> {
     #[typst_macros::time(name = "underline", span = self.span())]
     fn show(&self, _: &mut Engine, styles: StyleChain) -> SourceResult<Content> {
-        Ok(self.body().clone().styled(TextElem::set_deco(Decoration {
+        Ok(self.body().clone().styled(TextElem::set_deco(smallvec![Decoration {
             line: DecoLine::Underline {
                 stroke: self.stroke(styles).unwrap_or_default(),
                 offset: self.offset(styles),
@@ -97,7 +94,7 @@ impl Show for Packed<UnderlineElem> {
                 background: self.background(styles),
             },
             extent: self.extent(styles),
-        })))
+        }])))
     }
 }
 
@@ -181,7 +178,7 @@ pub struct OverlineElem {
 impl Show for Packed<OverlineElem> {
     #[typst_macros::time(name = "overline", span = self.span())]
     fn show(&self, _: &mut Engine, styles: StyleChain) -> SourceResult<Content> {
-        Ok(self.body().clone().styled(TextElem::set_deco(Decoration {
+        Ok(self.body().clone().styled(TextElem::set_deco(smallvec![Decoration {
             line: DecoLine::Overline {
                 stroke: self.stroke(styles).unwrap_or_default(),
                 offset: self.offset(styles),
@@ -189,7 +186,7 @@ impl Show for Packed<OverlineElem> {
                 background: self.background(styles),
             },
             extent: self.extent(styles),
-        })))
+        }])))
     }
 }
 
@@ -258,7 +255,7 @@ pub struct StrikeElem {
 impl Show for Packed<StrikeElem> {
     #[typst_macros::time(name = "strike", span = self.span())]
     fn show(&self, _: &mut Engine, styles: StyleChain) -> SourceResult<Content> {
-        Ok(self.body().clone().styled(TextElem::set_deco(Decoration {
+        Ok(self.body().clone().styled(TextElem::set_deco(smallvec![Decoration {
             // Note that we do not support evade option for strikethrough.
             line: DecoLine::Strikethrough {
                 stroke: self.stroke(styles).unwrap_or_default(),
@@ -266,7 +263,7 @@ impl Show for Packed<StrikeElem> {
                 background: self.background(styles),
             },
             extent: self.extent(styles),
-        })))
+        }])))
     }
 }
 
@@ -328,14 +325,14 @@ pub struct HighlightElem {
 impl Show for Packed<HighlightElem> {
     #[typst_macros::time(name = "highlight", span = self.span())]
     fn show(&self, _: &mut Engine, styles: StyleChain) -> SourceResult<Content> {
-        Ok(self.body().clone().styled(TextElem::set_deco(Decoration {
+        Ok(self.body().clone().styled(TextElem::set_deco(smallvec![Decoration {
             line: DecoLine::Highlight {
                 fill: self.fill(styles),
                 top_edge: self.top_edge(styles),
                 bottom_edge: self.bottom_edge(styles),
             },
             extent: self.extent(styles),
-        })))
+        }])))
     }
 }
 
@@ -343,26 +340,10 @@ impl Show for Packed<HighlightElem> {
 ///
 /// Can be positioned over, under, or on top of text, or highlight the text with
 /// a background.
-#[ty]
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Decoration {
     line: DecoLine,
     extent: Abs,
-}
-
-impl Fold for Decoration {
-    type Output = Vec<Self>;
-
-    fn fold(self, mut outer: Self::Output) -> Self::Output {
-        outer.insert(0, self);
-        outer
-    }
-}
-
-impl Repr for Decoration {
-    fn repr(&self) -> EcoString {
-        eco_format!("{self:?}")
-    }
 }
 
 /// A kind of decorative line.

--- a/crates/typst/src/text/raw.rs
+++ b/crates/typst/src/text/raw.rs
@@ -658,11 +658,8 @@ cast! {
 }
 
 impl Fold for SyntaxPaths {
-    type Output = Self;
-
-    fn fold(mut self, outer: Self::Output) -> Self::Output {
-        self.0.extend(outer.0);
-        self
+    fn fold(self, outer: Self) -> Self {
+        Self(self.0.fold(outer.0))
     }
 }
 

--- a/crates/typst/src/visualize/stroke.rs
+++ b/crates/typst/src/visualize/stroke.rs
@@ -330,6 +330,19 @@ impl<T: Numeric + Repr> Repr for Stroke<T> {
     }
 }
 
+impl<T: Numeric + Fold> Fold for Stroke<T> {
+    fn fold(self, outer: Self) -> Self {
+        Self {
+            paint: self.paint.or(outer.paint),
+            thickness: self.thickness.or(outer.thickness),
+            cap: self.cap.or(outer.cap),
+            join: self.join.or(outer.join),
+            dash: self.dash.or(outer.dash),
+            miter_limit: self.miter_limit.or(outer.miter_limit),
+        }
+    }
+}
+
 impl Resolve for Stroke {
     type Output = Stroke<Abs>;
 
@@ -341,21 +354,6 @@ impl Resolve for Stroke {
             join: self.join,
             dash: self.dash.resolve(styles),
             miter_limit: self.miter_limit,
-        }
-    }
-}
-
-impl Fold for Stroke<Abs> {
-    type Output = Self;
-
-    fn fold(self, outer: Self::Output) -> Self::Output {
-        Self {
-            paint: self.paint.or(outer.paint),
-            thickness: self.thickness.or(outer.thickness),
-            cap: self.cap.or(outer.cap),
-            join: self.join.or(outer.join),
-            dash: self.dash.or(outer.dash),
-            miter_limit: self.miter_limit.or(outer.miter_limit),
         }
     }
 }


### PR DESCRIPTION
This significantly simplifies the way `Fold` works:

 - Folding doesn't have the concept of an `Output` type anymore. Instead, things are always folded against themselves (`Self`).
 - Folding and resolving are now decoupled and, by extension, resolving can be fully decoupled from the style chain accessors. This means that https://github.com/typst/typst/pull/3290 can fold without resolving at the same time, so that changes to `#[resolve]` continue to not be breaking changes and overall things behave more predictably.
 - Fixes complex code involving folding `Option` and `Smart`: The reason for all the complexity is that there are two semantically different usages of these types: Typically, a fold of `Option<T>` should prefer an inner `None` against and outer X because the user literally wrote `none`. However, `Option<T>` is also sometimes used to express that the user wrote nothing (e.g. an omitted side in a `Sides` dictionary). Then, the outer X should be preferred. The few places where this is the case have now explicit comments to explain the difference.
 - Also removes a few unnecessary `#[ty]` and `cast!` usages for `#[internal]` types. This necessitated a bugfix for the `#[elem]` macro, which would erroneously include internal fields in the `Construct` implementation.