### PR TITLE
Remove an unnecessary clone in loop evaluation

### DIFF
--- a/crates/typst-syntax/src/ast.rs
+++ b/crates/typst-syntax/src/ast.rs
@@ -1967,7 +1967,7 @@ impl<'a> ForLoop<'a> {
     }
 
     /// The expression to iterate over.
-    pub fn iter(self) -> Expr<'a> {
+    pub fn iterable(self) -> Expr<'a> {
         self.0
             .children()
             .skip_while(|&c| c.kind() != SyntaxKind::In)

--- a/crates/typst/src/eval/call.rs
+++ b/crates/typst/src/eval/call.rs
@@ -467,7 +467,7 @@ impl<'a> CapturesVisitor<'a> {
             // active after the iterable is evaluated but before the body is
             // evaluated.
             Some(ast::Expr::For(expr)) => {
-                self.visit(expr.iter().to_untyped());
+                self.visit(expr.iterable().to_untyped());
                 self.internal.enter();
 
                 let pattern = expr.pattern();

--- a/crates/typst/src/eval/flow.rs
+++ b/crates/typst/src/eval/flow.rs
@@ -134,10 +134,11 @@ impl Eval for ast::ForLoop<'_> {
             }};
         }
 
-        let iter = self.iter().eval(vm)?;
+        let iterable = self.iterable().eval(vm)?;
+        let iterable_type = iterable.ty();
         let pattern = self.pattern();
 
-        match (&pattern, iter.clone()) {
+        match (&pattern, iterable) {
             (ast::Pattern::Normal(_), Value::Str(string)) => {
                 // Iterate over graphemes of string.
                 iter!(for pattern in string.as_str().graphemes(true));
@@ -151,10 +152,10 @@ impl Eval for ast::ForLoop<'_> {
                 iter!(for pattern in array);
             }
             (ast::Pattern::Normal(_), _) => {
-                bail!(self.iter().span(), "cannot loop over {}", iter.ty());
+                bail!(self.iterable().span(), "cannot loop over {}", iterable_type);
             }
             (_, _) => {
-                bail!(pattern.span(), "cannot destructure values of {}", iter.ty())
+                bail!(pattern.span(), "cannot destructure values of {}", iterable_type)
             }
         }
 


### PR DESCRIPTION
This patch also renamed `ForLoop::iter()` to `ForLoop::iterable()` for clarity. The unnecessary clone might result from thinking "iter" as "iterator", which is normally cheap to clone. However, the object returned from `ForLoop::iterable()` is not necessarily cheap to clone.