### PR TITLE
Ensure synthesized field access never panics

### DIFF
--- a/crates/typst/src/layout/page.rs
+++ b/crates/typst/src/layout/page.rs
@@ -331,7 +331,6 @@ pub struct PageElem {
     /// Whether the page should be aligned to an even or odd page.
     #[internal]
     #[synthesized]
-    #[default(None)]
     pub clear_to: Option<Parity>,
 }
 

--- a/crates/typst/src/model/bibliography.rs
+++ b/crates/typst/src/model/bibliography.rs
@@ -741,13 +741,19 @@ impl<'a> Generator<'a> {
             driver.citation(CitationRequest::new(
                 items,
                 style,
-                Some(locale(*first.lang(), *first.region())),
+                Some(locale(
+                    first.lang().copied().unwrap_or(Lang::ENGLISH),
+                    first.region().copied().flatten(),
+                )),
                 &LOCALES,
                 None,
             ));
         }
 
-        let locale = locale(*self.bibliography.lang(), *self.bibliography.region());
+        let locale = locale(
+            self.bibliography.lang().copied().unwrap_or(Lang::ENGLISH),
+            self.bibliography.region().copied().flatten(),
+        );
 
         // Add hidden items for everything if we should print the whole
         // bibliography.

--- a/crates/typst/src/model/document.rs
+++ b/crates/typst/src/model/document.rs
@@ -93,7 +93,7 @@ impl LayoutRoot for Packed<DocumentElem> {
                         .to_styled()
                         .map_or(next, |(elem, _)| elem)
                         .to_packed::<PageElem>()?
-                        .clear_to()
+                        .clear_to()?
                 });
                 let run = page.layout(engine, styles, &mut page_counter, extend_to)?;
                 pages.extend(run);

--- a/crates/typst/src/model/figure.rs
+++ b/crates/typst/src/model/figure.rs
@@ -371,7 +371,8 @@ impl Refable for Packed<FigureElem> {
     fn counter(&self) -> Counter {
         (**self)
             .counter()
-            .clone()
+            .cloned()
+            .flatten()
             .unwrap_or_else(|| Counter::of(FigureElem::elem()))
     }
 
@@ -393,7 +394,7 @@ impl Outlinable for Packed<FigureElem> {
         let mut realized = caption.body().clone();
         if let (
             Smart::Custom(Some(Supplement::Content(mut supplement))),
-            Some(counter),
+            Some(Some(counter)),
             Some(numbering),
         ) = (
             (**self).supplement(StyleChain::default()).clone(),
@@ -512,23 +513,19 @@ pub struct FigureCaption {
 
     /// The figure's supplement.
     #[synthesized]
-    #[default(None)]
     pub supplement: Option<Content>,
 
     /// How to number the figure.
     #[synthesized]
-    #[default(None)]
     pub numbering: Option<Numbering>,
 
     /// The counter for the figure.
     #[synthesized]
-    #[default(None)]
     pub counter: Option<Counter>,
 
     /// The figure's location.
     #[internal]
     #[synthesized]
-    #[default(None)]
     pub figure_location: Option<Location>,
 }
 
@@ -568,8 +565,13 @@ impl Show for Packed<FigureCaption> {
     fn show(&self, engine: &mut Engine, styles: StyleChain) -> SourceResult<Content> {
         let mut realized = self.body().clone();
 
-        if let (Some(mut supplement), Some(numbering), Some(counter), Some(location)) = (
-            self.supplement().clone(),
+        if let (
+            Some(Some(mut supplement)),
+            Some(Some(numbering)),
+            Some(Some(counter)),
+            Some(Some(location)),
+        ) = (
+            self.supplement().cloned(),
             self.numbering(),
             self.counter(),
             self.figure_location(),

--- a/crates/typst/src/text/raw.rs
+++ b/crates/typst/src/text/raw.rs
@@ -398,16 +398,18 @@ impl Synthesize for Packed<RawElem> {
 impl Show for Packed<RawElem> {
     #[typst_macros::time(name = "raw", span = self.span())]
     fn show(&self, _: &mut Engine, styles: StyleChain) -> SourceResult<Content> {
-        let mut lines = EcoVec::with_capacity((2 * self.lines().len()).saturating_sub(1));
-        for (i, line) in self.lines().iter().enumerate() {
+        let lines = self.lines().map(|v| v.as_slice()).unwrap_or_default();
+
+        let mut seq = EcoVec::with_capacity((2 * lines.len()).saturating_sub(1));
+        for (i, line) in lines.iter().enumerate() {
             if i != 0 {
-                lines.push(LinebreakElem::new().pack());
+                seq.push(LinebreakElem::new().pack());
             }
 
-            lines.push(line.clone().pack());
+            seq.push(line.clone().pack());
         }
 
-        let mut realized = Content::sequence(lines);
+        let mut realized = Content::sequence(seq);
         if self.block(styles) {
             // Align the text before inserting it into the block.
             realized = realized.aligned(self.align(styles).into());


### PR DESCRIPTION
This removes the mechanism to have defaults for synthesized fields, which was introduced in #2687 to prevent panics when synthesized fields were missing. Instead, all synthesized field access now must be prepared for missing fields and the `#[elem]` macro doesn't generate any unwrap() calls anymore.

The very constructed case of `#figure.caption[].supplement` doesn't compile anymore now (only with a manually constructed caption though), which is technically a breaking change, but in my opinion rather a bug fix.