### PR TITLE
font-exceptions: override weight of Arial Black

### DIFF
--- a/crates/typst/src/text/font/exceptions.rs
+++ b/crates/typst/src/text/font/exceptions.rs
@@ -44,6 +44,10 @@ pub fn find_exception(postscript_name: &str) -> Option<&'static Exception> {
 
 /// A map which keys are PostScript name and values are override entries.
 static EXCEPTION_MAP: phf::Map<&'static str, Exception> = phf::phf_map! {
+    // The old version of Arial-Black, published by Microsoft in 1996 in their "core fonts for the web" project, has a wrong weight of 400.
+    // See https://corefonts.sourceforge.net/.
+    "Arial-Black" => Exception::new()
+        .weight(900),
     "NewCM08-Book" => Exception::new()
         .family("New Computer Modern 08")
         .weight(450),


### PR DESCRIPTION
Closes https://github.com/typst/typst/issues/3213.

## Summary

The old version of Arial-Black, published by Microsoft in 1996 in their “core fonts for the web” project, has a wrong weight of 400. See https://corefonts.sourceforge.net/. This PR overrides the weight to 900.

## Description

As of Debian's [msttcorefonts 3.8.1](https://packages.debian.org/sid/ttf-mscorefonts-installer), the package installs the following fonts:

- Andale Mono
- Arial Black
- Arial (Bold, Italic, Bold Italic)
- Comic Sans MS (Bold)
- Courier New (Bold, Italic, Bold Italic)
- Georgia (Bold, Italic, Bold Italic)
- Impact
- Times New Roman (Bold, Italic, Bold Italic)
- Trebuchet (Bold, Italic, Bold Italic)
- Verdana (Bold, Italic, Bold Italic)
- Webdings

Of those, the only collision is Arial Black with Arial, since they have the same style, weight, and stretch.

Comparing a few font variants:

Source        | File Name         | `postScriptName` | `fontFamily` | `fontSubfamily` | `fullName`  | `usWeightClass` | version | year
------------- | ----------------- | ---------------- | ------------ | --------------- | ----------- | --------------- | ------- | ----
msttcorefonts | `Arial_Bold.ttf`  | Arial-BoldMT     | Arial        | Bold            | Arial Bold  | 700             | 2.35    | 1995
msttcorefonts | `Arial_Black.ttf` | Arial-Black      | Arial Black  | Regular         | Arial Black | 400             | 2.35    | 1995
macOS         | `Arial Black.ttf` | Arial-Black      | Arial Black  | Regular         | Arial Black | 900             | 5.00.1x | 2006
Windows 10    | `ariblk.ttf`      | Arial-Black      | Arial Black  | Regular         | Arial Black | 900             | 5.23    | 2016


This PR overrides `Arial-Black`'s weight class to 900.

### Font Families

Typst sanitizes the font family, removing “Black” from “Arial Black”, resulting Arial Black to be in the same font family as Arial.
Other environments are inconsistent in that regard.
Word on Windows and the font book on macOS show Arial Black as a separate font.
The Windows Font manager and Word on macOS do not list Arial Black separately, only as a variant of Arial.
I propose to keep Typst's current behavior in this regard and treat Arial Black as the same font family as Arial.

### Font Subfamilies

I am not sure about the convention of subfamilies and whether it would make sense to override Arial Black's font subfamily to `Black`.
Keeping it as is works fine, though, and would be the minimal change required to align the metadata to more recent versions of Arial.