### PR TITLE
Use heading's own location for numbering

### DIFF
--- a/crates/typst/src/introspection/counter.rs
+++ b/crates/typst/src/introspection/counter.rs
@@ -649,9 +649,9 @@ impl Show for Packed<DisplayElem> {
                     if func == HeadingElem::elem() {
                         HeadingElem::numbering_in(styles).clone()
                     } else if func == FigureElem::elem() {
-                        FigureElem::numbering_in(styles)
+                        FigureElem::numbering_in(styles).clone()
                     } else if func == EquationElem::elem() {
-                        EquationElem::numbering_in(styles)
+                        EquationElem::numbering_in(styles).clone()
                     } else {
                         None
                     }

--- a/crates/typst/src/math/equation.rs
+++ b/crates/typst/src/math/equation.rs
@@ -368,7 +368,7 @@ impl Outlinable for Packed<EquationElem> {
         let numbers = self
             .counter()
             .at(engine, self.location().unwrap())?
-            .display(engine, &numbering)?;
+            .display(engine, numbering)?;
 
         Ok(Some(supplement + numbers))
     }

--- a/crates/typst/src/math/equation.rs
+++ b/crates/typst/src/math/equation.rs
@@ -73,6 +73,7 @@ pub struct EquationElem {
     /// With @ratio, we get:
     /// $ F_n = floor(1 / sqrt(5) phi.alt^n) $
     /// ```
+    #[borrowed]
     pub numbering: Option<Numbering>,
 
     /// A supplement for the equation.
@@ -243,7 +244,9 @@ impl LayoutSingle for Packed<EquationElem> {
         if let Some(numbering) = (**self).numbering(styles) {
             let pod = Regions::one(regions.base(), Axes::splat(false));
             let counter = Counter::of(EquationElem::elem())
-                .display(self.span(), Some(numbering), false)
+                .at(engine, self.location().unwrap())?
+                .display(engine, numbering)?
+                .spanned(self.span())
                 .layout(engine, styles, pod)?
                 .into_frame();
 
@@ -338,8 +341,8 @@ impl Refable for Packed<EquationElem> {
         Counter::of(EquationElem::elem())
     }
 
-    fn numbering(&self) -> Option<Numbering> {
-        (**self).numbering(StyleChain::default())
+    fn numbering(&self) -> Option<&Numbering> {
+        (**self).numbering(StyleChain::default()).as_ref()
     }
 }
 

--- a/crates/typst/src/model/figure.rs
+++ b/crates/typst/src/model/figure.rs
@@ -399,7 +399,7 @@ impl Outlinable for Packed<FigureElem> {
         ) {
             let numbers = counter
                 .at(engine, self.location().unwrap())?
-                .display(engine, &numbering)?;
+                .display(engine, numbering)?;
 
             if !supplement.is_empty() {
                 supplement += TextElem::packed('\u{a0}');

--- a/crates/typst/src/model/figure.rs
+++ b/crates/typst/src/model/figure.rs
@@ -192,6 +192,7 @@ pub struct FigureElem {
     /// How to number the figure. Accepts a
     /// [numbering pattern or function]($numbering).
     #[default(Some(NumberingPattern::from_str("1").unwrap().into()))]
+    #[borrowed]
     pub numbering: Option<Numbering>,
 
     /// The vertical gap between the body and caption.
@@ -371,8 +372,8 @@ impl Refable for Packed<FigureElem> {
             .unwrap_or_else(|| Counter::of(FigureElem::elem()))
     }
 
-    fn numbering(&self) -> Option<Numbering> {
-        (**self).numbering(StyleChain::default())
+    fn numbering(&self) -> Option<&Numbering> {
+        (**self).numbering(StyleChain::default()).as_ref()
     }
 }
 
@@ -396,8 +397,9 @@ impl Outlinable for Packed<FigureElem> {
             (**self).counter(),
             self.numbering(),
         ) {
-            let location = self.location().unwrap();
-            let numbers = counter.at(engine, location)?.display(engine, &numbering)?;
+            let numbers = counter
+                .at(engine, self.location().unwrap())?
+                .display(engine, &numbering)?;
 
             if !supplement.is_empty() {
                 supplement += TextElem::packed('\u{a0}');

--- a/crates/typst/src/model/heading.rs
+++ b/crates/typst/src/model/heading.rs
@@ -147,11 +147,12 @@ impl Synthesize for Packed<HeadingElem> {
 
 impl Show for Packed<HeadingElem> {
     #[typst_macros::time(name = "heading", span = self.span())]
-    fn show(&self, _: &mut Engine, styles: StyleChain) -> SourceResult<Content> {
+    fn show(&self, engine: &mut Engine, styles: StyleChain) -> SourceResult<Content> {
         let mut realized = self.body().clone();
         if let Some(numbering) = (**self).numbering(styles).as_ref() {
             realized = Counter::of(HeadingElem::elem())
-                .display(self.span(), Some(numbering.clone()), false)
+                .at(engine, self.location().unwrap())?
+                .display(engine, numbering)?
                 .spanned(self.span())
                 + HElem::new(Em::new(0.3).into()).with_weak(true).pack()
                 + realized;
@@ -205,8 +206,8 @@ impl Refable for Packed<HeadingElem> {
         Counter::of(HeadingElem::elem())
     }
 
-    fn numbering(&self) -> Option<Numbering> {
-        (**self).numbering(StyleChain::default()).clone()
+    fn numbering(&self) -> Option<&Numbering> {
+        (**self).numbering(StyleChain::default()).as_ref()
     }
 }
 

--- a/crates/typst/src/model/outline.rs
+++ b/crates/typst/src/model/outline.rs
@@ -341,7 +341,7 @@ impl OutlineIndent {
                         let numbers = ancestor_outlinable
                             .counter()
                             .at(engine, ancestor.location().unwrap())?
-                            .display(engine, &numbering)?;
+                            .display(engine, numbering)?;
 
                         hidden += numbers + SpaceElem::new().pack();
                     };

--- a/crates/typst/src/model/reference.rs
+++ b/crates/typst/src/model/reference.rs
@@ -220,7 +220,7 @@ impl Show for Packed<RefElem> {
             let numbers = refable
                 .counter()
                 .at(engine, loc)?
-                .display(engine, &numbering.trimmed())?;
+                .display(engine, &numbering.clone().trimmed())?;
 
             let supplement = match self.supplement(styles).as_ref() {
                 Smart::Auto => refable.supplement(),
@@ -301,5 +301,5 @@ pub trait Refable {
     fn counter(&self) -> Counter;
 
     /// Returns the numbering of this element.
-    fn numbering(&self) -> Option<Numbering>;
+    fn numbering(&self) -> Option<&Numbering>;
 }


### PR DESCRIPTION
That way it's more efficient. It also happens that the original bug in https://github.com/typst/typst/issues/2584 doesn't reproduce anymore, but the underlying problem remains. I'll post more details on that issue.