### PR TITLE
SVG - Glyph ID String Generated From Hash Instead of Index

### DIFF
--- a/crates/typst-svg/src/lib.rs
+++ b/crates/typst-svg/src/lib.rs
@@ -1299,7 +1299,7 @@ struct Id(char, u128, usize);
 
 impl Display for Id {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}{:0X}", self.0, self.1)
+        write!(f, "{}{:0X}", self.0, self.2)
     }
 }
 


### PR DESCRIPTION
In the svg renderer, the display function for ID's (used for glyphs and diffs) references the "hash" property, not the "index" property, which results in much larger `xlink:href` and therefore significantly larger svg output files.

Previous:
```
<use xlink:href="#g14D8754CF2253E6C87B562F46932866A" x="0" fill="#000000"/>
```

With Change:
```
<use xlink:href="#g0" x="0" fill="#000000"/>
```

This error appears to have occurred in PR #2279.
Specifically [here]( https://github.com/typst/typst/commit/a4e357fb37d76d32d06ad8cc21e47bb2cc064cfd#diff-8cb8e763f7700894cce5b24647f215df15d7b5866dd4f630f9244cbca3be0c60L592-R923) where another property was added in the middle of the ID struct, without changing the corresponding reference in the display function, changing the referenced property to the value of the hash.

The change proposed in this PR is the minimum needed to fix the issue. 
Though it is unclear why ID's contain a hash to begin with.

The only way to get the ID is to input the hash, so if you already have it, why store it?
I guess if you have an instance an ID stored somewhere you could derive the hash?
But what can you do with the hash but compare it to another hash and see it's the same or different? 
And in that case you could just throw the hash you do have in the Deduplicator and see if they result in the same ID.

I did remove the hash from ID struct as an experiment, and it did not cause any apparent failures or issues.
But I wanted to keep this PR as simple as possible, so did not include more significant changes.