### PR TITLE
Fix error swallowing

### DIFF
--- a/crates/typst-cli/src/main.rs
+++ b/crates/typst-cli/src/main.rs
@@ -50,7 +50,7 @@ fn main() -> ExitCode {
         .leave_alternate_screen()
         .map_err(|err| eco_format!("failed to leave alternate screen ({err})"));
 
-    if let Err(msg) = res.or(res_leave) {
+    if let Some(msg) = res.err().or(res_leave.err()) {
         set_failed();
         print_error(&msg).expect("failed to print error");
     }


### PR DESCRIPTION
This PR fixes a bug where command errors are swallowed when leaving the alternate terminal screen was successful. The bug was introduced [here](https://github.com/typst/typst/commit/6999be9ab0d851d0b3b34bd311712c27887721f1#diff-cf35368aed7152fd1cfd5f30fc89b27f82d21cc874161c0540abe988582330c5R47-R53).