### PR TITLE
Support reading input from stdin

### DIFF
--- a/crates/typst-cli/src/watch.rs
+++ b/crates/typst-cli/src/watch.rs
@@ -168,7 +168,14 @@ impl Status {
         term_out.set_color(&color)?;
         write!(term_out, "watching")?;
         term_out.reset()?;
-        writeln!(term_out, " {}", command.common.input.display())?;
+        writeln!(
+            term_out,
+            " {}",
+            command
+                .common
+                .input()
+                .map_or("<stdin>".to_string(), |i| i.display().to_string())
+        )?;
 
         term_out.set_color(&color)?;
         write!(term_out, "writing to")?;

--- a/crates/typst-syntax/src/file.rs
+++ b/crates/typst-syntax/src/file.rs
@@ -57,6 +57,23 @@ impl FileId {
         id
     }
 
+    /// Create a new "fake" file specification which is *not* interned.
+    ///
+    /// Caution: the ID returned by this method is the *only* identifier of the
+    /// file, constructing a FileID with a path will *not* reuse the ID even if
+    /// the path is the same. This method should only be used for generating
+    /// "virtual" file ids such as content read from stdin.
+    #[track_caller]
+    pub fn new_fake(path: VirtualPath) -> Self {
+        let mut interner = INTERNER.write().unwrap();
+        let num = interner.from_id.len().try_into().expect("out of file ids");
+
+        let id = FileId(num);
+        let leaked = Box::leak(Box::new((None, path)));
+        interner.from_id.push(leaked);
+        id
+    }
+
     /// The package the file resides in, if any.
     pub fn package(&self) -> Option<&'static PackageSpec> {
         self.pair().0.as_ref()


### PR DESCRIPTION
This PR extends the ability of the CLI to be able to read from stdin. Using `-` as the input path will trigger this behavior.  
It enables various use cases like piping into the CLI (which is very useful when building automation around typst), and sending pre-processed files to it.

In order to do this, following changes are made to the code base:

- In `typst-syntax`, `FileId` gets a new method `new_fake`, to create new file ids which cannot be looked up with a path (i.e. the only identifier for it is the ID number itself.). This is to allocate a special "fake" `FileId` for stdin to distinguish it when reading the file.
- In `typst-cli`, the file reading logic in `world.rs` is rewritten so that every read operation goes through `FileReader`, which is a wrapper around `FileId` that chooses the correct behavior for the ID.
- Also in `world.rs` the field `input` is changed from `PathBuf` to `Option<PathBuf>`, and everywhere that uses it is changed too. Most of the use sites doesn't actually require `input` to be present, with two notable exceptions: 
    - In `compile.rs`, the `output` method contains an `expect` to unwrap the `Option`. This is ok because the CLI arg parsing ensures that user cannot have empty `output` in this case, and they can get meaningful error if it is broken.
    - In `watch.rs` the displayed filename defaults to `<stdin>`.
- In `args.rs` the positional argument `INPUT` has its own type and parser now. This is to treat `-` specially and to work around the weird special casing of `Option<T>` that `clap` applies. Code outside of this module only accesses the field through the method that converts it to an `Option`.

(Solves #348 and partially #410)