### PR TITLE
Update dictionary.insert() doc and tests

### DIFF
--- a/crates/typst/src/foundations/dict.rs
+++ b/crates/typst/src/foundations/dict.rs
@@ -182,8 +182,8 @@ impl Dict {
             .ok_or_else(|| missing_key_no_default(&key))
     }
 
-    /// Inserts a new pair into the dictionary and return the value. If the
-    /// dictionary already contains this key, the value is updated.
+    /// Inserts a new pair into the dictionary. If the dictionary already
+    /// contains this key, the value is updated.
     #[func]
     pub fn insert(
         &mut self,

--- a/tests/typ/compiler/dict.typ
+++ b/tests/typ/compiler/dict.typ
@@ -41,6 +41,16 @@
 #test((a: 1, b: 2).at("c", default: 3), 3)
 
 ---
+// Test insert.
+#{
+  let dict = (a: 1, b: 2)
+  dict.insert("b", 3)
+  test(dict, (a: 1, b: 3))
+  dict.insert("c", 5)
+  test(dict, (a: 1, b: 3, c: 5))
+}
+
+---
 // Test remove with default value.
 #{
   let dict = (a: 1, b: 2)


### PR DESCRIPTION
[dictionary.insert()](https://typst.app/docs/reference/foundations/dictionary/#definitions-insert) was not tested in test. This patch added that test.

The current doc for [dictionary.insert()](https://typst.app/docs/reference/foundations/dictionary/#definitions-insert) says it returns the value, but the test indicates the method returns none. Therefore, this patch updates the doc to reflect the situation.

---

Alternatively, one could modify the method's implementation to this so it returns the previous value before insertion:
```rust
// dict.rs, after change
#[func]
pub fn insert(
    &mut self,
    /// The key of the pair that should be inserted.
    key: DictKey,
    /// The value of the pair that should be inserted.
    value: Value,
) -> Option<Value> {
    // In the code below, the original trailing ";" was removed, so the entire function returns
    // what IndexMap's insert() returns.
    Arc::make_mut(&mut self.0).insert(key, value)
}
```
and accordingly this also needs to be updated so that the method's return value is received:
```rust
// method.rs, after change
"insert" => {
    output = match dict.insert(args.expect::<Str>("key")?, args.expect("value")?) {
        Some(v) => v,
        None => Value::None,
    }
}
```
but this alternative approach creates a conundrum. The return value is `none` in both cases: (1) the inserted key did exist and the previous value is `none`, and (2) the inserted key did not exist. Therefore, I decided against this alternative for now, but we can always visit the design later, since adding a return value to `insert()` would not be a breaking change.