### PR TITLE
Add warning when font style is not perfect match

### DIFF
--- a/crates/typst/src/math/equation.rs
+++ b/crates/typst/src/math/equation.rs
@@ -1,5 +1,6 @@
 use std::num::NonZeroUsize;
 
+use comemo::TrackedMut;
 use unicode_math_class::MathClass;
 
 use crate::diag::{bail, SourceResult};
@@ -385,7 +386,11 @@ fn find_math_font(
     let variant = variant(styles);
     let world = engine.world;
     let Some(font) = families(styles).find_map(|family| {
-        let id = world.book().select(family, variant)?;
+        let id = world.book().select(
+            family,
+            variant,
+            Some((TrackedMut::reborrow_mut(&mut engine.tracer), span)),
+        )?;
         let font = world.font(id)?;
         let _ = font.ttf().tables().math?.constants?;
         Some(font)

--- a/crates/typst/src/text/shift.rs
+++ b/crates/typst/src/text/shift.rs
@@ -155,7 +155,7 @@ fn is_shapable(engine: &Engine, text: &str, styles: StyleChain) -> bool {
     for family in TextElem::font_in(styles) {
         if let Some(font) = world
             .book()
-            .select(family.as_str(), variant(styles))
+            .select(family.as_str(), variant(styles), None)
             .and_then(|id| world.font(id))
         {
             return text.chars().all(|c| font.ttf().glyph_index(c).is_some());

--- a/crates/typst/src/visualize/image/svg.rs
+++ b/crates/typst/src/visualize/image/svg.rs
@@ -178,8 +178,11 @@ fn load_svg_fonts(
                     // and the current document font families.
                     let mut like = None;
                     for family in span.font.families.iter().chain(families) {
-                        let Some(id) = book.select(&family.to_lowercase(), variant)
-                        else {
+                        let Some(id) = book.select(
+                            &family.to_lowercase(),
+                            variant,
+                            Some((TrackedMut::reborrow_mut(&mut tracer), img_span)),
+                        ) else {
                             continue;
                         };
                         let Some(info) = book.info(id) else { continue };
@@ -198,8 +201,7 @@ fn load_svg_fonts(
                         like,
                         variant,
                         text,
-                        TrackedMut::reborrow_mut(&mut tracer),
-                        img_span,
+                        Some((TrackedMut::reborrow_mut(&mut tracer), img_span)),
                     ) {
                         if let Some(usvg_family) = load_into_db(id) {
                             span.font.families = vec![usvg_family];


### PR DESCRIPTION
This PR is based on #3352. This pr further add warnings when selected font style is not perfect match.

This typically happens when applying to `#strong` or `#emph` to certain text but the font itself doesn't provide a bold/italic variant

related issue: #2818