### PR TITLE
Catch duplicate dynamic keys in dictionary

### DIFF
--- a/tests/typ/compiler/dict.typ
+++ b/tests/typ/compiler/dict.typ
@@ -151,6 +151,10 @@
 #(a+b: 1, (a+b): 2, a: 3, ("made in berlin".at(1)): 4)
 
 ---
+#let other = (a: 2, "foo": 2, "bar": 2)
+#test((a: 1, foo: 1, ("bark".slice(0,3)): 1, ..other), (a: 2, foo: 2, "bar": 2))
+
+---
 #let func() = { "a" }
 // Error: 9-17 duplicate key: a
 #(a: 3, (func()): 4)

--- a/tests/typ/compiler/dict.typ
+++ b/tests/typ/compiler/dict.typ
@@ -135,14 +135,25 @@
 
 ---
 #let a = "hello"
-#let b = "world"
-#let c = "value"
-#let d = "conflict"
+// Error: 11-14 duplicate key: hello
+#((a): 1, (a): 2)
 
-#assert.eq(((a): b), ("hello": "world"))
-#assert.eq(((a): 1, (a): 2), ("hello": 2))
-#assert.eq((hello: 1, (a): 2), ("hello": 2))
-#assert.eq((a + b: c, (a + b): d, (a): "value2", a: "value3"), ("helloworld": "conflict", "hello": "value2", "a": "value3"))
+---
+#let a = "hello"
+// Error: 13-16 duplicate key: hello
+#(hello: 1, (a): 2)
+
+---
+#let a = "hello"
+#let b = "world"
+// Error: 11-16 duplicate key: helloworld
+// Error: 27-51 duplicate key: a
+#(a+b: 1, (a+b): 2, a: 3, ("made in berlin".at(1)): 4)
+
+---
+#let func() = { "a" }
+// Error: 9-17 duplicate key: a
+#(a: 3, (func()): 4)
 
 ---
 // Error: 7-10 expected identifier, found group


### PR DESCRIPTION
From #2559 is sounds the current inability to catch duplicate dynamically-evaluated keys was acquiesced as an unintended limitation. This patch adds checks at code evaluation that builds the dictionary.

The modified test in dict.typ showcased the changed behavior.

Please advise if accepting duplicate dynamic keys is actually really intended..? I think if users wanted to update the value corresponding to an existing key, they should explicitly do so with [at() (as an lvalue)](https://typst.app/docs/reference/foundations/dictionary/#definitions-at) or [insert()](https://typst.app/docs/reference/foundations/dictionary/#definitions-insert), instead of utilizing this undocumented "arcana".