### PR TITLE
Add `dictionary.from-pairs()`

### DIFF
--- a/crates/typst/src/foundations/dict.rs
+++ b/crates/typst/src/foundations/dict.rs
@@ -233,27 +233,28 @@ impl Dict {
             .collect()
     }
 
+    /// Converts an array of key and value pairs into a dictionary. Each pair is
+    /// represented as an array of length two.
     #[func]
     pub fn from_pairs(pairs: Array) -> StrResult<Dict> {
         let mut dict = Dict::new();
 
         for value in pairs.into_iter() {
             match value {
-                Value::Array(array) => {
-                    if array.len() == 2 {
-                        if let (Ok(Value::Str(key)), Ok(value)) = (array.first(), array.last()) {
-                            dict.insert(key, value);
-                        }
+                Value::Array(array) if array.len() == 2 => {
+                    if let (Ok(Value::Str(key)), Ok(value)) =
+                        (array.first(), array.last())
+                    {
+                        dict.insert(key, value);
                     } else {
-                        bail!("not an array of key-value pairs")
+                        bail!("first item of pair must be a string")
                     }
-                },
-                _ => bail!("not an array of key-value pairs"),
+                }
+                _ => bail!("must be an array of pairs (arrays of length 2)"),
             };
         }
 
         Ok(dict)
-
     }
 }
 

--- a/crates/typst/src/foundations/dict.rs
+++ b/crates/typst/src/foundations/dict.rs
@@ -7,7 +7,7 @@ use ecow::{eco_format, EcoString};
 use indexmap::IndexMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::diag::StrResult;
+use crate::diag::{bail, StrResult};
 use crate::foundations::{array, func, repr, scope, ty, Array, Repr, Str, Value};
 use crate::syntax::is_ident;
 use crate::util::ArcExt;
@@ -231,6 +231,29 @@ impl Dict {
             .iter()
             .map(|(k, v)| Value::Array(array![k.clone(), v.clone()]))
             .collect()
+    }
+
+    #[func]
+    pub fn from_pairs(pairs: Array) -> StrResult<Dict> {
+        let mut dict = Dict::new();
+
+        for value in pairs.into_iter() {
+            match value {
+                Value::Array(array) => {
+                    if array.len() == 2 {
+                        if let (Ok(Value::Str(key)), Ok(value)) = (array.first(), array.last()) {
+                            dict.insert(key, value);
+                        }
+                    } else {
+                        bail!("not an array of key-value pairs")
+                    }
+                },
+                _ => bail!("not an array of key-value pairs"),
+            };
+        }
+
+        Ok(dict)
+
     }
 }
 

--- a/tests/typ/compiler/dict.typ
+++ b/tests/typ/compiler/dict.typ
@@ -153,3 +153,17 @@
 // Error: 3-7 expected string, found boolean
 // Error: 16-18 expected string, found integer
 #(true: false, 42: 3)
+
+---
+/// Test constructor from pairs
+#let dict = (a: 1, b: 2, c: 3)
+#test(dictionary.from-pairs(dict.pairs()), dict)
+#test(dictionary.from-pairs((("a", 1), ("b", 2), ("a", 3))), (a: 3, b: 2))
+
+---
+// Error: 23-41 must be an array of pairs (arrays of length 2)
+#dictionary.from-pairs(((a: 1), (b: 2)))
+
+---
+// Error: 23-43 first item of pair must be a string
+#dictionary.from-pairs((("a", 1), (3, 2)))


### PR DESCRIPTION
This is an opinionated PR, so open to other ideas.

There isn't currently a convenient ‘opposite’ to `dictionary.pairs()`, other than inserting or joining manually, as in:
```typ
#let b = (:)
#for (k, v) in a { b.insert(k, v) }
#(a == b)
// or:
#(a == for (k, v) in a { ((k): v) })
```

This PR adds a `dictionary.from-pairs()` method such that `a == dictionary.from-pairs(dictionary.pairs(a))`.

Alternatively, this could be a constructor, i.e., `a == dictionary(a.pairs())` or `a == dicionary(..a.pairs())`. It could even be a method of `array`, which would look nice when, e.g., you want to filter a dictionary: `a.pairs().filter(..).to-dict()`.