### PR TITLE
Allow `calc.atan2` to take lengths

### DIFF
--- a/crates/typst/src/foundations/calc.rs
+++ b/crates/typst/src/foundations/calc.rs
@@ -362,7 +362,7 @@ pub fn atan2(
                 bail!(span, "lengths must have comparable units")
             }
         }
-        _ => bail!(span, "arguments must be of the same type"),
+        _ => bail!(span, "values must be both numbers or both lengths"),
     }
 }
 

--- a/tests/typ/compute/calc.typ
+++ b/tests/typ/compute/calc.typ
@@ -353,3 +353,9 @@
 ---
 // Error: 18-19 number must not be zero
 #range(10, step: 0)
+
+---
+// Test atan2 with length arguments
+#test(calc.atan2(2, 3), calc.atan2(2cm, 3cm))
+#test(calc.atan2(1, -5), calc.atan2(1em, -5em))
+#test(calc.atan2(0pt, 1pt), 90deg)


### PR DESCRIPTION
It’s mathematically sound to allow `x` and `y` to be lengths in `calc.atan2(x, y)`, so long as they are of “compatible” units (in the sense that `y/x` is well-defined). This PR ensures that both `calc.atan(5pt/3pt)` and `calc.atan2(3pt, 5pt)` just work.
Exactly the same check as `Length::try_div` is performed before computing `atan2` on the raw lengths.

I’m not sure what the performance impact is from turning`atan2` from `(Num, Num) -> Angle` into `(Span, Num|Length, Num|Length) -> SourceResult<Angle>`.

