### PR TITLE
lexer: Allow emphasis in Korean text without spaces 

### DIFF
--- a/crates/typst-syntax/src/lexer.rs
+++ b/crates/typst-syntax/src/lexer.rs
@@ -345,7 +345,10 @@ impl Lexer<'_> {
                 c.is_alphanumeric()
                     && !matches!(
                         c.script(),
-                        Script::Han | Script::Hiragana | Script::Katakana
+                        Script::Han
+                            | Script::Hiragana
+                            | Script::Katakana
+                            | Script::Hangul
                     )
             })
         };


### PR DESCRIPTION
Similar to #2648, we also want to do this for Hangul (Korean text).
Korean, while having spaces, have grammatical rules about attaching
suffixes to words without spaces. Most of the time you would prefer to
emphasize the word but not the grammatical suffix, which means a lot
of emphasis is done with in-word markers.

Progress:
- [x] Add Korean emphasis-in-middle test
- [x] Update lexer to allow emphasis in Korean text
