### PR TITLE
Fix named destinations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,8 +1616,9 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pdf-writer"
-version = "0.9.0"
-source = "git+https://github.com/heinenen/pdf-writer?branch=named_destinations#58c6dc1552aa72f5e2c07a37045526fcf365d34a"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644b654f2de28457bf1e25a4905a76a563d1128a33ce60cf042f721f6818feaf"
 dependencies = [
  "bitflags 1.3.2",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ oxipng = { version = "9.0", default-features = false, features = ["filetime", "p
 palette = { version = "0.7.3", default-features = false, features = ["approx", "libm"] }
 parking_lot = "0.12.1"
 pathdiff = "0.2"
-pdf-writer = "0.9"
+pdf-writer = "0.9.2"
 phf = { version = "0.11", features = ["macros"] }
 pixglyph = "0.3"
 proc-macro2 = "1"
@@ -122,9 +122,6 @@ xmp-writer = "0.2"
 xz2 = "0.1"
 yaml-front-matter = "0.1"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
-
-[patch.crates-io]
-pdf-writer = { git = 'https://github.com/heinenen/pdf-writer', branch = "named_destinations" }
 
 [profile.dev.package."*"]
 opt-level = 2

--- a/crates/typst/src/util/pico.rs
+++ b/crates/typst/src/util/pico.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt::{self, Debug, Formatter};
 use std::sync::RwLock;
@@ -23,7 +24,7 @@ struct Interner {
 /// slow to look up a string in the interner, so we want to avoid doing it
 /// unnecessarily. For this reason, the user should use the [`PicoStr::resolve`]
 /// method to get the underlying string, such that the lookup is done only once.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct PicoStr(u32);
 
 impl PicoStr {
@@ -60,6 +61,18 @@ cast! {
 impl Debug for PicoStr {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         self.resolve().fmt(f)
+    }
+}
+
+impl Ord for PicoStr {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.resolve().cmp(other.resolve())
+    }
+}
+
+impl PartialOrd for PicoStr {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
- Removes pdf-writer patch
- Fixes GoTo action by using string instead of name
- Fixes links to locations that have a label, but aren't the canonical element for that label referred to by the named destinations:
  ```typ
  = Introduction <label>
  #locate(loc => {
    let loc = query(<label>, loc).last().location()
    link(loc)[Go to back]
  })
  
  #pagebreak()
  
  = Background <label>
  ```