### PR TITLE
Improve documentation on syntactical modes

### DIFF
--- a/crates/typst/src/foundations/mod.rs
+++ b/crates/typst/src/foundations/mod.rs
@@ -257,7 +257,8 @@ pub fn eval(
     engine: &mut Engine,
     /// A string of Typst code to evaluate.
     source: Spanned<String>,
-    /// The syntactical mode in which the string is parsed.
+    /// The [syntactical mode]($reference/syntax/#modes) in which the string is
+    /// parsed.
     ///
     /// ```example
     /// #eval("= Heading", mode: "markup")

--- a/crates/typst/src/text/raw.rs
+++ b/crates/typst/src/text/raw.rs
@@ -141,8 +141,9 @@ pub struct RawElem {
     /// The language to syntax-highlight in.
     ///
     /// Apart from typical language tags known from Markdown, this supports the
-    /// `{"typ"}` and `{"typc"}` tags for Typst markup and Typst code,
-    /// respectively.
+    /// `{"typ"}` and `{"typc"}` tags for
+    /// [Typst markup]($reference/syntax/#markup) and
+    /// [Typst code]($reference/syntax/#code), respectively.
     ///
     /// ````example
     /// ```typ

--- a/docs/reference/syntax.md
+++ b/docs/reference/syntax.md
@@ -11,6 +11,18 @@ set and show rules, which let you style your document easily and automatically.
 All this is backed by a tightly integrated scripting language with built-in and
 user-defined functions.
 
+## Modes
+
+Typst has three syntactical modes: Markup, math, and code. Markup mode is the default in a Typst document, math mode lets you write mathematical formulas, and code mode lets you use Typst's scripting features.
+
+You can switch between two modes at any point by referring to the following table.
+
+| Initial mode  | New mode | Syntax                                                        | Example                                                      |
+|---------------|----------|---------------------------------------------------------------|--------------------------------------------------------------|
+| Markup / math | Code     | Prefix the code with `#`. You might want to use a code block. | `[#{1 + 2} is a number]` <br/> `[$4 + 2 = #{4 + 2}$]`        |
+| Markup / code | Math     | Surround the formula with `$`.                                | `[$-x$ is the opposite of $x$]` <br/> `{let eq = $y = x^2$}` |
+| Code          | Markup   | Surround markup with square brackets.                         | `{let brand = [*Typst!*]}`                                   |
+
 ## Markup
 Typst provides built-in markup for the most common document elements. Most of
 the syntax elements are just shortcuts for a corresponding function. The table

--- a/docs/reference/syntax.md
+++ b/docs/reference/syntax.md
@@ -12,16 +12,21 @@ All this is backed by a tightly integrated scripting language with built-in and
 user-defined functions.
 
 ## Modes
+Typst has three syntactical modes: Markup, math, and code. Markup mode is the 
+default in a Typst document, math mode lets you write mathematical formulas, and
+code mode lets you use Typst's scripting features.
 
-Typst has three syntactical modes: Markup, math, and code. Markup mode is the default in a Typst document, math mode lets you write mathematical formulas, and code mode lets you use Typst's scripting features.
+You can switch to a specific mode at any point by referring to the following
+table:
 
-You can switch between two modes at any point by referring to the following table.
+| New mode | Syntax                          | Example                         |
+|----------|---------------------------------|---------------------------------|
+| Code     | Prefix the code with `#`        | `[Number: #(1 + 2)]`            |
+| Math     | Surround equation with `[$..$]` | `[$-x$ is the opposite of $x$]` |
+| Markup   | Surround markup with `[[..]]`   | `{let name = [*Typst!*]}`       |
 
-| Initial mode  | New mode | Syntax                                                        | Example                                                      |
-|---------------|----------|---------------------------------------------------------------|--------------------------------------------------------------|
-| Markup / math | Code     | Prefix the code with `#`. You might want to use a code block. | `[#{1 + 2} is a number]` <br/> `[$4 + 2 = #{4 + 2}$]`        |
-| Markup / code | Math     | Surround the formula with `$`.                                | `[$-x$ is the opposite of $x$]` <br/> `{let eq = $y = x^2$}` |
-| Code          | Markup   | Surround markup with square brackets.                         | `{let brand = [*Typst!*]}`                                   |
+Once you have entered code mode with `#`, you don't need to use further hashes
+unless you switched back to markup or math mode in between.
 
 ## Markup
 Typst provides built-in markup for the most common document elements. Most of


### PR DESCRIPTION
This small PR improves the documentation of syntactical modes.

This is done by adding a section to [the Syntax page](https://typst.app/docs/reference/syntax/) explaining how to switch between modes. Although this section is redundant with the rest of the page, I think it makes it easier understand what syntactical modes are for people who haven't been using Typst for long enough to fully understand this concept.[^1][^2]

This PR also adds link to the Syntax page in the documentation for [`eval`](https://typst.app/docs/reference/foundations/eval/) and [`raw`](https://typst.app/docs/reference/text/raw/).

[^1]: An example of such person: https://github.com/typst/typst/discussions/3417#discussioncomment-8470655
[^2]: Another example of such person: https://github.com/typst/typst/issues/1511#issuecomment-1595363259