### PR TITLE
Add .at() to module

### DIFF
--- a/crates/typst/src/foundations/module.rs
+++ b/crates/typst/src/foundations/module.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 use ecow::{eco_format, EcoString};
 
 use crate::diag::StrResult;
-use crate::foundations::{func, repr, scope, ty, Content, Repr as OtherRepr, Scope, Str, Value};
+use crate::foundations::{
+    func, repr, scope, ty, Content, Repr as OtherRepr, Scope, Str, Value,
+};
 
 /// An evaluated module, either built-in or resulting from a file.
 ///
@@ -98,8 +100,6 @@ impl Module {
             Err(arc) => arc.content.clone(),
         }
     }
-
-
 }
 
 #[scope]
@@ -113,7 +113,11 @@ impl Module {
         #[named]
         default: Option<Value>,
     ) -> StrResult<Value> {
-        self.scope().get(&key).cloned().or(default).ok_or_else(|| missing_key_no_default(&key))
+        self.scope()
+            .get(&key)
+            .cloned()
+            .or(default)
+            .ok_or_else(|| missing_key_no_default(&key))
     }
 }
 


### PR DESCRIPTION
This is my first time committing, but essentially the idea is to add the `.at()` function onto the `module` type so that we can pull values, if defined, from an import.

For example:

`test1.typ`:

```typ
#include "test2.typ" as other_module

other_module.at("value_one")
other_module.at("value_two", default: none)
```

`test2.typ`:

```typ
#let value_one = 1
```

With this change, the above code would compile, allowing for some more flexibility with dynamic imports/modules.
