### PR TITLE
Add module -> dictionary conversion

### DIFF
--- a/crates/typst/src/foundations/dict.rs
+++ b/crates/typst/src/foundations/dict.rs
@@ -254,7 +254,7 @@ impl Dict {
     }
 }
 
-/// A value that can be cast to bytes.
+/// A value that can be cast to dictionary.
 pub struct ToDict(Dict);
 
 cast! {

--- a/crates/typst/src/foundations/dict.rs
+++ b/crates/typst/src/foundations/dict.rs
@@ -165,8 +165,7 @@ impl Dict {
     /// from individual pairs. Use the dictionary syntax `(key: value)` instead.
     ///
     /// ```example
-    /// #include "test.typ" as test
-    /// #dictionary(test)
+    /// #dictionary(sys).at("version")
     /// ```
     #[func(constructor)]
     pub fn construct(

--- a/crates/typst/src/foundations/dict.rs
+++ b/crates/typst/src/foundations/dict.rs
@@ -8,7 +8,9 @@ use indexmap::IndexMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::diag::{Hint, HintedStrResult, StrResult};
-use crate::foundations::{cast, array, func, repr, scope, ty, Module, Array, Repr, Str, Value};
+use crate::foundations::{
+    array, cast, func, repr, scope, ty, Array, Module, Repr, Str, Value,
+};
 use crate::syntax::is_ident;
 use crate::util::ArcExt;
 

--- a/crates/typst/src/foundations/dict.rs
+++ b/crates/typst/src/foundations/dict.rs
@@ -8,7 +8,7 @@ use indexmap::IndexMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::diag::{Hint, HintedStrResult, StrResult};
-use crate::foundations::{array, func, repr, scope, ty, Array, Repr, Str, Value};
+use crate::foundations::{cast, array, func, repr, scope, ty, Module, Array, Repr, Str, Value};
 use crate::syntax::is_ident;
 use crate::util::ArcExt;
 
@@ -156,6 +156,29 @@ impl Dict {
 
 #[scope]
 impl Dict {
+    /// Converts a value into a dictionary
+    ///
+    /// This function can convert a module into a dictionary
+    ///
+    /// ```example
+    /// #include "test.typ" as test
+    /// #dictionary(test)
+    /// ```
+    #[func(constructor)]
+    pub fn construct(
+        /// The value that should be converted to a dictionary.
+        value: ToDict,
+    ) -> Dict {
+        value.0
+    }
+
+    //pub fn from_module(
+    //    /// The module to turn into a dictionary
+    //    module: Module
+    //) -> Dict {
+    //    module.scope().iter().map(|(k, v)| (Str::from(k.clone()), v.clone())).collect::<Dict>()
+    //}
+
     /// The number of pairs in the dictionary.
     #[func(title = "Length")]
     pub fn len(&self) -> usize {
@@ -233,6 +256,14 @@ impl Dict {
             .map(|(k, v)| Value::Array(array![k.clone(), v.clone()]))
             .collect()
     }
+}
+
+/// A value that can be cast to bytes.
+pub struct ToDict(Dict);
+
+cast! {
+    ToDict,
+    v: Module => Self(v.scope().iter().map(|(k, v)| (Str::from(k.clone()), v.clone())).collect()),
 }
 
 impl Debug for Dict {

--- a/crates/typst/src/foundations/dict.rs
+++ b/crates/typst/src/foundations/dict.rs
@@ -174,13 +174,6 @@ impl Dict {
         value.0
     }
 
-    //pub fn from_module(
-    //    /// The module to turn into a dictionary
-    //    module: Module
-    //) -> Dict {
-    //    module.scope().iter().map(|(k, v)| (Str::from(k.clone()), v.clone())).collect::<Dict>()
-    //}
-
     /// The number of pairs in the dictionary.
     #[func(title = "Length")]
     pub fn len(&self) -> usize {

--- a/crates/typst/src/foundations/dict.rs
+++ b/crates/typst/src/foundations/dict.rs
@@ -158,9 +158,11 @@ impl Dict {
 
 #[scope]
 impl Dict {
-    /// Converts a value into a dictionary
+    /// Converts a value into a dictionary.
     ///
-    /// This function can convert a module into a dictionary
+    /// Note that this function is only intended for conversion of a
+    /// dictionary-like value to a dictionary, not for creation of a dictionary
+    /// from individual pairs. Use the dictionary syntax `(key: value)` instead.
     ///
     /// ```example
     /// #include "test.typ" as test

--- a/tests/typ/compiler/dict.typ
+++ b/tests/typ/compiler/dict.typ
@@ -84,6 +84,11 @@
 #test(dict, (a: 3, b: 1))
 
 ---
+// Test dictionary constructor
+#dictionary(sys).at("version")
+#dictionary(sys).at("no_crash", default: none)
+
+---
 // Test that removal keeps order.
 #let dict = (a: 1, b: 2, c: 3, d: 4)
 #dict.remove("b")


### PR DESCRIPTION
This aims to be a better solution than #3426. Rather then adding a `at()` function to modules, we instead allow the creation of a dictionary from a module.

For example:

`test1.typ`:

```typ
#include "test2.typ" as other_module

#let x = dictionary(other_module)
#x.at("value_one")
#x.at("value_two", default: none)
```

`test2.typ`:

```typ
#let value_one = 1
```

With this change, the above code would compile, allowing for some more flexibility with dynamic imports/modules.