### PR TITLE
add basic typst-docs cmd that spits out json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ package-lock.json
 # Nix
 /result
 .direnv/
+
+# typst-docs output
+_site

--- a/crates/typst-docs/Cargo.toml
+++ b/crates/typst-docs/Cargo.toml
@@ -10,6 +10,13 @@ publish = false
 doctest = false
 bench = false
 
+[[bin]]
+name = "typst-docs"
+required-features = ["cli"]
+
+[features]
+cli = ["clap", "typst-render", "serde_json"]
+
 [dependencies]
 typst = { workspace = true }
 comemo = { workspace = true }
@@ -25,6 +32,9 @@ typed-arena = { workspace = true }
 unicode_names2 = { workspace = true }
 unscanny = { workspace = true }
 yaml-front-matter = { workspace = true }
+clap = { workspace = true, optional = true }
+typst-render = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/crates/typst-docs/src/main.rs
+++ b/crates/typst-docs/src/main.rs
@@ -1,0 +1,114 @@
+use std::{
+    fs::{create_dir_all, write},
+    path::{Path, PathBuf},
+};
+
+use clap::Parser;
+use typst::{model::Document, visualize::Color};
+use typst_docs::{provide, Html, PageModel, Resolver};
+use typst_render::render;
+
+struct MyResolver<'a> {
+    out_dir: &'a Path,
+    verbose: bool,
+}
+impl<'a> Resolver for MyResolver<'a> {
+    fn commits(&self, from: &str, to: &str) -> Vec<typst_docs::Commit> {
+        if self.verbose {
+            eprintln!("commits({from}, {to})");
+        }
+        vec![]
+    }
+    fn example(
+        &self,
+        hash: u128,
+        source: Option<Html>,
+        document: &Document,
+    ) -> typst_docs::Html {
+        if self.verbose {
+            eprintln!(
+                "example(0x{hash:x}, {:?} chars, Document)",
+                source.as_ref().map(|s| s.as_str().len())
+            );
+        }
+
+        let frame = &document.pages.first().expect("page 0").frame;
+        let pixmap = render(frame, 2.0, Color::WHITE);
+        let filename = format!("{hash:x}.png");
+        let path = self.out_dir.join("assets").join("docs").join(&filename);
+        create_dir_all(path.parent().expect("parent")).expect("create dir");
+        pixmap.save_png(path.as_path()).expect("save png");
+        let src = format!("/assets/docs/{filename}");
+        eprintln!("Generated example image {path:?}");
+
+        if let Some(code) = source {
+            let code_safe = code.as_str();
+            Html::new(format!(
+                r#"<div class="previewed-code">
+                    <pre>{code_safe}</pre>
+                    <div class="preview">
+                        <img src="{src}" alt="Preview" width="480" height="190" />
+                    </div>
+                </div>"#
+            ))
+        } else {
+            Html::new(format!(
+                r#"<div class="preview">
+                <img src="{src}" alt="Preview" width="480" height="190" />
+            </div>"#
+            ))
+        }
+    }
+    fn image(&self, filename: &str, data: &[u8]) -> String {
+        if self.verbose {
+            eprintln!("image({filename}, {} bytes)", data.len());
+        }
+
+        let path = self.out_dir.join("assets").join("docs").join(filename);
+        create_dir_all(path.parent().expect("parent")).expect("create dir");
+        write(&path, data).expect("write image");
+        eprintln!("Created {} byte image at {path:?}", data.len());
+
+        format!("/assets/docs/{filename}")
+    }
+    fn link(&self, link: &str) -> Option<String> {
+        if self.verbose {
+            eprintln!("link({link})");
+        }
+        None
+    }
+}
+
+/// Generates the JSON representation of the documentation. This can be used
+/// to generate the HTML yourself. You are encouraged to post-process the generated
+/// JSON to rewrite links and other things to match your site's structure.
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct Args {
+    /// The generation process can produce additional assets. Namely images. This
+    /// option controls where to spit them out. It assumes that this is the base
+    /// folder of the site ("/" in the URL). Images & example renderings will be
+    /// placed in a folder called "assets/docs" under this directory and expected
+    /// to be made available at "/assets/docs/*".
+    #[arg(short, long, default_value = "_site")]
+    out_dir: PathBuf,
+
+    /// Enable verbose logging. This will print out all the calls to the resolver
+    /// and the paths of the generated assets.
+    #[arg(short, long)]
+    verbose: bool,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+
+    let root_pages = provide(&MyResolver {
+        out_dir: args.out_dir.as_path(),
+        verbose: args.verbose.clone(),
+    });
+    let json = serde_json::to_string_pretty(&root_pages)?;
+    println!("{json}");
+
+    eprintln!("All done!");
+    Ok(())
+}


### PR DESCRIPTION
WHY
- generates json which is wayyyy more usable for other tools in other langs
    - ex: using vitepress (js) + dynamic data loading to consume the json output; don't need to manually create a custom provider in rust = contributors don't need to learn rust just to understand how the json gets generated -- just use the builtin default typst-docs cli
    - ex: use github pages builtin jekyll system to use the json output as page content
    - ex: use jq to see what the generated HTML for a page I'm editing (locally!) would look like (the main HTML at least) when published
- lets you do a "cargo check" -like local "does this look good" pass to make sure that all the magic $thing links and image references _actually resolve_ so that it doesn't error in prod when trying to generate the official site
- solves the "waitaminute... how do I actually get some kind of sensible output??" (you don't have to create your own rust crate just to see the rendered docs lol) #2089 comment is a good example of confusion
- basically: you don't have to create a full rust project just to get the json repr of the pages lol
- is VERY TINY so hopefully minimal maintainer burden in addition to regular official closed-source docs

this pr stems from #3425 