### PR TITLE
fix IndexMap remove() deprecation warning

### DIFF
--- a/crates/typst/src/foundations/dict.rs
+++ b/crates/typst/src/foundations/dict.rs
@@ -92,7 +92,7 @@ impl Dict {
 
     /// Remove the value if the dictionary contains the given key.
     pub fn take(&mut self, key: &str) -> StrResult<Value> {
-        Arc::make_mut(&mut self.0).swap_remove(key).ok_or_else(|| missing_key(key))
+        Arc::make_mut(&mut self.0).shift_remove(key).ok_or_else(|| missing_key(key))
     }
 
     /// Whether the dictionary contains a specific key.

--- a/crates/typst/src/foundations/dict.rs
+++ b/crates/typst/src/foundations/dict.rs
@@ -92,7 +92,7 @@ impl Dict {
 
     /// Remove the value if the dictionary contains the given key.
     pub fn take(&mut self, key: &str) -> StrResult<Value> {
-        Arc::make_mut(&mut self.0).remove(key).ok_or_else(|| missing_key(key))
+        Arc::make_mut(&mut self.0).swap_remove(key).ok_or_else(|| missing_key(key))
     }
 
     /// Whether the dictionary contains a specific key.

--- a/crates/typst/src/foundations/dict.rs
+++ b/crates/typst/src/foundations/dict.rs
@@ -92,7 +92,9 @@ impl Dict {
 
     /// Remove the value if the dictionary contains the given key.
     pub fn take(&mut self, key: &str) -> StrResult<Value> {
-        Arc::make_mut(&mut self.0).shift_remove(key).ok_or_else(|| missing_key(key))
+        Arc::make_mut(&mut self.0)
+            .shift_remove(key)
+            .ok_or_else(|| missing_key(key))
     }
 
     /// Whether the dictionary contains a specific key.


### PR DESCRIPTION
![image](https://github.com/typst/typst/assets/61068799/e55cc8ea-bf71-4b4a-8187-a9189b2af4a6)
☝️ ive noticed that this message pops up as yellow text when `cargo build`-ing. this patch just uses the explicitly named alternative to fix the warning
https://docs.rs/indexmap/latest/indexmap/map/struct.IndexMap.html#method.remove

edit: fixes #3378