### PR TITLE
fix: `ToUnicode` in PDF should describe CID instead of GID

### DIFF
--- a/crates/typst-pdf/src/font.rs
+++ b/crates/typst-pdf/src/font.rs
@@ -146,7 +146,7 @@ pub(crate) fn write_fonts(ctx: &mut PdfContext) {
 
         // Write the /ToUnicode character map, which maps glyph ids back to
         // unicode codepoints to enable copying out of the PDF.
-        let cmap = create_cmap(ttf, glyph_set, font);
+        let cmap = create_cmap(font, glyph_set);
         ctx.pdf.cmap(cmap_ref, &cmap.finish());
 
         // Subset and write the font's bytes.
@@ -198,11 +198,9 @@ fn subset_tag(glyphs: &BTreeMap<u16, EcoString>) -> EcoString {
 }
 
 /// Create a /ToUnicode CMap.
-fn create_cmap(
-    ttf: &ttf_parser::Face,
-    glyph_set: &mut BTreeMap<u16, EcoString>,
-    font: &Font,
-) -> UnicodeCmap {
+fn create_cmap(font: &Font, glyph_set: &mut BTreeMap<u16, EcoString>) -> UnicodeCmap {
+    let ttf = font.ttf();
+
     // For glyphs that have codepoints mapping to them in the font's cmap table,
     // we prefer them over pre-existing text mappings from the document. Only
     // things that don't have a corresponding codepoint (or only a private-use


### PR DESCRIPTION
Fixes #3416

`ToUnicode` makes it possible to copy and search text in PDF. Previous implementation assumes CIDs (Character IDs) and GIDs (Glyph IDs) are the same in the font, but they may differ. For example, if you `testit cjk --pdf` and copy texts in the generated PDFs, you will find `���`. This PR fixes it.