### PR TITLE
`/Last` in PDF should refer to the last _immediate_ children

### DIFF
--- a/crates/typst-pdf/src/outline.rs
+++ b/crates/typst-pdf/src/outline.rs
@@ -97,7 +97,9 @@ pub(crate) fn write_outline(ctx: &mut PdfContext) -> Option<Ref> {
     ctx.pdf
         .outline(root_id)
         .first(start_ref)
-        .last(Ref::new(ctx.alloc.get() - 1))
+        .last(Ref::new(
+            ctx.alloc.get() - tree.last().map(|child| child.len() as i32).unwrap_or(1),
+        ))
         .count(tree.len() as i32);
 
     Some(root_id)
@@ -152,10 +154,9 @@ fn write_outline_item(
         outline.prev(prev_rev);
     }
 
-    if !node.children.is_empty() {
-        let current_child = Ref::new(id.get() + 1);
-        outline.first(current_child);
-        outline.last(Ref::new(next_ref.get() - 1));
+    if let Some(last_immediate_child) = node.children.last() {
+        outline.first(Ref::new(id.get() + 1));
+        outline.last(Ref::new(next_ref.get() - last_immediate_child.len() as i32));
         outline.count(-(node.children.len() as i32));
     }
 


### PR DESCRIPTION
Fixes #3205

`/Last` in PDF's `Outlines` should refer to the last _immediate_ children.

For example, in the following outline, `A`'s `/Last` should be `A.B`. In previous implementation, when `write_outline_item()` for `A`, `next_ref` is `B`, so `/Last` points to `A.B.B`. This PR makes it points to `A.B` instead.

- A 👈`id`, `node`
  - A.A
  - A.B 👈 `next_ref - last_immediate_child.len()`, `last_immediate_child`
    - A.B.A
    - A.B.B 👈 `next_ref - 1`
- B 👈 `next_ref = id + node.len()`