### PR TITLE
Refactoring how `MathRow` is laid out into a frame while respecting alignment points

### DIFF
--- a/crates/typst/src/math/align.rs
+++ b/crates/typst/src/math/align.rs
@@ -19,7 +19,7 @@ pub(super) struct AlignmentResult {
     pub width: Abs,
 }
 
-/// Determine the position of the alignment points.
+/// Determine the positions of the alignment points, according to the input rows combined.
 pub(super) fn alignments(rows: &[MathRow]) -> AlignmentResult {
     let mut widths = Vec::<Abs>::new();
 

--- a/crates/typst/src/math/matrix.rs
+++ b/crates/typst/src/math/matrix.rs
@@ -396,7 +396,7 @@ fn layout_vec_body(
         flat.push(ctx.layout_row(child, styles.chain(&denom_style))?);
     }
 
-    Ok(stack(ctx, styles, flat, align, gap, 0))
+    Ok(stack(flat, align, gap, 0))
 }
 
 /// Layout the inner contents of a matrix.
@@ -480,9 +480,7 @@ fn layout_mat_body(
         let mut y = Abs::zero();
 
         for (cell, &(ascent, descent)) in col.into_iter().zip(&heights) {
-            let cell = cell
-                .aligned_frame_builder(ctx, styles, &points, FixedAlignment::Center)
-                .build();
+            let cell = cell.into_line_frame(&points, FixedAlignment::Center);
             let pos = Point::new(
                 if points.is_empty() { x + (rcol - cell.width()) / 2.0 } else { x },
                 y + ascent - cell.ascent(),

--- a/crates/typst/src/math/matrix.rs
+++ b/crates/typst/src/math/matrix.rs
@@ -480,8 +480,9 @@ fn layout_mat_body(
         let mut y = Abs::zero();
 
         for (cell, &(ascent, descent)) in col.into_iter().zip(&heights) {
-            let cell =
-                cell.into_aligned_frame(ctx, styles, &points, FixedAlignment::Center);
+            let cell = cell
+                .aligned_frame_builder(ctx, styles, &points, FixedAlignment::Center)
+                .build();
             let pos = Point::new(
                 if points.is_empty() { x + (rcol - cell.width()) / 2.0 } else { x },
                 y + ascent - cell.ascent(),

--- a/crates/typst/src/math/row.rs
+++ b/crates/typst/src/math/row.rs
@@ -164,13 +164,8 @@ impl MathRow {
         align: FixedAlignment,
     ) -> MathRowFrameBuilder {
         let rows: Vec<_> = self.rows();
+        let row_count = rows.len();
         let alignments = alignments(&rows);
-
-        if !self.is_multiline() {
-            let frame = self.into_line_frame(&alignments.points, align);
-            let size = Size { x: frame.width(), y: frame.height() };
-            return MathRowFrameBuilder { size, frames: vec![(frame, Point::zero())] };
-        }
 
         let leading = if EquationElem::size_in(styles) >= MathSize::Text {
             ParElem::leading_in(styles)
@@ -181,7 +176,6 @@ impl MathRow {
 
         let mut frames: Vec<(Frame, Point)> = vec![];
         let mut size = Size::zero();
-        let row_count = rows.len();
         for (i, row) in rows.into_iter().enumerate() {
             if i == row_count - 1 && row.0.is_empty() {
                 continue;
@@ -387,16 +381,12 @@ pub struct MathRowFrameBuilder {
 
 impl MathRowFrameBuilder {
     /// Consumes the builder and returns a `Frame`.
-    pub fn build(mut self) -> Frame {
-        if self.frames.len() == 1 {
-            return self.frames.pop().unwrap().0;
+    pub fn build(self) -> Frame {
+        let mut frame = Frame::soft(self.size);
+        for (sub, pos) in self.frames.into_iter() {
+            frame.push_frame(pos, sub);
         }
 
-        let mut big_frame = Frame::soft(self.size);
-        for (frame, pos) in self.frames.into_iter() {
-            big_frame.push_frame(pos, frame);
-        }
-
-        big_frame
+        frame
     }
 }

--- a/crates/typst/src/math/row.rs
+++ b/crates/typst/src/math/row.rs
@@ -184,17 +184,16 @@ impl MathRow {
             }
 
             let sub = row.into_line_frame(&alignments.points, align);
-            let sub_size = sub.size();
             if i > 0 {
                 size.y += leading;
             }
 
             let mut pos = Point::with_y(size.y);
             if alignments.points.is_empty() {
-                pos.x = align.position(alignments.width - sub_size.x);
+                pos.x = align.position(alignments.width - sub.width());
             }
             size.x.set_max(sub.width());
-            size.y += sub_size.y;
+            size.y += sub.height();
             frames.push((sub, pos));
         }
 
@@ -389,7 +388,6 @@ impl MathRowFrameBuilder {
         for (sub, pos) in self.frames.into_iter() {
             frame.push_frame(pos, sub);
         }
-
         frame
     }
 }

--- a/crates/typst/src/math/row.rs
+++ b/crates/typst/src/math/row.rs
@@ -145,7 +145,7 @@ impl MathRow {
         if !self.is_multiline() {
             self.into_line_frame(&[], align)
         } else {
-            self.aligned_frame_builder(ctx, styles, align).build()
+            self.multiline_frame_builder(ctx, styles, align).build()
         }
     }
 
@@ -157,7 +157,9 @@ impl MathRow {
         }
     }
 
-    pub fn aligned_frame_builder(
+    /// Returns a builder that lays out `MathFragment`s into a multi-row frame. The set
+    /// of alignment points are computed from those rows combined.
+    pub fn multiline_frame_builder(
         self,
         ctx: &MathContext,
         styles: StyleChain,
@@ -199,6 +201,7 @@ impl MathRow {
         MathRowFrameBuilder { size, frames }
     }
 
+    /// Lay out `MathFragment`s into a one-row frame, with alignment points respected.
     pub fn into_line_frame(self, points: &[Abs], align: FixedAlignment) -> Frame {
         let ascent = self.ascent();
         let mut frame = Frame::soft(Size::new(Abs::zero(), ascent + self.descent()));

--- a/crates/typst/src/math/underover.rs
+++ b/crates/typst/src/math/underover.rs
@@ -290,7 +290,7 @@ fn layout_underoverspreader(
         baseline = rows.len() - 1;
     }
 
-    let frame = stack(ctx, styles, rows, FixedAlignment::Center, gap, baseline);
+    let frame = stack(rows, FixedAlignment::Center, gap, baseline);
     ctx.push(FrameFragment::new(ctx, styles, frame).with_class(body_class));
 
     Ok(())
@@ -301,8 +301,6 @@ fn layout_underoverspreader(
 /// Add a `gap` between each row and uses the baseline of the `baseline`th
 /// row for the whole frame.
 pub(super) fn stack(
-    ctx: &MathContext,
-    styles: StyleChain,
     rows: Vec<MathRow>,
     align: FixedAlignment,
     gap: Abs,
@@ -312,7 +310,7 @@ pub(super) fn stack(
     let AlignmentResult { points, width } = alignments(&rows);
     let rows: Vec<_> = rows
         .into_iter()
-        .map(|row| row.aligned_frame_builder(ctx, styles, &points, align).build())
+        .map(|row| row.into_line_frame(&points, align))
         .collect();
 
     let mut y = Abs::zero();

--- a/crates/typst/src/math/underover.rs
+++ b/crates/typst/src/math/underover.rs
@@ -312,7 +312,7 @@ pub(super) fn stack(
     let AlignmentResult { points, width } = alignments(&rows);
     let rows: Vec<_> = rows
         .into_iter()
-        .map(|row| row.into_aligned_frame(ctx, styles, &points, align))
+        .map(|row| row.aligned_frame_builder(ctx, styles, &points, align).build())
         .collect();
 
     let mut y = Abs::zero();


### PR DESCRIPTION
Note: as a collection of `MathFragment`s, struct `MathRow`--despite its name--can have multiple rows, delimited by `MathFragment::Linebreak`. Its `rows()` method returns a vector of those individual rows.

---

This PR deals with the routine ("the routine" below) that lays out `MathRow`'s rows into a frame with alignment points taken into account.

First, this PR improves the routine while keeping the same behavior:
* `MathRow.into_aligned_frame()` has an argument `points: &[Abs]`, but this argument is _only_ used in the special case where `MathRow` holds only one actual row, at the method's beginning: https://github.com/typst/typst/blob/0fb2a674841882bac80ea44e7aae1684a4289f6a/crates/typst/src/math/row.rs#L163-L165 and if there are multiple rows, the alignment points are recalculated in this method body, obscuring the method's caller-provided argument `points`, leading to confusion: https://github.com/typst/typst/blob/0fb2a674841882bac80ea44e7aae1684a4289f6a/crates/typst/src/math/row.rs#L180
  * In fact, having this one-row special case in this method seems to defeat the method's purpose: the methods intends to lay out multiple rows into a frame, and the alignment points are calculated & applied _uniformly for all rows_. https://github.com/typst/typst/blob/0fb2a674841882bac80ea44e7aae1684a4289f6a/crates/typst/src/math/row.rs#L180-L184
* Some call sites of `MathRow.into_aligned_frame()` actually build one-row frames. This is evident in the computation of the alignment points (by calling `alignments()`) before calling that method, and, as mentioned above, caller-provided alignment points `points` is only used in the one-row special case. Examples: 
https://github.com/typst/typst/blob/0fb2a674841882bac80ea44e7aae1684a4289f6a/crates/typst/src/math/underover.rs#L312-L316 https://github.com/typst/typst/blob/0fb2a674841882bac80ea44e7aae1684a4289f6a/crates/typst/src/math/matrix.rs#L478-L484
* Unnecessary arguments of the `stack()` function, which became clear as a result of refactoring.

Second, as a preparation for future dev works, this PR adds an indirection in the routine: instead of directly returning the resulting `Frame`, the new routine first returns a `MathRowFrameBuilder`, which can then build itself into a `Frame`. This way, the intermediate layout arrangement (e.g. the positions and sizes of each row) can be accessed from this builder. Exposing this layout info helps us to do operations for each line in the future, e.g. support numbering an equation block by each line.

Tests are still passing.