### PR TITLE
Use `Outer(H|V)Alignment` to constraint types

### DIFF
--- a/crates/typst/src/layout/align.rs
+++ b/crates/typst/src/layout/align.rs
@@ -503,27 +503,19 @@ where
     VAlignment: Into<V>,
 {
     /// The horizontal component.
-    pub fn x(self) -> Option<HAlignment> {
+    pub const fn x(self) -> Option<H> {
         match self {
-            Self::H(x) | Self::Both(x, _) => Some(x.into()),
+            Self::H(x) | Self::Both(x, _) => Some(x),
             Self::V(_) => None,
         }
     }
 
     /// The vertical component.
-    pub fn y(self) -> Option<VAlignment> {
+    pub const fn y(self) -> Option<V> {
         match self {
-            Self::V(y) | Self::Both(_, y) => Some(y.into()),
+            Self::V(y) | Self::Both(_, y) => Some(y),
             Self::H(_) => None,
         }
-    }
-
-    /// Normalize the alignment to a LTR-TTB space.
-    pub fn fix(self, text_dir: Dir) -> Axes<FixedAlignment> {
-        Axes::new(
-            self.x().unwrap_or_default().fix(text_dir),
-            self.y().unwrap_or_default().fix(),
-        )
     }
 }
 
@@ -540,6 +532,23 @@ impl Add<HAlignment> for OuterVAlignment {
 
     fn add(self, rhs: HAlignment) -> Self::Output {
         SpecificAlignment::Both(rhs, self)
+    }
+}
+
+impl<H, V> From<SpecificAlignment<H, V>> for Alignment
+where
+    H: Into<HAlignment> + Copy,
+    V: Into<VAlignment> + Copy,
+    HAlignment: Into<H>,
+    VAlignment: Into<V>,
+{
+    fn from(value: SpecificAlignment<H, V>) -> Alignment {
+        type FromType<H, V> = SpecificAlignment<H, V>;
+        match value {
+            FromType::H(x) => Alignment::H(x.into()),
+            FromType::V(y) => Alignment::V(y.into()),
+            FromType::Both(x, y) => Alignment::Both(x.into(), y.into()),
+        }
     }
 }
 

--- a/crates/typst/src/layout/page.rs
+++ b/crates/typst/src/layout/page.rs
@@ -12,11 +12,11 @@ use crate::foundations::{
 use crate::introspection::{Counter, CounterKey, ManualPageCounter};
 use crate::layout::{
     Abs, AlignElem, Alignment, Axes, ColumnsElem, Dir, Frame, HAlignment, LayoutMultiple,
-    Length, Point, Ratio, Regions, Rel, Sides, Size, VAlignment,
+    Length, OuterVAlignment, Point, Ratio, Regions, Rel, Sides, Size, SpecificAlignment,
+    VAlignment,
 };
 
 use crate::model::Numbering;
-use crate::syntax::Spanned;
 use crate::text::TextElem;
 use crate::util::{NonZeroExt, Numeric, Scalar};
 use crate::visualize::Paint;
@@ -221,17 +221,8 @@ pub struct PageElem {
     ///
     /// #lorem(30)
     /// ```
-    #[default(HAlignment::Center + VAlignment::Bottom)]
-    #[parse({
-        let option: Option<Spanned<Alignment>> = args.named("number-align")?;
-        if let Some(Spanned { v: align, span }) = option {
-            if align.y() == Some(VAlignment::Horizon) {
-                bail!(span, "page number cannot be `horizon`-aligned");
-            }
-        }
-        option.map(|spanned| spanned.v)
-    })]
-    pub number_align: Alignment,
+    #[default(HAlignment::Center + OuterVAlignment::Bottom)]
+    pub number_align: SpecificAlignment<HAlignment, OuterVAlignment>,
 
     /// The page's header. Fills the top margin of each page.
     ///

--- a/crates/typst/src/layout/page.rs
+++ b/crates/typst/src/layout/page.rs
@@ -431,7 +431,7 @@ impl Packed<PageElem> {
             counter
         }));
 
-        if matches!(number_align.y(), Some(VAlignment::Top)) {
+        if matches!(number_align.y(), Some(OuterVAlignment::Top)) {
             header = if header.is_some() { header } else { numbering_marginal };
         } else {
             footer = if footer.is_some() { footer } else { numbering_marginal };

--- a/tests/typ/layout/page-number-align.typ
+++ b/tests/typ/layout/page-number-align.typ
@@ -21,9 +21,5 @@
 #block(width: 100%, height: 100%, fill: aqua.lighten(50%))
 
 ---
-// Error: 25-39 expected `top` or `bottom` for the vertical component, found horizon
+// Error: 25-39 expected `top` or `bottom`, found horizon
 #set page(number-align: left + horizon)
-
----
-// Error: 25-39 expected `top` or `bottom` for the vertical component, found horizon
-#set page(number-align: horizon + left)

--- a/tests/typ/layout/page-number-align.typ
+++ b/tests/typ/layout/page-number-align.typ
@@ -21,5 +21,9 @@
 #block(width: 100%, height: 100%, fill: aqua.lighten(50%))
 
 ---
-// Error: 25-39 page number cannot be `horizon`-aligned
+// Error: 25-39 expected `top` or `bottom` for the vertical component, found horizon
 #set page(number-align: left + horizon)
+
+---
+// Error: 25-39 expected `top` or `bottom` for the vertical component, found horizon
+#set page(number-align: horizon + left)


### PR DESCRIPTION
In certain use cases, not all alignment positions are permissible. For example, a figure's caption can be put at the top or bottom of the figure itself, but not at the middle ("horizon"). Therefore, while `VAlignment::Top` and `VAlignment::Bottom` are allowed, `VAlignment::Horizon` should be disallowed.

To catch this, the codebase relies on manual `#[parse(...)]`-ing the input argument: if the user-provided value is parsed to be `VAlignment::Horizon`, throw an error. Though this prevents wrong user inputs (at Typst runtime), there's no type constraint during the codebase's compile-time analysis.

#3393 added `OuterHAlignment` and `OuterVAlignment` and used them for grid. This PR expands their usage to other places.

Notes:
* The `FromValue` trait for `SpecificAlignment<H, V>` does not implement its own low-level conversion, but uses `Outer(H|V)Alignment` and `(H|V)Alignment`'s existing `from_value()` code paths (including the code path for errors) instead.
* In align.rs, the variable names for horizontal/vertical components are `x`/`y` most of the time, but occasionally `h`/`v`. This PR consolidates all to `x`/`y`.