### PR TITLE
Add `tilde.dot`

### DIFF
--- a/crates/typst/src/symbols/sym.rs
+++ b/crates/typst/src/symbols/sym.rs
@@ -119,6 +119,7 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
     tilde: [
         op: '∼',
         basic: '~',
+        dot: '⩪',
         eq: '≃',
         eq.not: '≄',
         eq.rev: '⋍',


### PR DESCRIPTION
Adds ⩪ as `tilde.dot`. This symbol means "is approximately distributed as".