### PR TITLE
Fix renamed clippy option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,4 +137,4 @@ strip = true
 
 [workspace.lints.clippy]
 uninlined_format_args = "warn"
-blocks_in_if_conditions = "allow"
+blocks_in_conditions = "allow"


### PR DESCRIPTION
```sh
warning: lint `clippy::blocks_in_if_conditions` has been renamed to `clippy::blocks_in_conditions`
  |
  = help: use the new name `clippy::blocks_in_conditions`
  = note: requested on the command line with `-A clippy::blocks_in_if_conditions`
  = note: `#[warn(renamed_and_removed_lints)]` on by default
```