### PR TITLE
Separate user-visible permissive `Alignment`, and the internal types that enforce static type checking

### DIFF
--- a/crates/typst/src/foundations/content.rs
+++ b/crates/typst/src/foundations/content.rs
@@ -17,7 +17,9 @@ use crate::foundations::{
     Recipe, RecipeIndex, Repr, Selector, Str, Style, StyleChain, Styles, Value,
 };
 use crate::introspection::{Location, Meta, MetaElem};
-use crate::layout::{AlignElem, Alignment, Axes, Length, MoveElem, PadElem, Rel, Sides};
+use crate::layout::{
+    AlignElem, Axes, FullAlignment, Length, MoveElem, PadElem, Rel, Sides,
+};
 use crate::model::{Destination, EmphElem, StrongElem};
 use crate::realize::{Behave, Behaviour};
 use crate::syntax::Span;
@@ -482,7 +484,7 @@ impl Content {
     }
 
     /// Set alignments for this content.
-    pub fn aligned(self, align: Alignment) -> Self {
+    pub fn aligned(self, align: FullAlignment) -> Self {
         self.styled(AlignElem::set_alignment(align))
     }
 

--- a/crates/typst/src/foundations/fields.rs
+++ b/crates/typst/src/foundations/fields.rs
@@ -47,8 +47,16 @@ pub(crate) fn field(value: &Value, field: &str) -> StrResult<Value> {
                 }
             } else if let Some(align) = dynamic.downcast::<Alignment>() {
                 match field {
-                    "x" => align.x().into_value(),
-                    "y" => align.y().into_value(),
+                    "x" => (match align {
+                        Alignment::H(h) | Alignment::Both(h, _) => Some(*h),
+                        Alignment::V(_) => None,
+                    })
+                    .into_value(),
+                    "y" => (match align {
+                        Alignment::V(v) | Alignment::Both(_, v) => Some(*v),
+                        Alignment::H(_) => None,
+                    })
+                    .into_value(),
                     _ => return missing(),
                 }
             } else {

--- a/crates/typst/src/layout/flow.rs
+++ b/crates/typst/src/layout/flow.rs
@@ -9,7 +9,7 @@ use crate::introspection::{Meta, MetaElem};
 use crate::layout::{
     Abs, AlignElem, Axes, BlockElem, ColbreakElem, ColumnsElem, FixedAlignment, Fr,
     Fragment, Frame, FrameItem, LayoutMultiple, LayoutSingle, PlaceElem, Point, Regions,
-    Rel, Size, Spacing, VAlignment, VAxis, VElem,
+    Rel, Size, Spacing, VElem,
 };
 use crate::model::{FootnoteElem, FootnoteEntry, ParElem};
 use crate::util::Numeric;
@@ -311,7 +311,7 @@ impl<'a> FlowLayouter<'a> {
         let x_align = alignment.map_or(FixedAlignment::Center, |align| {
             align.x().unwrap_or_default().resolve(styles)
         });
-        let y_align = alignment.map(|align| align.y().map(VAlignment::fix));
+        let y_align = alignment.map(|align| align.y().map(|y| y.resolve(styles)));
         let mut frame = placed.layout(engine, styles, self.regions)?.into_frame();
         frame.meta(styles, false);
         let item = FlowItem::Placed { frame, x_align, y_align, delta, float, clearance };

--- a/crates/typst/src/layout/flow.rs
+++ b/crates/typst/src/layout/flow.rs
@@ -9,7 +9,7 @@ use crate::introspection::{Meta, MetaElem};
 use crate::layout::{
     Abs, AlignElem, Axes, BlockElem, ColbreakElem, ColumnsElem, FixedAlignment, Fr,
     Fragment, Frame, FrameItem, LayoutMultiple, LayoutSingle, PlaceElem, Point, Regions,
-    Rel, Size, Spacing, VAlignment, VElem,
+    Rel, Size, Spacing, VAlignment, VAxis, VElem,
 };
 use crate::model::{FootnoteElem, FootnoteEntry, ParElem};
 use crate::util::Numeric;

--- a/crates/typst/src/layout/grid/layout.rs
+++ b/crates/typst/src/layout/grid/layout.rs
@@ -18,8 +18,8 @@ use crate::foundations::{
     StyleChain, Value,
 };
 use crate::layout::{
-    Abs, Alignment, Axes, Dir, Fr, Fragment, Frame, FrameItem, LayoutMultiple, Length,
-    Point, Regions, Rel, Sides, Size, Sizing,
+    Abs, Axes, Dir, Fr, Fragment, Frame, FrameItem, FullAlignment, LayoutMultiple,
+    Length, Point, Regions, Rel, Sides, Size, Sizing,
 };
 use crate::syntax::Span;
 use crate::text::TextElem;
@@ -269,7 +269,7 @@ pub trait ResolvableCell {
         x: usize,
         y: usize,
         fill: &Option<Paint>,
-        align: Smart<Alignment>,
+        align: Smart<FullAlignment>,
         inset: Sides<Option<Rel<Length>>>,
         stroke: Sides<Option<Option<Arc<Stroke<Abs>>>>>,
         styles: StyleChain,
@@ -331,7 +331,7 @@ impl CellGrid {
         gutter: Axes<&[Sizing]>,
         items: I,
         fill: &Celled<Option<Paint>>,
-        align: &Celled<Smart<Alignment>>,
+        align: &Celled<Smart<FullAlignment>>,
         inset: Sides<Option<Rel<Length>>>,
         stroke: &ResolvedCelled<Sides<Option<Option<Arc<Stroke>>>>>,
         engine: &mut Engine,

--- a/crates/typst/src/layout/grid/mod.rs
+++ b/crates/typst/src/layout/grid/mod.rs
@@ -16,7 +16,7 @@ use crate::foundations::{
     cast, elem, scope, Array, Content, Fold, Packed, Show, Smart, StyleChain, Value,
 };
 use crate::layout::{
-    Abs, AlignElem, Alignment, Axes, Dir, Fragment, LayoutMultiple, Length,
+    Abs, AlignElem, Axes, Dir, Fragment, FullAlignment, LayoutMultiple, Length,
     OuterHAlignment, OuterVAlignment, Regions, Rel, Sides, Sizing,
 };
 use crate::syntax::Span;
@@ -232,7 +232,7 @@ pub struct GridElem {
     /// )
     /// ```
     #[borrowed]
-    pub align: Celled<Smart<Alignment>>,
+    pub align: Celled<Smart<FullAlignment>>,
 
     /// How to [stroke]($stroke) the cells.
     ///
@@ -630,7 +630,7 @@ pub struct GridCell {
     pub fill: Smart<Option<Paint>>,
 
     /// The cell's alignment override.
-    pub align: Smart<Alignment>,
+    pub align: Smart<FullAlignment>,
 
     /// The cell's inset override.
     pub inset: Smart<Sides<Option<Rel<Length>>>>,
@@ -658,7 +658,7 @@ impl ResolvableCell for Packed<GridCell> {
         x: usize,
         y: usize,
         fill: &Option<Paint>,
-        align: Smart<Alignment>,
+        align: Smart<FullAlignment>,
         inset: Sides<Option<Rel<Length>>>,
         stroke: Sides<Option<Option<Arc<Stroke<Abs>>>>>,
         styles: StyleChain,
@@ -752,7 +752,7 @@ impl From<Content> for GridCell {
 pub fn show_grid_cell(
     mut body: Content,
     inset: Smart<Sides<Option<Rel<Length>>>>,
-    align: Smart<Alignment>,
+    align: Smart<FullAlignment>,
 ) -> SourceResult<Content> {
     let inset = inset.unwrap_or_default().map(Option::unwrap_or_default);
 

--- a/crates/typst/src/layout/page.rs
+++ b/crates/typst/src/layout/page.rs
@@ -11,9 +11,9 @@ use crate::foundations::{
 };
 use crate::introspection::{Counter, CounterKey, ManualPageCounter};
 use crate::layout::{
-    Abs, AlignElem, Alignment, Axes, ColumnsElem, Dir, Frame, HAlignment, LayoutMultiple,
-    Length, OuterVAlignment, Point, Ratio, Regions, Rel, Sides, Size, SpecificAlignment,
-    VAlignment,
+    Abs, AlignElem, Alignment, Axes, ColumnsElem, Dir, Frame, FullAlignment, HAlignment,
+    LayoutMultiple, Length, OuterVAlignment, Point, Ratio, Regions, Rel, Sides, Size,
+    SpecificAlignment, VAlignment,
 };
 
 use crate::model::Numbering;
@@ -425,7 +425,7 @@ impl Packed<PageElem> {
             // We interpret the Y alignment as selecting header or footer
             // and then ignore it for aligning the actual number.
             if let Some(x) = number_align.x() {
-                counter = counter.aligned(x.into());
+                counter = counter.aligned(FullAlignment::H(x));
             }
 
             counter
@@ -467,16 +467,16 @@ impl Packed<PageElem> {
                     let ascent = header_ascent.relative_to(margin.top);
                     pos = Point::with_x(margin.left);
                     area = Size::new(pw, margin.top - ascent);
-                    align = Alignment::BOTTOM;
+                    align = FullAlignment::V(VAlignment::Bottom);
                 } else if ptr::eq(marginal, &footer) {
                     let descent = footer_descent.relative_to(margin.bottom);
                     pos = Point::new(margin.left, size.y - margin.bottom + descent);
                     area = Size::new(pw, margin.bottom - descent);
-                    align = Alignment::TOP;
+                    align = FullAlignment::V(VAlignment::Top);
                 } else {
                     pos = Point::zero();
                     area = size;
-                    align = HAlignment::Center + VAlignment::Horizon;
+                    align = FullAlignment::Both(HAlignment::Center, VAlignment::Horizon);
                 };
 
                 let pod = Regions::one(area, Axes::splat(true));

--- a/crates/typst/src/layout/page.rs
+++ b/crates/typst/src/layout/page.rs
@@ -11,9 +11,9 @@ use crate::foundations::{
 };
 use crate::introspection::{Counter, CounterKey, ManualPageCounter};
 use crate::layout::{
-    Abs, AlignElem, Alignment, Axes, ColumnsElem, Dir, Frame, FullAlignment, HAlignment,
-    LayoutMultiple, Length, OuterVAlignment, Point, Ratio, Regions, Rel, Sides, Size,
-    SpecificAlignment, VAlignment,
+    Abs, AlignElem, Alignment, Axes, ColumnsElem, ComposedAlignment, Dir, Frame,
+    FullAlignment, HAlignment, LayoutMultiple, Length, OuterVAlignment, Point, Ratio,
+    Regions, Rel, Sides, Size, VAlignment,
 };
 
 use crate::model::Numbering;
@@ -221,8 +221,8 @@ pub struct PageElem {
     ///
     /// #lorem(30)
     /// ```
-    #[default(SpecificAlignment::Both(HAlignment::Center, OuterVAlignment::Bottom))]
-    pub number_align: SpecificAlignment<HAlignment, OuterVAlignment>,
+    #[default(ComposedAlignment::Both(HAlignment::Center, OuterVAlignment::Bottom))]
+    pub number_align: ComposedAlignment<HAlignment, OuterVAlignment>,
 
     /// The page's header. Fills the top margin of each page.
     ///

--- a/crates/typst/src/layout/place.rs
+++ b/crates/typst/src/layout/place.rs
@@ -2,7 +2,8 @@ use crate::diag::{bail, At, Hint, SourceResult};
 use crate::engine::Engine;
 use crate::foundations::{elem, Content, Packed, Smart, StyleChain};
 use crate::layout::{
-    Alignment, Axes, Em, Fragment, LayoutMultiple, Length, Regions, Rel, VAlignment,
+    Axes, Em, Fragment, FullAlignment, HAlignment, LayoutMultiple, Length, Regions, Rel,
+    VAlignment,
 };
 use crate::realize::{Behave, Behaviour};
 
@@ -37,8 +38,8 @@ pub struct PlaceElem {
     /// that axis will be ignored, instead, the item will be placed in the
     /// origin of the axis.
     #[positional]
-    #[default(Smart::Custom(Alignment::START))]
-    pub alignment: Smart<Alignment>,
+    #[default(Smart::Custom(FullAlignment::H(HAlignment::Start)))]
+    pub alignment: Smart<FullAlignment>,
 
     /// Whether the placed element has floating layout.
     ///
@@ -116,7 +117,7 @@ impl Packed<PlaceElem> {
         let child = self
             .body()
             .clone()
-            .aligned(alignment.unwrap_or_else(|| Alignment::CENTER));
+            .aligned(alignment.unwrap_or_else(|| FullAlignment::H(HAlignment::Center)));
 
         let pod = Regions::one(base, Axes::splat(false));
         let frame = child.layout(engine, styles, pod)?.into_frame();

--- a/crates/typst/src/layout/sides.rs
+++ b/crates/typst/src/layout/sides.rs
@@ -323,7 +323,12 @@ impl Side {
 
 cast! {
     Side,
-    self => Alignment::from(self).into_value(),
+    self => (match self {
+        Side::Left => Alignment::LEFT,
+        Side::Top => Alignment::TOP,
+        Side::Right => Alignment::RIGHT,
+        Side::Bottom => Alignment::BOTTOM,
+    }).into_value(),
     align: Alignment => match align {
         Alignment::LEFT => Self::Left,
         Alignment::RIGHT => Self::Right,

--- a/crates/typst/src/layout/transform.rs
+++ b/crates/typst/src/layout/transform.rs
@@ -2,7 +2,7 @@ use crate::diag::SourceResult;
 use crate::engine::Engine;
 use crate::foundations::{elem, Content, Packed, Resolve, StyleChain};
 use crate::layout::{
-    Abs, Alignment, Angle, Axes, FixedAlignment, Frame, HAlignment, LayoutMultiple,
+    Abs, Angle, Axes, FixedAlignment, Frame, FullAlignment, HAlignment, LayoutMultiple,
     LayoutSingle, Length, Point, Ratio, Regions, Rel, Size, VAlignment,
 };
 
@@ -95,8 +95,8 @@ pub struct RotateElem {
     /// #box(rotate(30deg, origin: bottom + right, square()))
     /// ```
     #[fold]
-    #[default(HAlignment::Center + VAlignment::Horizon)]
-    pub origin: Alignment,
+    #[default(FullAlignment::Both(HAlignment::Center, VAlignment::Horizon))]
+    pub origin: FullAlignment,
 
     /// Whether the rotation impacts the layout.
     ///
@@ -183,8 +183,8 @@ pub struct ScaleElem {
     /// B#box(scale(75%, origin: bottom + left)[B])B
     /// ```
     #[fold]
-    #[default(HAlignment::Center + VAlignment::Horizon)]
-    pub origin: Alignment,
+    #[default(FullAlignment::Both(HAlignment::Center, VAlignment::Horizon))]
+    pub origin: FullAlignment,
 
     /// Whether the scaling impacts the layout.
     ///

--- a/crates/typst/src/math/equation.rs
+++ b/crates/typst/src/math/equation.rs
@@ -10,8 +10,8 @@ use crate::foundations::{
 };
 use crate::introspection::{Count, Counter, CounterUpdate, Locatable};
 use crate::layout::{
-    Abs, AlignElem, Alignment, Axes, Dir, Em, FixedAlignment, Frame, LayoutMultiple,
-    LayoutSingle, Point, Regions, Size,
+    Abs, AlignElem, Axes, Dir, Em, FixedAlignment, Frame, FullAlignment, HAlignment,
+    LayoutMultiple, LayoutSingle, Point, Regions, Size,
 };
 use crate::math::{scaled_font_size, LayoutMath, MathContext, MathSize, MathVariant};
 use crate::model::{Numbering, Outlinable, ParElem, Refable, Supplement};
@@ -155,7 +155,7 @@ impl ShowSet for Packed<EquationElem> {
     fn show_set(&self, styles: StyleChain) -> Styles {
         let mut out = Styles::new();
         if self.block(styles) {
-            out.set(AlignElem::set_alignment(Alignment::CENTER));
+            out.set(AlignElem::set_alignment(FullAlignment::H(HAlignment::Center)));
             out.set(EquationElem::set_size(MathSize::Display));
         }
         out.set(TextElem::set_weight(FontWeight::from_number(450)));

--- a/crates/typst/src/model/enum.rs
+++ b/crates/typst/src/model/enum.rs
@@ -6,8 +6,8 @@ use crate::diag::{bail, SourceResult};
 use crate::engine::Engine;
 use crate::foundations::{cast, elem, scope, Array, Content, Packed, Smart, StyleChain};
 use crate::layout::{
-    Alignment, Axes, BlockElem, Cell, CellGrid, Em, Fragment, GridLayouter, HAlignment,
-    LayoutMultiple, Length, Regions, Sizing, Spacing, VAlignment,
+    Axes, BlockElem, Cell, CellGrid, Em, Fragment, FullAlignment, GridLayouter,
+    HAlignment, LayoutMultiple, Length, Regions, Sizing, Spacing, VAlignment,
 };
 use crate::model::{Numbering, NumberingPattern, ParElem};
 use crate::text::TextElem;
@@ -178,8 +178,8 @@ pub struct EnumElem {
     /// 16. Sixteen
     /// 32. Thirty two
     /// ````
-    #[default(HAlignment::End + VAlignment::Top)]
-    pub number_align: Alignment,
+    #[default(FullAlignment::Both(HAlignment::End, VAlignment::Top))]
+    pub number_align: FullAlignment,
 
     /// The numbered list's items.
     ///

--- a/crates/typst/src/model/figure.rs
+++ b/crates/typst/src/model/figure.rs
@@ -14,8 +14,8 @@ use crate::introspection::{
     Count, Counter, CounterKey, CounterUpdate, Locatable, Location,
 };
 use crate::layout::{
-    Alignment, BlockElem, Em, HAlignment, Length, OuterVAlignment, PlaceElem, VAlignment,
-    VElem,
+    BlockElem, Em, FullAlignment, HAlignment, Length, OuterVAlignment, PlaceElem,
+    VAlignment, VElem,
 };
 use crate::model::{Numbering, NumberingPattern, Outlinable, Refable, Supplement};
 use crate::text::{Lang, Region, TextElem};
@@ -321,13 +321,15 @@ impl Show for Packed<FigureElem> {
             .with_body(Some(realized))
             .pack()
             .spanned(self.span())
-            .aligned(Alignment::CENTER);
+            .aligned(FullAlignment::H(HAlignment::Center));
 
         // Wrap in a float.
         if let Some(align) = self.placement(styles) {
             realized = PlaceElem::new(realized)
                 .with_float(true)
-                .with_alignment(align.map(|align| HAlignment::Center + align))
+                .with_alignment(
+                    align.map(|align| FullAlignment::Both(HAlignment::Center, align)),
+                )
                 .pack()
                 .spanned(self.span());
         }

--- a/crates/typst/src/model/list.rs
+++ b/crates/typst/src/model/list.rs
@@ -4,8 +4,8 @@ use crate::foundations::{
     cast, elem, scope, Array, Content, Depth, Func, Packed, Smart, StyleChain, Value,
 };
 use crate::layout::{
-    Axes, BlockElem, Cell, CellGrid, Em, Fragment, GridLayouter, HAlignment,
-    LayoutMultiple, Length, Regions, Sizing, Spacing, VAlignment,
+    Axes, BlockElem, Cell, CellGrid, Em, Fragment, FullAlignment, GridLayouter,
+    HAlignment, LayoutMultiple, Length, Regions, Sizing, Spacing, VAlignment,
 };
 use crate::model::ParElem;
 use crate::text::TextElem;
@@ -156,7 +156,7 @@ impl LayoutMultiple for Packed<ListElem> {
             .marker(styles)
             .resolve(engine, depth)?
             // avoid '#set align' interference with the list
-            .aligned(HAlignment::Start + VAlignment::Top);
+            .aligned(FullAlignment::Both(HAlignment::Start, VAlignment::Top));
 
         let mut cells = vec![];
         for item in self.children() {

--- a/crates/typst/src/model/quote.rs
+++ b/crates/typst/src/model/quote.rs
@@ -4,7 +4,9 @@ use crate::foundations::{
     cast, elem, Content, Depth, Label, NativeElement, Packed, Show, ShowSet, Smart,
     StyleChain, Styles,
 };
-use crate::layout::{Alignment, BlockElem, Em, HElem, PadElem, Spacing, VElem};
+use crate::layout::{
+    BlockElem, Em, FullAlignment, HAlignment, HElem, PadElem, Spacing, VElem,
+};
 use crate::model::{CitationForm, CiteElem};
 use crate::text::{SmartQuoteElem, SmartQuotes, SpaceElem, TextElem};
 
@@ -205,7 +207,8 @@ impl Show for Packed<QuoteElem> {
                 // Use v(0.9em, weak: true) bring the attribution closer to the
                 // quote.
                 let weak_v = VElem::weak(Spacing::Rel(Em::new(0.9).into())).pack();
-                realized += weak_v + Content::sequence(seq).aligned(Alignment::END);
+                realized += weak_v
+                    + Content::sequence(seq).aligned(FullAlignment::H(HAlignment::End));
             }
 
             realized = PadElem::new(realized).pack();

--- a/crates/typst/src/model/table.rs
+++ b/crates/typst/src/model/table.rs
@@ -9,7 +9,7 @@ use crate::foundations::{
     cast, elem, scope, Content, Fold, Packed, Show, Smart, StyleChain,
 };
 use crate::layout::{
-    show_grid_cell, Abs, Alignment, Axes, Cell, CellGrid, Celled, Dir, Fragment,
+    show_grid_cell, Abs, Axes, Cell, CellGrid, Celled, Dir, Fragment, FullAlignment,
     GridItem, GridLayouter, LayoutMultiple, Length, LinePosition, OuterHAlignment,
     OuterVAlignment, Regions, Rel, ResolvableCell, Sides, TrackSizings,
 };
@@ -162,7 +162,7 @@ pub struct TableElem {
     /// )
     /// ```
     #[borrowed]
-    pub align: Celled<Smart<Alignment>>,
+    pub align: Celled<Smart<FullAlignment>>,
 
     /// How to [stroke]($stroke) the cells.
     ///
@@ -518,7 +518,7 @@ pub struct TableCell {
     pub colspan: NonZeroUsize,
 
     /// The cell's alignment override.
-    pub align: Smart<Alignment>,
+    pub align: Smart<FullAlignment>,
 
     /// The cell's inset override.
     pub inset: Smart<Sides<Option<Rel<Length>>>>,
@@ -546,7 +546,7 @@ impl ResolvableCell for Packed<TableCell> {
         x: usize,
         y: usize,
         fill: &Option<Paint>,
-        align: Smart<Alignment>,
+        align: Smart<FullAlignment>,
         inset: Sides<Option<Rel<Length>>>,
         stroke: Sides<Option<Option<Arc<Stroke<Abs>>>>>,
         styles: StyleChain,

--- a/crates/typst/src/text/raw.rs
+++ b/crates/typst/src/text/raw.rs
@@ -15,7 +15,7 @@ use crate::foundations::{
     cast, elem, scope, Args, Array, Bytes, Content, Fold, NativeElement, Packed,
     PlainText, Show, ShowSet, Smart, StyleChain, Styles, Synthesize, Value,
 };
-use crate::layout::{BlockElem, Em, HAlignment};
+use crate::layout::{BlockElem, Em, FullAlignment, HAlignment};
 use crate::model::Figurable;
 use crate::syntax::{split_newlines, LinkedNode, Spanned};
 use crate::text::{
@@ -417,7 +417,7 @@ impl Show for Packed<RawElem> {
         let mut realized = Content::sequence(seq);
         if self.block(styles) {
             // Align the text before inserting it into the block.
-            realized = realized.aligned(self.align(styles).into());
+            realized = realized.aligned(FullAlignment::H(self.align(styles).into()));
             realized =
                 BlockElem::new().with_body(Some(realized)).pack().spanned(self.span());
         }

--- a/crates/typst/src/text/raw.rs
+++ b/crates/typst/src/text/raw.rs
@@ -417,7 +417,7 @@ impl Show for Packed<RawElem> {
         let mut realized = Content::sequence(seq);
         if self.block(styles) {
             // Align the text before inserting it into the block.
-            realized = realized.aligned(FullAlignment::H(self.align(styles).into()));
+            realized = realized.aligned(FullAlignment::H(self.align(styles)));
             realized =
                 BlockElem::new().with_body(Some(realized)).pack().spanned(self.span());
         }


### PR DESCRIPTION
`Alignment` is a permissive (since it accepts any alignment positions) and native type (since it derives the `#[ty(...)]` macro) that is used to accept user-provided typeless `Value`, during the evaluation phase.

Currently in the layout phase, places with more restrictions should use things like `SpecificAlignment<HAlignment, OuterVAlignment>`, and places where the full set of alignment points are allowed should use `SpecificAlignment<HAlignment, VAlignment>`. But in the later case, that type happens to be exactly the same as `Alignment`, so those places use `Alignment` instead. This PR intends to separate `Alignment` and the internal alignment types.

While doing so, this PR removes unnecessary methods and trait impls from the `Alignment` type, so that it doesn't duplicate  that of `SpecificAlignment<H, V>`.

Also, this PR renames the internal type `SpecificAlignment<H, V>` to `ComposedAlignment<H, V>`, because it is a composition of elemental horizontal and vertical alignments `(Outer)?(H|V)Alignment`, which are also internal types.