### PR TITLE
Add `base()` injection getter to the typst-docs `Resolver`

### DIFF
--- a/crates/typst-docs/src/html.rs
+++ b/crates/typst-docs/src/html.rs
@@ -307,7 +307,7 @@ impl<'a> Handler<'a> {
             return Ok(link);
         }
 
-        crate::link::resolve(link)
+        crate::link::resolve(link, self.resolver.base())
     }
 
     fn nesting(&self) -> usize {


### PR DESCRIPTION
WHY
- allow custom base urls
- fix the hack in https://github.com/typst/typst/pull/3429

why a separate pr? so that the prs are small and easy to ✅ approve
also it just seemed like a logical split since sooooo many spots were modified in this pr that it makes sense to review this one independent of the https://github.com/typst/typst/pull/3429 (which just focuses on the main.rs script)

this pr only focuses on allowing Resolver impl to override the `/docs/` default base URL to whatever they choose.

> i tracked down all matches for "/docs/" using vscode search and got a few options working:
> 
> 1. use a BASE_URL fallback to BASE_PATH fallback to "/docs/" global lazy static var
> 2. add a `base(&self) -> Option<&str>` `Resolver` method getter and fall back to `/docs/` called MULTIPLE TIMES wherever needed
> 3. add a `base(&self) -> Option<&str>` `Resolver` method getter and fall back to `/docs/` called ONCE and passed via params to all that need it
> 
> other options that are viable but I didn't explicitly try out yet:
> 
> 1. add a second `provide(resolver, base)` parameter and pass it via param drilling to all that need it
> 2. use a mutable global BASE var that can be mutated from outside the crate

> I like 2 best. I would adjust it to make it `base(&self) -> &str` and make it required.

https://github.com/typst/typst/pull/3429#issuecomment-1958951335