### PR TITLE
Add `vendor-openssl` feature flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       if: ${{ matrix.cross}}
       run: |
         cargo install cross --git https://github.com/cross-rs/cross.git
-        cross build -p typst-cli --release --target ${{ matrix.target }} --features self-update
+        cross build -p typst-cli --release --target ${{ matrix.target }} --features self-update vendor-openssl
 
     - name: Run Cargo
       if: ${{ !matrix.cross }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,6 +1535,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.1.6+3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439fac53e092cd7442a3660c85dde4643ab3b5bd39040912388dcdabf6b88085"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1542,6 +1551,7 @@ checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2634,6 +2644,7 @@ dependencies = [
  "notify",
  "once_cell",
  "open",
+ "openssl",
  "parking_lot",
  "pathdiff",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ native-tls = "0.2"
 notify = "6"
 once_cell = "1"
 open = "5.0.1"
+openssl = "0.10"
 oxipng = { version = "9.0", default-features = false, features = ["filetime", "parallel", "zopfli"] }
 palette = { version = "0.7.3", default-features = false, features = ["approx", "libm"] }
 parking_lot = "0.12.1"

--- a/crates/typst-cli/Cargo.toml
+++ b/crates/typst-cli/Cargo.toml
@@ -56,8 +56,10 @@ ureq = { workspace = true }
 xz2 = { workspace = true, optional = true }
 zip = { workspace = true, optional = true }
 
+# Explicitly depend on OpenSSL if applicable, so that we can add the
+# `openssl/vendored` feature to it if `vendor-openssl` is enabled.
 [target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios", target_os = "watchos", target_os = "tvos")))'.dependencies]
-openssl = { workspace = true, features = ["vendored"] }
+openssl = { workspace = true }
 
 [build-dependencies]
 clap = { workspace = true, features = ["string"] }
@@ -74,8 +76,11 @@ default = ["embed-fonts"]
 # - For code: Deja Vu Sans Mono
 embed-fonts = []
 
-# Permits the CLI to update itself without a package manager
+# Permits the CLI to update itself without a package manager.
 self-update = ["dep:self-replace", "dep:xz2", "dep:zip", "ureq/json"]
+
+# Whether to vendor OpenSSL. Not applicable to Windows and macOS builds.
+vendor-openssl = ["openssl/vendored"]
 
 [lints]
 workspace = true

--- a/crates/typst-cli/Cargo.toml
+++ b/crates/typst-cli/Cargo.toml
@@ -56,6 +56,9 @@ ureq = { workspace = true }
 xz2 = { workspace = true, optional = true }
 zip = { workspace = true, optional = true }
 
+[target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios", target_os = "watchos", target_os = "tvos")))'.dependencies]
+openssl = { workspace = true, features = ["vendored"] }
+
 [build-dependencies]
 clap = { workspace = true, features = ["string"] }
 clap_complete = { workspace = true }


### PR DESCRIPTION
On Linux, Typst CLI indirectly depends OpenSSL (via `native-tls`) for network access. `native-tls` defaults to dynamic linking. This broke the cross compilation in the release workflow (#3418).

I really wanted to do the dynamic way (because of security patches), but it just didn't work. The solutions in the cross wiki for OpenSSL all assume glibc rather than musl targets (which we currently don't use). We could switch back to glibc  and build on an older OS (to support older distributions), but even after successfully cross-compiling Typst to `aarch64-unknown-linux-gnu`, I got startup errors like `libssl.so.1.1: cannot open shared object file: No such file or directory`.

Vendoring isn't a great solution (because of security patches), but it is in line with providing the most portable binary (we already use musl). Note that this adds a build-time dependency on `perl` and `make` on Linux, but a C toolchain is already required.

Windows and macOS are not affected by thus and thus the openssl vendoring is guarded by `cfg`s.

Fixes #3418