### PR TITLE
Add search box to test-helper

### DIFF
--- a/tools/test-helper/extension.js
+++ b/tools/test-helper/extension.js
@@ -118,6 +118,7 @@ class Handler {
             'Typst.test-helper.preview',
             uri.path.split('/').pop()?.replace('.typ', '.png') ?? 'Test output',
             vscode.ViewColumn.Beside,
+            {enableFindWidget: true},
         )
         newPanel.onDidChangeViewState(() => {
             if (newPanel && newPanel.active && newPanel.visible) {


### PR DESCRIPTION
This way, with Ctrl+F (Command+F on macOS) developers can easily search in the stdout and stderr text body.