### PR TITLE
Fix out of flow check

### DIFF
--- a/crates/typst/src/layout/flow.rs
+++ b/crates/typst/src/layout/flow.rs
@@ -157,7 +157,8 @@ impl FlowItem {
         match self {
             Self::Placed { float: false, .. } => true,
             Self::Frame { frame, .. } => {
-                frame.items().all(|(_, item)| matches!(item, FrameItem::Meta(..)))
+                frame.size().is_zero()
+                    && frame.items().all(|(_, item)| matches!(item, FrameItem::Meta(..)))
             }
             _ => false,
         }


### PR DESCRIPTION
The code introduced in https://github.com/typst/typst/pull/2517 could move a frame it considers "out of flow" to a new region even though it had a non-zero size. In combination with padding, this led to weird phantom spacing in table rowspans.

It's a bit hard to reproduce this without the table code. This here demonstrates it conceptually, but doesn't actually trigger the problem because the block spacing below the `#block` leads to a `FrameItem::Absolute`, which then prevents the moving.

```typ
#set page(height: 60pt, margin: 10pt)
#block(stroke: 1pt, inset: 5pt)[
  #block(height: 20pt, counter(heading).update(1))
  #rect(height: 30pt, fill: red)
]
```

After this is merged, https://github.com/typst/typst/pull/3501 should correctly work in the following case:
```typ
#set page(width: 170pt, height: 50pt, margin: 10pt)
#set text(11pt)
#table(
  columns: (1fr, 1fr),
  [A],
  table.cell(rowspan: 2, lorem(4)),
  [B],
)
```

cc: @PgBiel @MDLC01 