### PR TITLE
Allow DTD in XML parsing

### DIFF
--- a/crates/typst/src/loading/xml.rs
+++ b/crates/typst/src/loading/xml.rs
@@ -1,4 +1,5 @@
 use ecow::EcoString;
+use roxmltree::ParsingOptions;
 
 use crate::diag::{format_xml_like_error, At, FileError, SourceResult};
 use crate::engine::Engine;
@@ -80,8 +81,12 @@ impl xml {
         let text = std::str::from_utf8(data.as_slice())
             .map_err(FileError::from)
             .at(span)?;
-        let document =
-            roxmltree::Document::parse(text).map_err(format_xml_error).at(span)?;
+        let document = roxmltree::Document::parse_with_options(
+            text,
+            ParsingOptions { allow_dtd: true, ..Default::default() },
+        )
+        .map_err(format_xml_error)
+        .at(span)?;
         Ok(convert_xml(document.root()))
     }
 }


### PR DESCRIPTION
Fix #3215. I don't know what is dtd, but they occurs in tmTheme files (theme files for typst). If we don't allow dtd, we may not be able to load tmTheme files in typst.