### PR TITLE
Add docs to nix src

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,9 +37,9 @@
             craneLib = crane.mkLib pkgs;
 
             # Typst files to include in the derivation.
-            # Here we include Rust files, assets and tests.
+            # Here we include Rust files, docs and tests.
             src = sourceByRegex ./. [
-              "(assets|crates|tests)(/.*)?"
+              "(docs|crates|tests)(/.*)?"
               ''Cargo\.(toml|lock)''
               ''build\.rs''
             ];


### PR DESCRIPTION
The nix build was not working with some of the new directory structures.
This adds the docs directory to nix src, and removes the assets directory.