### PR TITLE
Add `chunks` method to array

### DIFF
--- a/crates/typst/src/foundations/array.rs
+++ b/crates/typst/src/foundations/array.rs
@@ -741,7 +741,7 @@ impl Array {
         self,
         /// How many elements each chunk may at most contain.
         chunk_size: NonZeroUsize,
-        /// Whether to keep the remainder if its size is less than `chunk_size`.
+        /// Whether to keep the remainder if its size is less than `chunk-size`.
         #[named]
         #[default(false)]
         exact: bool,

--- a/crates/typst/src/foundations/array.rs
+++ b/crates/typst/src/foundations/array.rs
@@ -745,12 +745,12 @@ impl Array {
         #[named]
         #[default(false)]
         exact: bool,
-    ) -> StrResult<Array> {
+    ) -> Array {
         let to_array = |chunk| Array::from(chunk).into_value();
         if exact {
-            Ok(self.0.chunks_exact(chunk_size.get()).map(to_array).collect())
+            self.0.chunks_exact(chunk_size.get()).map(to_array).collect()
         } else {
-            Ok(self.0.chunks(chunk_size.get()).map(to_array).collect())
+            self.0.chunks(chunk_size.get()).map(to_array).collect()
         }
     }
 

--- a/crates/typst/src/foundations/array.rs
+++ b/crates/typst/src/foundations/array.rs
@@ -7,7 +7,7 @@ use ecow::{eco_format, EcoString, EcoVec};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
-use crate::diag::{At, SourceResult, StrResult};
+use crate::diag::{bail, At, SourceResult, StrResult};
 use crate::engine::Engine;
 use crate::eval::ops;
 use crate::foundations::{
@@ -722,6 +722,41 @@ impl Array {
         }
 
         Array(vec)
+    }
+
+    /// Splits an array into non-overlapping chunks, starting at the beginning,
+    /// ending with a single remainder chunk.
+    ///
+    /// All chunks but the last have `chunk_size` elements.
+    /// If `exact` is set to `{true}`, the remainder is dropped if it
+    /// contains less than `chunk_size` elements.
+    ///
+    /// ```example
+    /// #let array = (1, 2, 3, 4, 5, 6, 7, 8)
+    /// #array.chunks(3)
+    /// #array.chunks(3, exact: true)
+    /// ```
+    #[func]
+    pub fn chunks(
+        self,
+        /// How many elements each chunk may at most contain.
+        chunk_size: i64,
+        /// Whether to keep the remainder if its size is less than `chunk_size`.
+        #[named]
+        #[default(false)]
+        exact: bool,
+    ) -> StrResult<Array> {
+        if chunk_size <= 0 {
+            bail!("chunk size must be strictly greater than zero");
+        }
+
+        let to_array =
+            |chunk: &[Value]| chunk.iter().cloned().collect::<Array>().into_value();
+        if exact {
+            Ok(self.0.chunks_exact(chunk_size as usize).map(to_array).collect())
+        } else {
+            Ok(self.0.chunks(chunk_size as usize).map(to_array).collect())
+        }
     }
 
     /// Return a sorted version of this array, optionally by a given key

--- a/crates/typst/src/foundations/array.rs
+++ b/crates/typst/src/foundations/array.rs
@@ -1,13 +1,13 @@
 use std::cmp::Ordering;
 use std::fmt::{Debug, Formatter};
-use std::num::NonZeroI64;
+use std::num::{NonZeroI64, NonZeroUsize};
 use std::ops::{Add, AddAssign};
 
 use ecow::{eco_format, EcoString, EcoVec};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
-use crate::diag::{bail, At, SourceResult, StrResult};
+use crate::diag::{At, SourceResult, StrResult};
 use crate::engine::Engine;
 use crate::eval::ops;
 use crate::foundations::{
@@ -727,9 +727,9 @@ impl Array {
     /// Splits an array into non-overlapping chunks, starting at the beginning,
     /// ending with a single remainder chunk.
     ///
-    /// All chunks but the last have `chunk_size` elements.
+    /// All chunks but the last have `chunk-size` elements.
     /// If `exact` is set to `{true}`, the remainder is dropped if it
-    /// contains less than `chunk_size` elements.
+    /// contains less than `chunk-size` elements.
     ///
     /// ```example
     /// #let array = (1, 2, 3, 4, 5, 6, 7, 8)
@@ -740,22 +740,17 @@ impl Array {
     pub fn chunks(
         self,
         /// How many elements each chunk may at most contain.
-        chunk_size: i64,
+        chunk_size: NonZeroUsize,
         /// Whether to keep the remainder if its size is less than `chunk_size`.
         #[named]
         #[default(false)]
         exact: bool,
     ) -> StrResult<Array> {
-        if chunk_size <= 0 {
-            bail!("chunk size must be strictly greater than zero");
-        }
-
-        let to_array =
-            |chunk: &[Value]| chunk.iter().cloned().collect::<Array>().into_value();
+        let to_array = |chunk| Array::from(chunk).into_value();
         if exact {
-            Ok(self.0.chunks_exact(chunk_size as usize).map(to_array).collect())
+            Ok(self.0.chunks_exact(chunk_size.get()).map(to_array).collect())
         } else {
-            Ok(self.0.chunks(chunk_size as usize).map(to_array).collect())
+            Ok(self.0.chunks(chunk_size.get()).map(to_array).collect())
         }
     }
 

--- a/tests/typ/compiler/array.typ
+++ b/tests/typ/compiler/array.typ
@@ -237,6 +237,26 @@
 #test((1, 2, "b").intersperse("a"), (1, "a", 2, "a", "b"))
 
 ---
+// Test the `chunks` method.
+#test(().chunks(10), ())
+#test((1, 2, 3).chunks(10), ((1, 2, 3),))
+#test((1, 2, 3, 4, 5, 6).chunks(3), ((1, 2, 3), (4, 5, 6)))
+#test((1, 2, 3, 4, 5, 6, 7, 8).chunks(3), ((1, 2, 3), (4, 5, 6), (7, 8)))
+
+#test(().chunks(10, exact: true), ())
+#test((1, 2, 3).chunks(10, exact: true), ())
+#test((1, 2, 3, 4, 5, 6).chunks(3, exact: true), ((1, 2, 3), (4, 5, 6)))
+#test((1, 2, 3, 4, 5, 6, 7, 8).chunks(3, exact: true), ((1, 2, 3), (4, 5, 6)))
+
+---
+// Error: 2-21 chunk size must be strictly greater than zero
+#(1, 2, 3).chunks(0)
+
+---
+// Error: 2-22 chunk size must be strictly greater than zero
+#(1, 2, 3).chunks(-5)
+
+---
 // Test the `sorted` method.
 #test(().sorted(), ())
 #test(().sorted(key: x => x), ())

--- a/tests/typ/compiler/array.typ
+++ b/tests/typ/compiler/array.typ
@@ -249,11 +249,11 @@
 #test((1, 2, 3, 4, 5, 6, 7, 8).chunks(3, exact: true), ((1, 2, 3), (4, 5, 6)))
 
 ---
-// Error: 2-21 chunk size must be strictly greater than zero
+// Error: 19-20 number must be positive
 #(1, 2, 3).chunks(0)
 
 ---
-// Error: 2-22 chunk size must be strictly greater than zero
+// Error: 19-21 number must be positive
 #(1, 2, 3).chunks(-5)
 
 ---


### PR DESCRIPTION
There were a few times in the past where I required this feature, or others on the Discord did.
Especially when working with tables, it is quite useful.
I always used one of the following functions, but I think it is used often enough to warrant inclusion in the standard library.

```typ
#let chunks(array, n) = {
  range(array.len(), step: n)
    .map(i => array.slice(i, calc.min(array.len(), i + n)))
}

#let chunks-exact(array, n) = {
  range(array.len(), step: n)
    .map(i => array.slice(i, count: n))
}
```

They behave the same way as Rust's `chunks` and `chunks_exact` functions (I mean, they even use the same implementation).