### PR TITLE
Collect test matrix result into single job result

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,22 @@ env:
   RUSTDOCFLAGS: "-Dwarnings"
 
 jobs:
+  # This allows us to have one branch protection rule for the full test matrix.
+  # See: https://github.com/orgs/community/discussions/4324
   tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    needs: [test-matrix]
+    if: always()
+    steps:
+      - name: Tests successful
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: Tests failing
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1
+
+  test-matrix:
     name: Tests
     strategy:
       matrix:


### PR DESCRIPTION
This allows us to have one branch protection rule for the full test matrix and, by extension, to not break existing status checks on already open PRs. It also gives more flexibility should we update the matrix again in the future.