### PR TITLE
Fix metrics of fandol fonts

### DIFF
--- a/crates/typst/src/text/font/exceptions.rs
+++ b/crates/typst/src/text/font/exceptions.rs
@@ -49,7 +49,7 @@ static EXCEPTION_MAP: phf::Map<&'static str, Exception> = phf::phf_map! {
     "Arial-Black" => Exception::new()
         .weight(900),
     // Fandol fonts designed for Chinese typesetting.
-    // See https://ctan.org/tex-archive/fonts/fandol
+    // See https://ctan.org/tex-archive/fonts/fandol/.
     "FandolHei-Bold" => Exception::new()
         .weight(700),
     "FandolSong-Bold" => Exception::new()

--- a/crates/typst/src/text/font/exceptions.rs
+++ b/crates/typst/src/text/font/exceptions.rs
@@ -48,6 +48,12 @@ static EXCEPTION_MAP: phf::Map<&'static str, Exception> = phf::phf_map! {
     // See https://corefonts.sourceforge.net/.
     "Arial-Black" => Exception::new()
         .weight(900),
+    // Fandol fonts designed for Chinese typesetting.
+    // See https://ctan.org/tex-archive/fonts/fandol
+    "FandolHei-Bold" => Exception::new()
+        .weight(700),
+    "FandolSong-Bold" => Exception::new()
+        .weight(700),
     // Noto fonts
     "NotoNaskhArabicUISemi-Bold" => Exception::new()
         .family("Noto Naskh Arabic UI")


### PR DESCRIPTION
The fandol fonts is designed and widely used for Chinese typesetting. This series of fonts are well known as the default fonts of [ctex](https://ctex.org/).

To use fandol fonts in typst, we need to fix the wrong font weight for correct font fallback.