### PR TITLE
Consolidate what internal methods Counter's user-visible methods call

### DIFF
--- a/crates/typst/src/introspection/counter.rs
+++ b/crates/typst/src/introspection/counter.rs
@@ -406,9 +406,10 @@ impl Counter {
         /// - If it is a string, creates a custom counter that is only affected
         ///   by manual updates,
         /// - If it is the [`page`] function, counts through pages,
-        /// - If it is a `{<label>}`, counts through all elements with that label,
-        /// - If it is an element function or other [selectors]($selector), counts
-        ///   through the matching elements.
+        /// - If it is a [selector], counts through elements that matches with the
+        ///   selector. For example,
+        ///   - provide an element function: counts elements of that type,
+        ///   - provide a [`{<label>}`]($label): counts elements with that label.
         key: CounterKey,
     ) -> Counter {
         Self::new(key)

--- a/crates/typst/src/introspection/counter.rs
+++ b/crates/typst/src/introspection/counter.rs
@@ -213,7 +213,7 @@ impl Counter {
 
     /// The counter for the given element.
     pub fn of(func: Element) -> Self {
-        Self::construct(CounterKey::Selector(Selector::Elem(func, None)))
+        Self::new(CounterKey::Selector(Selector::Elem(func, None)))
     }
 
     /// Gets the current and final value of the state combined in one state.
@@ -405,14 +405,13 @@ impl Counter {
         ///
         /// - If it is a string, creates a custom counter that is only affected
         ///   by manual updates,
-        /// - If this is a `{<label>}`, counts through all elements with that
-        ///   label,
-        /// - If this is an element function or selector, counts through its
-        ///   elements,
-        /// - If this is the [`page`] function, counts through pages.
+        /// - If it is the [`page`] function, counts through pages,
+        /// - If it is a `{<label>}`, counts through all elements with that label,
+        /// - If it is an element function or other [selectors]($selector), counts
+        ///   through the matching elements.
         key: CounterKey,
     ) -> Counter {
-        Self(key)
+        Self::new(key)
     }
 
     /// Retrieves the value of the counter at the current location. Always


### PR DESCRIPTION
There is more than one way to instantiate a `Counter`, and this PR consolidates them into using the `new()` method behind the scene.

(If the current code was intended, it also helps to document why so. Especially, `Counter::new()` is right above `Counter::of()`)