### PR TITLE
Add top and bottom bracket accents

### DIFF
--- a/crates/typst/src/math/accent.rs
+++ b/crates/typst/src/math/accent.rs
@@ -51,6 +51,14 @@ pub struct AccentElem {
     /// | Circle        | `circle`        | `∘`       |
     /// | Double acute  | `acute.double`  | `˝`       |
     /// | Caron         | `caron`         | `ˇ`       |
+    /// | Top parenthesis  | `paren.t`    | `⏜`       |
+    /// | Bottom parenthesis  | `paren.b` | `⏝`       |
+    /// | Top brace     | `brace.t`       | `⏞`       |
+    /// | Bottom brace  | `brace.b`       | `⏟`       |
+    /// | Top bracket   | `bracket.t`     | `⎴`       |
+    /// | Bottom bracket | `bracket.b`    | `⎵`       |
+    /// | Top turtle shell | `turtle.t`   | `⏠`       |
+    /// | Bottom turtle shell | `turtle.b` | `⏡`       |
     /// | Right arrow   | `arrow`, `->`   | `→`       |
     /// | Left arrow    | `arrow.l`, `<-` | `←`       |
     /// | Left/Right arrow | `arrow.l.r`  | `↔`       |

--- a/crates/typst/src/symbols/symbol.rs
+++ b/crates/typst/src/symbols/symbol.rs
@@ -137,6 +137,11 @@ impl Symbol {
     /// Normalize an accent to a combining one. Keep it synced with the
     /// documenting table in accent.rs AccentElem.
     pub fn combining_accent(c: char) -> Option<char> {
+        // Certain non-combining marks are returned as such.
+        if matches!(c, '⏜' | '⏝' | '⎴' | '⎵' | '⏞' | '⏟' | '⏠' | '⏡') {
+            return Some(c);
+        }
+
         Some(match c {
             '\u{0300}' | '`' => '\u{0300}',
             '\u{0301}' | '´' => '\u{0301}',


### PR DESCRIPTION
This PR adds shorthands for `accent("AB", paren.t)` and others: `paren.t("AB")`.
I'm not totally sure if this is the way to go (especially because the characters used are not part of the [Combining Diacritical Marks for Symbols](https://graphemica.com/blocks/combining-diacritical-marks-for-symbols) block), but it seems good to me.

There is also a case to be made whether we want to add aliases for `paren.t` and `paren.b` a la `overarc` and `underarc`, as is common in LaTeX land.

See #3563 and #2404.