### PR TITLE
Remove dependency on unicode_names2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1651,16 +1651,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "phf_codegen"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
 name = "phf_generator"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1839,8 +1829,6 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
- "rand_chacha",
  "rand_core",
 ]
 
@@ -1859,9 +1847,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
-]
 
 [[package]]
 name = "rayon"
@@ -2668,7 +2653,6 @@ dependencies = [
  "typst-assets",
  "typst-dev-assets",
  "typst-render",
- "unicode_names2",
  "unscanny",
  "yaml-front-matter",
 ]
@@ -2912,29 +2896,6 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
-
-[[package]]
-name = "unicode_names2"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac64ef2f016dc69dfa8283394a70b057066eb054d5fcb6b9eb17bd2ec5097211"
-dependencies = [
- "phf",
- "unicode_names2_generator",
-]
-
-[[package]]
-name = "unicode_names2_generator"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "013f6a731e80f3930de580e55ba41dfa846de4e0fdee4a701f97989cb1597d6a"
-dependencies = [
- "getopts",
- "log",
- "phf_codegen",
- "rand",
- "time",
-]
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,6 @@ toml = { version = "0.8", default-features = false, features = ["parse", "displa
 ttf-parser = "0.20.0"
 two-face = { version = "0.3.0", default-features = false, features = ["syntect-fancy"] }
 typed-arena = "2"
-unicode_names2 = "1.2"
 unicode-bidi = "0.3.13"
 unicode-ident = "1.0"
 unicode-math-class = "0.1"

--- a/docs/Cargo.toml
+++ b/docs/Cargo.toml
@@ -31,7 +31,6 @@ serde = { workspace = true }
 serde_yaml = { workspace = true }
 syntect = { workspace = true, features = ["html"] }
 typed-arena = { workspace = true }
-unicode_names2 = { workspace = true }
 unscanny = { workspace = true }
 yaml-front-matter = { workspace = true }
 clap = { workspace = true, optional = true }

--- a/docs/src/lib.rs
+++ b/docs/src/lib.rs
@@ -11,7 +11,6 @@ pub use self::model::*;
 
 use comemo::Prehashed;
 use ecow::{eco_format, EcoString};
-use heck::ToTitleCase;
 use once_cell::sync::Lazy;
 use serde::Deserialize;
 use serde_yaml as yaml;
@@ -663,8 +662,6 @@ fn symbols_model(resolver: &dyn Resolver, group: &GroupData) -> SymbolsModel {
                 math_shorthand: shorthand(typst::syntax::ast::Shorthand::MATH_LIST),
                 codepoint: c as u32,
                 accent: typst::symbols::Symbol::combining_accent(c).is_some(),
-                unicode_name: unicode_names2::name(c)
-                    .map(|s| s.to_string().to_title_case().into()),
                 alternates: symbol
                     .variants()
                     .filter(|(other, _)| other != &variant)

--- a/docs/src/model.rs
+++ b/docs/src/model.rs
@@ -159,7 +159,6 @@ pub struct SymbolModel {
     pub name: EcoString,
     pub codepoint: u32,
     pub accent: bool,
-    pub unicode_name: Option<EcoString>,
     pub alternates: Vec<EcoString>,
     pub markup_shorthand: Option<&'static str>,
     pub math_shorthand: Option<&'static str>,


### PR DESCRIPTION
The unicode_names2 crate restricts the compatible versions of the time crate, which is unfortunate.

Since it doesn't add any new information to the docs model that couldn't be gathered from the consumer of typst-docs themselves, we can just remove it and handle that on the other side.