### PR TITLE
Remove `safe_div`

### DIFF
--- a/crates/typst/src/layout/abs.rs
+++ b/crates/typst/src/layout/abs.rs
@@ -117,17 +117,6 @@ impl Abs {
     pub fn approx_eq(self, other: Self) -> bool {
         self == other || (self - other).to_raw().abs() < 1e-6
     }
-
-    /// Perform a checked division by a number, returning zero if the result
-    /// is not finite.
-    pub fn safe_div(self, number: f64) -> Self {
-        let result = self.to_raw() / number;
-        if result.is_finite() {
-            Self::raw(result)
-        } else {
-            Self::zero()
-        }
-    }
 }
 
 impl Numeric for Abs {

--- a/crates/typst/src/layout/pad.rs
+++ b/crates/typst/src/layout/pad.rs
@@ -122,5 +122,5 @@ fn shrink(size: Size, padding: Sides<Rel<Abs>>) -> Size {
 ///   <=> (1 - p.rel) * w = s + p.abs
 ///   <=> w = (s + p.abs) / (1 - p.rel)
 fn grow(size: Size, padding: Sides<Rel<Abs>>) -> Size {
-    size.zip_map(padding.sum_by_axis(), |s, p| (s + p.abs).safe_div(1.0 - p.rel.get()))
+    size.zip_map(padding.sum_by_axis(), |s, p| (s + p.abs) / (1.0 - p.rel.get()))
 }

--- a/crates/typst/src/visualize/image/mod.rs
+++ b/crates/typst/src/visualize/image/mod.rs
@@ -209,7 +209,7 @@ impl LayoutSingle for Packed<ImageElem> {
             region
         } else if expand.x {
             // If just width is forced, take it.
-            Size::new(region.x, region.y.min(region.x.safe_div(px_ratio)))
+            Size::new(region.x, region.y.min(region.x / px_ratio))
         } else if expand.y {
             // If just height is forced, take it.
             Size::new(region.x.min(region.y * px_ratio), region.y)
@@ -220,7 +220,7 @@ impl LayoutSingle for Packed<ImageElem> {
             let natural = Axes::new(pxw, pxh).map(|v| Abs::inches(v / dpi));
             Size::new(
                 natural.x.min(region.x).min(region.y * px_ratio),
-                natural.y.min(region.y).min(region.x.safe_div(px_ratio)),
+                natural.y.min(region.y).min(region.x / px_ratio),
             )
         };
 
@@ -229,7 +229,7 @@ impl LayoutSingle for Packed<ImageElem> {
         let fitted = match fit {
             ImageFit::Cover | ImageFit::Contain => {
                 if wide == (fit == ImageFit::Contain) {
-                    Size::new(target.x, target.x.safe_div(px_ratio))
+                    Size::new(target.x, target.x / px_ratio)
                 } else {
                     Size::new(target.y * px_ratio, target.y)
                 }

--- a/tests/typ/bugs/measure-image.typ
+++ b/tests/typ/bugs/measure-image.typ
@@ -1,0 +1,8 @@
+// Test that image measurement doesn't turn `inf / some-value` into 0pt.
+// Ref: false
+
+---
+#context {
+  let size = measure(image("/assets/images/tiger.jpg"))
+  test(size, (width: 1024pt, height: 670pt))
+}


### PR DESCRIPTION
The `safe_div` function is completely superseded by `Scalar::new` NaN-checks and, in fact, problematic because it turns `inf / some-value` into zero rather than inf.