### PR TITLE
Implement `to-dict` method on arrays

### DIFF
--- a/crates/typst/src/foundations/array.rs
+++ b/crates/typst/src/foundations/array.rs
@@ -5,15 +5,16 @@ use std::ops::{Add, AddAssign};
 
 use comemo::Tracked;
 use ecow::{eco_format, EcoString, EcoVec};
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
-use crate::diag::{At, SourceResult, StrResult};
+use crate::diag::{bail, At, SourceResult, StrResult};
 use crate::engine::Engine;
 use crate::eval::ops;
 use crate::foundations::{
-    cast, func, repr, scope, ty, Args, Bytes, CastInfo, Context, FromValue, Func,
-    IntoValue, Reflect, Repr, Value, Version,
+    cast, func, repr, scope, ty, Args, Bytes, CastInfo, Context, Dict, FromValue, Func,
+    IntoValue, Reflect, Repr, Str, Value, Version,
 };
 use crate::syntax::Span;
 
@@ -853,6 +854,56 @@ impl Array {
         }
 
         Ok(Self(out))
+    }
+
+    /// Converts an array of pairs into a dictionary.
+    /// The first value of each pair is the key, the second the value.
+    ///
+    /// By default, the last pair with a certain key is selected.
+    /// If `grouped` is set to `{true}`, pairs with equal keys are grouped
+    /// together into arrays.
+    ///
+    /// ```example
+    /// (("apples", 2), ("peaches", 3), ("apples", 5)).to-dict()
+    /// (("apples", 2), ("peaches", 3), ("apples", 5)).to-dict(grouped: true)
+    /// ```
+    #[func]
+    pub fn to_dict(
+        self,
+        /// Whether pairs with equal keys are grouped together.
+        #[named]
+        #[default(false)]
+        grouped: bool,
+    ) -> StrResult<Dict> {
+        let pairs = self.into_iter().map(|value| {
+            let value_ty = value.ty();
+            let pair = value.cast::<Array>().map_err(|_| {
+                eco_format!("expected (str, any) pairs, found {}", value_ty)
+            })?;
+            if let [key, value] = pair.as_slice() {
+                let key = key.clone().cast::<Str>().map_err(|_| {
+                    eco_format!("expected key of type str, found {}", value.ty())
+                })?;
+                Ok((key, value.clone()))
+            } else {
+                bail!("expected pairs of length 2, found length {}", pair.len());
+            }
+        });
+        if grouped {
+            let mut map = IndexMap::new();
+            for res in pairs {
+                let (key, value) = res?;
+                let Value::Array(array) =
+                    map.entry(key).or_insert_with(|| Array::new().into_value())
+                else {
+                    unreachable!();
+                };
+                array.push(value);
+            }
+            Ok(map.into())
+        } else {
+            pairs.collect()
+        }
     }
 }
 

--- a/tests/typ/compiler/array.typ
+++ b/tests/typ/compiler/array.typ
@@ -314,16 +314,10 @@
 #test(("Hello", "World", "Hi", "There").dedup(key: x => x.at(0)), ("Hello", "World", "There"))
 
 ---
-// Test the `to-dict` method without grouping.
+// Test the `to-dict` method.
 #test(().to-dict(), (:))
 #test((("a", 1), ("b", 2), ("c", 3)).to-dict(), (a: 1, b: 2, c: 3))
 #test((("a", 1), ("b", 2), ("c", 3), ("b", 4)).to-dict(), (a: 1, b: 4, c: 3))
-
----
-// Test the `to-dict` method with grouping.
-#test(().to-dict(grouped: true), (:))
-#test((("a", 1), ("b", 2), ("c", 3)).to-dict(grouped: true), (a: (1,), b: (2,), c: (3,)))
-#test((("a", 1), ("b", 2), ("c", 3), ("b", 4)).to-dict(grouped: true), (a: (1,), b: (2, 4), c: (3,)))
 
 ---
 // Error: 2-16 expected (str, any) pairs, found integer

--- a/tests/typ/compiler/array.typ
+++ b/tests/typ/compiler/array.typ
@@ -307,11 +307,39 @@
 #test(("Jane", "John", "Eric", "John").dedup(), ("Jane", "John", "Eric"))
 
 ---
-// Test the `dedup` with the `key` argument.
+// Test the `dedup` method with the `key` argument.
 #test((1, 2, 3, 4, 5, 6).dedup(key: x => calc.rem(x, 2)), (1, 2))
 #test((1, 2, 3, 4, 5, 6).dedup(key: x => calc.rem(x, 3)), (1, 2, 3))
 #test(("Hello", "World", "Hi", "There").dedup(key: x => x.len()), ("Hello", "Hi"))
 #test(("Hello", "World", "Hi", "There").dedup(key: x => x.at(0)), ("Hello", "World", "There"))
+
+---
+// Test the `to-dict` method without grouping.
+#test(().to-dict(), (:))
+#test((("a", 1), ("b", 2), ("c", 3)).to-dict(), (a: 1, b: 2, c: 3))
+#test((("a", 1), ("b", 2), ("c", 3), ("b", 4)).to-dict(), (a: 1, b: 4, c: 3))
+
+---
+// Test the `to-dict` method with grouping.
+#test(().to-dict(grouped: true), (:))
+#test((("a", 1), ("b", 2), ("c", 3)).to-dict(grouped: true), (a: (1,), b: (2,), c: (3,)))
+#test((("a", 1), ("b", 2), ("c", 3), ("b", 4)).to-dict(grouped: true), (a: (1,), b: (2, 4), c: (3,)))
+
+---
+// Error: 2-16 expected (str, any) pairs, found integer
+#(1,).to-dict()
+
+---
+// Error: 2-19 expected pairs of length 2, found length 1
+#((1,),).to-dict()
+
+---
+// Error: 2-26 expected pairs of length 2, found length 3
+#(("key",1,2),).to-dict()
+
+---
+// Error: 2-21 expected key of type str, found integer
+#((1, 2),).to-dict()
 
 ---
 // Error: 9-26 unexpected argument: val


### PR DESCRIPTION
This PR adds a method to collect an array of pairs into a dictionary:
```typ
#assert.eq(
  (("apples", 2), ("peaches", 3), ("apples", 5)).to-dict(),
  (apples: 5, peaches: 3),
)
#assert.eq(
  ("apples", 2), ("peaches", 3), ("apples", 5)).to-dict(grouped: true),
  (apples: (2, 5), peaches: (3,)),
)
```

Supersedes #3383.
I selected `.to-dict()` in particular for being easy to chain, which to me seems like the primary use case for such a feature.
I also added a named argument `grouped` to group pairs of equal keys into arrays.