### PR TITLE
Generate PDF ID automatically unless we really have a stable ID

### DIFF
--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -9,7 +9,7 @@ use parking_lot::RwLock;
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use typst::diag::{bail, At, Severity, SourceDiagnostic, StrResult};
 use typst::eval::Tracer;
-use typst::foundations::Datetime;
+use typst::foundations::{Datetime, Smart};
 use typst::layout::Frame;
 use typst::model::Document;
 use typst::syntax::{FileId, Source, Span};
@@ -157,18 +157,13 @@ fn export(
         OutputFormat::Svg => {
             export_image(world, document, command, watching, ImageExportFormat::Svg)
         }
-        OutputFormat::Pdf => export_pdf(document, command, world),
+        OutputFormat::Pdf => export_pdf(document, command),
     }
 }
 
 /// Export to a PDF.
-fn export_pdf(
-    document: &Document,
-    command: &CompileCommand,
-    world: &SystemWorld,
-) -> StrResult<()> {
-    let ident = world.input().map(|i| i.to_string_lossy());
-    let buffer = typst_pdf::pdf(document, ident.as_deref(), now());
+fn export_pdf(document: &Document, command: &CompileCommand) -> StrResult<()> {
+    let buffer = typst_pdf::pdf(document, Smart::Auto, now());
     let output = command.output();
     fs::write(output, buffer)
         .map_err(|err| eco_format!("failed to write PDF file ({err})"))?;

--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -29,8 +29,6 @@ static STDIN_ID: Lazy<FileId> =
 pub struct SystemWorld {
     /// The working directory.
     workdir: Option<PathBuf>,
-    /// The canonical path to the input file.
-    input: Option<PathBuf>,
     /// The root relative to which absolute paths are resolved.
     root: PathBuf,
     /// The input path.
@@ -108,7 +106,6 @@ impl SystemWorld {
 
         Ok(Self {
             workdir: std::env::current_dir().ok(),
-            input,
             root,
             main,
             library: Prehashed::new(library),
@@ -150,11 +147,6 @@ impl SystemWorld {
             slot.reset();
         }
         self.now.take();
-    }
-
-    /// Return the canonical path to the input file.
-    pub fn input(&self) -> Option<&PathBuf> {
-        self.input.as_ref()
     }
 
     /// Lookup a source file by id.

--- a/crates/typst/src/model/document.rs
+++ b/crates/typst/src/model/document.rs
@@ -51,6 +51,9 @@ pub struct DocumentElem {
     ///
     /// The year component must be at least zero in order to be embedded into a
     /// PDF.
+    ///
+    /// If you want to create byte-by-byte reproducible PDFs, set this to
+    /// something other than `{auto}`.
     #[ghost]
     pub date: Smart<Option<Datetime>>,
 

--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -501,7 +501,7 @@ fn test(
         if let Some(pdf_path) = pdf_path {
             let pdf_data = typst_pdf::pdf(
                 &document,
-                Some(&format!("typst-test: {}", name.display())),
+                Smart::Custom(&format!("typst-test: {}", name.display())),
                 world.today(Some(0)),
             );
             fs::create_dir_all(pdf_path.parent().unwrap()).unwrap();


### PR DESCRIPTION
Changes ident in PDF export signature from `Option<&str>` to `Smart<&str>`. You should only pass `Smart::Custom` if you really have a stable ID (like the web app). The CLI does not have one and Typst LSP shouldn't either.