### PR TITLE
Documentation fixes

### DIFF
--- a/crates/typst/src/foundations/module.rs
+++ b/crates/typst/src/foundations/module.rs
@@ -10,7 +10,10 @@ use crate::foundations::{repr, ty, Content, Scope, Value};
 ///
 /// You can access definitions from the module using
 /// [field access notation]($scripting/#fields) and interact with it using the
-/// [import and include syntaxes]($scripting/#modules).
+/// [import and include syntaxes]($scripting/#modules). Alternatively, it is
+/// possible to convert a module to a dictionary, and therefore access its
+/// contents dynamically, using the
+/// [dictionary constructor]($dictionary#constructor).
 ///
 /// # Example
 /// ```example

--- a/crates/typst/src/foundations/module.rs
+++ b/crates/typst/src/foundations/module.rs
@@ -13,7 +13,7 @@ use crate::foundations::{repr, ty, Content, Scope, Value};
 /// [import and include syntaxes]($scripting/#modules). Alternatively, it is
 /// possible to convert a module to a dictionary, and therefore access its
 /// contents dynamically, using the
-/// [dictionary constructor]($dictionary#constructor).
+/// [dictionary constructor]($dictionary/#constructor).
 ///
 /// # Example
 /// ```example

--- a/crates/typst/src/layout/grid/mod.rs
+++ b/crates/typst/src/layout/grid/mod.rs
@@ -53,7 +53,7 @@ use crate::visualize::{Paint, Stroke};
 ///
 /// - `{auto}`: The track will be sized to fit its contents. It will be at most
 ///   as large as the remaining space. If there is more than one `{auto}` track
-///   which, and together they claim more than the available space, the `{auto}`
+///   width, and together they claim more than the available space, the `{auto}`
 ///   tracks will fairly distribute the available space among themselves.
 ///
 /// - A fixed or relative length (e.g. `{10pt}` or `{20% - 1cm}`): The track
@@ -72,8 +72,8 @@ use crate::visualize::{Paint, Stroke};
 ///
 /// # Examples
 /// The example below demonstrates the different track sizing options. It also
-/// shows how you can use [`grid.cell`]($grid.cell) in to make an individual
-/// cell span two grid tracks.
+/// shows how you can use [`grid.cell`]($grid.cell) to make an individual cell
+/// span two grid tracks.
 ///
 /// ```example
 /// // We use `rect` to emphasize the

--- a/crates/typst/src/layout/grid/mod.rs
+++ b/crates/typst/src/layout/grid/mod.rs
@@ -186,7 +186,7 @@ pub struct GridElem {
     /// How to fill the cells.
     ///
     /// This can be a color or a function that returns a color. The function is
-    /// passed the cells' column and row index, starting at zero. This can be
+    /// passed the cells' column and row indices, starting at zero. This can be
     /// used to implement striped grids.
     ///
     /// ```example
@@ -210,7 +210,7 @@ pub struct GridElem {
     ///
     /// This can either be a single alignment, an array of alignments
     /// (corresponding to each column) or a function that returns an alignment.
-    /// The function is passed the cells' column and row index, starting at
+    /// The function is passed the cells' column and row indices, starting at
     /// zero. If set to `{auto}`, the outer alignment is used.
     ///
     /// You can find an example for this argument at the

--- a/crates/typst/src/layout/layout.rs
+++ b/crates/typst/src/layout/layout.rs
@@ -11,7 +11,7 @@ use crate::syntax::Span;
 /// (width and height).
 ///
 /// The given function must accept a single parameter, `size`, which is a
-/// dictionary with keys `width` and `height`, both of type [`length`.
+/// dictionary with keys `width` and `height`, both of type [`length`].
 ///
 /// ```example
 /// #let text = lorem(30)

--- a/crates/typst/src/math/equation.rs
+++ b/crates/typst/src/math/equation.rs
@@ -80,7 +80,7 @@ pub struct EquationElem {
 
     /// The alignment of the equation numbering.
     ///
-    /// By default, the alignment is `{end} + {horizon}`. For the horizontal
+    /// By default, the alignment is `{end + horizon}`. For the horizontal
     /// component, you can use `{right}`, `{left}`, or `{start}` and `{end}`
     /// of the text direction; for the vertical component, you can use
     /// `{top}`, `{horizon}`, or `{bottom}`.

--- a/crates/typst/src/model/table.rs
+++ b/crates/typst/src/model/table.rs
@@ -152,7 +152,7 @@ pub struct TableElem {
     /// How to fill the cells.
     ///
     /// This can be a color or a function that returns a color. The function is
-    /// passed the cells' column and row index, starting at zero. This can be
+    /// passed the cells' column and row indices, starting at zero. This can be
     /// used to implement striped tables.
     ///
     /// ```example
@@ -176,8 +176,8 @@ pub struct TableElem {
     ///
     /// This can either be a single alignment, an array of alignments
     /// (corresponding to each column) or a function that returns an alignment.
-    /// The function is passed the cells' column and row index, starting at zero.
-    /// If set to `{auto}`, the outer alignment is used.
+    /// The function is passed the cells' column and row indices, starting at
+    /// zero. If set to `{auto}`, the outer alignment is used.
     ///
     /// ```example
     /// #table(

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -114,7 +114,7 @@ description: |
   - Fixed width adjustment of JIS-style Japanse punctuation
   - Fixed Finnish translation of "Listing"
   - Fixed Z-ordering of multiple text decorations (underlines, etc.)
-  - Fixed a bug due to with text [features]($text.features) could not be
+  - Fixed a bug due to which text [features]($text.features) could not be
     overridden in consecutive set rules
 
 - Model


### PR DESCRIPTION
This PR documents how to convert a module to a dictionary on the documentation for `module`. Previously, this was only present on the documentation for `dictionary` (in the argument type of the constructor).[^1]

I also included some other small documentation fixes.

Fixes #3598.

[^1]: Although I can't compile the docs locally, so I may be wrong.