### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM rust:alpine AS build
 COPY . /app
 WORKDIR /app
-ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
-RUN apk add --update musl-dev \
-    && cargo build -p typst-cli --release
+RUN apk add --update musl-dev openssl-dev openssl-libs-static \
+    && CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse \
+    OPENSSL_NO_PKG_CONFIG=1 OPENSSL_STATIC=1 OPENSSL_DIR=/usr/ \
+    cargo build -p typst-cli --release
 
 FROM alpine:latest
 WORKDIR /root/


### PR DESCRIPTION
I wanted to fix this a while ago, but then forgot. Seeing the RC release I took another look and got it to work.

Supersedes #3597. In contrast to that one this uses the pre-build static openssl libs from alpine instead of building them from scratch. That version could probably also be made to work by installing the necessary build dependencies.

I also inlined the environment variables, as the `ENV` command causes them to also be available at container runtime, which isn't needed/wanted here.

Maybe it would also be a good idea to run the docker image CI on every commit instead of just on releases.