### PR TITLE
Add stroked variants of suits

### DIFF
--- a/crates/typst/src/symbols/sym.rs
+++ b/crates/typst/src/symbols/sym.rs
@@ -486,7 +486,16 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
     refmark: '※',
     servicemark: '℠',
     maltese: '✠',
-    suit: [club: '♣', diamond: '♦', heart: '♥', spade: '♠'],
+    suit: [
+        club.filled: '♣',
+        club.stroked: '♧',
+        diamond.filled: '♦',
+        diamond.stroked: '♢',
+        heart.filled: '♥',
+        heart.stroked: '♡',
+        spade.filled: '♠',
+        spade.stroked: '♤',
+    ],
 
     // Shapes.
     bullet: '•',


### PR DESCRIPTION
This PR adds stroked variants of the suit symbols under `suit.{club,diamond,heart,spade}.stroked`. The previous suit symbols were renamed to `suit.{club,diamond,heart,spade}.filled`.

This is backward compatible, because the `filled` variants are specified first.