### PR TITLE
Update hline/vline stroke docs

### DIFF
--- a/crates/typst/src/layout/grid/mod.rs
+++ b/crates/typst/src/layout/grid/mod.rs
@@ -607,8 +607,8 @@ pub struct GridHLine {
 
     /// The line's stroke.
     ///
-    /// Specifying `{none}` interrupts previous hlines placed across this
-    /// line's range, but does not affect per-cell stroke or vlines.
+    /// Specifying `{none}` removes any lines previously placed across this
+    /// line's range, including hlines or per-cell stroke below it.
     #[resolve]
     #[fold]
     #[default(Some(Arc::new(Stroke::default())))]
@@ -662,8 +662,8 @@ pub struct GridVLine {
 
     /// The line's stroke.
     ///
-    /// Specifying `{none}` interrupts previous vlines placed across this
-    /// line's range, but does not affect per-cell stroke or hlines.
+    /// Specifying `{none}` removes any lines previously placed across this
+    /// line's range, including vlines or per-cell stroke below it.
     #[resolve]
     #[fold]
     #[default(Some(Arc::new(Stroke::default())))]

--- a/crates/typst/src/model/table.rs
+++ b/crates/typst/src/model/table.rs
@@ -610,8 +610,8 @@ pub struct TableHLine {
 
     /// The line's stroke.
     ///
-    /// Specifying `{none}` interrupts previous hlines placed across this
-    /// line's range, but does not affect per-cell stroke or vlines.
+    /// Specifying `{none}` removes any lines previously placed across this
+    /// line's range, including hlines or per-cell stroke below it.
     #[resolve]
     #[fold]
     #[default(Some(Arc::new(Stroke::default())))]
@@ -655,8 +655,8 @@ pub struct TableVLine {
 
     /// The line's stroke.
     ///
-    /// Specifying `{none}` interrupts previous vlines placed across this
-    /// line's range, but does not affect per-cell stroke or hlines.
+    /// Specifying `{none}` removes any lines previously placed across this
+    /// line's range, including vlines or per-cell stroke below it.
     #[resolve]
     #[fold]
     #[default(Some(Arc::new(Stroke::default())))]


### PR DESCRIPTION
#3473 updated hlines / vlines with a stroke of `none` such that they now remove cell stroke below them as well, but the docs weren't updated. This PR corrects that.

(Thanks @Andrew15-5 for noticing.)