### PR TITLE
Fix figure caption separator synthesis

### DIFF
--- a/crates/typst/src/model/figure.rs
+++ b/crates/typst/src/model/figure.rs
@@ -437,7 +437,7 @@ impl Outlinable for Packed<FigureElem> {
 ///   caption: [A rectangle],
 /// )
 /// ```
-#[elem(name = "caption", Show)]
+#[elem(name = "caption", Synthesize, Show)]
 pub struct FigureCaption {
     /// The caption's position in the figure. Either `{top}` or `{bottom}`.
     ///
@@ -543,6 +543,14 @@ impl FigureCaption {
                 TextElem::region_in(styles),
             ))
         })
+    }
+}
+
+impl Synthesize for Packed<FigureCaption> {
+    fn synthesize(&mut self, _: &mut Engine, styles: StyleChain) -> SourceResult<()> {
+        let elem = self.as_mut();
+        elem.push_separator(Smart::Custom(elem.get_separator(styles)));
+        Ok(())
     }
 }
 

--- a/tests/typ/bugs/3586-figure-caption-separator.typ
+++ b/tests/typ/bugs/3586-figure-caption-separator.typ
@@ -1,0 +1,7 @@
+// Test that figure caption separator is synthesized correctly.
+// https://github.com/typst/typst/issues/3586
+// Ref: false
+
+---
+#show figure.caption: c => test(c.separator, [#": "])
+#figure(table[], caption: [This is a test caption])


### PR DESCRIPTION
Fixes https://github.com/typst/typst/issues/3586