### PR TITLE
Revert use of alternate screen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,16 +502,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctrlc"
-version = "3.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b"
-dependencies = [
- "nix",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "data-url"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,17 +1394,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "nix"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags 2.4.2",
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -2605,7 +2584,6 @@ dependencies = [
  "clap_mangen",
  "codespan-reporting",
  "comemo",
- "ctrlc",
  "dirs",
  "ecow",
  "env_proxy",

--- a/crates/typst-cli/Cargo.toml
+++ b/crates/typst-cli/Cargo.toml
@@ -31,7 +31,6 @@ chrono = { workspace = true }
 clap = { workspace = true }
 codespan-reporting = { workspace = true }
 comemo = { workspace = true }
-ctrlc = { workspace = true }
 dirs = { workspace = true }
 ecow = { workspace = true }
 env_proxy = { workspace = true }

--- a/crates/typst-cli/src/main.rs
+++ b/crates/typst-cli/src/main.rs
@@ -19,7 +19,6 @@ use std::process::ExitCode;
 use clap::Parser;
 use codespan_reporting::term;
 use codespan_reporting::term::termcolor::WriteColor;
-use ecow::eco_format;
 use once_cell::sync::Lazy;
 
 use crate::args::{CliArguments, Command};
@@ -46,13 +45,7 @@ fn main() -> ExitCode {
         Command::Update(command) => crate::update::update(command),
     };
 
-    // Leave the alternate screen if it was opened. This operation is done here
-    // so that it is executed prior to printing the final error.
-    let res_leave = terminal::out()
-        .leave_alternate_screen()
-        .map_err(|err| eco_format!("failed to leave alternate screen ({err})"));
-
-    if let Some(msg) = res.err().or(res_leave.err()) {
+    if let Err(msg) = res {
         set_failed();
         print_error(&msg).expect("failed to print error");
     }

--- a/crates/typst-cli/src/watch.rs
+++ b/crates/typst-cli/src/watch.rs
@@ -20,12 +20,6 @@ use crate::{print_error, terminal};
 
 /// Execute a watching compilation command.
 pub fn watch(mut timer: Timer, mut command: CompileCommand) -> StrResult<()> {
-    // Enter the alternate screen and handle Ctrl-C ourselves.
-    terminal::out().init_exit_handler()?;
-    terminal::out()
-        .enter_alternate_screen()
-        .map_err(|err| eco_format!("failed to enter alternate screen ({err})"))?;
-
     // Create a file system watcher.
     let mut watcher = Watcher::new(command.output())?;
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -243,8 +243,6 @@ description: |
 - Command line interface
   - Added support for passing [inputs]($category/foundations/sys) via a CLI flag
   - When passing the filename `-`, Typst will now read input from stdin
-  - The watch mode now uses the alternate screen so that the original state of
-    the terminal is restored when exiting
   - Now uses the system-native TLS implementation for network fetching which
     should be generally more robust
   - Watch mode will now properly detect when a previously missing file is


### PR DESCRIPTION
The alternate screen doesn't support scrolling by default. A more comprehensive alternate screen solution could support it, but adding something so complex immediately before the release is a bit risky.

Fixes #3613

Alternative to https://github.com/typst/typst/pull/3642