### PR TITLE
Fix `Reflect` for `SpecificAlignment`

### DIFF
--- a/crates/typst/src/layout/align.rs
+++ b/crates/typst/src/layout/align.rs
@@ -607,7 +607,7 @@ where
     }
 
     fn output() -> CastInfo {
-        H::output() + V::output()
+        Alignment::output()
     }
 
     fn castable(value: &Value) -> bool {

--- a/crates/typst/src/layout/align.rs
+++ b/crates/typst/src/layout/align.rs
@@ -603,7 +603,7 @@ where
     V: Reflect,
 {
     fn input() -> CastInfo {
-        H::input() + V::input()
+        Alignment::input()
     }
 
     fn output() -> CastInfo {


### PR DESCRIPTION
`H::output() + V::output()` produces a `CastInfo::Union(..vec..)`, which means a list of alternative possible values. However, this cannot describe what `SpecificAlignment::Both(H, V)` can be casted to, because in this case both the horizontal and vertical component values exist at the same time.