### PR TITLE
Run release workflow on release publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@
 name: Build Release Binaries
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   build-release:


### PR DESCRIPTION
Per Github's documentation, https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release "created" triggers won't run on the creation of a draft release.

changing this to publish means that the workflow will run when the release is made public, whether or not it was a draft or a pre-release.