### PR TITLE
Fix all cargo doc warnings

### DIFF
--- a/crates/typst-render/src/lib.rs
+++ b/crates/typst-render/src/lib.rs
@@ -1080,7 +1080,7 @@ impl OutlineBuilder for WrappedPathBuilder {
     }
 }
 
-/// Additional methods for [`Length`].
+/// Additional methods for [`Abs`].
 trait AbsExt {
     /// Convert to a number of points as f32.
     fn to_f32(self) -> f32;

--- a/crates/typst/src/layout/inline/mod.rs
+++ b/crates/typst/src/layout/inline/mod.rs
@@ -1415,7 +1415,7 @@ fn reorder<'a>(line: &'a Line<'a>) -> (Vec<&Item<'a>>, bool) {
 /// How much a character should hang into the end margin.
 ///
 /// For more discussion, see:
-/// https://recoveringphysicist.com/21/
+/// <https://recoveringphysicist.com/21/>
 fn overhang(c: char) -> f64 {
     match c {
         // Dashes.

--- a/crates/typst/src/math/root.rs
+++ b/crates/typst/src/math/root.rs
@@ -50,7 +50,7 @@ impl LayoutMath for Packed<RootElem> {
 /// Layout a root.
 ///
 /// TeXbook page 443, page 360
-/// See also: https://www.w3.org/TR/mathml-core/#radicals-msqrt-mroot
+/// See also: <https://www.w3.org/TR/mathml-core/#radicals-msqrt-mroot>
 fn layout(
     ctx: &mut MathContext,
     styles: StyleChain,

--- a/crates/typst/src/visualize/color.rs
+++ b/crates/typst/src/visualize/color.rs
@@ -32,7 +32,7 @@ pub type Luma = palette::luma::Lumaa<encoding::Srgb, f32>;
 /// This is a minimal CMYK profile that only contains the necessary information
 /// to convert from CMYK to RGB. It is based on the CGATS TR 001-1995
 /// specification. See
-/// https://github.com/saucecontrol/Compact-ICC-Profiles#cmyk.
+/// <https://github.com/saucecontrol/Compact-ICC-Profiles#cmyk>.
 static CMYK_TO_XYZ: Lazy<Box<Profile>> =
     Lazy::new(|| Profile::new_from_slice(typst_assets::icc::CMYK_TO_XYZ, false).unwrap());
 


### PR DESCRIPTION
I ran `cargo doc --document-private-items --all` and there were a few warnings, mostly about links, fixed them up. Maybe we should add a CI check to make sure we don't introduce new ones.

These changes are entirely internal for developers working on typst