### PR TITLE
Add parallelogram symbols

### DIFF
--- a/crates/typst/src/symbols/sym.rs
+++ b/crates/typst/src/symbols/sym.rs
@@ -585,6 +585,10 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
         filled.small: '⬪',
         filled.medium: '⬧',
     ],
+    parallelogram: [
+        stroked: '▱',
+        filled: '▰',
+    ],
     star: [op: '⋆', stroked: '☆', filled: '★'],
 
     // Arrows, harpoons, and tacks.


### PR DESCRIPTION
Adds two new symbols: '▱' and '▰'.
Closes #3706 