### PR TITLE
Quote template entrypoint if it contains whitespace in the `typst init` instructions. 

### DIFF
--- a/crates/typst-cli/src/init.rs
+++ b/crates/typst-cli/src/init.rs
@@ -108,7 +108,7 @@ fn print_summary(
     out.set_color(&gray)?;
     write!(out, "> ")?;
     out.reset()?;
-    writeln!(out, "typst watch {}", template.entrypoint)?;
+    writeln!(out, "typst watch \"{}\"", template.entrypoint)?;
     writeln!(out)?;
     Ok(())
 }

--- a/crates/typst-cli/src/init.rs
+++ b/crates/typst-cli/src/init.rs
@@ -115,7 +115,7 @@ fn print_summary(
         template.entrypoint.to_string()
     };
 
-    writeln!(out, "typst watch {}", entrypoint)?;
+    writeln!(out, "typst watch {entrypoint}")?;
     writeln!(out)?;
     Ok(())
 }

--- a/crates/typst-cli/src/init.rs
+++ b/crates/typst-cli/src/init.rs
@@ -108,7 +108,14 @@ fn print_summary(
     out.set_color(&gray)?;
     write!(out, "> ")?;
     out.reset()?;
-    writeln!(out, "typst watch \"{}\"", template.entrypoint)?;
+    
+    let entrypoint: String = if template.entrypoint.contains(' ') {
+        format!("\"{}\"", template.entrypoint)
+    } else {
+        template.entrypoint.to_string()
+    };
+    
+    writeln!(out, "typst watch {}", entrypoint)?;
     writeln!(out)?;
     Ok(())
 }

--- a/crates/typst-cli/src/init.rs
+++ b/crates/typst-cli/src/init.rs
@@ -108,13 +108,13 @@ fn print_summary(
     out.set_color(&gray)?;
     write!(out, "> ")?;
     out.reset()?;
-    
+
     let entrypoint: String = if template.entrypoint.contains(' ') {
         format!("\"{}\"", template.entrypoint)
     } else {
         template.entrypoint.to_string()
     };
-    
+
     writeln!(out, "typst watch {}", entrypoint)?;
     writeln!(out)?;
     Ok(())


### PR DESCRIPTION
Solves https://github.com/typst/typst/issues/3747. 
It quotes any template entrypoint with whitespaces, and leaves single-word entrypoints as is. 

For templates with `entrypoint = "containing white spaces.typ"`
```
Successfully created new project from ... 🎉
To start writing, run:
> cd ...
> typst watch "containing white spaces.typ"
```
For templates with `entrypoint = "main.typ"`.
```
Successfully created new project from ... 🎉
To start writing, run:
> cd ...
> typst watch main.typ
```

My first contribution here, so let me know if this logic is better suited somewhere else. 