### PR TITLE
Escape path and entrypoint in `typst init` output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2132,6 +2132,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-escape"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2605,6 +2611,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml 0.9.32",
+ "shell-escape",
  "tar",
  "tempfile",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ semver = "1"
 serde = { version = "1.0.184", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
+shell-escape = "0.1.5"
 siphasher = "1"
 smallvec = { version = "1.11.1", features = ["union", "const_generics", "const_new"] }
 stacker = "0.1.15"

--- a/crates/typst-cli/Cargo.toml
+++ b/crates/typst-cli/Cargo.toml
@@ -51,6 +51,7 @@ semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+shell-escape = { workspace = true }
 tar = { workspace = true }
 tempfile = { workspace = true }
 toml = { workspace = true }

--- a/crates/typst-cli/src/init.rs
+++ b/crates/typst-cli/src/init.rs
@@ -104,11 +104,19 @@ fn print_summary(
     out.set_color(&gray)?;
     write!(out, "> ")?;
     out.reset()?;
-    writeln!(out, "cd {}", project_dir.display())?;
+    writeln!(
+        out,
+        "cd {}",
+        shell_escape::escape(project_dir.display().to_string().into()),
+    )?;
     out.set_color(&gray)?;
     write!(out, "> ")?;
     out.reset()?;
-    writeln!(out, "typst watch {}", template.entrypoint)?;
+    writeln!(
+        out,
+        "typst watch {}",
+        shell_escape::escape(template.entrypoint.to_string().into()),
+    )?;
     writeln!(out)?;
     Ok(())
 }


### PR DESCRIPTION
Fixes #3747.
Alternative to #3752 because I didn't find out that it existed until after I implemented it. 

~~EDIT: Due to failing CI pipelines, I published #3754 and rebased this PR onto it. Please only look at df996d3a9fb257fc0d0ff4d5ba38407ea3e47817 here for that reason.~~

This PR uses a very small and well-known crate `shell-escape` that will also escape things like tabs or quotation marks or anything else that could cause problems. It also escapes the path used for `cd`.