### PR TITLE
Fix warnings introduced by rust 1.77

### DIFF
--- a/crates/typst-cli/src/main.rs
+++ b/crates/typst-cli/src/main.rs
@@ -26,7 +26,7 @@ use crate::timings::Timer;
 
 thread_local! {
     /// The CLI's exit code.
-    static EXIT: Cell<ExitCode> = Cell::new(ExitCode::SUCCESS);
+    static EXIT: Cell<ExitCode> = const { Cell::new(ExitCode::SUCCESS) };
 }
 
 /// The parsed commandline arguments.

--- a/crates/typst-pdf/src/page.rs
+++ b/crates/typst-pdf/src/page.rs
@@ -316,9 +316,7 @@ impl PdfPageLabel {
             return None;
         };
 
-        let Some((prefix, kind, case)) = pat.pieces.first() else {
-            return None;
-        };
+        let (prefix, kind, case) = pat.pieces.first()?;
 
         // If there is a suffix, we cannot use the common style optimisation,
         // since PDF does not provide a suffix field.

--- a/crates/typst/src/layout/inline/mod.rs
+++ b/crates/typst/src/layout/inline/mod.rs
@@ -189,7 +189,7 @@ enum Segment<'a> {
     /// Horizontal spacing between other segments.
     Spacing(Spacing),
     /// A mathematical equation.
-    Equation(&'a Packed<EquationElem>, Vec<MathParItem>),
+    Equation(Vec<MathParItem>),
     /// A box with arbitrary content.
     Box(&'a Packed<BoxElem>, bool),
     /// Metadata.
@@ -205,7 +205,7 @@ impl Segment<'_> {
             Self::Box(_, frac) => {
                 (if frac { SPACING_REPLACE } else { OBJ_REPLACE }).len_utf8()
             }
-            Self::Equation(_, ref par_items) => {
+            Self::Equation(ref par_items) => {
                 par_items.iter().map(MathParItem::text).map(char::len_utf8).sum()
             }
             Self::Meta => 0,
@@ -521,7 +521,7 @@ fn collect<'a>(
                 frame.meta(styles, false);
             }
             full.extend(items.iter().map(MathParItem::text));
-            Segment::Equation(elem, items)
+            Segment::Equation(items)
         } else if let Some(elem) = child.to_packed::<BoxElem>() {
             let frac = elem.width(styles).is_fractional();
             full.push(if frac { SPACING_REPLACE } else { OBJ_REPLACE });
@@ -592,7 +592,7 @@ fn prepare<'a>(
                     items.push(Item::Fractional(v, None));
                 }
             },
-            Segment::Equation(_, par_items) => {
+            Segment::Equation(par_items) => {
                 for item in par_items {
                     match item {
                         MathParItem::Space(s) => items.push(Item::Absolute(s)),


### PR DESCRIPTION
The title should be self-explanatory. This PR should also fix the CI pipeline failing in #3753.
Actually, let me rebase that one in a second.

My thinking behind removing the `&Packed<EquationElem>` attribute is that it is not used and can be re-added if it is ever necessary. I liked that better than an `#[allow(unused)]`.