### PR TITLE
Add option to control zero padding of file numbers in output

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -90,6 +90,12 @@ pub struct CompileCommand {
     /// apart from file names and line numbers.
     #[arg(long = "timings", value_name = "OUTPUT_JSON")]
     pub timings: Option<Option<PathBuf>>,
+
+    /// Zero padding of the file number in the output file name
+    ///
+    /// This is only used when the output is rendered as many files
+    #[arg(long="zero-pad", action = clap::ArgAction::Set, default_value_t = true)]
+    pub zero_pad: bool,
 }
 
 /// Initializes a new project from a template

--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -208,7 +208,11 @@ fn export_image(
     // Find a number width that accommodates all pages. For instance, the
     // first page should be numbered "001" if there are between 100 and
     // 999 pages.
-    let width = 1 + document.pages.len().checked_ilog10().unwrap_or(0) as usize;
+    let width = 1 + if command.zero_pad {
+        document.pages.len().checked_ilog10().unwrap_or(0) as usize
+    } else {
+        0
+    };
 
     let cache = world.export_cache();
 


### PR DESCRIPTION
Motivation: Scripts which process generated output should not have to perform more work than necessary in detecting the number of generated output files. Currently, a zero padding is added to the file numbers `{n}` depending on the number of files. Compiling a document with 5 pages, changing it to produce 10 pages and re-compiling it leaves behind both `test-5.svg` as well as `test-05.svg`. By forcing no padding to be set, the scripts at least have a consistent way of referring to individual pages in a document.

New flag:

```
      --zero-pad <ZERO_PAD>
          Zero padding of the file number in the output file name [default: true] [possible values: true, false]
```

This is turned on by default for backward compatibility. One could pass `--zero-pad=false` to turn it off.

Thanks!