### PR TITLE
Fix patterns with spacing in PDF

### DIFF
--- a/crates/typst-pdf/src/pattern.rs
+++ b/crates/typst-pdf/src/pattern.rs
@@ -73,7 +73,9 @@ pub(crate) fn write_patterns(ctx: &mut PdfContext) {
         resources_map.finish();
         tiling_pattern
             .matrix(transform_to_array(
-                transform.pre_concat(Transform::scale(Ratio::one(), -Ratio::one())),
+                transform
+                    .pre_concat(Transform::scale(Ratio::one(), -Ratio::one()))
+                    .post_concat(Transform::translate(Abs::zero(), pattern.spacing().y)),
             ))
             .filter(Filter::FlateDecode);
     }
@@ -82,7 +84,7 @@ pub(crate) fn write_patterns(ctx: &mut PdfContext) {
 /// A pattern and its transform.
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct PdfPattern {
-    /// The transform to apply to the gradient.
+    /// The transform to apply to the pattern.
     pub transform: Transform,
     /// The pattern to paint.
     pub pattern: Pattern,


### PR DESCRIPTION
(Reported in https://discord.com/channels/1054443721975922748/1221820177038049390)

Patterns with spacing were previously offset on the y-axis by that spacing. The reason is that the pattern is kind of drawn in reverse because of the difference between typst coordinate space (left) and pdf coordinate space (right):

![Diagram](https://github.com/typst/typst/assets/7191192/0a19e91a-d832-43fb-9d0b-22f69d392eb6)

As the y-axis of the pdf points upwards, the pattern is also drawn upwards, which is why the spacing has to be accounted for in the translation. _(I hope the sketch at least somewhat represents what actually happens)_

**Before/After:**

```typ
#square(
  size: 50pt,
  stroke: 1pt,
  fill: pattern(
    square(fill: red, size: 8pt)
    spacing: (8pt, 8pt),
  )
)
```

![image](https://github.com/typst/typst/assets/7191192/ab4a8ad6-eb83-4a37-9b93-4054441b0b14)
