### PR TITLE
Dockerfile: add `ENTRYPOINT` directive

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Get current date
+        run: echo "TYPST_BUILD_DATE=\"$(date -u +'%Y-%m-%dT%H:%M:%SZ')\" >> ${GITHUB_ENV}"
+
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3.1.0
         with:
@@ -59,12 +62,15 @@ jobs:
           outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            REVISION=${{ github.sha }}
+            CREATED=${{ env.TYPST_BUILD_DATE }}
 
       - name: Export digest
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"     
+          touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
         uses: actions/upload-artifact@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+ARG CREATED
+ARG REVISION
+ARG TARGETPLATFORM
+
 FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
 FROM --platform=$BUILDPLATFORM rust:alpine AS build
 COPY --from=xx / /
@@ -11,7 +15,6 @@ RUN --mount=type=cache,target=/root/.cargo/git/db \
     CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse \
     cargo fetch
 
-ARG TARGETPLATFORM
 RUN xx-apk add --no-cache musl-dev openssl-dev openssl-libs-static
 RUN --mount=type=cache,target=/root/.cargo/git/db \
     --mount=type=cache,target=/root/.cargo/registry/cache \
@@ -23,5 +26,16 @@ RUN --mount=type=cache,target=/root/.cargo/git/db \
     xx-verify target/release/typst
 
 FROM alpine:latest
-WORKDIR /root/
+LABEL org.opencontainers.image.authors="The Typst Project Developers <hello@typst.app>"
+LABEL org.opencontainers.image.created=${CREATED}
+LABEL org.opencontainers.image.description="A markup-based typesetting system"
+LABEL org.opencontainers.image.documentation="https://typst.app/docs"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.revision=${REVISION}
+LABEL org.opencontainers.image.source="https://github.com/typst/typst"
+LABEL org.opencontainers.image.title="Typst Docker image"
+LABEL org.opencontainers.image.url="https://typst.app"
+LABEL org.opencontainers.image.vendor="Typst"
+
 COPY --from=build  /app/target/release/typst /bin
+ENTRYPOINT [ "/bin/typst" ]


### PR DESCRIPTION
Currently, running `docker run -it ghcr.io/typst/typst:latest` runs a root shell instead of running Typst.
I believe that the Typst container should only run Typst and nothing else.

Running a root shell inside a Docker image, instead of directly running the intended application (in this case, Typst), can present several risks and challenges, particularly around security and best practices. Here’s why it’s not advisable:

1. Security Risks: Running as root within a container, especially if it's interactive, significantly increases the risk of privilege escalation attacks.
2. Principle of Least Privilege: This principle advises that any process or user should have only the minimum privileges necessary to perform its function.
3. General ease of use: Using `docker run -it ghcr.io/typst/typst` runs Typst instead of running a shell, making the use of Typst within Docker is easier. 

As a workaround to use it, here's how I do... pretty ugly isn't it?: `docker run --entrypoint /bin/typst --mount type=bind,source="$(pwd)"/src,target=/src ghcr.io/typst/typst:latest compile /src/hello-world.typst`
I think there are room for improvements, and this is what this PR is fixing.

This PR fix this by:

1. Setting the `ENTRYPOINT` to `/bin/typst` by default
2. Hardening the image, do not use `root` user by default, use a dedicated user `typst`

I succeeded to build a project of mine by doing: 

```
docker build . -r typst:latest
docker run -v .:/home/typst -it typst:latest compile --root=. src/document/main.typ document1.pdf
```

