### PR TITLE
Read `SOURCE_DATE_EPOCH` for better reproducibility

### DIFF
--- a/crates/typst-cli/Cargo.toml
+++ b/crates/typst-cli/Cargo.toml
@@ -65,6 +65,7 @@ zip = { workspace = true, optional = true }
 openssl = { workspace = true }
 
 [build-dependencies]
+chrono = { workspace = true }
 clap = { workspace = true, features = ["string"] }
 clap_complete = { workspace = true }
 clap_mangen = { workspace = true }

--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -166,7 +166,10 @@ fn export(
 
 /// Export to a PDF.
 fn export_pdf(document: &Document, command: &CompileCommand) -> StrResult<()> {
-    let buffer = typst_pdf::pdf(document, Smart::Auto, now());
+    let timestamp = convert_datetime(
+        command.common.source_date_epoch.unwrap_or_else(chrono::Utc::now),
+    );
+    let buffer = typst_pdf::pdf(document, Smart::Auto, timestamp);
     command
         .output()
         .write(&buffer)
@@ -174,16 +177,15 @@ fn export_pdf(document: &Document, command: &CompileCommand) -> StrResult<()> {
     Ok(())
 }
 
-/// Get the current date and time in UTC.
-fn now() -> Option<Datetime> {
-    let now = chrono::Local::now().naive_utc();
+/// Convert [`chrono::DateTime`] to [`Datetime`]
+fn convert_datetime(date_time: chrono::DateTime<chrono::Utc>) -> Option<Datetime> {
     Datetime::from_ymd_hms(
-        now.year(),
-        now.month().try_into().ok()?,
-        now.day().try_into().ok()?,
-        now.hour().try_into().ok()?,
-        now.minute().try_into().ok()?,
-        now.second().try_into().ok()?,
+        date_time.year(),
+        date_time.month().try_into().ok()?,
+        date_time.day().try_into().ok()?,
+        date_time.hour().try_into().ok()?,
+        date_time.minute().try_into().ok()?,
+        date_time.second().try_into().ok()?,
     )
 }
 

--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use std::{fmt, fs, io, mem};
 
-use chrono::{DateTime, Datelike, Utc};
+use chrono::{DateTime, Datelike, FixedOffset, Local, Timelike, Utc};
 use comemo::Prehashed;
 use ecow::{eco_format, EcoString};
 use once_cell::sync::Lazy;
@@ -202,8 +202,11 @@ impl World for SystemWorld {
 
         // The time with the specified UTC offset, or within the local time zone.
         let with_offset = match offset {
-            None => now.naive_local(),
-            Some(o) => now.naive_utc() + chrono::Duration::try_hours(o)?,
+            None => now.with_timezone(&Local).fixed_offset(),
+            Some(hours) => {
+                let seconds = i32::try_from(hours).ok()?.checked_mul(3600)?;
+                now.with_timezone(&FixedOffset::east_opt(seconds)?)
+            }
         };
 
         Datetime::from_ymd(

--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use std::{fmt, fs, io, mem};
 
-use chrono::{DateTime, Datelike, FixedOffset, Local, Timelike, Utc};
+use chrono::{DateTime, Datelike, FixedOffset, Local, Utc};
 use comemo::Prehashed;
 use ecow::{eco_format, EcoString};
 use once_cell::sync::Lazy;

--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -200,15 +200,16 @@ impl World for SystemWorld {
             Now::System(time) => time.get_or_init(Utc::now),
         };
 
-        let naive = match offset {
+        // The time with the specified UTC offset, or within the local time zone.
+        let with_offset = match offset {
             None => now.naive_local(),
             Some(o) => now.naive_utc() + chrono::Duration::try_hours(o)?,
         };
 
         Datetime::from_ymd(
-            naive.year(),
-            naive.month().try_into().ok()?,
-            naive.day().try_into().ok()?,
+            with_offset.year(),
+            with_offset.month().try_into().ok()?,
+            with_offset.day().try_into().ok()?,
         )
     }
 }


### PR DESCRIPTION
Fixes #3806. Alternative to #3808.

I started this before PR was published, but continued developing it because I think this solution is superior:
- It uses the runtime environment variable, not the (cargo) build-time variable.
- It uses the environment variable in `World::today` as well. Therefore, documents that use `datetime.today()` will still be reproducible. This change is debatable, I admit, but I think fits better with the goals of reproducibility.
- It reads the environment variable at a better position in code. And this allows for better error handling (i.e. syntax and out of bounds errors are not hidden).

What I don't like:
- I needed to add `chrono` as a build dependency. I don't see a good way around this though.