### PR TITLE
Changed equation reference customization example to include a link

### DIFF
--- a/crates/typst/src/model/reference.rs
+++ b/crates/typst/src/model/reference.rs
@@ -77,10 +77,10 @@ use crate::text::TextElem;
 ///   let el = it.element
 ///   if el != none and el.func() == eq {
 ///     // Override equation references.
-///     numbering(
+///     link(el.location(),numbering(
 ///       el.numbering,
 ///       ..counter(eq).at(el.location())
-///     )
+///     ))
 ///   } else {
 ///     // Other references as usual.
 ///     it


### PR DESCRIPTION
In the documentation of the reference function, there is an example to customize the equation reference style. However, the example code removes the clickable link. I added the link again.