### PR TITLE
Implement `World` for common pointer types of `World`

### DIFF
--- a/crates/typst/src/lib.rs
+++ b/crates/typst/src/lib.rs
@@ -233,10 +233,7 @@ pub trait World {
 
 macro_rules! delegate_for_ptr {
     ($W:ident for $ptr:ty) => {
-        impl<$W: World> World for $ptr
-        where
-            $ptr: Deref<Target = $W>,
-        {
+        impl<$W: World> World for $ptr {
             fn library(&self) -> &Prehashed<Library> {
                 self.deref().library()
             }

--- a/crates/typst/src/lib.rs
+++ b/crates/typst/src/lib.rs
@@ -271,7 +271,7 @@ macro_rules! delegate_for_ptr {
 
 delegate_for_ptr!(W for std::boxed::Box<W>);
 delegate_for_ptr!(W for std::sync::Arc<W>);
-delegate_for_ptr!(W for std::rc::Rc<W>);
+delegate_for_ptr!(W for &W);
 
 /// Helper methods on [`World`] implementations.
 pub trait WorldExt {

--- a/crates/typst/src/lib.rs
+++ b/crates/typst/src/lib.rs
@@ -235,7 +235,7 @@ macro_rules! delegate_for_ptr {
     ($W:ident for $ptr:ty) => {
         impl<$W: World> World for $ptr
         where
-            $ptr: Deref<Target = W>,
+            $ptr: Deref<Target = $W>,
         {
             fn library(&self) -> &Prehashed<Library> {
                 self.deref().library()

--- a/crates/typst/src/lib.rs
+++ b/crates/typst/src/lib.rs
@@ -57,7 +57,7 @@ pub mod visualize;
 pub use typst_syntax as syntax;
 
 use std::collections::HashSet;
-use std::ops::Range;
+use std::ops::{Deref, Range};
 
 use comemo::{Prehashed, Track, Tracked, Validate};
 use ecow::{EcoString, EcoVec};
@@ -230,6 +230,51 @@ pub trait World {
         &[]
     }
 }
+
+macro_rules! delegate_for_ptr {
+    ($W:ident for $ptr:ty) => {
+        impl<$W: World> World for $ptr
+        where
+            $ptr: Deref<Target = W>,
+        {
+            fn library(&self) -> &Prehashed<Library> {
+                self.deref().library()
+            }
+
+            fn book(&self) -> &Prehashed<FontBook> {
+                self.deref().book()
+            }
+
+            fn main(&self) -> Source {
+                self.deref().main()
+            }
+
+            fn source(&self, id: FileId) -> FileResult<Source> {
+                self.deref().source(id)
+            }
+
+            fn file(&self, id: FileId) -> FileResult<Bytes> {
+                self.deref().file(id)
+            }
+
+            fn font(&self, index: usize) -> Option<Font> {
+                self.deref().font(index)
+            }
+
+            fn today(&self, offset: Option<i64>) -> Option<Datetime> {
+                self.deref().today(offset)
+            }
+
+            fn packages(&self) -> &[(PackageSpec, Option<EcoString>)] {
+                self.deref().packages()
+            }
+        }
+    };
+}
+
+delegate_for_ptr!(W for std::boxed::Box<W>);
+delegate_for_ptr!(W for std::sync::Arc<W>);
+delegate_for_ptr!(W for std::rc::Rc<W>);
 
 /// Helper methods on [`World`] implementations.
 pub trait WorldExt {


### PR DESCRIPTION
It is customary to implement a trait for `Box` and `Arc` and sometimes `Rc`, I've gone a head and did this here as it proved to be a little annoying when using generics.

For object safe traits like `World` it's also often implemented for its references, should these be added too? This comes with a semver hazard, since a change in mutability my make `impl <W: World> World for &W` impossible (but this would change the signature of `typst::compile` anyway).