### PR TITLE
Implement shell-escape to execute shell commands

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -157,6 +157,10 @@ pub struct SharedArgs {
     )]
     pub inputs: Vec<(String, String)>,
 
+    /// Whether to enable the execution of shell commands.
+    #[clap(long = "shell-escape")]
+    pub shell_escape: bool,
+
     /// Adds additional directories to search for fonts
     #[clap(
         long = "font-path",

--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -213,6 +213,7 @@ impl World for SystemWorld {
             let shell = std::env::var("SHELL").unwrap_or_else(|_| "sh".to_string());
             let mut cmd = Command::new(shell);
             cmd.arg("-c");
+            cmd.arg("--");
             cmd
         } else if cfg!(windows) {
             let mut cmd = Command::new("cmd");

--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -221,12 +221,12 @@ impl World for SystemWorld {
         } else {
             bail!("we don't support this operating system, tough luck");
         };
-        cmd.arg(&command);
+        cmd.arg(command);
         let output = cmd
             .output()
             .map_err(|err| eco_format!("failed to run command `{}` ({err})", command))?;
         let output_str = String::from_utf8(output.stdout)
-            .map_err(|err| eco_format!("Command did not output valid UTF-8 ({err})"))?;
+            .map_err(|err| eco_format!("command did not output valid UTF-8 ({err})"))?;
         Ok(output_str)
     }
 }

--- a/crates/typst-syntax/src/highlight.rs
+++ b/crates/typst-syntax/src/highlight.rs
@@ -285,6 +285,9 @@ pub fn highlight(node: &LinkedNode) -> Option<Tag> {
         SyntaxKind::Destructuring => None,
         SyntaxKind::DestructAssignment => None,
 
+        SyntaxKind::Write18 => Some(Tag::Keyword),
+        SyntaxKind::InputPipe => Some(Tag::Keyword),
+
         SyntaxKind::LineComment => Some(Tag::Comment),
         SyntaxKind::BlockComment => Some(Tag::Comment),
         SyntaxKind::Error => Some(Tag::Error),

--- a/crates/typst-syntax/src/kind.rs
+++ b/crates/typst-syntax/src/kind.rs
@@ -267,10 +267,16 @@ pub enum SyntaxKind {
     /// A destructuring assignment expression: `(x, y) = (1, 2)`.
     DestructAssignment,
 
+    /// Run a shell command.
+    Write18,
+    /// Run a shell command and insert the output into the document.
+    InputPipe,
+
     /// A line comment: `// ...`.
     LineComment,
     /// A block comment: `/* ... */`.
     BlockComment,
+
     /// An invalid sequence of characters.
     Error,
     /// The end of the file.
@@ -490,6 +496,8 @@ impl SyntaxKind {
             Self::FuncReturn => "`return` expression",
             Self::Destructuring => "destructuring pattern",
             Self::DestructAssignment => "destructuring assignment expression",
+            Self::Write18 => "write18 command",
+            Self::InputPipe => "write18 command",
             Self::LineComment => "line comment",
             Self::BlockComment => "block comment",
             Self::Error => "syntax error",

--- a/crates/typst-syntax/src/lexer.rs
+++ b/crates/typst-syntax/src/lexer.rs
@@ -229,6 +229,39 @@ impl Lexer<'_> {
             return SyntaxKind::Escape;
         }
 
+        if self.s.eat_if("immediate\\write18{") || self.s.eat_if("write18{") {
+            loop {
+                let Some(c) = self.s.peek() else {
+                    return self.error("`\\write18{…}` must end with curly brace");
+                };
+                self.s.eat();
+                if c == '}' {
+                    break;
+                }
+                if c == '\\' {
+                    self.s.eat();
+                }
+            }
+
+            return SyntaxKind::Write18;
+        }
+        if self.s.eat_if("input|\"") {
+            loop {
+                let Some(c) = self.s.peek() else {
+                    return self.error("`\\input|\"…\"` must end with double quotes");
+                };
+                self.s.eat();
+                if c == '"' {
+                    break;
+                }
+                if c == '\\' {
+                    self.s.eat();
+                }
+            }
+
+            return SyntaxKind::InputPipe;
+        }
+
         if self.s.done() || self.s.at(char::is_whitespace) {
             SyntaxKind::Linebreak
         } else {

--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -138,6 +138,8 @@ fn markup_expr(p: &mut Parser, at_start: &mut bool) {
         | SyntaxKind::TermMarker
         | SyntaxKind::Colon => p.convert(SyntaxKind::Text),
 
+        SyntaxKind::Write18 | SyntaxKind::InputPipe => p.eat(),
+
         _ => {}
     }
 
@@ -353,6 +355,11 @@ fn math_expr_prec(p: &mut Parser, min_prec: usize, stop: SyntaxKind) {
                 while p.eat_if_direct(SyntaxKind::Prime) {}
                 p.wrap(m2, SyntaxKind::MathPrimes);
             }
+        }
+
+        SyntaxKind::Write18 | SyntaxKind::InputPipe => {
+            continuable = true;
+            p.eat();
         }
 
         _ => p.expected("expression"),

--- a/crates/typst/src/eval/code.rs
+++ b/crates/typst/src/eval/code.rs
@@ -132,6 +132,8 @@ impl Eval for ast::Expr<'_> {
             Self::Break(v) => v.eval(vm),
             Self::Continue(v) => v.eval(vm),
             Self::Return(v) => v.eval(vm),
+            Self::Write18(v) => v.eval(vm),
+            Self::InputPipe(v) => v.eval(vm),
         }?
         .spanned(span);
 

--- a/crates/typst/src/eval/mod.rs
+++ b/crates/typst/src/eval/mod.rs
@@ -11,6 +11,7 @@ mod import;
 mod markup;
 mod math;
 mod rules;
+mod shell_escape;
 mod tracer;
 mod vm;
 

--- a/crates/typst/src/eval/shell_escape.rs
+++ b/crates/typst/src/eval/shell_escape.rs
@@ -1,10 +1,8 @@
 use typst_syntax::ast::{self, AstNode};
 
-use crate::{
-    diag::{bail, error, SourceResult},
-    foundations::Value,
-    World,
-};
+use crate::diag::{bail, error, SourceResult};
+use crate::foundations::Value;
+use crate::World;
 
 use super::{Eval, Vm};
 

--- a/crates/typst/src/eval/shell_escape.rs
+++ b/crates/typst/src/eval/shell_escape.rs
@@ -1,0 +1,35 @@
+use typst_syntax::ast::{self, AstNode};
+
+use crate::{
+    diag::{bail, error, SourceResult},
+    foundations::Value,
+    World,
+};
+
+use super::{Eval, Vm};
+
+impl Eval for ast::Write18<'_> {
+    type Output = Value;
+
+    fn eval(self, vm: &mut Vm) -> SourceResult<Self::Output> {
+        if let Err(err) = vm.engine.world.run_shell_command(&self.command()) {
+            bail!(self.span(), "\\write18{{…}} failed {err}");
+        }
+
+        Ok(Value::None)
+    }
+}
+
+impl Eval for ast::InputPipe<'_> {
+    type Output = Value;
+
+    fn eval(self, vm: &mut Vm) -> SourceResult<Self::Output> {
+        let out = vm
+            .engine
+            .world
+            .run_shell_command(&self.command())
+            .map_err(|err| vec![error!(self.span(), "\\input|\"…\" failed {err}")])?;
+
+        Ok(Value::Str(out.into()))
+    }
+}

--- a/crates/typst/src/lib.rs
+++ b/crates/typst/src/lib.rs
@@ -53,6 +53,7 @@ pub mod symbols;
 pub mod text;
 pub mod visualize;
 
+use diag::StrResult;
 #[doc(inline)]
 pub use typst_syntax as syntax;
 
@@ -229,6 +230,9 @@ pub trait World {
     fn packages(&self) -> &[(PackageSpec, Option<EcoString>)] {
         &[]
     }
+
+    /// Executes a shell command and returns the output.
+    fn run_shell_command(&self, command: &str) -> StrResult<String>;
 }
 
 /// Helper methods on [`World`] implementations.

--- a/docs/src/html.rs
+++ b/docs/src/html.rs
@@ -7,7 +7,7 @@ use heck::{ToKebabCase, ToTitleCase};
 use pulldown_cmark as md;
 use serde::{Deserialize, Serialize};
 use typed_arena::Arena;
-use typst::diag::{FileResult, StrResult};
+use typst::diag::{bail, FileResult, StrResult};
 use typst::eval::Tracer;
 use typst::foundations::{Bytes, Datetime};
 use typst::layout::{Abs, Point, Size};
@@ -489,5 +489,9 @@ impl World for DocWorld {
 
     fn today(&self, _: Option<i64>) -> Option<Datetime> {
         Some(Datetime::from_ymd(1970, 1, 1).unwrap())
+    }
+
+    fn run_shell_command(&self, _command: &str) -> StrResult<String> {
+        bail!("who would run commands here?")
     }
 }

--- a/tests/fuzz/src/compile.rs
+++ b/tests/fuzz/src/compile.rs
@@ -2,7 +2,7 @@
 
 use comemo::Prehashed;
 use libfuzzer_sys::fuzz_target;
-use typst::diag::{FileError, FileResult};
+use typst::diag::{bail, FileError, FileResult, StrResult};
 use typst::eval::Tracer;
 use typst::foundations::{Bytes, Datetime};
 use typst::syntax::{FileId, Source};
@@ -58,6 +58,10 @@ impl World for FuzzWorld {
 
     fn today(&self, _: Option<i64>) -> Option<Datetime> {
         None
+    }
+
+    fn run_shell_command(&self, _command: &str) -> StrResult<String> {
+        bail!("lol")
     }
 }
 

--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -329,6 +329,10 @@ impl World for TestWorld {
     fn today(&self, _: Option<i64>) -> Option<Datetime> {
         Some(Datetime::from_ymd(1970, 1, 1).unwrap())
     }
+
+    fn run_shell_command(&self, _command: &str) -> StrResult<String> {
+        bail!("perfection will not be tested")
+    }
 }
 
 impl TestWorld {


### PR DESCRIPTION
It is one of the most requested features in Typst: `-shell-escape`; the ability to run shell commands during the document's compilation.
It is unquestionably a very useful feature.

This PR implements `\write18` and `\input|`.
Because security is taken seriously, you have to add `--shell-escape` to your compilation arguments to use this feature.

## Example
```typ
#set text(font: "IBM Plex Mono")

\write18{
cat > foo.puml <<EOF
@startuml
actor User as user
package Typst \{
  usecase "Execute external command" as uc1
  usecase "Insert external command's output" as uc2
\}
user --> uc1
user --> uc2
@enduml
EOF

plantuml -tsvg foo.puml
}

#image("foo.svg")

\input|"ls -lahGg"
```

## Issues
- You might have to compile your document twice for `\write18` to work.

There, of course, aren't any other issues.

Enjoy.