### PR TITLE
Fix source path resolution in import analysis

### DIFF
--- a/crates/typst-ide/src/analyze.rs
+++ b/crates/typst-ide/src/analyze.rs
@@ -50,6 +50,9 @@ pub fn analyze_expr(
 
 /// Try to load a module from the current source file.
 pub fn analyze_import(world: &dyn World, source: &LinkedNode) -> Option<Value> {
+    // Use span in the node for resolving imports with relative paths.
+    let source_span = source.span();
+
     let (source, _) = analyze_expr(world, source).into_iter().next()?;
     if source.scope().is_some() {
         return Some(source);
@@ -73,7 +76,7 @@ pub fn analyze_import(world: &dyn World, source: &LinkedNode) -> Option<Value> {
         Scopes::new(Some(world.library())),
         Span::detached(),
     );
-    typst::eval::import(&mut vm, source, Span::detached(), true)
+    typst::eval::import(&mut vm, source, source_span, true)
         .ok()
         .map(Value::Module)
 }


### PR DESCRIPTION
Originally the span related to changes in this PR was only used for error messages and the location was stored in the VM. But today it is wrong indeed. Fix it to recover import analysis for `typst-ide`.