### PR TITLE
Remove SOURCE_DATE_EPOCH CLI argument

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -171,8 +171,13 @@ pub struct SharedArgs {
     /// The document's creation date formatted as a UNIX timestamp.
     ///
     /// For more information, see <https://reproducible-builds.org/specs/source-date-epoch/>.
-    #[clap(env = "SOURCE_DATE_EPOCH", value_parser = parse_source_date_epoch)]
-    pub source_date_epoch: Option<DateTime<Utc>>,
+    #[clap(
+        long = "creation-timestamp",
+        env = "SOURCE_DATE_EPOCH",
+        value_name = "UNIX_TIMESTAMP",
+        value_parser = parse_source_date_epoch,
+    )]
+    pub creation_timestamp: Option<DateTime<Utc>>,
 
     /// The format to emit diagnostics in
     #[clap(

--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -167,7 +167,7 @@ fn export(
 /// Export to a PDF.
 fn export_pdf(document: &Document, command: &CompileCommand) -> StrResult<()> {
     let timestamp = convert_datetime(
-        command.common.source_date_epoch.unwrap_or_else(chrono::Utc::now),
+        command.common.creation_timestamp.unwrap_or_else(chrono::Utc::now),
     );
     let buffer = typst_pdf::pdf(document, Smart::Auto, timestamp);
     command

--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -105,7 +105,7 @@ impl SystemWorld {
         let mut searcher = FontSearcher::new();
         searcher.search(&command.font_paths);
 
-        let now = match command.source_date_epoch {
+        let now = match command.creation_timestamp {
             Some(time) => Now::Fixed(time),
             None => Now::System(OnceLock::new()),
         };


### PR DESCRIPTION
This is a fix for the argument parsing being broken by #3809.

The environment variable is still read, but now `--creation-timestamp` can be used as an alternative.

The reason I use this solution instead of `std::env::var("SOURCE_DATE_EPOCH")`, is that:
1. The environment variable is documented better (just use `--help`)
2. Parsing should happen prior to compilation so that errors are caught quickly. Using `clap` makes that easy because no new logic and data structures need to be written.