### PR TITLE
Add basic vector methods to add, sub, mul, div content of arrays element by element

### DIFF
--- a/crates/typst/src/foundations/array.rs
+++ b/crates/typst/src/foundations/array.rs
@@ -1,8 +1,7 @@
-use core::mem::ManuallyDrop;
+use core::mem::{self, ManuallyDrop};
 use core::ptr::NonNull;
 use std::cmp::Ordering;
 use std::fmt::{Debug, Formatter};
-use std::mem;
 use std::num::{NonZeroI64, NonZeroUsize};
 use std::ops::{Add, AddAssign};
 

--- a/tests/typ/compiler/array.typ
+++ b/tests/typ/compiler/array.typ
@@ -336,6 +336,122 @@
 #((1, 2),).to-dict()
 
 ---
+// Test the `vector-add` method.
+#test(().vector-add(), ())
+#test((1, 10).vector-add((2, 20)), (3, 30))
+#test((1, 10).vector-add((2, 20), (3, 30)), (6, 60))
+
+---
+// Error: 21-23 expected array of length 2, found length 0
+#(1, 10).vector-add(())
+
+---
+// Error: 21-25 expected array of length 2, found length 1
+#(1, 10).vector-add((2,))
+
+---
+// Error: 21-30 expected array of length 2, found length 3
+#(1, 10).vector-add((2,20,30))
+
+---
+// Error: 21-38 unexpected argument: val
+#(1, 10).vector-add(val: "applicable")
+
+---
+// Error: 30-47 unexpected argument: val
+#(1, 10).vector-add((2, 10), val: "applicable")
+
+---
+// Error: 30-47 cannot add integer and string
+#(1, 10).vector-add((2, 10), (0, "applicable"))
+
+---
+// Test the `vector-sub` method.
+#test(().vector-sub(), ())
+#test((10, 100).vector-sub((5, 2)), (5, 98))
+#test((10, 100).vector-sub((5, 2), (2, 50)), (3, 48))
+
+---
+// Error: 21-23 expected array of length 2, found length 0
+#(1, 10).vector-sub(())
+
+---
+// Error: 21-25 expected array of length 2, found length 1
+#(1, 10).vector-sub((2,))
+
+---
+// Error: 21-30 expected array of length 2, found length 3
+#(1, 10).vector-sub((2,20,30))
+
+---
+// Error: 21-38 unexpected argument: val
+#(1, 10).vector-sub(val: "applicable")
+
+---
+// Error: 30-47 unexpected argument: val
+#(1, 10).vector-sub((2, 10), val: "applicable")
+
+---
+// Error: 30-47 cannot subtract string from integer
+#(1, 10).vector-sub((2, 10), (0, "applicable"))
+
+---
+// Test the `vector-mul` method.
+#test(().vector-mul(), ())
+#test((1, 10).vector-mul((2, 20)), (2, 200))
+#test((1, 10).vector-mul((2, 20), (3, 30)), (6, 6000))
+
+---
+// Error: 21-23 expected array of length 2, found length 0
+#(1, 10).vector-mul(())
+
+---
+// Error: 21-25 expected array of length 2, found length 1
+#(1, 10).vector-mul((2,))
+
+---
+// Error: 21-30 expected array of length 2, found length 3
+#(1, 10).vector-mul((2,20,30))
+
+---
+// Error: 21-38 unexpected argument: val
+#(1, 10).vector-mul(val: "applicable")
+
+---
+// Error: 30-47 unexpected argument: val
+#(1, 10).vector-mul((2, 10), val: "applicable")
+
+---
+// Test the `vector-div` method.
+#test(().vector-div(), ())
+#test((10, 100).vector-div((2, 5)), (5, 20))
+#test((10, 100).vector-div((2, 5), (5, 4)), (1, 5))
+
+---
+// Error: 21-23 expected array of length 2, found length 0
+#(1, 10).vector-div(())
+
+---
+// Error: 21-25 expected array of length 2, found length 1
+#(1, 10).vector-div((2,))
+
+---
+// Error: 21-30 expected array of length 2, found length 3
+#(1, 10).vector-div((2,20,30))
+
+---
+// Error: 21-38 unexpected argument: val
+#(1, 10).vector-div(val: "applicable")
+
+---
+// Error: 30-47 unexpected argument: val
+#(1, 10).vector-div((2, 10), val: "applicable")
+
+---
+// Error: 30-47 cannot divide float by string
+#(1, 10).vector-div((2, 10), (1, "applicable"))
+
+---
 // Error: 9-26 unexpected argument: val
 #().zip(val: "applicable")
 


### PR DESCRIPTION
This PR adds a methods to add, subtract, multiply, divide content of one or more arrays element by element.
Like a `zip` method, this methods also *variadic*. In case of subtraction, the `i`th elements of subsequent arrays will subtracted from the `i`th element of the first array. The same division, the `i`th elements of the first array will be divided to `i`th elements of subsequent arrays.

## Use cases

Typst combines two things: a simple markup language and programming. These two things help you do calculations and formatting in one document. But since Typst is also used by engineers (like me), it really lacks basic matrix and vector operations on arrays. I realize it's a bit overkill to add matrix methods, but having basic vector operations would be really cool. Additional vector or matrix operations can be easily obtained by combining these and existing methods. For example, the dot product can be obtained like this: `(1, 2, 3).vector-mul((4, 5, 6)).sum()`

## User-facing API

```rust
#assert.eq(
  (1, 2).vector-add((3, 4), (5, 6)),
  (9, 12),
)
#assert.eq(
  (10, 30).vector-sub((2, 3), (5, 5)),
  (3, 22),
)
#assert.eq(
  (1, 2).vector-mul((3, 4), (5, 6)),
  (15, 48),
)
#assert.eq(
  (20, 30).vector-div((2, 5), (5, 2)),
  (2, 3),
)
```