### PR TITLE
SyntaxKind::Eof => SyntaxKind::End to better express its usage

### DIFF
--- a/crates/typst-syntax/src/highlight.rs
+++ b/crates/typst-syntax/src/highlight.rs
@@ -288,7 +288,7 @@ pub fn highlight(node: &LinkedNode) -> Option<Tag> {
         SyntaxKind::LineComment => Some(Tag::Comment),
         SyntaxKind::BlockComment => Some(Tag::Comment),
         SyntaxKind::Error => Some(Tag::Error),
-        SyntaxKind::Eof => None,
+        SyntaxKind::End => None,
     }
 }
 

--- a/crates/typst-syntax/src/kind.rs
+++ b/crates/typst-syntax/src/kind.rs
@@ -273,8 +273,8 @@ pub enum SyntaxKind {
     BlockComment,
     /// An invalid sequence of characters.
     Error,
-    /// The end of the file.
-    Eof,
+    /// The end of token stream.
+    End,
 }
 
 impl SyntaxKind {
@@ -295,7 +295,7 @@ impl SyntaxKind {
     pub fn is_terminator(self) -> bool {
         matches!(
             self,
-            Self::Eof
+            Self::End
                 | Self::Semicolon
                 | Self::RightBrace
                 | Self::RightParen
@@ -493,7 +493,7 @@ impl SyntaxKind {
             Self::LineComment => "line comment",
             Self::BlockComment => "block comment",
             Self::Error => "syntax error",
-            Self::Eof => "end of file",
+            Self::End => "end of tokens",
         }
     }
 }

--- a/crates/typst-syntax/src/lexer.rs
+++ b/crates/typst-syntax/src/lexer.rs
@@ -95,7 +95,7 @@ impl Lexer<'_> {
     pub fn next(&mut self) -> SyntaxKind {
         if self.mode == LexMode::Raw {
             let Some((kind, end)) = self.raw.pop() else {
-                return SyntaxKind::Eof;
+                return SyntaxKind::End;
             };
             self.s.jump(end);
             return kind;
@@ -119,7 +119,7 @@ impl Lexer<'_> {
                 LexMode::Raw => unreachable!(),
             },
 
-            None => SyntaxKind::Eof,
+            None => SyntaxKind::End,
         }
     }
 

--- a/crates/typst-syntax/src/node.rs
+++ b/crates/typst-syntax/src/node.rs
@@ -303,7 +303,7 @@ impl SyntaxNode {
     /// In contrast to `default()`, this is a const fn.
     pub(super) const fn arbitrary() -> Self {
         Self(Repr::Leaf(LeafNode {
-            kind: SyntaxKind::Eof,
+            kind: SyntaxKind::End,
             text: EcoString::new(),
             span: Span::detached(),
         }))

--- a/crates/typst-syntax/src/reparser.rs
+++ b/crates/typst-syntax/src/reparser.rs
@@ -160,7 +160,7 @@ fn try_reparse(
         // Stop parsing early if this kind is encountered.
         let stop_kind = match parent_kind {
             Some(_) => SyntaxKind::RightBracket,
-            None => SyntaxKind::Eof,
+            None => SyntaxKind::End,
         };
 
         // Reparse!

--- a/crates/typst/src/layout/inline/mod.rs
+++ b/crates/typst/src/layout/inline/mod.rs
@@ -894,7 +894,7 @@ fn linebreak_optimized<'a>(
     let mut lines = Vec::with_capacity(16);
     breakpoints(p, |end, breakpoint| {
         let k = table.len();
-        let eof = end == p.bidi.text.len();
+        let is_end = end == p.bidi.text.len();
         let mut best: Option<Entry> = None;
 
         // Find the optimal predecessor.
@@ -946,7 +946,7 @@ fn linebreak_optimized<'a>(
                     active += 1;
                 }
                 MAX_COST
-            } else if breakpoint == Breakpoint::Mandatory || eof {
+            } else if breakpoint == Breakpoint::Mandatory || is_end {
                 // This is a mandatory break and the line is not overfull, so
                 // all breakpoints before this one become inactive since no line
                 // can span above the mandatory break.
@@ -964,7 +964,7 @@ fn linebreak_optimized<'a>(
             };
 
             // Penalize runts.
-            if k == i + 1 && eof {
+            if k == i + 1 && is_end {
                 cost += RUNT_COST;
             }
 


### PR DESCRIPTION
This token actually means "this lexer won't yield any more tokens in its current configuration", not it's not necessarily an end-of-file sigil.

Alternatives discussed:
* Seprate its usage into `SyntaxKind::Eof` for end-of-file and a new `SyntaxKind::NewlineAfterExpr`: unnecessarily detailed for the purpose of parsing, and it needs more code changes elsewhere, thus error-prone: not all `Eof` should be replaced with `Eof || NewlineAfterExpr` (pseudocode).
* Name it `SyntaxKind::EndOfLine`: a line-end does not always indicate an end of code expression.
* Name it `SyntaxKind::EndOfExpr`: a code expression does not always ends with this token. For example, an end-of-file or a right-brace `}` can end an expression.
* Use `None`: Typst used `Option<SyntaxKind>` originally, but having a special token is more convenient.