### PR TITLE
Add --make-deps CLI argument (#2877)

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -72,6 +72,10 @@ pub struct CompileCommand {
     #[clap(required_if_eq("input", "-"), value_parser = ValueParser::new(output_value_parser))]
     pub output: Option<Output>,
 
+    /// Output a Makefile rule describing the current compilation
+    #[clap(long = "makefile-deps", value_name = "PATH")]
+    pub makefile_deps: Option<PathBuf>,
+
     /// The format of the output file, inferred from the extension by default
     #[arg(long = "format", short = 'f')]
     pub format: Option<OutputFormat>,

--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -73,8 +73,8 @@ pub struct CompileCommand {
     pub output: Option<Output>,
 
     /// Output a Makefile rule describing the current compilation
-    #[clap(long = "makefile-deps", value_name = "PATH")]
-    pub makefile_deps: Option<PathBuf>,
+    #[clap(long = "make-deps", value_name = "PATH")]
+    pub make_deps: Option<PathBuf>,
 
     /// The format of the output file, inferred from the extension by default
     #[arg(long = "format", short = 'f')]

--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -378,7 +378,9 @@ fn create_makefile_deps(
                     // `munge`'s source contains a comment here that says: "A
                     // space or tab preceded by 2N+1 backslashes represents N
                     // backslashes followed by space..."
-                    res.push_str(&"\\".repeat(slashes + 1));
+                    for _ in 0..slashes + 1 {
+                        res.push('\\');
+                    }
                     slashes = 0;
                 }
                 '#' => {

--- a/crates/typst-cli/src/main.rs
+++ b/crates/typst-cli/src/main.rs
@@ -16,9 +16,7 @@ use std::cell::Cell;
 use std::io::{self, Write};
 use std::process::ExitCode;
 
-use args::{Input, Output};
-use clap::error::ErrorKind;
-use clap::{CommandFactory, Parser};
+use clap::Parser;
 use codespan_reporting::term;
 use codespan_reporting::term::termcolor::WriteColor;
 use once_cell::sync::Lazy;
@@ -32,32 +30,7 @@ thread_local! {
 }
 
 /// The parsed commandline arguments.
-static ARGS: Lazy<CliArguments> = Lazy::new(|| {
-    let args = CliArguments::parse();
-
-    // Validate the combination of input, output, and makefile_deps. There may
-    // be a more elegant way to do this once the following issue is addressed:
-    // https://github.com/clap-rs/clap/issues/3008. Don't change this without
-    // ensuring it won't break the use of makefile_deps in compile.rs
-    let (Command::Compile(ref command) | Command::Watch(ref command)) = args.command
-    else {
-        return args;
-    };
-    if command.makefile_deps.is_none()
-        || matches!(
-            (&command.common.input, &command.output),
-            (Input::Path(_), Some(Output::Path(_)))
-        )
-    {
-        return args;
-    }
-    CliArguments::command()
-        .error(
-            ErrorKind::ArgumentConflict,
-            "use of --makefile-deps requires INPUT and OUTPUT paths",
-        )
-        .exit()
-});
+static ARGS: Lazy<CliArguments> = Lazy::new(CliArguments::parse);
 
 /// Entry point.
 fn main() -> ExitCode {


### PR DESCRIPTION
This pull request adds support for a `--make-deps` argument (which is valid for the compile and watch subcommands). When provided, the CLI will output a Makefile rule describing the current compilation to the given path.

There are a few design choices that I made which I wasn't sure 100% sure about, so I'll mention them here in case anyone thinks a different approach would be better:
1. In terms of relative vs absolute paths, we use the output path exactly as it was given on the command line. For dependencies, if they are within the project root then we use a path relative to the project root, otherwise we use their absolute path.
2. If the output path contains invalid unicode, we throw an error. If one of the dependencies does, we silently skip it (we can't correctly escape it without it being valid unicode, and if we mess up the escaping the entire rule might be malformed) and just output a rule that will work for the other paths.
3. ~~In terms of valid argument combinations, I've tried to enforce that input and output must both be provided and be paths for the `--make-deps` flag to be valid. It doesn't look like its possible to enforce this with the builtin Clap options though, so I had to add some custom validation logic to main. We could get rid of this (and just limit things to `--makefile-deps` requiring the output argument), but the tradeoff is that then the Makefile rule we output won't be valid if input was from stdin or output was stdout.~~ I've removed this cause it was messy, and we just throw the error when writing the file if there's an issue.
4. Feel free to suggest changes to the flag name/documentation.

Closes #2877.