### PR TITLE
Mention `fields` function in docs

### DIFF
--- a/docs/reference/scripting.md
+++ b/docs/reference/scripting.md
@@ -231,8 +231,8 @@ The body of a loop can be a code or content block:
 - `{while condition [..]}`
 
 ## Fields
-You can use the `fields` function to list the fields of a value and you can
-use _dot notation_ to access fields on a value.
+You can use _dot notation_ to access fields on a value. For values of type
+`content`, you can also use the `fields` function to list the fields.
 
 The value in question can be either:
 - a [dictionary] that has the specified key,

--- a/docs/reference/scripting.md
+++ b/docs/reference/scripting.md
@@ -232,7 +232,8 @@ The body of a loop can be a code or content block:
 
 ## Fields
 You can use _dot notation_ to access fields on a value. For values of type
-`content`, you can also use the `fields` function to list the fields.
+[`content`], you can also use the [`fields`]($content.fields) function to list
+the fields.
 
 The value in question can be either:
 - a [dictionary] that has the specified key,

--- a/docs/reference/scripting.md
+++ b/docs/reference/scripting.md
@@ -231,8 +231,10 @@ The body of a loop can be a code or content block:
 - `{while condition [..]}`
 
 ## Fields
-You can use _dot notation_ to access fields on a value. The value in question
-can be either:
+You can use the `fields` function to list the fields of a value and you can
+use _dot notation_ to access fields on a value.
+
+The value in question can be either:
 - a [dictionary] that has the specified key,
 - a [symbol] that has the specified modifier,
 - a [module] containing the specified definition,
@@ -242,13 +244,15 @@ can be either:
   element was constructed.
 
 ```example
+#let it = [= Heading]
+#it.body \
+#it.depth \
+#it.fields()
+
 #let dict = (greet: "Hello")
 #dict.greet \
 #emoji.face
 
-#let it = [= Heading]
-#it.body \
-#it.depth
 ```
 
 ## Methods


### PR DESCRIPTION
While doing typst scripting, I often wonder: _what fields can I überhaupt access here?_ 

This PR suggests to mention the function on the `scripting` documentation page (<https://typst.app/docs/reference/scripting/>).

(By the way, I'm having a blast writing my PhD thesis in typst. I used to always carry some exotic LaTeX template around to get the document to print the way my field required, but with typst I have solved my styling in about 40 lines and a few hours. No need for hours of tuning nor thousands of lines of code. Amazing work by you on figuring out the right abstractions!)