### PR TITLE
Fix header query example

### DIFF
--- a/crates/typst/src/introspection/query.rs
+++ b/crates/typst/src/introspection/query.rs
@@ -21,6 +21,9 @@ use crate::introspection::Location;
 /// that sub-headings are not included in the table of contents and after
 /// `here()` ensures that the "Table of Contents" heading is not included.
 ///
+/// Note that we open a `context` to be able to use the `query` function. The
+/// code within the context block runs once per page.
+///
 /// ```example
 /// >>> #set page(
 /// >>>  width: 240pt,

--- a/crates/typst/src/introspection/query.rs
+++ b/crates/typst/src/introspection/query.rs
@@ -13,58 +13,50 @@ use crate::introspection::Location;
 ///
 
 /// # Finding elements
-/// In the example below, we create a custom page header that displays the text
-/// "Typst Academy" in small capitals and the current section title. On the
-/// first page, the section title is omitted because the header is before the
-/// first section heading.
+/// In the example below, we manually create a table of contents instead of
+/// using the [`outline`] function.
 ///
-/// To realize this layout, we open a `context` and then query for all headings
-/// after the [current location]($here). The code within the context block
-/// runs twice: Once per page.
-///
-/// - On the first page the query for all headings before the current location
-///   yields an empty array: There are no previous headings. We check for this
-///   case and just display "Typst Academy".
-///
-/// - For the second page, we retrieve the last element from the query's result.
-///   This is the latest heading before the current position and as such, it is
-///   the heading of the section we are currently in. We access its content
-///   through the `body` field and display it alongside "Typst Academy".
+/// To do this, we first query for all headings in the document at level 1 and
+/// after the current location. Querying only for headings at level 1 ensures
+/// that sub-headings are not included in the table of contents and after
+/// `here()` ensures that the "Table of Contents" heading is not included.
 ///
 /// ```example
 /// >>> #set page(
-/// >>>   width: 240pt,
-/// >>>   height: 180pt,
-/// >>>   margin: (top: 35pt, rest: 15pt),
-/// >>>   header-ascent: 12pt,
+/// >>>  width: 240pt,
+/// >>>  height: 180pt,
+/// >>>  margin: (top: 20pt, bottom: 35pt)
 /// >>> )
-/// #set page(header: context {
-///   let elems = query(
-///     selector(heading).before(here()),
+/// #set page(numbering: "1")
+///
+/// = Table of Contents
+/// \
+/// #context {
+///   let chapters = query(
+///     selector(heading.where(level: 1)).after(here())
 ///   )
-///   let academy = smallcaps[
-///     Typst Academy
-///   ]
-///   if elems.len() == 0 {
-///     align(right, academy)
-///   } else {
-///     let body = elems.last().body
-///     academy + h(1fr) + emph(body)
+///   for chapter in chapters {
+///     let page_number = chapter.location().page()
+///     [#chapter.body #h(1fr) #page_number \ ]
 ///   }
-/// })
+/// }
+///
+/// #pagebreak()
 ///
 /// = Introduction
-/// #lorem(23)
+/// #lorem(10)
+///
+/// == Sub-Heading
+/// #lorem(8)
+///
+/// #pagebreak()
 ///
 /// = Background
-/// #lorem(30)
-///
-/// = Analysis
-/// #lorem(15)
+/// #lorem(18)
 /// ```
 ///
-/// You can get the location of the elements returned by `query` with
-/// [`location`]($content.location).
+/// To get the page numbers, we first get the location of the elements returned
+/// by `query` with [`location`]($content.location).
 ///
 /// # A word of caution { #caution }
 /// To resolve all your queries, Typst evaluates and layouts parts of the

--- a/crates/typst/src/introspection/query.rs
+++ b/crates/typst/src/introspection/query.rs
@@ -18,9 +18,9 @@ use crate::introspection::Location;
 ///
 /// To do this, we first query for all headings in the document at level 1 and
 /// where `outlined` is true. Querying only for headings at level 1 ensures
-/// that sub-headings are not included in the table of contents and the
-/// `outlined` field is used to exclude  the "Table of Contents" heading.
-///
+/// that, for the purpose of this example, sub-headings are not included in the
+/// table of contents. The `outlined` field is used to exclude the "Table of
+/// Contents" heading itself.
 ///
 /// Note that we open a `context` to be able to use the `query` function.
 ///
@@ -32,34 +32,42 @@ use crate::introspection::Location;
 /// >>> )
 /// #set page(numbering: "1")
 ///
-/// #set heading(outlined: false)
-/// = Table of Contents
+/// #heading(outlined: false)[
+///   Table of Contents
+/// ]
 /// #context {
 ///   let chapters = query(
-///     heading.where(level: 1).and(heading.where(outlined: true))
+///     heading.where(
+///       level: 1,
+///       outlined: true,
+///     )
 ///   )
 ///   for chapter in chapters {
-///     let nr = chapter.location().page()
+///     let loc = chapter.location()
+///     let nr = numbering(
+///       loc.page-numbering(),
+///       ..counter(page).at(loc),
+///     )
 ///     [#chapter.body #h(1fr) #nr \ ]
 ///   }
 /// }
 ///
-/// #set heading(outlined: true)
 /// = Introduction
 /// #lorem(10)
-///
 /// #pagebreak()
 ///
 /// == Sub-Heading
 /// #lorem(8)
 ///
 /// = Discussion
-///
 /// #lorem(18)
 /// ```
 ///
 /// To get the page numbers, we first get the location of the elements returned
-/// by `query` with [`location`]($content.location).
+/// by `query` with [`location`]($content.location). We then also retrieve the
+/// [page numbering]($location.page-numbering) and [page
+/// counter]($counter/#page-counter) at that location and apply the numbering to
+/// the counter.
 ///
 /// # A word of caution { #caution }
 /// To resolve all your queries, Typst evaluates and layouts parts of the

--- a/crates/typst/src/introspection/query.rs
+++ b/crates/typst/src/introspection/query.rs
@@ -17,12 +17,12 @@ use crate::introspection::Location;
 /// using the [`outline`] function.
 ///
 /// To do this, we first query for all headings in the document at level 1 and
-/// after the current location. Querying only for headings at level 1 ensures
-/// that sub-headings are not included in the table of contents and after
-/// `here()` ensures that the "Table of Contents" heading is not included.
+/// where `outlined` is true. Querying only for headings at level 1 ensures
+/// that sub-headings are not included in the table of contents and the
+/// `outlined` field is used to exclude  the "Table of Contents" heading.
 ///
-/// Note that we open a `context` to be able to use the `query` function. The
-/// code within the context block runs once per page.
+///
+/// Note that we open a `context` to be able to use the `query` function.
 ///
 /// ```example
 /// >>> #set page(
@@ -32,29 +32,29 @@ use crate::introspection::Location;
 /// >>> )
 /// #set page(numbering: "1")
 ///
+/// #set heading(outlined: false)
 /// = Table of Contents
-/// \
 /// #context {
 ///   let chapters = query(
-///     selector(heading.where(level: 1)).after(here())
+///     heading.where(level: 1).and(heading.where(outlined: true))
 ///   )
 ///   for chapter in chapters {
-///     let page_number = chapter.location().page()
-///     [#chapter.body #h(1fr) #page_number \ ]
+///     let nr = chapter.location().page()
+///     [#chapter.body #h(1fr) #nr \ ]
 ///   }
 /// }
 ///
-/// #pagebreak()
-///
+/// #set heading(outlined: true)
 /// = Introduction
 /// #lorem(10)
+///
+/// #pagebreak()
 ///
 /// == Sub-Heading
 /// #lorem(8)
 ///
-/// #pagebreak()
+/// = Discussion
 ///
-/// = Background
 /// #lorem(18)
 /// ```
 ///


### PR DESCRIPTION
I was using the query example (https://typst.app/docs/reference/introspection/query/) to print chapter numbers in the header of my pages. However, the example uses `selector(heading).before(here())` to find the chapter that it should print. For example, if I have a section called _Chapter 2_ on a new page, then the example will print _Chapter 1_ in the header. So, that means that it looks like being in _Chapter 1_ even though _Chapter 2_ just started. This bug is visible in the original example when adding `#pagebreak()` before `= Background`.

This PR suggests to fix this example by, unfortunately, increasing the number of lines of code. I tried to keep the code as simple as possible.