### PR TITLE
Include numbering in PDF bookmark #2416

### DIFF
--- a/crates/typst-pdf/src/outline.rs
+++ b/crates/typst-pdf/src/outline.rs
@@ -88,7 +88,7 @@ pub(crate) fn write_outline(ctx: &mut PdfContext) -> Option<Ref> {
     let root_id = ctx.alloc.bump();
     let start_ref = ctx.alloc;
 
-    write_bookmark(ctx, root_id, &mut tree, &mut vec![]);
+    write_bookmark(ctx, root_id, &tree, &mut vec![]);
 
     ctx.pdf
         .outline(root_id)
@@ -162,7 +162,7 @@ fn write_outline_item(
         node.element.numbering().as_ref()
     {
         // Apply the numbering pattern to `numbers` and concatenate with the node's element body
-        format!("{} {}", pattern.apply(&numbers), node.element.body().plain_text().trim())
+        format!("{} {}", pattern.apply(numbers), node.element.body().plain_text().trim())
     } else {
         // Fallback if no numbering pattern is present; adjust as necessary
         node.element.body().plain_text().trim().to_string()
@@ -190,10 +190,10 @@ fn write_outline_item(
 }
 
 // write bookmark with number
-fn write_bookmark<'a>(
+fn write_bookmark(
     ctx: &mut PdfContext,
     root_id: Ref,
-    nodes: &[HeadingNode<'a>],
+    nodes: &[HeadingNode],
     numbers: &mut Vec<usize>,
 ) {
     let len = nodes.len();


### PR DESCRIPTION
The PR is for including number in bookmark, this idea just when write bookmark based on header element index and level and Numbering::Pattern to re-create number of the corresponding header element. The assumption is that in the same level if the Numbering::Pattern are different we should reset number from 1 e.g:

<img width="1009" alt="image" src="https://github.com/typst/typst/assets/8064750/8842e151-b061-4829-b5f8-253845bb66bb">

Appex part is using "Letter, Upper" Numbering::Pattern and it's different with the content catalog, so we should reset from 1.