### PR TITLE
Better instruction in test READMEs

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -24,14 +24,17 @@ You may want to [make yourself an alias](#making-an-alias) like:
 testit
 ```
 
-Running all tests whose paths contain the string `page` or `stack`.
+Running all tests whose names contain the string `page` or `stack`. Note each
+`.typ` file in this directory can contain multiple tests, each of which is a
+section of Typst code following `--- {name} ---`.
 ```bash
+# Add --verbose to list which tests were run.
 testit page stack
 ```
 
-Running a test with the exact filename `page.typ`.
+Running a test with the exact test name `math-attach-mixed`.
 ```bash
-testit --exact page.typ
+testit --exact math-attach-mixed
 ```
 
 To make the integration tests go faster they don't generate PDFs by default.

--- a/tools/test-helper/README.md
+++ b/tools/test-helper/README.md
@@ -1,29 +1,34 @@
 # Test helper
 
 This is a small VS Code extension that helps with managing Typst's test suite.
-When installed, a new Code Lens appears in all `.typ` files in the `tests`
-folder. It provides the following actions:
+When installed, for all `.typ` files in the `tests` directory, the following
+Code Lens buttons will appear above every test's name:
 
 - View: Opens the output and reference image of a test to the side.
 - Run: Runs the test and shows the results to the side.
+- Save: Runs the test with `--update` to save the reference image.
 - Terminal: Runs the test in the integrated terminal.
 
-In the side panel, there are a few menu actions at the top right:
+In the side panel opened by the Code Lens buttons, there are a few menu buttons
+at the top right:
 
-- Refresh: Reloads the panel to reflect changes to the images
-- Run: Runs the test and shows the results
-- Save: Runs the test with `--update` to save the reference image
+- Refresh: Reloads the panel to reflect changes to the images.
+- Run: Runs the test and shows the results.
+- Save: Runs the test with `--update` to save the reference image.
 
 ## Installation
-First, you need to build the extension:
+In order for VS Code to run the extension with its built-in
+[Node](https://nodejs.org) engine, you need to first build it from source.
+Navigate to `test-helper` directory and build the extension:
 ```bash
-npm i
-npm run build
+npm install    # Install the dependencies.
+npm run build  # Build the extension from source.
 ```
 
-Then, you can easily install and (and keep it up-to-date) via VS Code's UI:
+Then, you can easily install it (and keep it up-to-date) via VS Code's UI:
 - Go to View > Command Palette or press Cmd/Ctrl+P,
-- In the drop down list, pick command "Developer: Install extension from
-  location",
+- In the drop down list, pick command "Developer: Install Extension from
+  Location",
 - Select this `test-helper` directory in the file explorer dialogue box. VS Code
-  will add the extension's path to `~/.vscode/extensions/extensions.json`.
+  will add the extension's path to `~/.vscode/extensions/extensions.json` (or
+  `%USERPROFILE%\.vscode\extensions\extensions.json` on Windows).

--- a/tools/test-helper/package.json
+++ b/tools/test-helper/package.json
@@ -4,9 +4,6 @@
   "displayName": "Typst Test Helper",
   "description": "Helps to run, compare and update Typst tests.",
   "version": "0.0.1",
-  "engines": {
-    "vscode": "^1.71.0"
-  },
   "categories": [
     "Other"
   ],
@@ -97,8 +94,12 @@
     "watch": "tsc -watch -p ./"
   },
   "devDependencies": {
-    "@types/vscode": "^1.88.0",
     "@types/node": "18.x",
+    "@types/vscode": "^1.88.0",
     "typescript": "^5.3.3"
+  },
+  "engines": {
+    "vscode": "^1.88.0"
   }
 }
+


### PR DESCRIPTION
Though it originally started out as a PR to add the missing documentation for the "Save" CodeLens button and to fix outdated instruction about `--exact` in tests/README.md, this PR also suggests other edits. For example, it clarifies the actions provided by Code Lens are rendered as clickable buttons, so that developers unfamiliar with the concept can easily grasp it.

This PR also updates package.json's requirement for VSCode version in `engines` according to `devDependencies`.