### PR TITLE
Enhance the test runner: regex, --list, --path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2778,6 +2778,7 @@ dependencies = [
  "oxipng",
  "parking_lot",
  "rayon",
+ "regex",
  "tiny-skia",
  "ttf-parser",
  "typst",

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -25,6 +25,7 @@ once_cell = { workspace = true }
 oxipng = { workspace = true }
 parking_lot = { workspace = true }
 rayon = { workspace = true }
+regex = { workspace = true }
 tiny-skia = { workspace = true }
 ttf-parser = { workspace = true }
 unscanny = { workspace = true }

--- a/tests/README.md
+++ b/tests/README.md
@@ -73,12 +73,12 @@ There are, broadly speaking, three kinds of tests:
   use of `test` or `assert.eq` (both are very similar, `test` is just shorter)
   to ensure certain properties hold when executing the Typst code.
 
-- Tests that ensure the code fails with a particular error: Those have inline
-  annotations like `// Error: 2-7 thing was wrong`. An annotation can be
-  either an "Error", a "Warning", or a "Hint". The range designates where
-  in the next non-comment line the error is and after it follows the message.
-  If the error is in a line further below, you can also write ranges like
-  `3:2-3:7` to indicate the 2-7 column in the 3rd non-comment line.
+- Tests that ensure the code emits particular diagnostic messages: Those have
+  inline annotations like `// Error: 2-7 thing was wrong`. An annotation can
+  start with either "Error", "Warning", or "Hint". The range designates the
+  code span the diagnostic message refers to in the first non-comment line
+  below. If the code span is in a line further below, you can write ranges
+  like `3:2-3:7` to indicate the 2-7 column in the 3rd non-comment line.
 
 - Tests that ensure certain visual output is produced: Those render the result
   of the test with the `typst-render` crate and compare against a reference

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,7 +3,7 @@
 ## Directory structure
 Top level directory structure:
 - `src`: Testing code.
-- `suite`: Input files. Mostly organize in parallel to the code. Each file can
+- `suite`: Input files. Mostly organized in parallel to the code. Each file can
            contain multiple tests, each of which is a section of Typst code
            following `--- {name} ---`.
 - `ref`: Reference images which the output is compared with to determine whether
@@ -22,7 +22,7 @@ cargo test --workspace --test tests
 ```
 
 You may want to [make yourself an alias](#making-an-alias) `testit` so that you can
-write shorter command. In examples below, we will use this alias.
+write shorter commands. In the examples below, we will use this alias.
 
 Running all tests with the given name pattern. You can use
 [regular expression](https://docs.rs/regex/latest/regex/)s.
@@ -51,7 +51,7 @@ testit --exact math-attach-mixed
 
 You may find more options in the help message:
 ```bash
-testit -h              # Or --help for more details
+testit --help
 ```
 
 To make the integration tests go faster they don't generate PDFs by default.

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,7 +3,9 @@
 ## Directory structure
 Top level directory structure:
 - `src`: Testing code.
-- `suite`: Input files. Mostly organize in parallel to the code.
+- `suite`: Input files. Mostly organize in parallel to the code. Each file can
+           contain multiple tests, each of which is a section of Typst code
+           following `--- {name} ---`.
 - `ref`: Reference images which the output is compared with to determine whether
          a test passed or failed.
 - `store`: Store for PNG, PDF, and SVG output files produced by the tests.
@@ -19,22 +21,37 @@ Running just the integration tests (the tests in this directory):
 cargo test --workspace --test tests
 ```
 
-You may want to [make yourself an alias](#making-an-alias) like:
+You may want to [make yourself an alias](#making-an-alias) `testit` so that you can
+write shorter command. In examples below, we will use this alias.
+
+Running all tests with the given name pattern. You can use
+[regular expression](https://docs.rs/regex/latest/regex/)s.
 ```bash
-testit
+testit math            # The name has "math" anywhere
+testit math page       # The name has "math" or "page" anywhere
+testit "^math" "^page" # The name begins with "math" or "page"
+testit "^(math|page)"  # Same as above.
 ```
 
-Running all tests whose names contain the string `page` or `stack`. Note each
-`.typ` file in this directory can contain multiple tests, each of which is a
-section of Typst code following `--- {name} ---`.
+Running all tests discovered under given paths:
 ```bash
-# Add --verbose to list which tests were run.
-testit page stack
+testit -p tests/suite/math/attach.typ
+testit -p tests/suite/model -p tests/suite/text
+```
+
+Running tests that begin with `issue` under a given path:
+```bash
+testit "^issue" -p tests/suite/model
 ```
 
 Running a test with the exact test name `math-attach-mixed`.
 ```bash
 testit --exact math-attach-mixed
+```
+
+You may find more options in the help message:
+```bash
+testit -h              # Or --help for more details
 ```
 
 To make the integration tests go faster they don't generate PDFs by default.
@@ -82,7 +99,7 @@ If you created a new test or fixed a bug in an existing test, you need to update
 the reference image used for comparison. For this, you can use the `--update`
 flag:
 ```bash
-testit mytest --update
+testit --exact my-test-name --update
 ```
 
 If you use the VS Code test helper extension (see the `tools` folder), you can
@@ -92,7 +109,7 @@ alternatively use the save button to update the reference image.
 If you want to have a quicker way to run the tests, consider adding a shortcut
 to your shell profile so that you can simply write something like:
 ```bash
-testit empty.typ
+testit --exact my-test-name
 ```
 
 ### Bash

--- a/tests/README.md
+++ b/tests/README.md
@@ -77,7 +77,7 @@ There are, broadly speaking, three kinds of tests:
   annotations like `// Error: 2-7 thing was wrong`. An annotation can be
   either an "Error", a "Warning", or a "Hint". The range designates where
   in the next non-comment line the error is and after it follows the message.
-  If you the error is in a line further below, you can also write ranges like
+  If the error is in a line further below, you can also write ranges like
   `3:2-3:7` to indicate the 2-7 column in the 3rd non-comment line.
 
 - Tests that ensure certain visual output is produced: Those render the result

--- a/tests/src/args.rs
+++ b/tests/src/args.rs
@@ -1,7 +1,7 @@
-use regex::Regex;
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
+use regex::Regex;
 
 /// Typst's test runner.
 #[derive(Debug, Clone, Parser)]

--- a/tests/src/args.rs
+++ b/tests/src/args.rs
@@ -1,19 +1,30 @@
+use regex::Regex;
+use std::path::PathBuf;
+
 use clap::{Parser, Subcommand};
 
 /// Typst's test runner.
 #[derive(Debug, Clone, Parser)]
+#[command(bin_name = "cargo test --workspace --test tests --")]
 #[clap(name = "typst-test", author)]
 pub struct CliArguments {
     /// The command to run.
     #[command(subcommand)]
     pub command: Option<Command>,
-    /// All the tests that contain the filter string will be run.
-    pub filter: Vec<String>,
-    /// Runs only the tests with the exact specified `filter` names.
+    /// All the tests whose names match the test name pattern will be run.
+    #[arg(value_parser = Regex::new)]
+    pub pattern: Vec<Regex>,
+    /// Restricts test selection within the given path.
+    #[arg(short, long, value_parser = |s: &str| PathBuf::from(s).canonicalize())]
+    pub path: Vec<PathBuf>,
+    /// Only selects the test that matches with the test name verbatim.
     #[arg(short, long)]
     pub exact: bool,
-    /// Whether to update the reference images of non-passing tests.
-    #[arg(short, long)]
+    /// Lists what tests will be run, without actually running them.
+    #[arg(long, group = "action")]
+    pub list: bool,
+    /// Updates the reference images of non-passing tests.
+    #[arg(short, long, group = "action")]
     pub update: bool,
     /// The scaling factor to render the output image with.
     ///
@@ -26,7 +37,7 @@ pub struct CliArguments {
     /// Exports SVG outputs into the artifact store.
     #[arg(long)]
     pub svg: bool,
-    /// Whether to display the syntax tree.
+    /// Displays the syntax tree.
     #[arg(long)]
     pub syntax: bool,
     /// Prevents the terminal from being cleared of test names.

--- a/tests/src/logger.rs
+++ b/tests/src/logger.rs
@@ -6,7 +6,7 @@ use crate::run::TestResult;
 
 /// Receives status updates by individual test runs.
 pub struct Logger<'a> {
-    filtered: usize,
+    selected: usize,
     passed: usize,
     failed: usize,
     skipped: usize,
@@ -19,9 +19,9 @@ pub struct Logger<'a> {
 
 impl<'a> Logger<'a> {
     /// Create a new logger.
-    pub fn new(filtered: usize, skipped: usize) -> Self {
+    pub fn new(selected: usize, skipped: usize) -> Self {
         Self {
-            filtered,
+            selected,
             passed: 0,
             failed: 0,
             skipped,
@@ -86,10 +86,10 @@ impl<'a> Logger<'a> {
 
     /// Prints a summary and returns whether the test suite passed.
     pub fn finish(&self) -> bool {
-        let Self { filtered, passed, failed, skipped, .. } = *self;
+        let Self { selected, passed, failed, skipped, .. } = *self;
 
         eprintln!("{passed} passed, {failed} failed, {skipped} skipped");
-        assert_eq!(filtered, passed + failed, "not all tests were executed succesfully");
+        assert_eq!(selected, passed + failed, "not all tests were executed succesfully");
 
         if self.mismatched_image {
             eprintln!("  pass the --update flag to update the reference images");
@@ -121,7 +121,7 @@ impl<'a> Logger<'a> {
 
         // Print the status line.
         let done = self.failed + self.passed;
-        if done < self.filtered {
+        if done < self.selected {
             if self.last_change.elapsed() > Duration::from_secs(2) {
                 for test in &self.active {
                     writeln!(out, "⏰ {test} is taking a long time ...")?;
@@ -131,7 +131,7 @@ impl<'a> Logger<'a> {
                 }
             }
             if self.terminal {
-                writeln!(out, "💨 {done} / {}", self.filtered)?;
+                writeln!(out, "💨 {done} / {}", self.selected)?;
                 self.temp_lines += 1;
             }
         }

--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -72,16 +72,14 @@ fn test() {
         }
     };
 
+    let selected = tests.len();
     if ARGS.list {
         for test in tests.iter() {
             println!("{test}");
         }
-        println!("{} selected, {skipped} skipped", tests.len());
+        eprintln!("{selected} selected, {skipped} skipped");
         return;
-    }
-
-    let selected = tests.len();
-    if selected == 0 {
+    } else if selected == 0 {
         eprintln!("no test selected");
         return;
     }

--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -72,14 +72,22 @@ fn test() {
         }
     };
 
-    let filtered = tests.len();
-    if filtered == 0 {
+    if ARGS.list {
+        for test in tests.iter() {
+            println!("{test}");
+        }
+        println!("{} selected, {skipped} skipped", tests.len());
+        return;
+    }
+
+    let selected = tests.len();
+    if selected == 0 {
         eprintln!("no test selected");
         return;
     }
 
     // Run the tests.
-    let logger = Mutex::new(Logger::new(filtered, skipped));
+    let logger = Mutex::new(Logger::new(selected, skipped));
     std::thread::scope(|scope| {
         let logger = &logger;
         let (sender, receiver) = std::sync::mpsc::channel();


### PR DESCRIPTION
This PR implements the discussed non-breaking enhancements in the test runner:
1. `--list` to list all tests selected, without actually running them.
2. Allow selecting tests by regular expressions (like `grep -e`), e.g. `"^math"` [^1] selects tests whose names begin with `math`. If the input is `math`, the current behavior of selecting tests whose names contain `math` anywhere is naturally preserved.
3. `--path` to select tests only under the given paths [^2]. This path can point to a directory or a test file.

Misc:
* `--list` and `--update` are in the same [`clap::ArgGroup`](https://docs.rs/clap/latest/clap/struct.ArgGroup.html) so that they are mutually exclusive.
* Renamed some words from `filtered` to `selected` because the former sounds a bit ambiguous: people may misinterpret it as items that were filtered out. The latter makes it clear that it refers items that remain. It also matches with the message `no test selected`.
* Added `#[command(bin_name = ...)]` on top of `struct CliArguments` so that the help message shows a ready-to-use
  ```
  Usage: cargo test --workspace --test tests -- [OPTIONS] [PATTERN]... [COMMAND]
  ```
  instead of a confusing hint like
  ```
  tests-fcc508040e1de134 [OPTIONS] [PATTERN]... [COMMAND]
  ```
  Similar benefit to the error message's hint.

[^1]: Regular expressions often need quotes to prevent being messed up by the shell's scripting parser.
[^2]: Path specification doesn't support regular expression to avoid cross-platform issues.