### PR TITLE
Fix the Chinese translation for 'equation' used as a supplement

### DIFF
--- a/crates/typst/translations/zh-TW.txt
+++ b/crates/typst/translations/zh-TW.txt
@@ -1,6 +1,6 @@
 figure = 圖
 # table = 
-equation = 方程式
+equation = 式
 bibliography = 書目
 heading = 小節
 outline = 目錄

--- a/crates/typst/translations/zh.txt
+++ b/crates/typst/translations/zh.txt
@@ -1,6 +1,6 @@
 figure = 图
 table = 表
-equation = 公式
+equation = 式
 bibliography = 参考文献
 heading = 小节
 outline = 目录


### PR DESCRIPTION
As discussed, the consensus is that "式" is the appropriate Chinese word for the [supplement](https://typst.app/docs/reference/math/equation/#parameters-supplement) in references to math expressions. Examples in  teaching materials: [this](https://cdn.discordapp.com/attachments/1176062736514429008/1230687103000510585/IMG_1232.jpg?ex=663439ae&is=6621c4ae&hm=ab7a245969dc3b56eabe4ad0774e201feffc47ea1ac9974a25c2888909004071) and [this](https://github.com/typst/typst/assets/18319900/2a5a5617-7c95-40a3-bd60-b99ee27607b1).

@peng1999 @Myriad-Dreamin @OrangeX4