### PR TITLE
Add `append` method to `array`

### DIFF
--- a/crates/typst/src/foundations/array.rs
+++ b/crates/typst/src/foundations/array.rs
@@ -882,6 +882,30 @@ impl Array {
             })
             .collect()
     }
+
+    /// Takes arrays and creates a new array that sequentially contains
+    /// all the elements of the provided arrays.
+    ///
+    /// In other words, joins all provided lists onto the end of the first list.
+    ///
+    /// This function is variadic, meaning that you can append multiple
+    /// arrays at once: `{(1, 2).append(("A", "B"), (10, 20))}` returns
+    /// `{(1, 2, "A", "B", 10, 20)}`.
+    ///
+    #[func]
+    pub fn append(
+        mut self,
+        /// The arrays to append.
+        #[variadic]
+        others: Vec<Array>,
+    ) -> SourceResult<Array> {
+        self.0.reserve(others.iter().map(|x| x.0.len()).sum());
+        for array in others {
+            self.0.extend(array.0)
+        }
+
+        Ok(self)
+    }
 }
 
 /// A value that can be cast to bytes.

--- a/tests/suite/foundations/array.typ
+++ b/tests/suite/foundations/array.typ
@@ -492,3 +492,19 @@
 --- array-unclosed ---
 // Error: 3-4 unclosed delimiter
 #{(}
+
+--- array-append ---
+// Test the `append` method.
+#test(().append(), ())
+#test((1,).append(), (1,))
+#test((1,).append(()), (1,))
+#test(("a", "b", "c").append((1, 2, 3)), ("a", "b", "c", 1, 2, 3))
+#test(("a", "b", "c").append((1, 2, 3), (5, 6)), ("a", "b", "c", 1, 2, 3, 5, 6))
+
+--- array-append-wrong-input-1 ---
+// Error: 23-26 expected array, found string
+#(true, false).append("5")
+
+--- array-append-wrong-input-2 ---
+// Error: 20-21 expected array, found integer
+#("a", "b").append(1)


### PR DESCRIPTION
Add `append` method to array that takes several arrays and creates a new array that sequentially contains all the elements of the provided arrays.

## User-facing API

```rust
#assert.eq(
  (1, 2).append(("A", "B"), (10, 20)),
  (1, 2, "A", "B", 10, 20),
)
```
## Analogues in other languages

- **Gleam**: https://hexdocs.pm/gleam_stdlib/gleam/list.html#append
- **Common Lisp**: http://clhs.lisp.se/Body/f_append.htm
- **Rust**: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.chain

## Why is this function needed?

This function is a standard function on lists in almost all programming languages.

I really missed this feature when working with [path](https://typst.app/docs/reference/visualize/path/), that is, when translating vertices from `typst` format to `svg` format. It is very inconvenient that in order to connect two arrays of arrays you have to use a `for` loop. This function, in turn, allows you to ergonomically create a chain of functions, for example like this:
```rust
#let res = arr
	.map(x => some_function_with_long_name(x))
	.filter(x => other_function_with_long_name(x))
	.append(..arr2.map(x => x * 2)) // <-- In the middle of the chain!
        .map(x => additional_function(x));
```