### PR TITLE
Make `array.repeat` public

### DIFF
--- a/crates/typst/src/eval/ops.rs
+++ b/crates/typst/src/eval/ops.rs
@@ -329,8 +329,8 @@ pub fn mul(lhs: Value, rhs: Value) -> StrResult<Value> {
 
         (Str(a), Int(b)) => Str(a.repeat(Value::Int(b).cast()?)?),
         (Int(a), Str(b)) => Str(b.repeat(Value::Int(a).cast()?)?),
-        (Array(a), Int(b)) => Array(a.repeat(Value::Int(b).cast()?)?),
-        (Int(a), Array(b)) => Array(b.repeat(Value::Int(a).cast()?)?),
+        (Array(a), Int(b)) => Array(a.repeat_content(Value::Int(b).cast()?)?),
+        (Int(a), Array(b)) => Array(b.repeat_content(Value::Int(a).cast()?)?),
         (Content(a), b @ Int(_)) => Content(a.repeat(b.cast()?)),
         (a @ Int(_), Content(b)) => Content(b.repeat(a.cast()?)),
 

--- a/crates/typst/src/foundations/array.rs
+++ b/crates/typst/src/foundations/array.rs
@@ -1,5 +1,6 @@
 use std::cmp::Ordering;
 use std::fmt::{Debug, Formatter};
+use std::iter;
 use std::num::{NonZeroI64, NonZeroUsize};
 use std::ops::{Add, AddAssign};
 
@@ -135,8 +136,9 @@ impl Array {
             .filter(|&v| v < self.0.len() + end_ok as usize)
     }
 
-    /// Repeat this array `n` times.
-    pub fn repeat(&self, n: usize) -> StrResult<Self> {
+    /// Repeat the content of this array `n` times, that is, creates an
+    /// array that contains elements of the original array repeated n times.
+    pub fn repeat_content(&self, n: usize) -> StrResult<Self> {
         let count = self
             .len()
             .checked_mul(n)
@@ -881,6 +883,24 @@ impl Array {
                 }
             })
             .collect()
+    }
+
+    /// Builds an array of a given value a given number of times.
+    ///
+    /// ```example
+    /// array.repeat("apples", 2)
+    /// ```
+    #[func]
+    pub fn repeat(
+        /// The value that will be repeated to build the array.
+        value: Value,
+        /// Length of the array. Must be positive.
+        times: i64,
+    ) -> StrResult<Array> {
+        match usize::try_from(times) {
+            Ok(times) => Ok(iter::repeat(value).take(times).collect()),
+            _ => Err(format!("Cannot create array with the length: {times}").into()),
+        }
     }
 }
 

--- a/tests/suite/foundations/array.typ
+++ b/tests/suite/foundations/array.typ
@@ -492,3 +492,16 @@
 --- array-unclosed ---
 // Error: 3-4 unclosed delimiter
 #{(}
+
+--- array-repeat ---
+// Test the `join` method.
+#test(().repeat(2), ((), ()))
+#test((1,).repeat(3), ((1,), (1,), (1,)))
+#test(array.repeat("a", 4), ("a", "a", "a", "a"))
+#test(array.repeat(5, 0), ())
+#test((3,) * 2, (3, 3))
+#test(2 * (3,), (3, 3))
+
+--- array-repeat-negative-length ---
+// Error: 2-21 Cannot create array with the length: -5
+#array.repeat(1, -5)


### PR DESCRIPTION
The repeat function is useful not only for multiplication, but also for creating an array from a single value.

## User-facing API

```rust
#assert.eq(
  array.repeat("A", 2),
  ("A", "A"),
)
```

## Analogues in other languages

* **Gleam**: https://hexdocs.pm/gleam_stdlib/gleam/list.html#repeat
* **Common Lisp**: https://www.lispworks.com/documentation/HyperSpec/Body/f_mk_lis.htm
* **Rust**: https://doc.rust-lang.org/std/iter/fn.repeat.html, https://doc.rust-lang.org/std/array/fn.from_fn.html