### PR TITLE
Add keywords for `emph` and `strong` functions

### DIFF
--- a/crates/typst/src/model/emph.rs
+++ b/crates/typst/src/model/emph.rs
@@ -26,7 +26,7 @@ use crate::text::{ItalicToggle, TextElem};
 /// This function also has dedicated syntax: To emphasize content, simply
 /// enclose it in underscores (`_`). Note that this only works at word
 /// boundaries. To emphasize part of a word, you have to use the function.
-#[elem(title = "Emphasis", Show)]
+#[elem(title = "Emphasis", keywords = ["italic"], Show)]
 pub struct EmphElem {
     /// The content to emphasize.
     #[required]

--- a/crates/typst/src/model/strong.rs
+++ b/crates/typst/src/model/strong.rs
@@ -21,7 +21,7 @@ use crate::text::{TextElem, WeightDelta};
 /// simply enclose it in stars/asterisks (`*`). Note that this only works at
 /// word boundaries. To strongly emphasize part of a word, you have to use the
 /// function.
-#[elem(title = "Strong Emphasis", Show)]
+#[elem(title = "Strong Emphasis", keywords = ["bold", "weight"], Show)]
 pub struct StrongElem {
     /// The delta to apply on the font weight.
     ///


### PR DESCRIPTION
As illustrated by https://github.com/typst/typst/issues/3979#issuecomment-2069044556, finding the `emph` and `strong` functions is not easy for new users. This PR adds the keyword "italic" to `emph` and the keywords "bold" and "weight" to `strong` to solve this problem.