### PR TITLE
Add `exact` argument to `array.zip`

### DIFF
--- a/crates/typst/src/foundations/array.rs
+++ b/crates/typst/src/foundations/array.rs
@@ -524,22 +524,24 @@ impl Array {
         // If there is more than one array, we use the manual method.
         let mut out = Self::with_capacity(self.len());
         let arrays = args.all::<Spanned<Array>>()?;
-        let errs = arrays
-            .iter()
-            .filter(|sp| sp.v.len() != self.len())
-            .map(|Spanned { v, span }| {
-                SourceDiagnostic::error(
-                    *span,
-                    eco_format!(
-                        "array has different length ({}) from first array ({})",
-                        v.len(),
-                        self.len()
-                    ),
-                )
-            })
-            .collect::<EcoVec<_>>();
-        if !errs.is_empty() {
-            return Err(errs);
+        if exact {
+            let errs = arrays
+                .iter()
+                .filter(|sp| sp.v.len() != self.len())
+                .map(|Spanned { v, span }| {
+                    SourceDiagnostic::error(
+                        *span,
+                        eco_format!(
+                            "array has different length ({}) from first array ({})",
+                            v.len(),
+                            self.len()
+                        ),
+                    )
+                })
+                .collect::<EcoVec<_>>();
+            if !errs.is_empty() {
+                return Err(errs);
+            }
         }
 
         let mut iterators =

--- a/crates/typst/src/foundations/array.rs
+++ b/crates/typst/src/foundations/array.rs
@@ -7,7 +7,6 @@ use comemo::Tracked;
 use ecow::{eco_format, EcoString, EcoVec};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
-use typst_syntax::Spanned;
 
 use crate::diag::{bail, At, SourceResult, StrResult};
 use crate::engine::Engine;
@@ -16,7 +15,7 @@ use crate::foundations::{
     cast, func, repr, scope, ty, Args, Bytes, CastInfo, Context, Dict, FromValue, Func,
     IntoValue, Reflect, Repr, Str, Value, Version,
 };
-use crate::syntax::Span;
+use crate::syntax::{Span, Spanned};
 
 /// Create a new [`Array`] from values.
 #[macro_export]
@@ -483,10 +482,9 @@ impl Array {
     #[func]
     pub fn zip(
         self,
-        /// The real arguments (the other arguments are just for the docs, this
-        /// function is a bit involved, so we parse the arguments manually).
+        /// The real arguments (the `others` arguments are just for the docs, this
+        /// function is a bit involved, so we parse the positional arguments manually).
         args: &mut Args,
-        #[external]
         #[named]
         #[default(false)]
         exact: bool,
@@ -495,8 +493,6 @@ impl Array {
         #[variadic]
         others: Vec<Array>,
     ) -> SourceResult<Array> {
-        let exact: bool = args.named("exact")?.unwrap_or_default();
-
         let remaining = args.remaining();
 
         // Fast path for one array.
@@ -511,7 +507,7 @@ impl Array {
             if exact && self.len() != other.len() {
                 bail!(
                     other_span,
-                    "Second argument has different length ({}) from first argument ({})",
+                    "second array has different length ({}) from first array ({})",
                     other.len(),
                     self.len()
                 );
@@ -531,7 +527,7 @@ impl Array {
         {
             bail!(
                 *span,
-                "Argument has different length ({}) from first argument ({})",
+                "array has different length ({}) from first array ({})",
                 v.len(),
                 self.len()
             );

--- a/crates/typst/src/foundations/array.rs
+++ b/crates/typst/src/foundations/array.rs
@@ -485,6 +485,8 @@ impl Array {
         /// The real arguments (the `others` arguments are just for the docs, this
         /// function is a bit involved, so we parse the positional arguments manually).
         args: &mut Args,
+        /// Whether all arrays have to have the same length.
+        /// For example, `(1, 2).zip((1, 2, 3), exact: true)` produces an error.
         #[named]
         #[default(false)]
         exact: bool,

--- a/tests/suite/foundations/array.typ
+++ b/tests/suite/foundations/array.typ
@@ -364,6 +364,11 @@
 // Error: 13-22 second array has different length (3) from first array (2)
 #(1, 2).zip((1, 2, 3), exact: true)
 
+--- array-zip-exact-multi-error ---
+// Error: 13-22 array has different length (3) from first array (2)
+// Error: 24-36 array has different length (4) from first array (2)
+#(1, 2).zip((1, 2, 3), (1, 2, 3, 4), exact: true)
+
 --- array-enumerate ---
 // Test the `enumerate` method.
 #test(().enumerate(), ())

--- a/tests/suite/foundations/array.typ
+++ b/tests/suite/foundations/array.typ
@@ -350,6 +350,7 @@
 #test((1,).zip(()), ())
 #test((1,).zip((2,)), ((1, 2),))
 #test((1, 2).zip((3, 4)), ((1, 3), (2, 4)))
+#test((1, 2).zip((3, 4), exact: true), ((1, 3), (2, 4)))
 #test((1, 2, 3, 4).zip((5, 6)), ((1, 5), (2, 6)))
 #test(((1, 2), 3).zip((4, 5)), (((1, 2), 4), (3, 5)))
 #test((1, "hi").zip((true, false)), ((1, true), ("hi", false)))
@@ -358,6 +359,10 @@
 #test((1,).zip((2,), (3,)), ((1, 2, 3),))
 #test((1, 2, 3).zip(), ((1,), (2,), (3,)))
 #test(array.zip(()), ())
+
+--- array-zip-exact-error ---
+// Error: 13-22 second array has different length (3) from first array (2)
+#(1, 2).zip((1, 2, 3), exact: true)
 
 --- array-enumerate ---
 // Test the `enumerate` method.


### PR DESCRIPTION
This adds a named argument `exact: bool` (default `false`) to `array.zip` that, when enabled, checks whether all given arrays are actually the same length and errors if they are not.

## Motivation
I had a situation where a table was missing a row because I constructed it using `array.zip` and I accidentally made one of my columns shorter than the others. This lets users easily enforce the abscence of such a bug.

## Alternatives
Of course, this behavior can be implemented in typst already:
```typst
let checked-zip(first, ..arrs) = {
  for arr in arrs.pos() {
    if arr.len() != first.len() {
      panic("arguments have different lengths")
    }
  }
  array.zip(first, ..arrs)
}
```
However, I think that this is still something important enough to warrant inclusion in the method itself,
and doing it natively also allows for better error messages.

## Documentation and Tests
I haven't written tests and documentation for this yet to save on effort in case this PR is rejected. I will add them if it is approved.