### PR TITLE
Add parameter to select pages to be exported by CLI

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -1,4 +1,5 @@
 use std::fmt::{self, Display, Formatter};
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
@@ -75,6 +76,10 @@ pub struct CompileCommand {
     /// For example, `doc-page-{0p}-of-{t}.png` creates `doc-page-01-of-10.png` and so on.
     #[clap(required_if_eq("input", "-"), value_parser = ValueParser::new(output_value_parser))]
     pub output: Option<Output>,
+
+    /// Which pages to export. When unspecified, all document pages are exported.
+    #[arg(long = "pages", value_delimiter = ',')]
+    pub pages: Option<Vec<NonZeroUsize>>,
 
     /// Output a Makefile rule describing the current compilation
     #[clap(long = "make-deps", value_name = "PATH")]

--- a/tests/src/run.rs
+++ b/tests/src/run.rs
@@ -176,7 +176,7 @@ impl<'a> Runner<'a> {
         // Write PDF if requested.
         if crate::ARGS.pdf {
             let pdf_path = format!("{}/pdf/{}.pdf", crate::STORE_PATH, self.test.name);
-            let pdf = typst_pdf::pdf(document, Smart::Auto, None);
+            let pdf = typst_pdf::pdf(document, Smart::Auto, None, None);
             std::fs::write(pdf_path, pdf).unwrap();
         }
 


### PR DESCRIPTION
Closes https://github.com/typst/typst/issues/3095

Adds the `--pages` parameter to `typst compile` and `typst watch` which allows selecting which pages should be exported by the CLI. Supports all export formats (PDF, PNG, SVG).

- **Syntax:**
   - **Simple:** `typst compile --pages 5,6,11 a.typ a.pdf` to export a PDF with just pages 5, 6, 11.
   - **Ranges:** `typst watch --pages 11-13,15- a.typ a-{n}.png` to export pages 11 to 13 (inclusive), as well as any pages after page 15. **(Not yet implemented)**

- **Implementation:**
   - Had to refactor `typst-pdf` in several places to consider non-exported pages. Changed `ctx.pages` to `Vec<Option<EncodedPage>>` to preserve the relation between indices and real page numbers.
   - For PNG and SVG, the implementation was trivial, since each page is a separate exported file.

- **Decisions:**
  - [ ] (PDF) Should non-exported headings be excluded from PDF bookmarks? Currently, I have excluded them, as this seems to make sense (otherwise they would be broken links).
  - [ ] (PDF) The PDF's `xmp.num_pages` metadata should only contain the amount of exported pages (and should thus always correspond to the number of pages in the actual PDF, not necessarily in the original Typst document), correct? (I have assumed so for now)
  - [ ] (PNG/SVG) When using `exported-name-{n}.png` (for example), should `{n}` correspond to the real page number in the original typst document? (i.e. with `--pages 5,6,7` you'd get `name-5.png`, `name-6.png` and `name-7.png` instead of `name-1.png`, `name-2.png` and `name-3.png`) I've assumed so for now as well, as I'd say this would be expected.

- **TODO:**
   - [ ] Support ranges in `--pages`
   - [ ] Recheck PDF changes
   - [ ] Undraft