### PR TITLE
Ignore whitespace in csv files

### DIFF
--- a/crates/typst/src/loading/csv.rs
+++ b/crates/typst/src/loading/csv.rs
@@ -109,11 +109,12 @@ impl csv {
             let item = if let Some(headers) = &headers {
                 let mut dict = Dict::new();
                 for (field, value) in headers.iter().zip(&row) {
-                    dict.insert(field.into(), value.into_value());
+                    dict.insert(field.trim().into(), value.trim().into_value());
                 }
                 dict.into_value()
             } else {
-                let sub = row.into_iter().map(|field| field.into_value()).collect();
+                let sub =
+                    row.into_iter().map(|field| field.trim().into_value()).collect();
                 Value::Array(sub)
             };
             array.push(item);


### PR DESCRIPTION
Nothing big :) Just adds three `.trims()` to remove any unnecessary whitespace in the csv file when loading.
Whitespace in csvs shouldn't have meaning. Still caring the whitespace over just makes it more annoying to work with the csv data in typst. 

The csv
```csv
asdlkf, asldkfjasdf
asd,     asdlkf
a   ,    asdf
```
will end up like this (after the change)
```
(
  ("asdlkf", "asldkfjasdf"),
  ("asd", "asdlkf"),
  ("a", "asdf"),
)
```
instead of this (before the change)
```
(
  ("asdlkf", " asldkfjasdf"),
  ("asd", "     asdlkf"),
  ("a   ", "    asdf"),
)
```