### PR TITLE
Transpose `Option` and `Smart`

### DIFF
--- a/crates/typst/src/model/bibliography.rs
+++ b/crates/typst/src/model/bibliography.rs
@@ -105,8 +105,7 @@ pub struct BibliographyElem {
     /// The bibliography's heading will not be numbered by default, but you can
     /// force it to be with a show-set rule:
     /// `{show bibliography: set heading(numbering: "1.")}`
-    #[default(Some(Smart::Auto))]
-    pub title: Option<Smart<Content>>,
+    pub title: Smart<Option<Content>>,
 
     /// Whether to include all works from the given bibliography files, even
     /// those that weren't cited in the document.
@@ -213,11 +212,9 @@ impl Show for Packed<BibliographyElem> {
         const INDENT: Em = Em::new(1.5);
 
         let mut seq = vec![];
-        if let Some(title) = self.title(styles) {
-            let title = title.unwrap_or_else(|| {
-                TextElem::packed(Self::local_name_in(styles)).spanned(self.span())
-            });
-
+        if let Some(title) = self.title(styles).unwrap_or_else(|| {
+            Some(TextElem::packed(Self::local_name_in(styles)).spanned(self.span()))
+        }) {
             seq.push(
                 HeadingElem::new(title)
                     .with_level(Smart::Custom(NonZeroUsize::ONE))

--- a/crates/typst/src/model/outline.rs
+++ b/crates/typst/src/model/outline.rs
@@ -73,8 +73,7 @@ pub struct OutlineElem {
     /// The outline's heading will not be numbered by default, but you can
     /// force it to be with a show-set rule:
     /// `{show outline: set heading(numbering: "1.")}`
-    #[default(Some(Smart::Auto))]
-    pub title: Option<Smart<Content>>,
+    pub title: Smart<Option<Content>>,
 
     /// The type of element to include in the outline.
     ///
@@ -193,11 +192,9 @@ impl Show for Packed<OutlineElem> {
     fn show(&self, engine: &mut Engine, styles: StyleChain) -> SourceResult<Content> {
         let mut seq = vec![ParbreakElem::new().pack()];
         // Build the outline title.
-        if let Some(title) = self.title(styles) {
-            let title = title.unwrap_or_else(|| {
-                TextElem::packed(Self::local_name_in(styles)).spanned(self.span())
-            });
-
+        if let Some(title) = self.title(styles).unwrap_or_else(|| {
+            Some(TextElem::packed(Self::local_name_in(styles)).spanned(self.span()))
+        }) {
             seq.push(
                 HeadingElem::new(title)
                     .with_depth(NonZeroUsize::ONE)


### PR DESCRIPTION
@laurmaedje has expressed a preference for `Smart<Option<T>>` over `Option<Smart<T>>`, at least when the default value is supposed to be `auto` instead of `none` ([message](https://discord.com/channels/1054443721975922748/1088371867913572452/1235136097919434772)).

* ✅ `OutlineElement`
  * ⏰ Not touching `indent` for now, at least until the deprecated `true` and `false` options get removed.
* ✅ `BibliographyElement`
  * ⏰ The return type for `CslStyle::parse_smart` has `Option<Smart<T>>`. Not sure what to do with this yet.
* ❌ `Margin::sides` is `Sides<Option<Smart<Rel<Length>>>>`, which reportedly has to be `Option<Smart<..>>`
* 🙁 `lr.rs` functions: making them take `Smart<Option<Rel<Length>>>` is possible, but the logic is cleaner with `Option<Smart<Rel<Length>>>`.
* 🙁 `FigureElem::placement` (has `none` as the default value)
* ❓ `PolygonElem::regular`’s `stroke` param (`Option<Smart<Option<Stroke>>>`?!!)
* ❓ `ImageElem::decode`’s `format`, `width`, and `height` params