### PR TITLE
Update rust-toolchain version for fuzz

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2023-09-13
+      - uses: dtolnay/rust-toolchain@1.77.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo install cargo-fuzz
       - run: cd tests/fuzz && cargo fuzz build --dev


### PR DESCRIPTION
It appears the fuzzing errors raised in [PR #4055](https://github.com/typst/typst/actions/runs/8915667828/job/24485719477?pr=4055) `use of unstable library feature 'saturating_int_impl'` is because the Rust version in the `fuzz` workflow is outdated. See an explanation for a [similar issue](https://github.com/bevyengine/bevy/discussions/11661#discussioncomment-8345118).