### PR TITLE
Add shorthands for symbols U+22B6 (Original Of) and U+22B7 (Image Of)

### DIFF
--- a/crates/typst/src/symbols/sym.rs
+++ b/crates/typst/src/symbols/sym.rs
@@ -331,6 +331,8 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
     ],
     equiv: ['≡', not: '≢'],
     prop: '∝',
+    original: '⊶',
+    image: '⊷',
 
     // Set theory.
     emptyset: ['∅', rev: '⦰'],


### PR DESCRIPTION
Addresses issue #4044.