### PR TITLE
Add --no-system-fonts option to compile, watch, and fonts commands

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -167,14 +167,9 @@ pub struct SharedArgs {
     )]
     pub inputs: Vec<(String, String)>,
 
-    /// Adds additional directories to search for fonts
-    #[clap(
-        long = "font-path",
-        env = "TYPST_FONT_PATHS",
-        value_name = "DIR",
-        value_delimiter = ENV_PATH_SEP,
-    )]
-    pub font_paths: Vec<PathBuf>,
+    /// Font search settings
+    #[clap(flatten)]
+    pub font_settings: FontSettings,
 
     /// The document's creation date formatted as a UNIX timestamp.
     ///
@@ -274,6 +269,17 @@ fn parse_input_pair(raw: &str) -> Result<(String, String), String> {
 /// Lists all discovered fonts in system and custom font paths
 #[derive(Debug, Clone, Parser)]
 pub struct FontsCommand {
+    /// Font search settings
+    #[clap(flatten)]
+    pub font_settings: FontSettings,
+
+    /// Also lists style variants of each font family
+    #[arg(long)]
+    pub variants: bool,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct FontSettings {
     /// Adds additional directories to search for fonts
     #[clap(
         long = "font-path",
@@ -283,9 +289,9 @@ pub struct FontsCommand {
     )]
     pub font_paths: Vec<PathBuf>,
 
-    /// Also lists style variants of each font family
-    #[arg(long)]
-    pub variants: bool,
+    /// Excludes system fonts from search
+    #[clap(long = "no-system-fonts")]
+    pub no_system_fonts: bool,
 }
 
 /// Which format to use for diagnostics.

--- a/crates/typst-cli/src/fonts.rs
+++ b/crates/typst-cli/src/fonts.rs
@@ -12,7 +12,7 @@ use crate::args::FontsCommand;
 /// Execute a font listing command.
 pub fn fonts(command: &FontsCommand) -> StrResult<()> {
     let mut searcher = FontSearcher::new();
-    searcher.search(&command.font_paths);
+    searcher.search(&command.font_paths, true);
 
     for (name, infos) in searcher.book.families() {
         println!("{name}");
@@ -66,7 +66,7 @@ impl FontSearcher {
     }
 
     /// Search everything that is available.
-    pub fn search(&mut self, font_paths: &[PathBuf]) {
+    pub fn search(&mut self, font_paths: &[PathBuf], load_system_fonts: bool) {
         let mut db = Database::new();
 
         // Font paths have highest priority.
@@ -75,7 +75,9 @@ impl FontSearcher {
         }
 
         // System fonts have second priority.
-        db.load_system_fonts();
+        if load_system_fonts {
+            db.load_system_fonts();
+        }
 
         for face in db.faces() {
             let path = match &face.source {

--- a/crates/typst-cli/src/fonts.rs
+++ b/crates/typst-cli/src/fonts.rs
@@ -7,12 +7,12 @@ use typst::diag::StrResult;
 use typst::text::{Font, FontBook, FontInfo, FontVariant};
 use typst_timing::TimingScope;
 
-use crate::args::FontsCommand;
+use crate::args::{FontSettings, FontsCommand};
 
 /// Execute a font listing command.
 pub fn fonts(command: &FontsCommand) -> StrResult<()> {
     let mut searcher = FontSearcher::new();
-    searcher.search(&command.font_paths, true);
+    searcher.search(&command.font_settings);
 
     for (name, infos) in searcher.book.families() {
         println!("{name}");
@@ -66,16 +66,16 @@ impl FontSearcher {
     }
 
     /// Search everything that is available.
-    pub fn search(&mut self, font_paths: &[PathBuf], load_system_fonts: bool) {
+    pub fn search(&mut self, font_settings: &FontSettings) {
         let mut db = Database::new();
 
         // Font paths have highest priority.
-        for path in font_paths {
+        for path in &font_settings.font_paths {
             db.load_fonts_dir(path);
         }
 
         // System fonts have second priority.
-        if load_system_fonts {
+        if !font_settings.no_system_fonts {
             db.load_system_fonts();
         }
 

--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -103,7 +103,7 @@ impl SystemWorld {
         };
 
         let mut searcher = FontSearcher::new();
-        searcher.search(&command.font_paths);
+        searcher.search(&command.font_paths, true);
 
         let now = match command.creation_timestamp {
             Some(time) => Now::Fixed(time),

--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -103,7 +103,7 @@ impl SystemWorld {
         };
 
         let mut searcher = FontSearcher::new();
-        searcher.search(&command.font_paths, true);
+        searcher.search(&command.font_settings);
 
         let now = match command.creation_timestamp {
             Some(time) => Now::Fixed(time),

--- a/crates/typst/src/text/mod.rs
+++ b/crates/typst/src/text/mod.rs
@@ -109,7 +109,8 @@ pub struct TextElem {
     ///   `New Computer Modern Math`, and `DejaVu Sans Mono`. In addition, you
     ///   can use the `--font-path` argument or `TYPST_FONT_PATHS` environment
     ///   variable to add directories that should be scanned for fonts. The
-    ///   priority is: `--font-paths` > system fonts > embedded fonts. Run
+    ///   priority is: `--font-paths` > system fonts (if
+    /// `--no-system-fonts` is not passed) > embedded fonts. Run
     ///   `typst fonts` to see the fonts that Typst has discovered on your
     ///   system.
     ///


### PR DESCRIPTION
See #3892.

I added a separate `FontSettings` struct for font search-related options.