### PR TITLE
[Draft] Add font objects

### DIFF
--- a/crates/typst/src/foundations/styles.rs
+++ b/crates/typst/src/foundations/styles.rs
@@ -15,7 +15,7 @@ use crate::foundations::{
 };
 use crate::introspection::Locatable;
 use crate::syntax::Span;
-use crate::text::{FontFamily, FontList, TextElem};
+use crate::text::{FontList, FontListEntry, TextElem};
 use crate::utils::LazyHash;
 
 /// Provides access to active styles.
@@ -139,7 +139,7 @@ impl Styles {
 
     /// Set a font family composed of a preferred family and existing families
     /// from a style chain.
-    pub fn set_family(&mut self, preferred: FontFamily, existing: StyleChain) {
+    pub fn set_family(&mut self, preferred: FontListEntry, existing: StyleChain) {
         self.set(TextElem::set_font(FontList(
             std::iter::once(preferred)
                 .chain(TextElem::font_in(existing).into_iter().cloned())

--- a/crates/typst/src/math/ctx.rs
+++ b/crates/typst/src/math/ctx.rs
@@ -22,8 +22,8 @@ use crate::model::ParElem;
 use crate::realize::StyleVec;
 use crate::syntax::{is_newline, Span};
 use crate::text::{
-    features, BottomEdge, BottomEdgeMetric, Font, TextElem, TextSize, TopEdge,
-    TopEdgeMetric,
+    features, BottomEdge, BottomEdgeMetric, Font, FontListEntry, TextElem, TextSize,
+    TopEdge, TopEdgeMetric,
 };
 
 macro_rules! scaled {
@@ -71,6 +71,7 @@ impl<'a, 'b, 'v> MathContext<'a, 'b, 'v> {
         styles: StyleChain<'a>,
         base: Size,
         font: &'a Font,
+        fle: &FontListEntry,
     ) -> Self {
         let math_table = font.ttf().tables().math.unwrap();
         let gsub_table = font.ttf().tables().gsub;
@@ -89,7 +90,9 @@ impl<'a, 'b, 'v> MathContext<'a, 'b, 'v> {
                 _ => None,
             });
 
-        let features = features(styles);
+        let base_features = features(styles);
+        let mut features = fle.features();
+        features.extend_from_slice(&base_features);
         let glyphwise_tables = gsub_table.map(|gsub| {
             features
                 .into_iter()

--- a/crates/typst/src/math/equation.rs
+++ b/crates/typst/src/math/equation.rs
@@ -20,7 +20,8 @@ use crate::math::{
 use crate::model::{Numbering, Outlinable, ParElem, Refable, Supplement};
 use crate::syntax::Span;
 use crate::text::{
-    families, variant, Font, FontFamily, FontList, FontWeight, LocalName, TextElem,
+    families, variant, Font, FontFamily, FontList, FontListEntry, FontWeight, LocalName,
+    TextElem,
 };
 use crate::utils::{NonZeroExt, Numeric};
 use crate::World;
@@ -188,8 +189,8 @@ impl ShowSet for Packed<EquationElem> {
             out.set(EquationElem::set_size(MathSize::Text));
         }
         out.set(TextElem::set_weight(FontWeight::from_number(450)));
-        out.set(TextElem::set_font(FontList(vec![FontFamily::new(
-            "New Computer Modern Math",
+        out.set(TextElem::set_font(FontList(vec![FontListEntry::from_family(
+            FontFamily::new("New Computer Modern Math"),
         )])));
         out
     }

--- a/crates/typst/src/text/mod.rs
+++ b/crates/typst/src/text/mod.rs
@@ -34,9 +34,13 @@ use ecow::{eco_format, EcoString};
 use rustybuzz::Feature;
 use smallvec::SmallVec;
 use ttf_parser::{Rect, Tag};
+use typst_macros::func;
+use typst_macros::scope;
+use typst_macros::ty;
 
 use crate::diag::{bail, warning, HintedStrResult, SourceResult};
 use crate::engine::Engine;
+use crate::foundations::Value;
 use crate::foundations::{
     cast, category, dict, elem, Args, Array, Cast, Category, Construct, Content, Dict,
     Fold, NativeElement, Never, Packed, PlainText, Repr, Resolve, Scope, Set, Smart,
@@ -788,6 +792,41 @@ cast! {
     FontFamily,
     self => self.0.into_value(),
     string: EcoString => Self::new(&string),
+}
+
+/// A specification for a font.
+#[ty(scope, cast, name = "font")]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct FontListEntry {
+    /// The font family.
+    family: FontFamily,
+}
+
+impl FontListEntry {
+    pub fn from_family(family: &str) -> Self {
+        FontListEntry { family: FontFamily::new(family) }
+    }
+}
+
+#[scope]
+impl FontListEntry {
+    /// Constructs a new font.
+    #[func(constructor)]
+    pub fn construct(family: FontFamily) -> FontListEntry {
+        FontListEntry { family }
+    }
+}
+
+impl Repr for FontListEntry {
+    fn repr(&self) -> EcoString {
+        eco_format!("font({})", self.family.0.repr())
+    }
+}
+
+cast! {
+    FontListEntry,
+    self => Value::dynamic(self),
+    string: EcoString => Self::from_family(&string),
 }
 
 /// Font family fallback list.

--- a/crates/typst/src/text/raw.rs
+++ b/crates/typst/src/text/raw.rs
@@ -9,7 +9,7 @@ use syntect::highlighting::{self as synt, Theme};
 use syntect::parsing::{SyntaxDefinition, SyntaxSet, SyntaxSetBuilder};
 use unicode_segmentation::UnicodeSegmentation;
 
-use super::Lang;
+use super::{FontListEntry, Lang};
 use crate::diag::{At, FileError, HintedStrResult, SourceResult, StrResult};
 use crate::engine::Engine;
 use crate::foundations::{
@@ -461,7 +461,9 @@ impl ShowSet for Packed<RawElem> {
         out.set(TextElem::set_lang(Lang::ENGLISH));
         out.set(TextElem::set_hyphenate(Hyphenate(Smart::Custom(false))));
         out.set(TextElem::set_size(TextSize(Em::new(0.8).into())));
-        out.set(TextElem::set_font(FontList(vec![FontFamily::new("DejaVu Sans Mono")])));
+        out.set(TextElem::set_font(FontList(vec![FontListEntry::from_family(
+            FontFamily::new("DejaVu Sans Mono"),
+        )])));
         out.set(SmartQuoteElem::set_enabled(false));
         if self.block(styles) {
             out.set(ParElem::set_shrink(false));

--- a/crates/typst/src/text/shift.rs
+++ b/crates/typst/src/text/shift.rs
@@ -155,7 +155,7 @@ fn is_shapable(engine: &Engine, text: &str, styles: StyleChain) -> bool {
     for family in TextElem::font_in(styles) {
         if let Some(font) = world
             .book()
-            .select(family.as_str(), variant(styles))
+            .select(family.family.as_str(), variant(styles))
             .and_then(|id| world.font(id))
         {
             return text.chars().all(|c| font.ttf().glyph_index(c).is_some());


### PR DESCRIPTION
See #3488 and #3331.

* [X] Add `font` type (implicitly convertible from string)
* [ ] Add per-`font` OpenType features – will be a lot more complicated because `text::features` assumes that text will use the same OpenType features regardless of which font is selected.
* [ ] Add per-`font` Unicode ranges

Unresolved questions:

* Should we deprecate OpenType feature-related options on `text`?
