### PR TITLE
Run PDF and SVG export in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on: [push, pull_request, merge_group]
 env:
   RUSTFLAGS: "-Dwarnings"
   RUSTDOCFLAGS: "-Dwarnings"
+  TYPST_TESTS_EXTENDED: true
 
 jobs:
   # This allows us to have one branch protection rule for the full test matrix.

--- a/tests/src/args.rs
+++ b/tests/src/args.rs
@@ -31,10 +31,16 @@ pub struct CliArguments {
     /// Does not affect the comparison or the reference image.
     #[arg(short, long, default_value_t = 1.0)]
     pub scale: f32,
-    /// Exports PDF outputs into the artifact store.
+    /// Whether to run the tests in extended mode, including PDF and SVG
+    /// export.
+    ///
+    /// This is used in CI.
+    #[arg(long, env = "TYPST_TESTS_EXTENDED")]
+    pub extended: bool,
+    /// Runs PDF export.
     #[arg(long)]
     pub pdf: bool,
-    /// Exports SVG outputs into the artifact store.
+    /// Runs SVG export.
     #[arg(long)]
     pub svg: bool,
     /// Displays the syntax tree.
@@ -46,6 +52,18 @@ pub struct CliArguments {
     /// How many threads to spawn when running the tests.
     #[arg(short = 'j', long)]
     pub num_threads: Option<usize>,
+}
+
+impl CliArguments {
+    /// Whether to run PDF export.
+    pub fn pdf(&self) -> bool {
+        self.pdf || self.extended
+    }
+
+    /// Whether to run SVG export.
+    pub fn svg(&self) -> bool {
+        self.svg || self.extended
+    }
 }
 
 /// What to do.

--- a/tests/src/run.rs
+++ b/tests/src/run.rs
@@ -174,14 +174,14 @@ impl<'a> Runner<'a> {
         std::fs::write(&live_path, data).unwrap();
 
         // Write PDF if requested.
-        if crate::ARGS.pdf {
+        if crate::ARGS.pdf() {
             let pdf_path = format!("{}/pdf/{}.pdf", crate::STORE_PATH, self.test.name);
             let pdf = typst_pdf::pdf(document, Smart::Auto, None);
             std::fs::write(pdf_path, pdf).unwrap();
         }
 
         // Write SVG if requested.
-        if crate::ARGS.svg {
+        if crate::ARGS.svg() {
             let svg_path = format!("{}/svg/{}.svg", crate::STORE_PATH, self.test.name);
             let svg = typst_svg::svg_merged(document, Abs::pt(5.0));
             std::fs::write(svg_path, svg).unwrap();


### PR DESCRIPTION
We don't have proper PDF and SVG tests yet, but we should at least run them to catch potential panics.