### PR TITLE
Revise docs for `place` element

### DIFF
--- a/crates/typst/src/layout/place.rs
+++ b/crates/typst/src/layout/place.rs
@@ -78,9 +78,13 @@ pub struct PlaceElem {
     ///   place(center, dx: amount - 32pt, dy: amount)[A]
     /// }
     /// ```
+    ///
+    /// This currently does not affect layout, even if `float` is `{true}`.
     pub dx: Rel<Length>,
 
     /// The vertical displacement of the placed content.
+    ///
+    /// This currently does not affect layout, even if `float` is `{true}`.
     pub dy: Rel<Length>,
 
     /// The content to place.

--- a/crates/typst/src/layout/place.rs
+++ b/crates/typst/src/layout/place.rs
@@ -30,8 +30,9 @@ use crate::realize::{Behave, Behaviour};
 pub struct PlaceElem {
     /// Relative to which position in the parent container to place the content.
     ///
-    /// Cannot be `{auto}` if `float` is `{false}` and must be either
-    /// `{auto}`, `{top}`, or `{bottom}` if `float` is `{true}`.
+    /// If `float` is `{false}`, then this can be any alignment other than `{auto}`.
+    ///
+    /// If `float` is `{true}`, then this must be `{auto}`, `{top}`, or `{bottom}`.
     ///
     /// When an axis of the page is `{auto}` sized, all alignments relative to
     /// that axis will be ignored, instead, the item will be placed in the

--- a/crates/typst/src/layout/place.rs
+++ b/crates/typst/src/layout/place.rs
@@ -78,12 +78,16 @@ pub struct PlaceElem {
     /// }
     /// ```
     ///
-    /// This currently does not affect layout, even if `float` is `{true}`.
+    /// This is always ignored by the layout algorithm. In other words,
+    /// the inner content is treated as if it were wrapped in a
+    /// `{move}` element.
     pub dx: Rel<Length>,
 
     /// The vertical displacement of the placed content.
     ///
-    /// This currently does not affect layout, even if `float` is `{true}`.
+    /// This is always ignored by the layout algorithm. In other words,
+    /// the inner content is treated as if it were wrapped in a
+    /// `{move}` element.
     pub dy: Rel<Length>,
 
     /// The content to place.

--- a/crates/typst/src/layout/place.rs
+++ b/crates/typst/src/layout/place.rs
@@ -78,16 +78,16 @@ pub struct PlaceElem {
     /// }
     /// ```
     ///
-    /// This is always ignored by the layout algorithm. In other words,
-    /// the inner content is treated as if it were wrapped in a
-    /// `{move}` element.
+    /// This does not affect the layout of in-flow content.
+    /// In other words, the placed content is treated as if it
+    /// were wrapped in a [`move`] element.
     pub dx: Rel<Length>,
 
     /// The vertical displacement of the placed content.
     ///
-    /// This is always ignored by the layout algorithm. In other words,
-    /// the inner content is treated as if it were wrapped in a
-    /// `{move}` element.
+    /// This does not affect the layout of in-flow content.
+    /// In other words, the placed content is treated as if it
+    /// were wrapped in a [`move`] element.
     pub dy: Rel<Length>,
 
     /// The content to place.

--- a/crates/typst/src/layout/place.rs
+++ b/crates/typst/src/layout/place.rs
@@ -30,9 +30,8 @@ use crate::realize::{Behave, Behaviour};
 pub struct PlaceElem {
     /// Relative to which position in the parent container to place the content.
     ///
-    /// If `float` is `{false}`, then this can be any alignment other than `{auto}`.
-    ///
-    /// If `float` is `{true}`, then this must be `{auto}`, `{top}`, or `{bottom}`.
+    /// - If `float` is `{false}`, then this can be any alignment other than `{auto}`.
+    /// - If `float` is `{true}`, then this must be `{auto}`, `{top}`, or `{bottom}`.
     ///
     /// When an axis of the page is `{auto}` sized, all alignments relative to
     /// that axis will be ignored, instead, the item will be placed in the


### PR DESCRIPTION
A small PR to make it clear that `alignment` can be any alignment other than `auto` when `float` is `false`.