### PR TITLE
Add `CITATION.cff` file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,25 +10,18 @@ type: software
 authors:
   - given-names: Laurenz
     family-names: Mädje
+    email: laurenz.maedje@typst.app
   - given-names: Martin
     family-names: Haug
+    email: martin.haug@typst.app
   - name: The Typst Project Developers
-    email: hello@typst.app
 identifiers:
   - type: url
     value: >-
       https://laurmaedje.github.io/programmable-markup-language-for-typesetting.pdf
-    description: A Programmable Markup Language for Typesetting
+    description: "Typst: A Programmable Markup Language for Typesetting"
 repository-code: 'https://github.com/typst/typst'
 url: 'https://typst.app/'
-abstract: >-
-  Typst was initiated in 2019 at the Technical University of
-  Berlin by Martin Haug and Laurenz Mädje. Developed in
-  Rust, this programmable markup language for typesetting
-  became the subject of their master's theses, which they
-  wrote in 2022. After several years of closed-source
-  development, Typst was open-sourced and released to the
-  public in 2023.
 keywords:
   - typesetting
   - markup language

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,35 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: Typst
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Laurenz
+    family-names: Mädje
+  - given-names: Martin
+    family-names: Haug
+  - name: The Typst Project Developers
+    email: hello@typst.app
+identifiers:
+  - type: url
+    value: >-
+      https://laurmaedje.github.io/programmable-markup-language-for-typesetting.pdf
+    description: A Programmable Markup Language for Typesetting
+repository-code: 'https://github.com/typst/typst'
+url: 'https://typst.app/'
+abstract: >-
+  Typst was initiated in 2019 at the Technical University of
+  Berlin by Martin Haug and Laurenz Mädje. Developed in
+  Rust, this programmable markup language for typesetting
+  became the subject of their master's theses, which they
+  wrote in 2022. After several years of closed-source
+  development, Typst was open-sourced and released to the
+  public in 2023.
+keywords:
+  - typesetting
+  - markup language
+license: Apache-2.0


### PR DESCRIPTION
Hello,

I frequently need to cite Typst in the documents I write, and noticed that GitHub supports a specific citation file format (`CITATION.cff`). Having this file would enhance the visibility and proper citation of Typst directly from the GitHub repository page.

GitHub's support for the `CITATION.cff` files enables easy access to citation information, which can be automatically parsed and displayed on the project page. More details can be found in the [GitHub documentation on citation files](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files).

Would you be interested in adding such a file to the project?

When Github detect such a file in a repo, a new link is displayed on the right side:

![image](https://github.com/typst/typst/assets/252042/824dfcbf-04a7-487b-b0f1-354eaff60253)

Clicking on the link open a box:

![image](https://github.com/typst/typst/assets/252042/9ff1d002-7d18-4bc8-b8db-21f56e5abbf2)

Screenshots from https://github.com/citation-file-format/citation-file-format

Related to https://github.com/typst/typst/discussions/4108