### PR TITLE
Add element-wise operations for arrays

### DIFF
--- a/crates/typst-syntax/src/ast.rs
+++ b/crates/typst-syntax/src/ast.rs
@@ -1431,6 +1431,14 @@ pub enum BinOp {
     MulAssign,
     /// The divide-assign operator: `/=`.
     DivAssign,
+    /// The element-wise addition operator: `.`.
+    DotAdd,
+    /// The element-wise subtraction operator: `.-`.
+    DotSub,
+    /// The element-wise multiplication operator: `.*`.
+    DotMul,
+    /// The element-wise division operator: `./`.
+    DotDiv,
 }
 
 impl BinOp {
@@ -1455,6 +1463,10 @@ impl BinOp {
             SyntaxKind::HyphEq => Self::SubAssign,
             SyntaxKind::StarEq => Self::MulAssign,
             SyntaxKind::SlashEq => Self::DivAssign,
+            SyntaxKind::DotAdd => Self::DotAdd,
+            SyntaxKind::DotSub => Self::DotSub,
+            SyntaxKind::DotMul => Self::DotMul,
+            SyntaxKind::DotDiv => Self::DotDiv,
             _ => return Option::None,
         })
     }
@@ -1481,6 +1493,10 @@ impl BinOp {
             Self::SubAssign => 1,
             Self::MulAssign => 1,
             Self::DivAssign => 1,
+            Self::DotAdd => 5,
+            Self::DotSub => 5,
+            Self::DotMul => 6,
+            Self::DotDiv => 6,
         }
     }
 
@@ -1506,6 +1522,10 @@ impl BinOp {
             Self::SubAssign => Assoc::Right,
             Self::MulAssign => Assoc::Right,
             Self::DivAssign => Assoc::Right,
+            Self::DotAdd => Assoc::Left,
+            Self::DotSub => Assoc::Left,
+            Self::DotMul => Assoc::Left,
+            Self::DotDiv => Assoc::Left,
         }
     }
 
@@ -1531,6 +1551,10 @@ impl BinOp {
             Self::SubAssign => "-=",
             Self::MulAssign => "*=",
             Self::DivAssign => "/=",
+            Self::DotAdd => ".+",
+            Self::DotSub => ".-",
+            Self::DotMul => ".*",
+            Self::DotDiv => "./",
         }
     }
 }

--- a/crates/typst-syntax/src/highlight.rs
+++ b/crates/typst-syntax/src/highlight.rs
@@ -225,6 +225,11 @@ pub fn highlight(node: &LinkedNode) -> Option<Tag> {
         SyntaxKind::Arrow => Some(Tag::Operator),
         SyntaxKind::Root => Some(Tag::MathOperator),
 
+        SyntaxKind::DotAdd |
+        SyntaxKind::DotSub |
+        SyntaxKind::DotMul |
+        SyntaxKind::DotDiv => Some(Tag::Operator),
+
         SyntaxKind::Not => Some(Tag::Keyword),
         SyntaxKind::And => Some(Tag::Keyword),
         SyntaxKind::Or => Some(Tag::Keyword),
@@ -409,8 +414,9 @@ fn highlight_html_impl(html: &mut String, node: &LinkedNode) {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::ops::Range;
+
+    use super::*;
 
     #[test]
     fn test_highlighting() {

--- a/crates/typst-syntax/src/highlight.rs
+++ b/crates/typst-syntax/src/highlight.rs
@@ -225,10 +225,10 @@ pub fn highlight(node: &LinkedNode) -> Option<Tag> {
         SyntaxKind::Arrow => Some(Tag::Operator),
         SyntaxKind::Root => Some(Tag::MathOperator),
 
-        SyntaxKind::DotAdd |
-        SyntaxKind::DotSub |
-        SyntaxKind::DotMul |
-        SyntaxKind::DotDiv => Some(Tag::Operator),
+        SyntaxKind::DotAdd
+        | SyntaxKind::DotSub
+        | SyntaxKind::DotMul
+        | SyntaxKind::DotDiv => Some(Tag::Operator),
 
         SyntaxKind::Not => Some(Tag::Keyword),
         SyntaxKind::And => Some(Tag::Keyword),

--- a/crates/typst-syntax/src/kind.rs
+++ b/crates/typst-syntax/src/kind.rs
@@ -149,6 +149,16 @@ pub enum SyntaxKind {
     /// A root: `√`, `∛` or `∜`.
     Root,
 
+    // Element-wise operations for tuples or arrays
+    /// The element-wise addition operator: `.`.
+    DotAdd,
+    /// The element-wise subtraction operator: `.-`.
+    DotSub,
+    /// The element-wise multiplication operator: `.*`.
+    DotMul,
+    /// The element-wise division operator: `./`.
+    DotDiv,
+
     /// The `not` operator.
     Not,
     /// The `and` operator.
@@ -432,6 +442,10 @@ impl SyntaxKind {
             Self::Dots => "dots",
             Self::Arrow => "arrow",
             Self::Root => "root",
+            Self::DotAdd => "element-wise addition operator",
+            Self::DotSub => "element-wise subtraction operator",
+            Self::DotMul => "element-wise multiplication operator",
+            Self::DotDiv => "element-wise division operator",
             Self::Not => "operator `not`",
             Self::And => "operator `and`",
             Self::Or => "operator `or`",

--- a/crates/typst-syntax/src/lexer.rs
+++ b/crates/typst-syntax/src/lexer.rs
@@ -582,6 +582,10 @@ impl Lexer<'_> {
             '`' => self.raw(),
             '<' if self.s.at(is_id_continue) => self.label(),
             '0'..='9' => self.number(start, c),
+            '.' if self.s.eat_if('+') => SyntaxKind::DotAdd,
+            '.' if self.s.eat_if('-') => SyntaxKind::DotSub,
+            '.' if self.s.eat_if('*') => SyntaxKind::DotMul,
+            '.' if self.s.eat_if('/') => SyntaxKind::DotDiv,
             '.' if self.s.at(char::is_ascii_digit) => self.number(start, c),
             '"' => self.string(),
 

--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -708,9 +708,7 @@ fn code_expr_prec(p: &mut Parser, atomic: bool, min_prec: usize) {
             continue;
         }
 
-        let binop = if p.at_set(set::BINARY_OP) {
-            ast::BinOp::from_kind(p.current())
-        } else if p.at_set(set::ELEMENTWISE_OP) {
+        let binop = if p.at_set(set::BINARY_OP) || p.at_set(set::ELEMENTWISE_OP) {
             ast::BinOp::from_kind(p.current())
         } else if min_prec <= ast::BinOp::NotIn.precedence() && p.eat_if(SyntaxKind::Not) {
             if p.at(SyntaxKind::In) {

--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -5,8 +5,8 @@ use std::ops::{Index, IndexMut, Range};
 use ecow::{eco_format, EcoString};
 use unicode_math_class::MathClass;
 
+use crate::{ast, is_ident, is_newline, Lexer, LexMode, set, SyntaxKind, SyntaxNode};
 use crate::set::SyntaxSet;
-use crate::{ast, is_ident, is_newline, set, LexMode, Lexer, SyntaxKind, SyntaxNode};
 
 /// Parses a source file.
 pub fn parse(text: &str) -> SyntaxNode {
@@ -710,8 +710,9 @@ fn code_expr_prec(p: &mut Parser, atomic: bool, min_prec: usize) {
 
         let binop = if p.at_set(set::BINARY_OP) {
             ast::BinOp::from_kind(p.current())
-        } else if min_prec <= ast::BinOp::NotIn.precedence() && p.eat_if(SyntaxKind::Not)
-        {
+        } else if p.at_set(set::ELEMENTWISE_OP) {
+            ast::BinOp::from_kind(p.current())
+        } else if min_prec <= ast::BinOp::NotIn.precedence() && p.eat_if(SyntaxKind::Not) {
             if p.at(SyntaxKind::In) {
                 Some(ast::BinOp::NotIn)
             } else {

--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -5,8 +5,8 @@ use std::ops::{Index, IndexMut, Range};
 use ecow::{eco_format, EcoString};
 use unicode_math_class::MathClass;
 
-use crate::{ast, is_ident, is_newline, Lexer, LexMode, set, SyntaxKind, SyntaxNode};
 use crate::set::SyntaxSet;
+use crate::{ast, is_ident, is_newline, set, LexMode, Lexer, SyntaxKind, SyntaxNode};
 
 /// Parses a source file.
 pub fn parse(text: &str) -> SyntaxNode {
@@ -710,7 +710,8 @@ fn code_expr_prec(p: &mut Parser, atomic: bool, min_prec: usize) {
 
         let binop = if p.at_set(set::BINARY_OP) || p.at_set(set::ELEMENTWISE_OP) {
             ast::BinOp::from_kind(p.current())
-        } else if min_prec <= ast::BinOp::NotIn.precedence() && p.eat_if(SyntaxKind::Not) {
+        } else if min_prec <= ast::BinOp::NotIn.precedence() && p.eat_if(SyntaxKind::Not)
+        {
             if p.at(SyntaxKind::In) {
                 Some(ast::BinOp::NotIn)
             } else {

--- a/crates/typst-syntax/src/set.rs
+++ b/crates/typst-syntax/src/set.rs
@@ -40,7 +40,7 @@ impl SyntaxSet {
 
     /// Whether the set contains the given syntax kind.
     pub const fn contains(&self, kind: SyntaxKind) -> bool {
-        assert!((kind as usize) < BITS as usize);
+        assert!((kind as usize) < BITS);
         let idx = (kind as usize) / 128;
         (self.bits[idx] & bit(kind)) != 0
     }

--- a/crates/typst-syntax/src/set.rs
+++ b/crates/typst-syntax/src/set.rs
@@ -13,9 +13,7 @@ pub struct SyntaxSet {
 impl SyntaxSet {
     /// Create a new set from a slice of kinds.
     pub const fn new() -> Self {
-        Self {
-            bits: [0; 2],
-        }
+        Self { bits: [0; 2] }
     }
 
     /// Insert a syntax kind into the set.
@@ -31,10 +29,7 @@ impl SyntaxSet {
     /// Combine two syntax sets.
     pub const fn union(self, other: Self) -> Self {
         Self {
-            bits: [
-                self.bits[0] | other.bits[0],
-                self.bits[1] | other.bits[1],
-            ],
+            bits: [self.bits[0] | other.bits[0], self.bits[1] | other.bits[1]],
         }
     }
 

--- a/crates/typst/src/foundations/array.rs
+++ b/crates/typst/src/foundations/array.rs
@@ -8,12 +8,14 @@ use ecow::{eco_format, EcoString, EcoVec};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
-use crate::diag::{bail, At, SourceDiagnostic, SourceResult, StrResult};
+#[doc(inline)]
+pub use crate::__array as array;
+use crate::diag::{At, bail, SourceDiagnostic, SourceResult, StrResult};
 use crate::engine::Engine;
 use crate::eval::ops;
 use crate::foundations::{
-    cast, func, repr, scope, ty, Args, Bytes, CastInfo, Context, Dict, FromValue, Func,
-    IntoValue, Reflect, Repr, Str, Value, Version,
+    Args, Bytes, cast, CastInfo, Context, Dict, FromValue, func, Func, IntoValue, Reflect, repr,
+    Repr, scope, Str, ty, Value, Version,
 };
 use crate::syntax::{Span, Spanned};
 
@@ -34,9 +36,6 @@ macro_rules! __array {
         ),*])
     };
 }
-
-#[doc(inline)]
-pub use crate::__array as array;
 
 /// A sequence of values.
 ///
@@ -98,6 +97,9 @@ impl Array {
     pub fn iter(&self) -> std::slice::Iter<Value> {
         self.0.iter()
     }
+
+    /// Access the internal vector of values.
+    pub fn values(&self) -> &EcoVec<Value> { &self.0 }
 
     /// Mutably borrow the first value in the array.
     pub fn first_mut(&mut self) -> StrResult<&mut Value> {

--- a/crates/typst/src/foundations/array.rs
+++ b/crates/typst/src/foundations/array.rs
@@ -10,12 +10,12 @@ use smallvec::SmallVec;
 
 #[doc(inline)]
 pub use crate::__array as array;
-use crate::diag::{At, bail, SourceDiagnostic, SourceResult, StrResult};
+use crate::diag::{bail, At, SourceDiagnostic, SourceResult, StrResult};
 use crate::engine::Engine;
 use crate::eval::ops;
 use crate::foundations::{
-    Args, Bytes, cast, CastInfo, Context, Dict, FromValue, func, Func, IntoValue, Reflect, repr,
-    Repr, scope, Str, ty, Value, Version,
+    cast, func, repr, scope, ty, Args, Bytes, CastInfo, Context, Dict, FromValue, Func,
+    IntoValue, Reflect, Repr, Str, Value, Version,
 };
 use crate::syntax::{Span, Spanned};
 
@@ -99,7 +99,9 @@ impl Array {
     }
 
     /// Access the internal vector of values.
-    pub fn values(&self) -> &EcoVec<Value> { &self.0 }
+    pub fn values(&self) -> &EcoVec<Value> {
+        &self.0
+    }
 
     /// Mutably borrow the first value in the array.
     pub fn first_mut(&mut self) -> StrResult<&mut Value> {

--- a/tests/suite/foundations/array.typ
+++ b/tests/suite/foundations/array.typ
@@ -514,4 +514,162 @@
 
 --- array-reduce-unexpected-argument ---
 // Error: 19-21 unexpected argument
-#(1, 2, 3).reduce(() => none) 
+#(1, 2, 3).reduce(() => none)
+
+--- elementwise-add ---
+#{
+  let a = (1, 2, 3);
+  let b = (4, 5, 6);
+  let c = a .+ b;
+  test(c, (5, 7, 9))
+}
+
+--- elementwise-sub ---
+#{
+  let a = (10, 20, 30);
+  let b = (1, 2, 3);
+  let c = a .- b;
+  test(c, (9, 18, 27))
+}
+
+--- elementwise-mul ---
+#{
+  let a = (1, 2, 3);
+  let b = (4, 5, 6);
+  let c = a .* b;
+  test(c, (4, 10, 18))
+}
+
+--- elementwise-div ---
+#{
+  let a = (10, 20, 30);
+  let b = (2, 4, 5);
+  let c = a ./ b;
+  test(c, (5, 5, 6))
+}
+
+--- elementwise-add-float ---
+#{
+  let a = (1.5, 2.5, 3.5);
+  let b = (0.5, 1.5, 2.5);
+  let c = a .+ b;
+  test(c, (2.0, 4.0, 6.0))
+}
+
+--- elementwise-sub-negative ---
+#{
+  let a = (1, -2, 3);
+  let b = (-1, 2, -3);
+  let c = a .- b;
+  test(c, (2, -4, 6))
+}
+
+--- elementwise-mul-mixed ---
+#{
+  let a = (1, 2.5, 3);
+  let b = (4.0, 5, 6);
+  let c = a .* b;
+  test(c, (4.0, 12.5, 18))
+}
+
+--- elementwise-div-integer-float ---
+#{
+  let a = (10, 20.0, 30);
+  let b = (2.0, 4, 5);
+  let c = a ./ b;
+  test(c, (5.0, 5.0, 6.0))
+}
+
+--- elementwise-add-length-mismatch ---
+#{
+  let a = (1, 2, 3)
+  let b = (4, 5)
+  // Error: 11-17 Arrays must have the same length for element-wise operations
+  let c = a .+ b
+}
+
+--- elementwise-div-by-zero ---
+#{
+  let a = (10, 20, 30)
+  let b = (2, 0, 5)
+  // Error: 11-17 Failed to perform division on 20 and 0: Division by zero
+  let c = a ./ b
+}
+
+--- elementwise-operations-on-empty-arrays ---
+#{
+  let a = ();
+  let b = ();
+  let c = a .+ b;
+  test(c, ())
+}
+
+--- elementwise-mixed-types ---
+#{
+  let a = (1, "text", 3)
+  let b = (4, " more", 6)
+  test(a.+b,(5, "text more", 9))
+}
+
+--- elementwise-add-nested-arrays ---
+#{
+  let a = ((1, 2), (3, 4))
+  let b = ((5, 6), (7, 8))
+  test(a.+b,((1, 2, 5, 6), (3, 4, 7, 8)))
+}
+
+
+--- elementwise-add-with-nones ---
+#{
+  let a = (1, none, 3)
+  let b = (4, 5, none)
+  test(a.+b,(5, 5, 3))
+}
+
+--- elementwise-operations-mixed-numbers ---
+#{
+  let a = (1, 2.0, 3);
+  let b = (4.0, 5, 6.5);
+  let c = a .+ b;
+  test(c, (5.0, 7.0, 9.5))
+}
+
+--- elementwise-sub-zero ---
+#{
+  let a = (0, 0, 0);
+  let b = (1, 2, 3);
+  let c = a .- b;
+  test(c, (-1, -2, -3))
+}
+
+--- elementwise-mul-with-zeros ---
+#{
+  let a = (1, 2, 0);
+  let b = (0, 5, 6);
+  let c = a .* b;
+  test(c, (0, 10, 0))
+}
+
+--- elementwise-div-float-results ---
+#{
+  let a = (9, 25, 49);
+  let b = (3, 5, 7);
+  let c = a ./ b;
+  test(c, (3.0, 5.0, 7.0))
+}
+
+--- elementwise-combined-operations ---
+#{
+  let a = (1, 2, 3)
+  let b = (4, 5, 6)
+  let c = a .+ b .- a .* b ./ b
+  test(c, (4.0, 5.0, 6.0))
+}
+
+--- elementwise-nested-operations ---
+#{
+  let a = (1, 2, 3);
+  let b = (4, 5, 6);
+  let c = (a .+ b) .* (a .- b);
+  test(c, (-15, -21, -27))
+}

--- a/tests/suite/foundations/array.typ
+++ b/tests/suite/foundations/array.typ
@@ -518,65 +518,65 @@
 
 --- elementwise-add ---
 #{
-  let a = (1, 2, 3);
-  let b = (4, 5, 6);
-  let c = a .+ b;
+  let a = (1, 2, 3)
+  let b = (4, 5, 6)
+  let c = a .+ b
   test(c, (5, 7, 9))
 }
 
 --- elementwise-sub ---
 #{
-  let a = (10, 20, 30);
-  let b = (1, 2, 3);
-  let c = a .- b;
+  let a = (10, 20, 30)
+  let b = (1, 2, 3)
+  let c = a .- b
   test(c, (9, 18, 27))
 }
 
 --- elementwise-mul ---
 #{
-  let a = (1, 2, 3);
-  let b = (4, 5, 6);
-  let c = a .* b;
+  let a = (1, 2, 3)
+  let b = (4, 5, 6)
+  let c = a .* b
   test(c, (4, 10, 18))
 }
 
 --- elementwise-div ---
 #{
-  let a = (10, 20, 30);
-  let b = (2, 4, 5);
-  let c = a ./ b;
+  let a = (10, 20, 30)
+  let b = (2, 4, 5)
+  let c = a ./ b
   test(c, (5, 5, 6))
 }
 
 --- elementwise-add-float ---
 #{
-  let a = (1.5, 2.5, 3.5);
-  let b = (0.5, 1.5, 2.5);
-  let c = a .+ b;
+  let a = (1.5, 2.5, 3.5)
+  let b = (0.5, 1.5, 2.5)
+  let c = a .+ b
   test(c, (2.0, 4.0, 6.0))
 }
 
 --- elementwise-sub-negative ---
 #{
-  let a = (1, -2, 3);
-  let b = (-1, 2, -3);
-  let c = a .- b;
+  let a = (1, -2, 3)
+  let b = (-1, 2, -3)
+  let c = a .- b
   test(c, (2, -4, 6))
 }
 
 --- elementwise-mul-mixed ---
 #{
-  let a = (1, 2.5, 3);
-  let b = (4.0, 5, 6);
-  let c = a .* b;
+  let a = (1, 2.5, 3)
+  let b = (4.0, 5, 6)
+  let c = a .* b
   test(c, (4.0, 12.5, 18))
 }
 
 --- elementwise-div-integer-float ---
 #{
-  let a = (10, 20.0, 30);
-  let b = (2.0, 4, 5);
-  let c = a ./ b;
+  let a = (10, 20.0, 30)
+  let b = (2.0, 4, 5)
+  let c = a ./ b
   test(c, (5.0, 5.0, 6.0))
 }
 
@@ -584,7 +584,7 @@
 #{
   let a = (1, 2, 3)
   let b = (4, 5)
-  // Error: 11-17 Arrays must have the same length for element-wise operations
+  // Error: 11-17 arrays must have the same length for element-wise operations
   let c = a .+ b
 }
 
@@ -592,15 +592,15 @@
 #{
   let a = (10, 20, 30)
   let b = (2, 0, 5)
-  // Error: 11-17 Failed to perform division on 20 and 0: Division by zero
+  // Error: 11-17 failed to perform division on 20 and 0: cannot divide by zero
   let c = a ./ b
 }
 
 --- elementwise-operations-on-empty-arrays ---
 #{
-  let a = ();
-  let b = ();
-  let c = a .+ b;
+  let a = ()
+  let b = ()
+  let c = a .+ b
   test(c, ())
 }
 
@@ -628,33 +628,33 @@
 
 --- elementwise-operations-mixed-numbers ---
 #{
-  let a = (1, 2.0, 3);
-  let b = (4.0, 5, 6.5);
-  let c = a .+ b;
+  let a = (1, 2.0, 3)
+  let b = (4.0, 5, 6.5)
+  let c = a .+ b
   test(c, (5.0, 7.0, 9.5))
 }
 
 --- elementwise-sub-zero ---
 #{
-  let a = (0, 0, 0);
-  let b = (1, 2, 3);
-  let c = a .- b;
+  let a = (0, 0, 0)
+  let b = (1, 2, 3)
+  let c = a .- b
   test(c, (-1, -2, -3))
 }
 
 --- elementwise-mul-with-zeros ---
 #{
-  let a = (1, 2, 0);
-  let b = (0, 5, 6);
-  let c = a .* b;
+  let a = (1, 2, 0)
+  let b = (0, 5, 6)
+  let c = a .* b
   test(c, (0, 10, 0))
 }
 
 --- elementwise-div-float-results ---
 #{
-  let a = (9, 25, 49);
-  let b = (3, 5, 7);
-  let c = a ./ b;
+  let a = (9, 25, 49)
+  let b = (3, 5, 7)
+  let c = a ./ b
   test(c, (3.0, 5.0, 7.0))
 }
 
@@ -668,8 +668,120 @@
 
 --- elementwise-nested-operations ---
 #{
-  let a = (1, 2, 3);
-  let b = (4, 5, 6);
-  let c = (a .+ b) .* (a .- b);
+  let a = (1, 2, 3)
+  let b = (4, 5, 6)
+  let c = (a .+ b) .* (a .- b)
   test(c, (-15, -21, -27))
+}
+
+--- elementwise-add-scalar-array ---
+#{
+  let a = 2
+  let b = (1, 2, 3)
+  let c = a .+ b
+  test(c, (3, 4, 5))
+}
+
+--- elementwise-add-array-scalar ---
+#{
+  let a = (1, 2, 3)
+  let b = 2
+  let c = a .+ b
+  test(c, (3, 4, 5))
+}
+
+--- elementwise-add-scalar-scalar ---
+#{
+  let a = 5
+  let b = 3
+  // Error: 11-17 cannot use this operator on scalars
+  let c = a .+ b
+  }
+
+--- elementwise-sub-scalar-array ---
+#{
+  let a = 5
+  let b = (1, 2, 3)
+  let c = a .- b
+  test(c, (4, 3, 2))
+}
+
+--- elementwise-sub-array-scalar ---
+#{
+  let a = (1, 2, 3)
+  let b = 1
+  let c = a .- b
+  test(c, (0, 1, 2))
+}
+
+--- elementwise-sub-scalar-scalar ---
+#{
+  let a = 10
+  let b = 3
+  // Error: 11-17 cannot use this operator on scalars
+  let c = a .- b
+}
+
+--- elementwise-mul-scalar-array ---
+#{
+  let a = 2
+  let b = (1, 2, 3)
+  let c = a .* b
+  test(c, (2, 4, 6))
+}
+
+--- elementwise-mul-array-scalar ---
+#{
+  let a = (1, 2, 3)
+  let b = 2
+  let c = a .* b
+  test(c, (2, 4, 6))
+}
+
+--- elementwise-mul-scalar-scalar ---
+#{
+  let a = 2
+  let b = 3
+  // Error: 11-17 cannot use this operator on scalars
+  let c = a .* b
+}
+
+--- elementwise-div-array-scalar ---
+#{
+  let a = (10, 20, 30)
+  let b = 2
+  let c = a ./ b
+  test(c, (5, 10, 15))
+}
+
+--- elementwise-div-scalar-scalar ---
+#{
+  let a = 10
+  let b = 2
+  // Error: 11-17 cannot use this operator on scalars
+  let c = a ./ b
+}
+
+--- elementwise-div-invalid-scalar-array ---
+#{
+  let a = 10
+  let b = (1, 2, 3)
+  // Error: 11-17 cannot divide scalar by array
+  let c = a ./ b
+}
+
+--- elementwise-div-scalar-array-string ---
+#{
+  let a = "a"
+  let b = ("a", "b", "c")
+  let c = a .+ b
+  test(c, ("aa", "ab", "ac"))
+}
+
+--- elementwise-div-array-scalar-string ---
+#{
+  let a = ("a", "b", "c")
+  let b = "a"
+  let c = a .+ b
+  test(c, ("aa", "ba", "ca"))
 }


### PR DESCRIPTION
#### Context and Objective

This pull request proposes adding element-wise operations inspired by Julia for arrays in Typst (issue #4106) . The added syntax allows for concise and intuitive element-wise addition, subtraction, multiplication, and division. These changes aim to enhance Typst's numerical computation capabilities.

#### Changes Made

1. **Addition of Element-wise Operators:**
   - Added element-wise operators (`DotAdd`, `DotSub`, `DotMul`, `DotDiv`) to `BinOp`.
   - Updated the logic to handle these new operators in `highlight.rs`, `lexer.rs`, and `parser.rs`.
   - Defined element-wise operations (`elementwise_add`, `elementwise_sub`, `elementwise_mul`, `elementwise_div`) for arrays in `ops.rs`.

2. **Updates to Foundations:**
   - Added the `values` method to access the internal values of arrays in `array.rs`.

3. **Refactoring `SyntaxSet`:**
   - Refactored `SyntaxSet` due to the initial limitation where the number of `SyntaxKind` variants exceeded 128, causing assertions. 
   - Used an array of `u128` to represent the bits, allowing for handling up to 256 variants of `SyntaxKind`.
   - Updated methods to manipulate this new `SyntaxSet`:
     - `new()`
     - `add()`
     - `union()`
     - `contains()`

4. **Unit Tests:**
   - Added comprehensive unit tests in `array.typ` to verify the new element-wise operation functionalities:
     - Basic operations: Addition, subtraction, multiplication, and division.
     - Handling edge cases: Arrays of different lengths, division by zero, mixed data types, empty arrays.
     - Combined and nested operations.

#### Use Case

The new syntax allows for concise and intuitive element-wise operations on arrays:

```typst
let a = (1,2,3)
let b = (4,5,6)

// Element-wise operations
let c = a .+ b
let d = a .- b
let e = a .* b
let f = a ./ b
