### PR TITLE
Extended cargo installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,10 +118,15 @@ Typst's CLI is available from different sources:
   - macOS: `brew install typst`
   - Windows: `winget install --id Typst.Typst`
 
-- If you have a [Rust][rust] toolchain installed, you can also install the
-  latest development version with
-  `cargo install --git https://github.com/typst/typst --locked typst-cli`. Note that this
-  will be a "nightly" version that may be broken or not yet properly documented.
+- If you have a [Rust][rust] toolchain installed, you can also install a specific version with:
+  ```
+  cargo install --git https://github.com/typst/typst --tag v0.11.0 --locked typst-cli
+  ```
+  Or you can install the latest development version. Note that this will be a "nightly" version that may be broken or not yet properly documented with:
+  ```
+  cargo install --git https://github.com/typst/typst --locked typst-cli
+  ```
+
 
 - Nix users can use the `typst` package with `nix-shell -p typst` or build and
   run the bleeding edge version with `nix run github:typst/typst -- --version`.

--- a/README.md
+++ b/README.md
@@ -118,14 +118,19 @@ Typst's CLI is available from different sources:
   - macOS: `brew install typst`
   - Windows: `winget install --id Typst.Typst`
 
-- If you have a [Rust][rust] toolchain installed, you can also install a specific version with `--tag`. For example, you can install v0.11.0 with the command below.
+- If you have a [Rust][rust] toolchain installed, you can install Typst with:
+
   ```
-  cargo install --git https://github.com/typst/typst --tag v0.11.0 --locked typst-cli
+  cargo install --locked typst-cli
   ```
-  Or you can install the latest development version. Note that this will be a "nightly" version that may be broken or not yet properly documented with:
+
+  Or you can install the latest development version with:
+
   ```
   cargo install --git https://github.com/typst/typst --locked typst-cli
   ```
+
+  Note that this will be a "nightly" version that may be broken or not yet properly documented
 
 
 - Nix users can use the `typst` package with `nix-shell -p typst` or build and

--- a/README.md
+++ b/README.md
@@ -118,23 +118,16 @@ Typst's CLI is available from different sources:
   - macOS: `brew install typst`
   - Windows: `winget install --id Typst.Typst`
 
-- If you have a [Rust][rust] toolchain installed, you can install Typst with:
+- If you have a [Rust][rust] toolchain installed, you can install
+  - the latest released Typst version with
+    `cargo install --locked typst-cli`
+  - a development version with
+    `cargo install --git https://github.com/typst/typst --locked typst-cli`
 
-  ```
-  cargo install --locked typst-cli
-  ```
-
-  Or you can install the latest development version with:
-
-  ```
-  cargo install --git https://github.com/typst/typst --locked typst-cli
-  ```
-
-  Note that this will be a "nightly" version that may be broken or not yet properly documented
-
-
-- Nix users can use the `typst` package with `nix-shell -p typst` or build and
-  run the bleeding edge version with `nix run github:typst/typst -- --version`.
+- Nix users can
+  - use the `typst` package with `nix-shell -p typst`
+  - build and run a development version with
+    `nix run github:typst/typst -- --version`.
 
 - Docker users can run a prebuilt image with
   `docker run -it ghcr.io/typst/typst:latest`.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Typst's CLI is available from different sources:
   - macOS: `brew install typst`
   - Windows: `winget install --id Typst.Typst`
 
-- If you have a [Rust][rust] toolchain installed, you can also install a specific version with:
+- If you have a [Rust][rust] toolchain installed, you can also install a specific version with `--tag`. For example, you can install v0.11.0 with the command below.
   ```
   cargo install --git https://github.com/typst/typst --tag v0.11.0 --locked typst-cli
   ```


### PR DESCRIPTION
extended cargo installation instructions in `README.md` by mentioning how to install a specific tag