### PR TITLE
Mention how to get the current compiler version in version documentation

### DIFF
--- a/crates/typst/src/foundations/version.rs
+++ b/crates/typst/src/foundations/version.rs
@@ -18,6 +18,8 @@ use crate::foundations::{cast, func, repr, scope, ty, Repr};
 /// special case, the empty version (that has no components at all) is the same
 /// as `0`, `0.0`, `0.0.0`, and so on.
 ///
+/// The current version of the Typst compiler is available as `sys.version`.
+///
 /// You can convert a version to an array of explicitly given components using
 /// the [`array`] constructor.
 #[ty(scope, cast)]


### PR DESCRIPTION
This small PR adds a mention of the `sys.version` constant to [the documentation for the Version type](https://typst.app/docs/reference/foundations/version/).