### PR TITLE
Pin `cross` in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Run Cross
       if: ${{ matrix.cross }}
       run: |
-        cargo install cross --git https://github.com/cross-rs/cross.git
+        cargo install cross --git https://github.com/cross-rs/cross.git --locked --rev 085092ca
         cross build -p typst-cli --release --target ${{ matrix.target }} --features self-update,vendor-openssl
 
     - name: Run Cargo


### PR DESCRIPTION
Everything needs to be pinned ... we can also switch to a cargo version in the future, but this was easiest for now since it's the exact one that was used successfully for 0.11.