### PR TITLE
Hint for language-region pair on `text.lang`

### DIFF
--- a/crates/typst/src/text/mod.rs
+++ b/crates/typst/src/text/mod.rs
@@ -29,13 +29,14 @@ pub use self::smartquote::*;
 pub use self::space::*;
 
 use std::fmt::{self, Debug, Formatter};
+use std::str::FromStr;
 
 use ecow::{eco_format, EcoString};
 use rustybuzz::{Feature, Tag};
 use smallvec::SmallVec;
 use ttf_parser::Rect;
 
-use crate::diag::{bail, warning, SourceResult, StrResult};
+use crate::diag::{bail, warning, At, Hint, SourceResult, StrResult};
 use crate::engine::Engine;
 use crate::foundations::{
     cast, category, dict, elem, Args, Array, Cast, Category, Construct, Content, Dict,
@@ -393,6 +394,7 @@ pub struct TextElem {
     /// = Einleitung
     /// In diesem Dokument, ...
     /// ```
+    #[parse(parse_lang(args)?)]
     #[default(Lang::ENGLISH)]
     #[ghost]
     pub lang: Lang,
@@ -1299,4 +1301,28 @@ cast! {
         v.finish(&["hyphenation", "runt", "widow", "orphan"])?;
         ret
     },
+}
+
+/// Function to parse the language argument.
+/// Provides a hint if a region is used in the language parameter.
+fn parse_lang(args: &mut Args) -> SourceResult<Option<Lang>> {
+    let Some(Spanned { v: iso, span }) = args.named::<Spanned<EcoString>>("lang")? else {
+        return Ok(None);
+    };
+
+    let result = Lang::from_str(&iso);
+    if result.is_err() {
+        if let Some((lang, region)) = iso.split_once('-') {
+            if Lang::from_str(lang).is_ok() && Region::from_str(region).is_ok() {
+                return result
+                    .hint(eco_format!(
+                        "you should leave only \"{}\" in the `lang` parameter and specify \"{}\" in the `region` parameter",
+                        lang, region,
+                    ))
+                    .at(span)
+                    .map(Some);
+            }
+        }
+    }
+    result.at(span).map(Some)
 }

--- a/tests/suite/text/lang.typ
+++ b/tests/suite/text/lang.typ
@@ -78,3 +78,8 @@
 #outline()
 #set text(lang: "qaa", region: "aa")
 #outline()
+
+--- text-lang-hint-region-parameter ---
+// Error: 17-24 expected two or three letter language code (ISO 639-1/2/3)
+// Hint: 17-24 you should leave only "en" in the `lang` parameter and specify "gb" in the `region` parameter
+#set text(lang: "en-gb")


### PR DESCRIPTION
This pr closes #4142 . If I get it correctly, `text.lang` is the only place parsing ISO language code.

I added a new function `parse_lang` to parse an argument for `text.lang`:
1. Use `Lang::from_str` to parse the arg. If success, all done.
2. Check whether the arg is a lang-region pair. If so, give a hint.