### PR TITLE
Do not show tracepoints outside of root by default

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -209,6 +209,14 @@ pub struct SharedArgs {
         value_parser = clap::value_parser!(DiagnosticFormat)
     )]
     pub diagnostic_format: DiagnosticFormat,
+
+    /// Where diagnostics should be reported
+    #[clap(
+        long,
+        default_value_t = DiagnosticLocation::WithinRoot,
+        value_parser = clap::value_parser!(DiagnosticLocation)
+    )]
+    pub diagnostic_location: DiagnosticLocation,
 }
 
 /// Parses a UNIX timestamp according to <https://reproducible-builds.org/specs/source-date-epoch/>
@@ -360,6 +368,25 @@ pub enum DiagnosticFormat {
 }
 
 impl Display for DiagnosticFormat {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.to_possible_value()
+            .expect("no values are skipped")
+            .get_name()
+            .fmt(f)
+    }
+}
+
+/// The place where diagnostics should be located.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, ValueEnum)]
+pub enum DiagnosticLocation {
+    /// Locate diagnostics at the function call that caused them within the
+    /// current root
+    WithinRoot,
+    /// Locate diagnostics at the place they originated
+    Source,
+}
+
+impl Display for DiagnosticLocation {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         self.to_possible_value()
             .expect("no values are skipped")

--- a/crates/typst-cli/src/query.rs
+++ b/crates/typst-cli/src/query.rs
@@ -31,8 +31,14 @@ pub fn query(command: &QueryCommand) -> StrResult<()> {
             let data = retrieve(&world, command, &document)?;
             let serialized = format(data, command)?;
             println!("{serialized}");
-            print_diagnostics(&world, &[], &warnings, command.common.diagnostic_format)
-                .map_err(|err| eco_format!("failed to print diagnostics ({err})"))?;
+            print_diagnostics(
+                &world,
+                &[],
+                &warnings,
+                command.common.diagnostic_format,
+                command.common.diagnostic_location,
+            )
+            .map_err(|err| eco_format!("failed to print diagnostics ({err})"))?;
         }
 
         // Print diagnostics.
@@ -43,6 +49,7 @@ pub fn query(command: &QueryCommand) -> StrResult<()> {
                 &errors,
                 &warnings,
                 command.common.diagnostic_format,
+                command.common.diagnostic_location,
             )
             .map_err(|err| eco_format!("failed to print diagnostics ({err})"))?;
         }


### PR DESCRIPTION
This PR changes the default way tracebacks are displayed to exclude tracepoints that are within a package. This can be reverted to show full tracebacks using by passing `--diagnostic-location source` to the CLI.

The goal is to reduce the noise for the end user when compiling a Typst file via the CLI.

I'm not sure if "diagnostic location" is the right name for that. I'm not sure either how to properly test that.