### PR TITLE
Update 3-advanced.md

### DIFF
--- a/docs/tutorial/3-advanced.md
+++ b/docs/tutorial/3-advanced.md
@@ -338,7 +338,7 @@ a way to set any of that, we need to write our own heading show rule.
 >>> )
 #show heading: it => [
   #set align(center)
-  #set text(12pt, weight: "regular")
+  #set text(13pt, weight: "regular")
   #block(smallcaps(it.body))
 ]
 
@@ -417,7 +417,7 @@ differentiate between section and subsection headings:
   level: 1
 ): it => block(width: 100%)[
   #set align(center)
-  #set text(12pt, weight: "regular")
+  #set text(13pt, weight: "regular")
   #smallcaps(it.body)
 ]
 


### PR DESCRIPTION
The conference style guide requests that the first level heading is in 13pt, so the font size has been changed from 12pt to 13pt in the respective show rule(s).