### PR TITLE
Improving error message for invalid file types

### DIFF
--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -8,9 +8,7 @@ use codespan_reporting::term;
 use ecow::{eco_format, EcoString};
 use parking_lot::RwLock;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
-use typst::diag::{
-    bail, At, FileError, FileResult, Severity, SourceDiagnostic, StrResult,
-};
+use typst::diag::{bail, At, FileError, Severity, SourceDiagnostic, StrResult};
 use typst::eval::Tracer;
 use typst::foundations::{Datetime, Smart};
 use typst::layout::{Frame, PageRanges};

--- a/crates/typst/src/diag.rs
+++ b/crates/typst/src/diag.rs
@@ -349,6 +349,23 @@ impl<T> Hint<T> for HintedStrResult<T> {
     }
 }
 
+/// Enrich a [`SourceResult`] with a hint.
+/// All returned errors receive the hint.
+pub trait SourceHint<T> {
+    /// Add the hint to all returned errors.
+    fn hint(self, hint: impl Into<EcoString>) -> SourceResult<T>;
+}
+
+impl<T> SourceHint<T> for SourceResult<T> {
+    fn hint(self, hint: impl Into<EcoString>) -> SourceResult<T> {
+        self.map_err(|mut error| {
+            let hint = hint.into();
+            error.make_mut().iter_mut().for_each(|error| error.hint(hint.clone()));
+            error
+        })
+    }
+}
+
 /// A result type with a file-related error.
 pub type FileResult<T> = Result<T, FileError>;
 

--- a/crates/typst/src/diag.rs
+++ b/crates/typst/src/diag.rs
@@ -349,23 +349,6 @@ impl<T> Hint<T> for HintedStrResult<T> {
     }
 }
 
-/// Enrich a [`SourceResult`] with a hint.
-/// All returned errors receive the hint.
-pub trait SourceHint<T> {
-    /// Add the hint to all returned errors.
-    fn hint(self, hint: impl Into<EcoString>) -> SourceResult<T>;
-}
-
-impl<T> SourceHint<T> for SourceResult<T> {
-    fn hint(self, hint: impl Into<EcoString>) -> SourceResult<T> {
-        self.map_err(|mut error| {
-            let hint = hint.into();
-            error.make_mut().iter_mut().for_each(|error| error.hint(hint.clone()));
-            error
-        })
-    }
-}
-
 /// A result type with a file-related error.
 pub type FileResult<T> = Result<T, FileError>;
 


### PR DESCRIPTION
Closes #2486 

Refactored code for loading main source file with utf-8 error detection, providing a helpful message. See examples below:

```
> ./typst compile typst

error: file is not valid utf-8
 = hint: a file without an extension (`.something`) is not usually a Typst file. Check if you meant to add `.typ` to its name.
```

```
> ./typst.exe compile typst.exe

error: file is not valid utf-8
 = hint: a file with the `.exe` extension is not usually a Typst file. Check if you meant to use `.typ` instead.
```