### PR TITLE
Rephrase the sentence on variable scope in Scripting documentation

### DIFF
--- a/docs/reference/scripting.md
+++ b/docs/reference/scripting.md
@@ -68,8 +68,9 @@ As already demonstrated above, variables can be defined with `{let}` bindings.
 The variable is assigned the value of the expression that follows the `=` sign.
 The assignment of a value is optional, if no value is assigned, the variable
 will be initialized as `{none}`. The `{let}` keyword can also be used to create
-a [custom named function]($function/#defining-functions). Let bindings can be
-accessed for the rest of the containing block or document.
+a [custom named function]($function/#defining-functions). Variables can be
+accessed for the rest of the containing block (or the rest of the file if there
+is no containing block).
 
 ```example
 #let name = "Typst"


### PR DESCRIPTION
Following the discussion on #4245, this PR changes the sentence that describe the scope of variables. The first sentence of the paragraph already explains that variables are introduced using `let` bindings, so I did not repeat that.