### PR TITLE
Fixes #4265: Added ceil and floor symbols

### DIFF
--- a/crates/typst/src/symbols/sym.rs
+++ b/crates/typst/src/symbols/sym.rs
@@ -41,6 +41,8 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
     paren: [l: '(', r: ')', t: '⏜', b: '⏝'],
     brace: [l: '{', r: '}', t: '⏞', b: '⏟'],
     bracket: [l: '[', l.double: '⟦', r: ']', r.double: '⟧', t: '⎴', b: '⎵'],
+    ceil: [l: '⌈', r: '⌉'],
+    floor: [l: '⌊', r: '⌋'],
     shell: [l: '〔', r: '〕', t: '⏠', b: '⏡'],
     bar: [v: '|', v.double: '‖', v.triple: '⦀', v.broken: '¦', v.circle: '⦶', h: '―'],
     fence: [l: '⧘', l.double: '⧚', r: '⧙', r.double: '⧛', dotted: '⦙'],


### PR DESCRIPTION
added floor and ceiling symbols to sym as floor.l, floor.r, ceil.l, ceil.r