### PR TITLE
Add named symbols: `⌈`, `⌉`, `⌊`, `⌋`

### DIFF
--- a/crates/typst/src/math/mod.rs
+++ b/crates/typst/src/math/mod.rs
@@ -187,8 +187,6 @@ pub fn module() -> Module {
     math.define_elem::<PrimesElem>();
     math.define_func::<abs>();
     math.define_func::<norm>();
-    math.define_func::<floor>();
-    math.define_func::<ceil>();
     math.define_func::<round>();
     math.define_func::<sqrt>();
     math.define_func::<upright>();

--- a/crates/typst/src/symbols/sym.rs
+++ b/crates/typst/src/symbols/sym.rs
@@ -64,6 +64,14 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
         spheric.rev: '⦠',
         spheric.top: '⦡',
     ],
+    ceil: [
+        #[call(crate::math::ceil)] l: '⌈',
+        r: '⌉',
+    ],
+    floor: [
+        #[call(crate::math::floor)] l: '⌊',
+        r: '⌋',
+    ],
 
     // Punctuation.
     amp: ['&', inv: '⅋'],

--- a/docs/src/lib.rs
+++ b/docs/src/lib.rs
@@ -542,7 +542,7 @@ fn group_page(
     let mut outline_items = vec![];
     for name in &group.filter {
         let value = group.module().scope().get(name).unwrap();
-        let Value::Func(func) = value else { panic!("not a function") };
+        let Ok(ref func) = value.clone().cast::<Func>() else { panic!("not a function") };
         let func = func_model(resolver, func, &path, true);
         let id_base = urlify(&eco_format!("functions-{}", func.name));
         let children = func_outline(&func, &id_base);


### PR DESCRIPTION
This pr closes #4265 .

```typ
#grid(
  columns: (1fr, 1fr),
  align: (start + horizon, end + horizon),
  align(center, table(
    columns: 4,
    align: center + horizon,
    table.cell(colspan: 2)[In Markup Mode], table.cell(colspan: 2)[In Math Mode],
    ```typst #sym.floor```, sym.floor, ```typst $floor$```, $floor$,
    ```typst #sym.ceil```, sym.ceil, ```typst $ceil$```, $ceil$,
    ```typst #sym.floor.l```, sym.floor.l, ```typst $floor.l$```, $floor.l$,
    ```typst #sym.floor.r```, sym.floor.r, ```typst $floor.r$```, $floor.r$,
    ```typst #sym.ceil.l```, sym.ceil.l, ```typst $ceil.l$```, $ceil.l$,
    ```typst #sym.ceil.r```, sym.ceil.r, ```typst $ceil.r$```, $ceil.r$,
  )),
  [
    $ round(A) $
    $ floor.l A ceil.r $
    $ ceil.l A floor.r $
    $ floor.l A floor.r = floor.l(A) = floor(A) $
    $ ceil.l A ceil.r = ceil.l(A) = ceil(A) $
  ],
)
```

![image](https://github.com/typst/typst/assets/69834864/ee36a55b-c0d5-4027-95a7-5187bb7702cb)
