### PR TITLE
Bump libc to v0.2.155

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,9 +1218,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libdeflate-sys"


### PR DESCRIPTION
Upgrade libc to v0.2.155 to support LoongArch64.

Resolve the following errors:
```
error[E0425]: cannot find value `__SIZEOF_PTHREAD_RWLOCK_T` in the crate root
    --> /home/alpine/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.153/src/unix/linux_like/linux/align.rs:139:30
     |
139  |                 size: [u8; ::__SIZEOF_PTHREAD_RWLOCK_T],
     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^ help: a constant with a similar name exists: `__SIZEOF_PTHREAD_RWLOCKATTR_T`
     |
    ::: /home/alpine/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.153/src/unix/linux_like/linux/musl/mod.rs:637:1
     |
637  | pub const __SIZEOF_PTHREAD_RWLOCKATTR_T: usize = 8;
     | --------------------------------------------------- similarly named constant `__SIZEOF_PTHREAD_RWLOCKATTR_T` defined here
     |
    ::: /home/alpine/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.153/src/unix/linux_like/linux/mod.rs:5682:1
     |
5682 | expand_align!();
     | --------------- in this macro invocation
     |
     = note: this error originates in the macro `expand_align` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find value `__SIZEOF_PTHREAD_BARRIER_T` in the crate root
    --> /home/alpine/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.153/src/unix/linux_like/linux/align.rs:167:30
     |
167  |                 size: [u8; ::__SIZEOF_PTHREAD_BARRIER_T],
     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a constant with a similar name exists: `__SIZEOF_PTHREAD_BARRIERATTR_T`
```

Libc release notes :https://github.com/rust-lang/libc/releases

Thanks.
