### PR TITLE
Reorder syntax kinds

### DIFF
--- a/crates/typst-syntax/src/kind.rs
+++ b/crates/typst-syntax/src/kind.rs
@@ -4,6 +4,16 @@
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[repr(u8)]
 pub enum SyntaxKind {
+    /// The end of token stream.
+    End,
+    /// An invalid sequence of characters.
+    Error,
+
+    /// A line comment: `// ...`.
+    LineComment,
+    /// A block comment: `/* ... */`.
+    BlockComment,
+
     /// The contents of a file or content block.
     Markup,
     /// Plain text without markup.
@@ -266,15 +276,6 @@ pub enum SyntaxKind {
     Destructuring,
     /// A destructuring assignment expression: `(x, y) = (1, 2)`.
     DestructAssignment,
-
-    /// A line comment: `// ...`.
-    LineComment,
-    /// A block comment: `/* ... */`.
-    BlockComment,
-    /// An invalid sequence of characters.
-    Error,
-    /// The end of token stream.
-    End,
 }
 
 impl SyntaxKind {
@@ -352,7 +353,7 @@ impl SyntaxKind {
     pub fn is_trivia(self) -> bool {
         matches!(
             self,
-            Self::Space | Self::Parbreak | Self::LineComment | Self::BlockComment
+            Self::LineComment | Self::BlockComment | Self::Space | Self::Parbreak
         )
     }
 
@@ -364,6 +365,10 @@ impl SyntaxKind {
     /// A human-readable name for the kind.
     pub fn name(self) -> &'static str {
         match self {
+            Self::End => "end of tokens",
+            Self::Error => "syntax error",
+            Self::LineComment => "line comment",
+            Self::BlockComment => "block comment",
             Self::Markup => "markup",
             Self::Text => "text",
             Self::Space => "space",
@@ -490,10 +495,6 @@ impl SyntaxKind {
             Self::FuncReturn => "`return` expression",
             Self::Destructuring => "destructuring pattern",
             Self::DestructAssignment => "destructuring assignment expression",
-            Self::LineComment => "line comment",
-            Self::BlockComment => "block comment",
-            Self::Error => "syntax error",
-            Self::End => "end of tokens",
         }
     }
 }


### PR DESCRIPTION
This moves the special tokens and comments up because comments are used in the SyntaxSet, which can only hold kinds with discriminator <= 127. This gives us some breathing room to introduce new SyntaxKinds, as in #4228.