### PR TITLE
Fix race condition in interners

### DIFF
--- a/crates/typst-syntax/src/file.rs
+++ b/crates/typst-syntax/src/file.rs
@@ -36,17 +36,20 @@ impl FileId {
     #[track_caller]
     pub fn new(package: Option<PackageSpec>, path: VirtualPath) -> Self {
         // Try to find an existing entry that we can reuse.
+        //
+        // We could check with just a read lock, but if the pair is not yet
+        // present, we would then need to recheck after acquiring a write lock,
+        // which is probably not worth it.
         let pair = (package, path);
-        if let Some(&id) = INTERNER.read().unwrap().to_id.get(&pair) {
+        let mut interner = INTERNER.write().unwrap();
+        if let Some(&id) = interner.to_id.get(&pair) {
             return id;
         }
-
-        let mut interner = INTERNER.write().unwrap();
-        let num = interner.from_id.len().try_into().expect("out of file ids");
 
         // Create a new entry forever by leaking the pair. We can't leak more
         // than 2^16 pair (and typically will leak a lot less), so its not a
         // big deal.
+        let num = interner.from_id.len().try_into().expect("out of file ids");
         let id = FileId(num);
         let leaked = Box::leak(Box::new(pair));
         interner.to_id.insert(leaked, id);


### PR DESCRIPTION
The same PackageSpec-Path pair (FileId) or string (PicoStr) could get different IDs if two threads raced in the construction.