### PR TITLE
Allow compile query

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -80,6 +80,14 @@ pub struct CompileCommand {
     #[clap(required_if_eq("input", "-"), value_parser = ValueParser::new(output_value_parser))]
     pub output: Option<Output>,
 
+    /// Defines which element to retrieve.
+    #[arg(long = "selector", default_value = None)]
+    pub selector: Option<String>,
+
+    /// Specify which element to render after selection.
+    #[arg(long = "element_number", short = 'n', default_value_t = 0)]
+    pub element_number: usize,
+
     /// Which pages to export. When unspecified, all document pages are exported.
     ///
     /// Pages to export are separated by commas, and can be either simple page

--- a/crates/typst-cli/src/query.rs
+++ b/crates/typst-cli/src/query.rs
@@ -28,7 +28,7 @@ pub fn query(command: &QueryCommand) -> StrResult<()> {
     match result {
         // Retrieve and print query results.
         Ok(document) => {
-            let data = retrieve(&world, command, &document)?;
+            let data = retrieve(&world, &command.selector, &document)?;
             let serialized = format(data, command)?;
             println!("{serialized}");
             print_diagnostics(&world, &[], &warnings, command.common.diagnostic_format)
@@ -52,14 +52,14 @@ pub fn query(command: &QueryCommand) -> StrResult<()> {
 }
 
 /// Retrieve the matches for the selector.
-fn retrieve(
+pub fn retrieve(
     world: &dyn World,
-    command: &QueryCommand,
+    selector: &str,
     document: &Document,
 ) -> StrResult<Vec<Content>> {
     let selector = eval_string(
         world.track(),
-        &command.selector,
+        selector,
         Span::detached(),
         EvalMode::Code,
         Scope::default(),


### PR DESCRIPTION
This PR adds the ability to compile query via CLI. It extends compile sub-command. Implementation of [#3015](https://github.com/typst/typst/issues/3015).

Currently, it lacks support of (1) keeping context values like counters and states, and (2) styles of target content - result of query which we render.

To resolve (1) I tried to rebuild the `Locator` from the frames of the first compilation, but results were incorrect. I also tried to keep `Locator` from the entire build of the document. This attempt was also unsuccessful.

I could solve issue (2) by abusing `Tracer`, but looking for a cleaner solution.

To see those experiments, look at [this branch](https://github.com/remimimimimi/typst/commits/query-compile/).

List of unsolved problems:
- [ ] Preserve context values
- [ ] Keep styles
- [ ] Decide which sub-command will implement this functionality - `compile` vs `query`