### PR TITLE
Bump SVG & PDF cinematic universe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,12 +701,14 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a595cb550439a117696039dfc69830492058211b771a2a165379f2a1a53d84d"
 dependencies = [
- "roxmltree",
+ "roxmltree 0.19.0",
 ]
 
 [[package]]
 name = "fontdb"
-version = "0.17.0"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e32eac81c1135c1df01d4e6d4233c47ba11f6a6d07f33e0bba09d18797077770"
 dependencies = [
  "fontconfig-parser",
  "log",
@@ -1617,11 +1619,11 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pdf-writer"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e9127455063c816e661caac9ecd9043ad2871f55be93014e6838a8ced2332b"
+checksum = "af6a7882fda7808481d43c51cadfc3ec934c6af72612a1fe6985ce329a2f0469"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "itoa",
  "memchr",
  "ryu",
@@ -1683,8 +1685,9 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pixglyph"
-version = "0.3.0"
-source = "git+https://github.com/typst/pixglyph?branch=bump-ttf-parser-to-0.21#36207637d8f31bfb028863d5b09cd2969dac7ba9"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a64dec9fae2e0f75bb2a7d910b4e8b0d15ecd706fb0d61394774b3223c50a97"
 dependencies = [
  "ttf-parser 0.21.1",
 ]
@@ -1908,7 +1911,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "resvg"
-version = "0.41.0"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "944d052815156ac8fa77eaac055220e95ba0b01fa8887108ca710c03805d9051"
 dependencies = [
  "gif",
  "jpeg-decoder",
@@ -1940,6 +1945,12 @@ name = "roxmltree"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f"
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rustc-hash"
@@ -2267,6 +2278,7 @@ checksum = "09eab8a83bff89ba2200bd4c59be45c7c787f988431b936099a5a266c957f2f9"
 [[package]]
 name = "svg2pdf"
 version = "0.9.1"
+source = "git+https://github.com/typst/svg2pdf#e969b054d2c2c44e88906efa41821d47622c086a"
 dependencies = [
  "fontdb",
  "image 0.25.1",
@@ -2278,7 +2290,7 @@ dependencies = [
  "siphasher 1.0.1",
  "subsetter",
  "tiny-skia",
- "ttf-parser 0.20.0",
+ "ttf-parser 0.21.1",
  "unicode-properties",
  "usvg",
 ]
@@ -2582,7 +2594,7 @@ dependencies = [
  "qcms",
  "rayon",
  "regex",
- "roxmltree",
+ "roxmltree 0.20.0",
  "rustybuzz 0.13.0",
  "serde",
  "serde_json",
@@ -2763,7 +2775,7 @@ dependencies = [
  "image 0.24.9",
  "pixglyph",
  "resvg",
- "roxmltree",
+ "roxmltree 0.20.0",
  "tiny-skia",
  "ttf-parser 0.21.1",
  "typst",
@@ -2987,7 +2999,9 @@ dependencies = [
 
 [[package]]
 name = "usvg"
-version = "0.41.0"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84ea542ae85c715f07b082438a4231c3760539d902e11d093847a0b22963032"
 dependencies = [
  "base64 0.22.0",
  "data-url",
@@ -2997,7 +3011,7 @@ dependencies = [
  "kurbo",
  "log",
  "pico-args",
- "roxmltree",
+ "roxmltree 0.20.0",
  "rustybuzz 0.14.0",
  "simplecss",
  "siphasher 1.0.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,7 +715,7 @@ dependencies = [
  "memmap2",
  "slotmap",
  "tinyvec",
- "ttf-parser 0.21.1",
+ "ttf-parser",
 ]
 
 [[package]]
@@ -1689,7 +1689,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a64dec9fae2e0f75bb2a7d910b4e8b0d15ecd706fb0d61394774b3223c50a97"
 dependencies = [
- "ttf-parser 0.21.1",
+ "ttf-parser",
 ]
 
 [[package]]
@@ -1988,22 +1988,6 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "rustybuzz"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88117946aa1bfb53c2ae0643ceac6506337f44887f8c9fbfb43587b1cc52ba49"
-dependencies = [
- "bitflags 2.4.2",
- "bytemuck",
- "smallvec",
- "ttf-parser 0.20.0",
- "unicode-bidi-mirroring",
- "unicode-ccc",
- "unicode-properties",
- "unicode-script",
-]
-
-[[package]]
-name = "rustybuzz"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7730060ad401b0d1807c904ea56735288af101430aa0d2ab8358b789f5f37002"
@@ -2011,7 +1995,7 @@ dependencies = [
  "bitflags 2.4.2",
  "bytemuck",
  "smallvec",
- "ttf-parser 0.21.1",
+ "ttf-parser",
  "unicode-bidi-mirroring",
  "unicode-ccc",
  "unicode-properties",
@@ -2277,8 +2261,9 @@ checksum = "09eab8a83bff89ba2200bd4c59be45c7c787f988431b936099a5a266c957f2f9"
 
 [[package]]
 name = "svg2pdf"
-version = "0.9.1"
-source = "git+https://github.com/typst/svg2pdf#e969b054d2c2c44e88906efa41821d47622c086a"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31565956eb1dc398c0d9776ee1d1bac4e34759af63dcbe0520df32313a5b53b"
 dependencies = [
  "fontdb",
  "image 0.25.1",
@@ -2290,7 +2275,7 @@ dependencies = [
  "siphasher 1.0.1",
  "subsetter",
  "tiny-skia",
- "ttf-parser 0.21.1",
+ "ttf-parser",
  "unicode-properties",
  "usvg",
 ]
@@ -2532,12 +2517,6 @@ dependencies = [
 
 [[package]]
 name = "ttf-parser"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
-
-[[package]]
-name = "ttf-parser"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
@@ -2595,7 +2574,7 @@ dependencies = [
  "rayon",
  "regex",
  "roxmltree 0.20.0",
- "rustybuzz 0.13.0",
+ "rustybuzz",
  "serde",
  "serde_json",
  "serde_yaml 0.9.32",
@@ -2605,7 +2584,7 @@ dependencies = [
  "syntect",
  "time",
  "toml",
- "ttf-parser 0.21.1",
+ "ttf-parser",
  "two-face",
  "typed-arena",
  "typst-assets",
@@ -2756,7 +2735,7 @@ dependencies = [
  "pdf-writer",
  "subsetter",
  "svg2pdf",
- "ttf-parser 0.21.1",
+ "ttf-parser",
  "typst",
  "typst-assets",
  "typst-macros",
@@ -2777,7 +2756,7 @@ dependencies = [
  "resvg",
  "roxmltree 0.20.0",
  "tiny-skia",
- "ttf-parser 0.21.1",
+ "ttf-parser",
  "typst",
  "typst-macros",
  "typst-timing",
@@ -2792,7 +2771,7 @@ dependencies = [
  "comemo",
  "ecow",
  "flate2",
- "ttf-parser 0.21.1",
+ "ttf-parser",
  "typst",
  "typst-macros",
  "typst-timing",
@@ -2828,7 +2807,7 @@ dependencies = [
  "rayon",
  "regex",
  "tiny-skia",
- "ttf-parser 0.21.1",
+ "ttf-parser",
  "typst",
  "typst-assets",
  "typst-dev-assets",
@@ -3012,7 +2991,7 @@ dependencies = [
  "log",
  "pico-args",
  "roxmltree 0.20.0",
- "rustybuzz 0.14.0",
+ "rustybuzz",
  "simplecss",
  "siphasher 1.0.1",
  "strict-num",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,7 +392,7 @@ dependencies = [
  "comemo-macros",
  "once_cell",
  "parking_lot",
- "siphasher 1.0.0",
+ "siphasher 1.0.1",
 ]
 
 [[package]]
@@ -707,15 +707,14 @@ dependencies = [
 [[package]]
 name = "fontdb"
 version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0299020c3ef3f60f526a4f64ab4a3d4ce116b1acbf24cdd22da0068e5d81dc3"
+source = "git+https://github.com/laurmaedje/fontdb?branch=push-face-info#e2c2a4376a2628c6ed2c64bb01406980a8f916b9"
 dependencies = [
  "fontconfig-parser",
  "log",
  "memmap2",
  "slotmap",
  "tinyvec",
- "ttf-parser",
+ "ttf-parser 0.21.1",
 ]
 
 [[package]]
@@ -781,16 +780,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
-]
-
-[[package]]
-name = "gif"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045"
-dependencies = [
- "color_quant",
- "weezl",
 ]
 
 [[package]]
@@ -1054,10 +1043,26 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "color_quant",
- "gif 0.13.1",
+ "gif",
  "jpeg-decoder",
  "num-traits",
  "png",
+]
+
+[[package]]
+name = "image"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd54d660e773627692c524beaad361aca785a4f9f5730ce91f42aabe5bce3d11"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "gif",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -1203,11 +1208,12 @@ dependencies = [
 
 [[package]]
 name = "kurbo"
-version = "0.9.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd85a5776cd9500c2e2059c8c76c3b01528566b7fcbaf8098b55a33fc298849b"
+checksum = "6e5aa9f0f96a938266bdb12928a67169e8d22c6a786fda8ed984b85e6ba93c3c"
 dependencies = [
  "arrayvec",
+ "smallvec",
 ]
 
 [[package]]
@@ -1679,10 +1685,9 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 [[package]]
 name = "pixglyph"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e0f8ad4c197db38125b880c3c44544788665c7d5f4c42f5a35da44bca1a712"
+source = "git+https://github.com/typst/pixglyph?branch=bump-ttf-parser-to-0.21#36207637d8f31bfb028863d5b09cd2969dac7ba9"
 dependencies = [
- "ttf-parser",
+ "ttf-parser 0.21.1",
 ]
 
 [[package]]
@@ -1904,15 +1909,13 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "resvg"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c34501046959e06470ba62a2dc7f31c15f94ac250d842a45f9e012f4ee40c1e"
+version = "0.41.0"
+source = "git+https://github.com/laurmaedje/resvg?branch=font-provider#c11f38e116dacf2cc7972b52e65c368fdb14313d"
 dependencies = [
- "gif 0.12.0",
+ "gif",
  "jpeg-decoder",
  "log",
  "pico-args",
- "png",
  "rgb",
  "svgtypes",
  "tiny-skia",
@@ -1976,14 +1979,14 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "rustybuzz"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0ae5692c5beaad6a9e22830deeed7874eae8a4e3ba4076fb48e12c56856222c"
+checksum = "88117946aa1bfb53c2ae0643ceac6506337f44887f8c9fbfb43587b1cc52ba49"
 dependencies = [
  "bitflags 2.4.2",
  "bytemuck",
  "smallvec",
- "ttf-parser",
+ "ttf-parser 0.20.0",
  "unicode-bidi-mirroring",
  "unicode-ccc",
  "unicode-properties",
@@ -2160,9 +2163,9 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "siphasher"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54ac45299ccbd390721be55b412d41931911f654fa99e2cb8bfb57184b2061fe"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slotmap"
@@ -2249,27 +2252,32 @@ checksum = "09eab8a83bff89ba2200bd4c59be45c7c787f988431b936099a5a266c957f2f9"
 
 [[package]]
 name = "svg2pdf"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba36b330062be8497fd96597227a757b621b86c4d24d164b06e4522b52b3693e"
+version = "0.9.1"
+source = "git+https://github.com/typst/svg2pdf?branch=font-provider#89c02097a46f3facb35ec3e8ac35a6e66f198fa4"
 dependencies = [
- "image",
+ "fontdb",
+ "image 0.25.1",
+ "log",
  "miniz_oxide",
  "once_cell",
  "pdf-writer",
  "resvg",
+ "siphasher 1.0.1",
+ "subsetter",
  "tiny-skia",
+ "ttf-parser 0.20.0",
+ "unicode-properties",
  "usvg",
 ]
 
 [[package]]
 name = "svgtypes"
-version = "0.13.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e44e288cd960318917cbd540340968b90becc8bc81f171345d706e7a89d9d70"
+checksum = "fae3064df9b89391c9a76a0425a69d124aee9c5c28455204709e72c39868a43c"
 dependencies = [
  "kurbo",
- "siphasher 0.3.11",
+ "siphasher 1.0.1",
 ]
 
 [[package]]
@@ -2504,6 +2512,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
 
 [[package]]
+name = "ttf-parser"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
+
+[[package]]
 name = "two-face"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2541,7 +2555,7 @@ dependencies = [
  "icu_provider_blob",
  "icu_segmenter",
  "if_chain",
- "image",
+ "image 0.24.9",
  "indexmap 2.2.5",
  "kamadak-exif",
  "kurbo",
@@ -2560,13 +2574,13 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml 0.9.32",
- "siphasher 1.0.0",
+ "siphasher 1.0.1",
  "smallvec",
  "stacker",
  "syntect",
  "time",
  "toml",
- "ttf-parser",
+ "ttf-parser 0.21.1",
  "two-face",
  "typed-arena",
  "typst-assets",
@@ -2710,14 +2724,14 @@ dependencies = [
  "bytemuck",
  "comemo",
  "ecow",
- "image",
+ "image 0.24.9",
  "indexmap 2.2.5",
  "miniz_oxide",
  "once_cell",
  "pdf-writer",
  "subsetter",
  "svg2pdf",
- "ttf-parser",
+ "ttf-parser 0.21.1",
  "typst",
  "typst-assets",
  "typst-macros",
@@ -2733,12 +2747,12 @@ version = "0.11.0"
 dependencies = [
  "bytemuck",
  "comemo",
- "image",
+ "image 0.24.9",
  "pixglyph",
  "resvg",
  "roxmltree",
  "tiny-skia",
- "ttf-parser",
+ "ttf-parser 0.21.1",
  "typst",
  "typst-macros",
  "typst-timing",
@@ -2753,7 +2767,7 @@ dependencies = [
  "comemo",
  "ecow",
  "flate2",
- "ttf-parser",
+ "ttf-parser 0.21.1",
  "typst",
  "typst-macros",
  "typst-timing",
@@ -2789,7 +2803,7 @@ dependencies = [
  "rayon",
  "regex",
  "tiny-skia",
- "ttf-parser",
+ "ttf-parser 0.21.1",
  "typst",
  "typst-assets",
  "typst-dev-assets",
@@ -2817,7 +2831,7 @@ dependencies = [
  "once_cell",
  "portable-atomic",
  "rayon",
- "siphasher 1.0.0",
+ "siphasher 1.0.1",
  "thin-vec",
 ]
 
@@ -2857,15 +2871,15 @@ checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-bidi-mirroring"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d12260fb92d52f9008be7e4bca09f584780eb2266dc8fecc6a192bec561694"
+checksum = "23cb788ffebc92c5948d0e997106233eeb1d8b9512f93f41651f52b6c5f5af86"
 
 [[package]]
 name = "unicode-ccc"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2520efa644f8268dce4dcd3050eaa7fc044fca03961e9998ac7e2e92b77cf1"
+checksum = "1df77b101bcc4ea3d78dafc5ad7e4f58ceffe0b2b16bf446aeb50b6cb4157656"
 
 [[package]]
 name = "unicode-ident"
@@ -2960,62 +2974,28 @@ dependencies = [
 
 [[package]]
 name = "usvg"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377f62b4a3c173de8654c1aa80ab1dac1154e6f13a779a9943e53780120d1625"
+version = "0.41.0"
+source = "git+https://github.com/laurmaedje/resvg?branch=font-provider#c11f38e116dacf2cc7972b52e65c368fdb14313d"
 dependencies = [
- "base64 0.21.7",
- "log",
- "pico-args",
- "usvg-parser",
- "usvg-text-layout",
- "usvg-tree",
- "xmlwriter",
-]
-
-[[package]]
-name = "usvg-parser"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "351a05e6f2023d6b4e946f734240a3927aefdcf930d7d42587a2c8a8869814b0"
-dependencies = [
+ "base64 0.22.0",
  "data-url",
  "flate2",
+ "fontdb",
  "imagesize",
  "kurbo",
  "log",
+ "pico-args",
  "roxmltree",
- "simplecss",
- "siphasher 0.3.11",
- "svgtypes",
- "usvg-tree",
-]
-
-[[package]]
-name = "usvg-text-layout"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c41888b9d5cf431fe852eaf9d047bbde83251b98f1749c2f08b1071e6db46e2"
-dependencies = [
- "fontdb",
- "kurbo",
- "log",
  "rustybuzz",
- "unicode-bidi",
- "unicode-script",
- "unicode-vo",
- "usvg-tree",
-]
-
-[[package]]
-name = "usvg-tree"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18863e0404ed153d6e56362c5b1146db9f4f262a3244e3cf2dbe7d8a85909f05"
-dependencies = [
+ "simplecss",
+ "siphasher 1.0.1",
  "strict-num",
  "svgtypes",
  "tiny-skia-path",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
 ]
 
 [[package]]
@@ -3513,4 +3493,19 @@ dependencies = [
  "log",
  "simd-adler32",
  "typed-arena",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec866b44a2a1fd6133d363f073ca1b179f438f99e7e5bfb1e33f7181facfe448"
+dependencies = [
+ "zune-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,8 +706,7 @@ dependencies = [
 
 [[package]]
 name = "fontdb"
-version = "0.16.2"
-source = "git+https://github.com/laurmaedje/fontdb?branch=push-face-info#e2c2a4376a2628c6ed2c64bb01406980a8f916b9"
+version = "0.17.0"
 dependencies = [
  "fontconfig-parser",
  "log",
@@ -1910,7 +1909,6 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 [[package]]
 name = "resvg"
 version = "0.41.0"
-source = "git+https://github.com/laurmaedje/resvg?branch=font-provider#c11f38e116dacf2cc7972b52e65c368fdb14313d"
 dependencies = [
  "gif",
  "jpeg-decoder",
@@ -1987,6 +1985,22 @@ dependencies = [
  "bytemuck",
  "smallvec",
  "ttf-parser 0.20.0",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
+
+[[package]]
+name = "rustybuzz"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7730060ad401b0d1807c904ea56735288af101430aa0d2ab8358b789f5f37002"
+dependencies = [
+ "bitflags 2.4.2",
+ "bytemuck",
+ "smallvec",
+ "ttf-parser 0.21.1",
  "unicode-bidi-mirroring",
  "unicode-ccc",
  "unicode-properties",
@@ -2253,7 +2267,6 @@ checksum = "09eab8a83bff89ba2200bd4c59be45c7c787f988431b936099a5a266c957f2f9"
 [[package]]
 name = "svg2pdf"
 version = "0.9.1"
-source = "git+https://github.com/typst/svg2pdf?branch=font-provider#89c02097a46f3facb35ec3e8ac35a6e66f198fa4"
 dependencies = [
  "fontdb",
  "image 0.25.1",
@@ -2570,7 +2583,7 @@ dependencies = [
  "rayon",
  "regex",
  "roxmltree",
- "rustybuzz",
+ "rustybuzz 0.13.0",
  "serde",
  "serde_json",
  "serde_yaml 0.9.32",
@@ -2975,7 +2988,6 @@ dependencies = [
 [[package]]
 name = "usvg"
 version = "0.41.0"
-source = "git+https://github.com/laurmaedje/resvg?branch=font-provider#c11f38e116dacf2cc7972b52e65c368fdb14313d"
 dependencies = [
  "base64 0.22.0",
  "data-url",
@@ -2986,7 +2998,7 @@ dependencies = [
  "log",
  "pico-args",
  "roxmltree",
- "rustybuzz",
+ "rustybuzz 0.14.0",
  "simplecss",
  "siphasher 1.0.1",
  "strict-num",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ dirs = "5"
 ecow = { version = "0.2", features = ["serde"] }
 env_proxy = "0.4"
 flate2 = "1"
-fontdb = { version = "0.17", default-features = false }
+fontdb = { version = "0.18", default-features = false }
 fs_extra = "1.3"
 hayagriva = "0.5.3"
 heck = "0.4"
@@ -74,9 +74,9 @@ oxipng = { version = "9.0", default-features = false, features = ["filetime", "p
 palette = { version = "0.7.3", default-features = false, features = ["approx", "libm"] }
 parking_lot = "0.12.1"
 pathdiff = "0.2"
-pdf-writer = "0.9.3"
+pdf-writer = "0.10.0"
 phf = { version = "0.11", features = ["macros"] }
-pixglyph = "0.3"
+pixglyph = "0.4"
 png = "0.17"
 portable-atomic = "1.6"
 proc-macro2 = "1"
@@ -85,8 +85,8 @@ quote = "1"
 qcms = "0.3.0"
 rayon = "1.7.0"
 regex = "1"
-resvg = { version = "0.41", default-features = false, features = ["raster-images"] }
-roxmltree = "0.19"
+resvg = { version = "0.42", default-features = false, features = ["raster-images"] }
+roxmltree = "0.20"
 rustybuzz = "0.13"
 same-file = "1"
 self-replace = "1.3.7"
@@ -99,7 +99,7 @@ siphasher = "1"
 smallvec = { version = "1.11.1", features = ["union", "const_generics", "const_new"] }
 stacker = "0.1.15"
 subsetter = "0.1.1"
-svg2pdf = "0.9.1"
+svg2pdf = { git = "https://github.com/typst/svg2pdf" }
 syn = { version = "2", features = ["full", "extra-traits"] }
 syntect = { version = "5", default-features = false, features = ["parsing", "regex-fancy", "plist-load", "yaml-load"] }
 tar = "0.4"
@@ -119,7 +119,7 @@ unicode-script = "0.5"
 unicode-segmentation = "1"
 unscanny = "0.1"
 ureq = { version = "2", default-features = false, features = ["native-tls", "gzip", "json"] }
-usvg = { version = "0.41", default-features = false, features = ["text"] }
+usvg = { version = "0.42", default-features = false, features = ["text"] }
 walkdir = "2"
 wasmi = "0.31.0"
 xmlparser = "0.13.5"
@@ -142,10 +142,3 @@ strip = true
 [workspace.lints.clippy]
 uninlined_format_args = "warn"
 blocks_in_conditions = "allow"
-
-[patch.crates-io]
-pixglyph = { git = "https://github.com/typst/pixglyph", branch = "bump-ttf-parser-to-0.21" }
-svg2pdf = { path = "../svg2pdf" }
-usvg = { path = "../resvg/crates/usvg" }
-resvg = { path = "../resvg/crates/resvg" }
-fontdb = { path = "../fontdb" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ dirs = "5"
 ecow = { version = "0.2", features = ["serde"] }
 env_proxy = "0.4"
 flate2 = "1"
-fontdb = { version = "0.16.2", default-features = false }
+fontdb = { version = "0.17", default-features = false }
 fs_extra = "1.3"
 hayagriva = "0.5.3"
 heck = "0.4"
@@ -145,7 +145,7 @@ blocks_in_conditions = "allow"
 
 [patch.crates-io]
 pixglyph = { git = "https://github.com/typst/pixglyph", branch = "bump-ttf-parser-to-0.21" }
-svg2pdf = { git = "https://github.com/typst/svg2pdf", branch = "font-provider" }
-usvg = { git = "https://github.com/laurmaedje/resvg", branch = "font-provider" }
-resvg = { git = "https://github.com/laurmaedje/resvg", branch = "font-provider" }
-fontdb = { git = "https://github.com/laurmaedje/fontdb", branch = "push-face-info" }
+svg2pdf = { path = "../svg2pdf" }
+usvg = { path = "../resvg/crates/usvg" }
+resvg = { path = "../resvg/crates/resvg" }
+fontdb = { path = "../fontdb" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ dirs = "5"
 ecow = { version = "0.2", features = ["serde"] }
 env_proxy = "0.4"
 flate2 = "1"
-fontdb = { version = "0.16", default-features = false }
+fontdb = { version = "0.16.2", default-features = false }
 fs_extra = "1.3"
 hayagriva = "0.5.3"
 heck = "0.4"
@@ -60,7 +60,7 @@ if_chain = "1"
 image = { version = "0.24", default-features = false, features = ["png", "jpeg", "gif"] }
 indexmap = { version = "2", features = ["serde"] }
 kamadak-exif = "0.5"
-kurbo = "0.9" # in sync with usvg
+kurbo = "0.11"
 libfuzzer-sys = "0.4"
 lipsum = "0.9"
 log = "0.4"
@@ -85,9 +85,9 @@ quote = "1"
 qcms = "0.3.0"
 rayon = "1.7.0"
 regex = "1"
-resvg = { version = "0.38.0", default-features = false, features = ["raster-images"] }
+resvg = { version = "0.41", default-features = false, features = ["raster-images"] }
 roxmltree = "0.19"
-rustybuzz = "0.12.1"
+rustybuzz = "0.13"
 same-file = "1"
 self-replace = "1.3.7"
 semver = "1"
@@ -99,7 +99,7 @@ siphasher = "1"
 smallvec = { version = "1.11.1", features = ["union", "const_generics", "const_new"] }
 stacker = "0.1.15"
 subsetter = "0.1.1"
-svg2pdf = "0.10"
+svg2pdf = "0.9.1"
 syn = { version = "2", features = ["full", "extra-traits"] }
 syntect = { version = "5", default-features = false, features = ["parsing", "regex-fancy", "plist-load", "yaml-load"] }
 tar = "0.4"
@@ -108,7 +108,7 @@ thin-vec = "0.2.13"
 time = { version = "0.3.20", features = ["formatting", "macros", "parsing"] }
 tiny-skia = "0.11"
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }
-ttf-parser = "0.20.0"
+ttf-parser = "0.21.0"
 two-face = { version = "0.3.0", default-features = false, features = ["syntect-fancy"] }
 typed-arena = "2"
 unicode-bidi = "0.3.13"
@@ -119,7 +119,7 @@ unicode-script = "0.5"
 unicode-segmentation = "1"
 unscanny = "0.1"
 ureq = { version = "2", default-features = false, features = ["native-tls", "gzip", "json"] }
-usvg = { version = "0.38.0", default-features = false, features = ["text"] }
+usvg = { version = "0.41", default-features = false, features = ["text"] }
 walkdir = "2"
 wasmi = "0.31.0"
 xmlparser = "0.13.5"
@@ -142,3 +142,10 @@ strip = true
 [workspace.lints.clippy]
 uninlined_format_args = "warn"
 blocks_in_conditions = "allow"
+
+[patch.crates-io]
+pixglyph = { git = "https://github.com/typst/pixglyph", branch = "bump-ttf-parser-to-0.21" }
+svg2pdf = { git = "https://github.com/typst/svg2pdf", branch = "font-provider" }
+usvg = { git = "https://github.com/laurmaedje/resvg", branch = "font-provider" }
+resvg = { git = "https://github.com/laurmaedje/resvg", branch = "font-provider" }
+fontdb = { git = "https://github.com/laurmaedje/fontdb", branch = "push-face-info" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ rayon = "1.7.0"
 regex = "1"
 resvg = { version = "0.42", default-features = false, features = ["raster-images"] }
 roxmltree = "0.20"
-rustybuzz = "0.13"
+rustybuzz = "0.14"
 same-file = "1"
 self-replace = "1.3.7"
 semver = "1"
@@ -99,7 +99,7 @@ siphasher = "1"
 smallvec = { version = "1.11.1", features = ["union", "const_generics", "const_new"] }
 stacker = "0.1.15"
 subsetter = "0.1.1"
-svg2pdf = { git = "https://github.com/typst/svg2pdf" }
+svg2pdf = "0.11.0"
 syn = { version = "2", features = ["full", "extra-traits"] }
 syntect = { version = "5", default-features = false, features = ["parsing", "regex-fancy", "plist-load", "yaml-load"] }
 tar = "0.4"

--- a/crates/typst-pdf/src/image.rs
+++ b/crates/typst-pdf/src/image.rs
@@ -132,7 +132,10 @@ pub fn deferred_image(image: Image) -> (Deferred<EncodedImage>, Option<ColorSpac
 
             EncodedImage::Raster { data, filter, has_color, width, height, icc, alpha }
         }
-        ImageKind::Svg(svg) => EncodedImage::Svg(encode_svg(svg)),
+        ImageKind::Svg(svg) => {
+            let (chunk, id) = encode_svg(svg);
+            EncodedImage::Svg(chunk, id)
+        }
     });
 
     (deferred, color_space)
@@ -178,23 +181,8 @@ fn encode_alpha(raster: &RasterImage) -> (Vec<u8>, Filter) {
 /// Encode an SVG into a chunk of PDF objects.
 ///
 /// The main XObject will have ID 1.
-fn encode_svg(svg: &SvgImage) -> Chunk {
-    let mut chunk = Chunk::new();
-
-    // Safety: We do not keep any references to tree nodes beyond the
-    // scope of `with`.
-    unsafe {
-        svg.with(|tree| {
-            svg2pdf::convert_tree_into(
-                tree,
-                svg2pdf::Options::default(),
-                &mut chunk,
-                Ref::new(1),
-            );
-        });
-    }
-
-    chunk
+fn encode_svg(svg: &SvgImage) -> (Chunk, Ref) {
+    svg2pdf::to_chunk(svg.tree(), svg2pdf::ConversionOptions::default(), svg.fontdb())
 }
 
 /// A pre-encoded image.
@@ -219,5 +207,5 @@ pub enum EncodedImage {
     /// A vector graphic.
     ///
     /// The chunk is the SVG converted to PDF objects.
-    Svg(Chunk),
+    Svg(Chunk, Ref),
 }

--- a/crates/typst-pdf/src/image.rs
+++ b/crates/typst-pdf/src/image.rs
@@ -90,12 +90,12 @@ pub fn write_images(context: &WithGlobalRefs) -> (PdfChunk, HashMap<Image, Ref>)
                         }
                     }
                 }
-                EncodedImage::Svg(svg_chunk) => {
+                EncodedImage::Svg(svg_chunk, id) => {
                     let mut map = HashMap::new();
                     svg_chunk.renumber_into(&mut chunk.chunk, |old| {
                         *map.entry(old).or_insert_with(|| chunk.alloc.bump())
                     });
-                    out.insert(image.clone(), map[&Ref::new(1)]);
+                    out.insert(image.clone(), map[&id]);
                 }
             }
         }
@@ -179,10 +179,8 @@ fn encode_alpha(raster: &RasterImage) -> (Vec<u8>, Filter) {
 }
 
 /// Encode an SVG into a chunk of PDF objects.
-///
-/// The main XObject will have ID 1.
 fn encode_svg(svg: &SvgImage) -> (Chunk, Ref) {
-    svg2pdf::to_chunk(svg.tree(), svg2pdf::ConversionOptions::default(), svg.fontdb())
+    svg2pdf::to_chunk(svg.tree(), svg2pdf::ConversionOptions::default())
 }
 
 /// A pre-encoded image.

--- a/crates/typst-render/src/image.rs
+++ b/crates/typst-render/src/image.rs
@@ -72,15 +72,14 @@ fn scaled_texture(image: &Image, w: u32, h: u32) -> Option<Arc<sk::Pixmap>> {
         }
         // Safety: We do not keep any references to tree nodes beyond the scope
         // of `with`.
-        ImageKind::Svg(svg) => unsafe {
-            svg.with(|tree| {
-                let ts = tiny_skia::Transform::from_scale(
-                    w as f32 / tree.size.width(),
-                    h as f32 / tree.size.height(),
-                );
-                resvg::render(tree, ts, &mut pixmap.as_mut())
-            });
-        },
+        ImageKind::Svg(svg) => {
+            let tree = svg.tree();
+            let ts = tiny_skia::Transform::from_scale(
+                w as f32 / tree.size().width(),
+                h as f32 / tree.size().height(),
+            );
+            resvg::render(tree, ts, &mut pixmap.as_mut())
+        }
     }
     Some(Arc::new(pixmap))
 }

--- a/crates/typst/src/layout/inline/shaping.rs
+++ b/crates/typst/src/layout/inline/shaping.rs
@@ -6,7 +6,8 @@ use std::sync::Arc;
 
 use az::SaturatingAs;
 use ecow::EcoString;
-use rustybuzz::{ShapePlan, Tag, UnicodeBuffer};
+use rustybuzz::{ShapePlan, UnicodeBuffer};
+use ttf_parser::Tag;
 use unicode_script::{Script, UnicodeScript};
 
 use super::SpanMapper;

--- a/crates/typst/src/text/font/color.rs
+++ b/crates/typst/src/text/font/color.rs
@@ -168,8 +168,7 @@ fn draw_svg_glyph(
 
     // Parse SVG.
     let opts = usvg::Options::default();
-    let tree =
-        usvg::Tree::from_xmltree(&document, &opts, &fontdb::Database::new()).ok()?;
+    let tree = usvg::Tree::from_xmltree(&document, &opts).ok()?;
 
     let bbox = tree.root().bounding_box();
     let width = bbox.width() as f64;

--- a/crates/typst/src/text/font/variant.rs
+++ b/crates/typst/src/text/font/variant.rs
@@ -141,6 +141,12 @@ impl Debug for FontWeight {
     }
 }
 
+impl From<fontdb::Weight> for FontWeight {
+    fn from(weight: fontdb::Weight) -> Self {
+        Self::from_number(weight.0)
+    }
+}
+
 cast! {
     FontWeight,
     self => IntoValue::into_value(match self {
@@ -248,6 +254,7 @@ impl Default for FontStretch {
         Self::NORMAL
     }
 }
+
 impl Repr for FontStretch {
     fn repr(&self) -> EcoString {
         self.to_ratio().repr()

--- a/crates/typst/src/text/mod.rs
+++ b/crates/typst/src/text/mod.rs
@@ -32,9 +32,9 @@ use std::fmt::{self, Debug, Formatter};
 use std::str::FromStr;
 
 use ecow::{eco_format, EcoString};
-use rustybuzz::{Feature, Tag};
+use rustybuzz::Feature;
 use smallvec::SmallVec;
-use ttf_parser::Rect;
+use ttf_parser::{Rect, Tag};
 
 use crate::diag::{bail, warning, At, Hint, SourceResult, StrResult};
 use crate::engine::Engine;

--- a/crates/typst/src/visualize/image/svg.rs
+++ b/crates/typst/src/visualize/image/svg.rs
@@ -1,17 +1,17 @@
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use comemo::Tracked;
 use ecow::EcoString;
-use once_cell::sync::Lazy;
-use siphasher::sip128::Hasher128;
-use usvg::{ImageHrefResolver, Node, PostProcessingSteps, TreeParsing, TreePostProc};
 
 use crate::diag::{format_xml_like_error, StrResult};
 use crate::foundations::Bytes;
 use crate::layout::Axes;
-use crate::text::{FontVariant, FontWeight};
+use crate::text::{
+    Font, FontBook, FontFlags, FontStretch, FontStyle, FontVariant, FontWeight,
+};
 use crate::visualize::Image;
 use crate::World;
 
@@ -23,23 +23,24 @@ pub struct SvgImage(Arc<Repr>);
 struct Repr {
     data: Bytes,
     size: Axes<f64>,
+    fontdb: fontdb::Database,
     font_hash: u128,
-    tree: sync::SyncTree,
+    tree: usvg::Tree,
 }
 
 impl SvgImage {
     /// Decode an SVG image without fonts.
     #[comemo::memoize]
     pub fn new(data: Bytes) -> StrResult<SvgImage> {
-        let mut tree =
-            usvg::Tree::from_data(&data, &OPTIONS).map_err(format_usvg_error)?;
-        tree.calculate_bounding_boxes();
+        let fontdb = fontdb::Database::new();
+        let tree = usvg::Tree::from_data(&data, &options(), &fontdb)
+            .map_err(format_usvg_error)?;
         Ok(Self(Arc::new(Repr {
             data,
             size: tree_size(&tree),
             font_hash: 0,
-            // Safety: We just created the tree and hold the only reference.
-            tree: unsafe { sync::SyncTree::new(tree) },
+            tree,
+            fontdb,
         })))
     }
 
@@ -50,21 +51,17 @@ impl SvgImage {
         world: Tracked<dyn World + '_>,
         families: &[String],
     ) -> StrResult<SvgImage> {
-        let mut tree =
-            usvg::Tree::from_data(&data, &OPTIONS).map_err(format_usvg_error)?;
-        let mut font_hash = 0;
-        if tree.has_text_nodes() {
-            let (fontdb, hash) = load_svg_fonts(world, &mut tree, families);
-            tree.postprocess(PostProcessingSteps::default(), &fontdb);
-            font_hash = hash;
-        }
-        tree.calculate_bounding_boxes();
+        let book = world.book();
+        let provider = TypstFontProvider::new(world, book, families);
+        let tree = usvg::Tree::from_data(&data, &options(), &provider)
+            .map_err(format_usvg_error)?;
+        let font_hash = 0;
         Ok(Self(Arc::new(Repr {
             data,
             size: tree_size(&tree),
             font_hash,
-            // Safety: We just created the tree and hold the only reference.
-            tree: unsafe { sync::SyncTree::new(tree) },
+            tree,
+            fontdb: provider.db.into_inner(),
         })))
     }
 
@@ -83,34 +80,14 @@ impl SvgImage {
         self.0.size.y
     }
 
-    /// Performs an operation with the usvg tree.
-    ///
-    /// This makes the tree uniquely available to the current thread and blocks
-    /// other accesses to it.
-    ///
-    /// # Safety
-    /// The caller may not hold any references to `Rc`s contained in the usvg
-    /// Tree after `f` returns.
-    ///
-    /// # Why is it unsafe?
-    /// Sadly, usvg's Tree is neither `Sync` nor `Send` because it uses `Rc`
-    /// internally and sending a tree to another thread could result in data
-    /// races when an `Rc`'s ref-count is modified from two threads at the same
-    /// time.
-    ///
-    /// However, access to the tree is actually safe if we don't clone `Rc`s /
-    /// only clone them while holding a mutex and drop all clones before the
-    /// mutex is released. Sadly, we can't enforce this variant at the type
-    /// system level. Therefore, access is guarded by this function (which makes
-    /// it reasonable hard to keep references around) and its usage still
-    /// remains `unsafe` (because it's still possible to have `Rc`s escape).
-    ///
-    /// See also: <https://github.com/RazrFalcon/resvg/issues/544>
-    pub unsafe fn with<F>(&self, f: F)
-    where
-        F: FnOnce(&usvg::Tree),
-    {
-        self.0.tree.with(f)
+    /// Access the usvg tree.
+    pub fn tree(&self) -> &usvg::Tree {
+        &self.0.tree
+    }
+
+    /// Access the font database.
+    pub fn fontdb(&self) -> &fontdb::Database {
+        &self.0.fontdb
     }
 }
 
@@ -121,6 +98,129 @@ impl Hash for Repr {
         // all used fonts gives us something similar.
         self.data.hash(state);
         self.font_hash.hash(state);
+    }
+}
+
+/// Provides Typst's fonts to usvg.
+struct TypstFontProvider<'a> {
+    book: &'a FontBook,
+    world: Tracked<'a, dyn World + 'a>,
+    families: &'a [String],
+    db: RefCell<fontdb::Database>,
+    to_id: RefCell<HashMap<usize, Option<fontdb::ID>>>,
+    from_id: RefCell<HashMap<fontdb::ID, Font>>,
+}
+
+impl<'a> TypstFontProvider<'a> {
+    /// Create a new font provider.
+    fn new(
+        world: Tracked<'a, dyn World + 'a>,
+        book: &'a FontBook,
+        families: &'a [String],
+    ) -> Self {
+        Self {
+            book,
+            world,
+            families,
+            db: RefCell::new(fontdb::Database::new()),
+            to_id: RefCell::new(HashMap::new()),
+            from_id: RefCell::new(HashMap::new()),
+        }
+    }
+}
+
+impl usvg::FontProvider for TypstFontProvider<'_> {
+    fn find_font(&self, font: &usvg::Font) -> Option<fontdb::ID> {
+        let variant = FontVariant {
+            style: font.style().into(),
+            weight: FontWeight::from_number(font.weight()),
+            stretch: font.stretch().into(),
+        };
+
+        // Find a family that is available.
+        font.families()
+            .iter()
+            .filter_map(|family| match family {
+                usvg::FontFamily::Named(named) => Some(named),
+                _ => None,
+            })
+            .chain(self.families)
+            .filter_map(|named| self.book.select(&named.to_lowercase(), variant))
+            .find_map(|index| self.get_or_load(index))
+    }
+
+    fn find_fallback_font(
+        &self,
+        c: char,
+        base_font_id: fontdb::ID,
+        _used_fonts: &[fontdb::ID],
+    ) -> Option<fontdb::ID> {
+        let index = {
+            let from_id = self.from_id.borrow();
+            let font = from_id.get(&base_font_id)?;
+            let info = font.info();
+            self.book.select_fallback(
+                Some(info),
+                info.variant,
+                c.encode_utf8(&mut [0; 4]),
+            )?
+        };
+        self.get_or_load(index)
+    }
+
+    fn with_database(&self, f: &mut dyn FnMut(&fontdb::Database)) {
+        f(&self.db.borrow());
+    }
+}
+
+impl TypstFontProvider<'_> {
+    /// Tries to retrieve the ID for the index or loads the font, allocating
+    /// a new ID.
+    fn get_or_load(&self, index: usize) -> Option<fontdb::ID> {
+        *self
+            .to_id
+            .borrow_mut()
+            .entry(index)
+            .or_insert_with(|| self.load(index))
+    }
+
+    /// Tries to load the font with the given index in the font book into the
+    /// database and returns its ID.
+    fn load(&self, index: usize) -> Option<fontdb::ID> {
+        let font = self.world.font(index)?;
+        let info = font.info();
+        let variant = info.variant;
+        let id = self.db.borrow_mut().push_face_info(fontdb::FaceInfo {
+            id: fontdb::ID::dummy(),
+            source: fontdb::Source::Binary(Arc::new(font.data().clone())),
+            index: font.index(),
+            families: vec![(
+                info.family.clone(),
+                ttf_parser::Language::English_UnitedStates,
+            )],
+            post_script_name: String::new(),
+            style: match variant.style {
+                FontStyle::Normal => fontdb::Style::Normal,
+                FontStyle::Italic => fontdb::Style::Italic,
+                FontStyle::Oblique => fontdb::Style::Oblique,
+            },
+            weight: fontdb::Weight(variant.weight.to_number()),
+            // TODO: Round to closest.
+            stretch: match variant.stretch {
+                FontStretch::ULTRA_CONDENSED => ttf_parser::Width::UltraCondensed,
+                FontStretch::EXTRA_CONDENSED => ttf_parser::Width::ExtraCondensed,
+                FontStretch::CONDENSED => ttf_parser::Width::Condensed,
+                FontStretch::SEMI_CONDENSED => ttf_parser::Width::SemiCondensed,
+                FontStretch::SEMI_EXPANDED => ttf_parser::Width::SemiExpanded,
+                FontStretch::EXPANDED => ttf_parser::Width::Expanded,
+                FontStretch::EXTRA_EXPANDED => ttf_parser::Width::ExtraExpanded,
+                FontStretch::ULTRA_EXPANDED => ttf_parser::Width::UltraExpanded,
+                _ => ttf_parser::Width::Normal,
+            },
+            monospaced: info.flags.contains(FontFlags::MONOSPACE),
+        });
+        self.from_id.borrow_mut().insert(id, font);
+        Some(id)
     }
 }
 
@@ -147,104 +247,9 @@ static OPTIONS: Lazy<usvg::Options> = Lazy::new(|| usvg::Options {
     ..Default::default()
 });
 
-/// Discover and load the fonts referenced by an SVG.
-fn load_svg_fonts(
-    world: Tracked<dyn World + '_>,
-    tree: &mut usvg::Tree,
-    families: &[String],
-) -> (fontdb::Database, u128) {
-    let book = world.book();
-    let mut fontdb = fontdb::Database::new();
-    let mut hasher = siphasher::sip128::SipHasher13::new();
-    let mut loaded = HashMap::<usize, Option<String>>::new();
-
-    // Loads a font into the database and return it's usvg-compatible name.
-    let mut load_into_db = |id: usize| -> Option<String> {
-        loaded
-            .entry(id)
-            .or_insert_with(|| {
-                let font = world.font(id)?;
-                fontdb.load_font_source(fontdb::Source::Binary(Arc::new(
-                    font.data().clone(),
-                )));
-                font.data().hash(&mut hasher);
-                font.find_name(ttf_parser::name_id::TYPOGRAPHIC_FAMILY)
-                    .or_else(|| font.find_name(ttf_parser::name_id::FAMILY))
-            })
-            .clone()
-    };
-
-    // Determine the best font for each text node.
-    for child in &mut tree.root.children {
-        traverse_svg(child, &mut |node| {
-            let usvg::Node::Text(ref mut text) = node else { return };
-            for chunk in &mut text.chunks {
-                'spans: for span in &mut chunk.spans {
-                    let Some(text) = chunk.text.get(span.start..span.end) else {
-                        continue;
-                    };
-                    let variant = FontVariant {
-                        style: span.font.style.into(),
-                        weight: FontWeight::from_number(span.font.weight),
-                        stretch: span.font.stretch.into(),
-                    };
-
-                    // Find a font that covers the whole text among the span's fonts
-                    // and the current document font families.
-                    let mut like = None;
-                    for family in span.font.families.iter().chain(families) {
-                        let Some(id) = book.select(&family.to_lowercase(), variant)
-                        else {
-                            continue;
-                        };
-                        let Some(info) = book.info(id) else { continue };
-                        like.get_or_insert(info);
-
-                        if text.chars().all(|c| info.coverage.contains(c as u32)) {
-                            if let Some(usvg_family) = load_into_db(id) {
-                                span.font.families = vec![usvg_family];
-                                continue 'spans;
-                            }
-                        }
-                    }
-
-                    // If we didn't find a match, select a fallback font.
-                    if let Some(id) = book.select_fallback(like, variant, text) {
-                        if let Some(usvg_family) = load_into_db(id) {
-                            span.font.families = vec![usvg_family];
-                        }
-                    }
-                }
-            }
-        });
-    }
-
-    (fontdb, hasher.finish128().as_u128())
-}
-
-/// Search for all font families referenced by an SVG.
-fn traverse_svg<F>(node: &mut usvg::Node, f: &mut F)
-where
-    F: FnMut(&mut usvg::Node),
-{
-    f(node);
-
-    node.subroots_mut(|subroot| {
-        for child in &mut subroot.children {
-            traverse_svg(child, f);
-        }
-    });
-
-    if let Node::Group(ref mut group) = node {
-        for child in &mut group.children {
-            traverse_svg(child, f);
-        }
-    }
-}
-
-/// The ceiled pixel size of an SVG.
+/// The pixel size of an SVG.
 fn tree_size(tree: &usvg::Tree) -> Axes<f64> {
-    Axes::new(tree.size.width() as f64, tree.size.height() as f64)
+    Axes::new(tree.size().width() as f64, tree.size().height() as f64)
 }
 
 /// Format the user-facing SVG decoding error message.
@@ -258,42 +263,4 @@ fn format_usvg_error(error: usvg::Error) -> EcoString {
         }
         usvg::Error::ParsingFailed(error) => format_xml_like_error("SVG", error),
     }
-}
-
-mod sync {
-    use std::sync::Mutex;
-
-    /// A synchronized wrapper around a `usvg::Tree`.
-    pub struct SyncTree(Mutex<usvg::Tree>);
-
-    impl SyncTree {
-        /// Create a new synchronized tree.
-        ///
-        /// # Safety
-        /// The tree must be completely owned by `tree`, there may not be any
-        /// other references to `Rc`s contained in it.
-        pub unsafe fn new(tree: usvg::Tree) -> Self {
-            Self(Mutex::new(tree))
-        }
-
-        /// Perform an operation with the usvg tree.
-        ///
-        /// # Safety
-        /// The caller may not hold any references to `Rc`s contained in
-        /// the usvg Tree after returning.
-        pub unsafe fn with<F>(&self, f: F)
-        where
-            F: FnOnce(&usvg::Tree),
-        {
-            let tree = self.0.lock().unwrap();
-            f(&tree)
-        }
-    }
-
-    // Safety: usvg's Tree is only non-Sync and non-Send because it uses `Rc`
-    // internally. By wrapping it in a mutex and forbidding outstanding
-    // references to the tree to remain after a `with` call, we guarantee that
-    // no two threads try to change a ref-count at the same time.
-    unsafe impl Sync for SyncTree {}
-    unsafe impl Send for SyncTree {}
 }


### PR DESCRIPTION
This PR updates:

- `resvg` to v0.42
- `usvg` to v0.42
- `pdf-writer` to v0.10
- `svg2pdf` to v0.11
- `fontdb` to v0.18
- `rustybuzz` to v0.14
- `ttf-parser` to v0.21
- `kurbo` to v0.11
- `pixglyph` to v0.4
- `roxmltree` to v0.20

The new font loading code for SVGs is still a bit rough and will be improved, hence draft.