### PR TITLE
Fix emoji advance in PDF export

### DIFF
--- a/crates/typst-pdf/src/color_font.rs
+++ b/crates/typst-pdf/src/color_font.rs
@@ -69,7 +69,8 @@ pub fn write_color_fonts(
                     .font
                     .advance(color_glyph.gid)
                     .unwrap_or(Em::new(0.0))
-                    .to_font_units();
+                    .get() as f32
+                    * scale_factor;
                 widths.push(width);
                 chunk
                     .stream(
@@ -239,8 +240,10 @@ impl ColorFontMap<()> {
             }
 
             let frame = frame_for_glyph(font, gid);
-            let width = font.advance(gid).unwrap_or(Em::new(0.0)).to_font_units();
-            let instructions = content::build(&mut self.resources, &frame, Some(width));
+            let width =
+                font.advance(gid).unwrap_or(Em::new(0.0)).get() * font.units_per_em();
+            let instructions =
+                content::build(&mut self.resources, &frame, Some(width as f32));
             color_font.glyphs.push(ColorGlyph { gid, instructions });
             color_font.glyph_indices.insert(gid, index);
 


### PR DESCRIPTION
`to_font_units` assumes a font matrix with a 1000 scale factor, which is not always the case for Type3 fonts (the scale factor is the em square size).

Fix #4117