### PR TITLE
Add hint when string is used in place of label

### DIFF
--- a/crates/typst-syntax/src/lexer.rs
+++ b/crates/typst-syntax/src/lexer.rs
@@ -920,10 +920,11 @@ fn is_math_id_continue(c: char) -> bool {
 }
 
 #[inline]
-pub fn is_valid_in_label_literal(c: char) -> bool {
+fn is_valid_in_label_literal(c: char) -> bool {
     is_id_continue(c) || matches!(c, ':' | '.')
 }
 
+/// Returns true if this string is valid in a label literal.
 pub fn is_valid_label_literal_id(id: &str) -> bool {
     !id.is_empty() && id.chars().all(is_valid_in_label_literal)
 }

--- a/crates/typst-syntax/src/lexer.rs
+++ b/crates/typst-syntax/src/lexer.rs
@@ -408,7 +408,7 @@ impl Lexer<'_> {
     }
 
     fn ref_marker(&mut self) -> SyntaxKind {
-        self.s.eat_while(is_valid_in_label);
+        self.s.eat_while(is_valid_in_label_literal);
 
         // Don't include the trailing characters likely to be part of text.
         while matches!(self.s.scout(-1), Some('.' | ':')) {
@@ -419,7 +419,7 @@ impl Lexer<'_> {
     }
 
     fn label(&mut self) -> SyntaxKind {
-        let label = self.s.eat_while(is_valid_in_label);
+        let label = self.s.eat_while(is_valid_in_label_literal);
         if label.is_empty() {
             return self.error("label cannot be empty");
         }
@@ -920,6 +920,10 @@ fn is_math_id_continue(c: char) -> bool {
 }
 
 #[inline]
-pub fn is_valid_in_label(c: char) -> bool {
+pub fn is_valid_in_label_literal(c: char) -> bool {
     is_id_continue(c) || matches!(c, ':' | '.')
+}
+
+pub fn is_valid_label_literal_id(id: &str) -> bool {
+    !id.is_empty() && id.chars().all(is_valid_in_label_literal)
 }

--- a/crates/typst-syntax/src/lexer.rs
+++ b/crates/typst-syntax/src/lexer.rs
@@ -408,7 +408,7 @@ impl Lexer<'_> {
     }
 
     fn ref_marker(&mut self) -> SyntaxKind {
-        self.s.eat_while(|c| is_id_continue(c) || matches!(c, ':' | '.'));
+        self.s.eat_while(is_valid_in_label);
 
         // Don't include the trailing characters likely to be part of text.
         while matches!(self.s.scout(-1), Some('.' | ':')) {
@@ -419,7 +419,7 @@ impl Lexer<'_> {
     }
 
     fn label(&mut self) -> SyntaxKind {
-        let label = self.s.eat_while(|c| is_id_continue(c) || matches!(c, ':' | '.'));
+        let label = self.s.eat_while(is_valid_in_label);
         if label.is_empty() {
             return self.error("label cannot be empty");
         }
@@ -917,4 +917,9 @@ fn is_math_id_start(c: char) -> bool {
 #[inline]
 fn is_math_id_continue(c: char) -> bool {
     is_xid_continue(c) && c != '_'
+}
+
+#[inline]
+pub fn is_valid_in_label(c: char) -> bool {
+    is_id_continue(c) || matches!(c, ':' | '.')
 }

--- a/crates/typst-syntax/src/lexer.rs
+++ b/crates/typst-syntax/src/lexer.rs
@@ -919,6 +919,7 @@ fn is_math_id_continue(c: char) -> bool {
     is_xid_continue(c) && c != '_'
 }
 
+/// Whether a character can be part of a label literal's name.
 #[inline]
 fn is_valid_in_label_literal(c: char) -> bool {
     is_id_continue(c) || matches!(c, ':' | '.')

--- a/crates/typst-syntax/src/lib.rs
+++ b/crates/typst-syntax/src/lib.rs
@@ -19,8 +19,8 @@ pub use self::file::FileId;
 pub use self::highlight::{highlight, highlight_html, Tag};
 pub use self::kind::SyntaxKind;
 pub use self::lexer::{
-    is_id_continue, is_id_start, is_ident, is_newline, is_valid_in_label, link_prefix,
-    split_newlines,
+    is_id_continue, is_id_start, is_ident, is_newline, is_valid_in_label_literal,
+    is_valid_label_literal_id, link_prefix, split_newlines,
 };
 pub use self::node::{LinkedChildren, LinkedNode, Side, SyntaxError, SyntaxNode};
 pub use self::parser::{parse, parse_code, parse_math};

--- a/crates/typst-syntax/src/lib.rs
+++ b/crates/typst-syntax/src/lib.rs
@@ -19,8 +19,8 @@ pub use self::file::FileId;
 pub use self::highlight::{highlight, highlight_html, Tag};
 pub use self::kind::SyntaxKind;
 pub use self::lexer::{
-    is_id_continue, is_id_start, is_ident, is_newline, is_valid_in_label_literal,
-    is_valid_label_literal_id, link_prefix, split_newlines,
+    is_id_continue, is_id_start, is_ident, is_newline, is_valid_label_literal_id,
+    link_prefix, split_newlines,
 };
 pub use self::node::{LinkedChildren, LinkedNode, Side, SyntaxError, SyntaxNode};
 pub use self::parser::{parse, parse_code, parse_math};

--- a/crates/typst-syntax/src/lib.rs
+++ b/crates/typst-syntax/src/lib.rs
@@ -19,7 +19,8 @@ pub use self::file::FileId;
 pub use self::highlight::{highlight, highlight_html, Tag};
 pub use self::kind::SyntaxKind;
 pub use self::lexer::{
-    is_id_continue, is_id_start, is_ident, is_newline, link_prefix, split_newlines,
+    is_id_continue, is_id_start, is_ident, is_newline, is_valid_in_label, link_prefix,
+    split_newlines,
 };
 pub use self::node::{LinkedChildren, LinkedNode, Side, SyntaxError, SyntaxNode};
 pub use self::parser::{parse, parse_code, parse_math};

--- a/crates/typst/src/foundations/cast.rs
+++ b/crates/typst/src/foundations/cast.rs
@@ -44,7 +44,7 @@ pub trait Reflect {
     /// dynamic checks instead of optimized machine code for each type).
     fn castable(value: &Value) -> bool;
 
-    /// Produce an error message for an inacceptable value type.
+    /// Produce an error message for an unacceptable value type.
     ///
     /// ```ignore
     /// assert_eq!(

--- a/crates/typst/src/foundations/cast.rs
+++ b/crates/typst/src/foundations/cast.rs
@@ -15,8 +15,6 @@ use crate::syntax::{Span, Spanned};
 #[doc(inline)]
 pub use typst_macros::{cast, Cast};
 
-use super::is_valid_in_label_literal;
-
 /// Determine details of a type.
 ///
 /// Type casting works as follows:
@@ -338,7 +336,7 @@ impl CastInfo {
             }
         } else if let Value::Str(s) = found {
             if !matching_type && parts.iter().any(|p| p == "label") {
-                if is_valid_in_label_literal(s) {
+                if typst_syntax::is_valid_label_literal_id(s) {
                     msg.hint(eco_format!(
                         "use `<{s}>` or `label({})` to create a label",
                         s.repr()

--- a/crates/typst/src/foundations/cast.rs
+++ b/crates/typst/src/foundations/cast.rs
@@ -15,6 +15,8 @@ use crate::syntax::{Span, Spanned};
 #[doc(inline)]
 pub use typst_macros::{cast, Cast};
 
+use super::is_valid_in_label_literal;
+
 /// Determine details of a type.
 ///
 /// Type casting works as follows:
@@ -335,9 +337,13 @@ impl CastInfo {
                 msg.hint(eco_format!("a length needs a unit - did you mean {i}pt?"));
             }
         }
-        if let Value::Str(_) = found {
+        if let Value::Str(s) = found {
             if !matching_type && parts.iter().any(|p| p == "label") {
-                msg.hint("use the <label> syntax to create a label or the label function to convert a string to a label");
+                if is_valid_in_label_literal(s) {
+                    msg.hint(eco_format!("use `<{s}>` to create a label or the label function to convert a string to a label"));
+                } else {
+                    msg.hint("use the label function to convert a string to a label");
+                }
             }
         }
 

--- a/crates/typst/src/foundations/cast.rs
+++ b/crates/typst/src/foundations/cast.rs
@@ -330,19 +330,21 @@ impl CastInfo {
             write!(msg, "{}", found.ty()).unwrap();
         }
 
-        let mut msg = HintedString::new(msg.into());
+        let mut msg: HintedString = msg.into();
 
         if let Value::Int(i) = found {
             if !matching_type && parts.iter().any(|p| p == "length") {
                 msg.hint(eco_format!("a length needs a unit - did you mean {i}pt?"));
             }
-        }
-        if let Value::Str(s) = found {
+        } else if let Value::Str(s) = found {
             if !matching_type && parts.iter().any(|p| p == "label") {
                 if is_valid_in_label_literal(s) {
-                    msg.hint(eco_format!("use `<{s}>` to create a label or the label function to convert a string to a label"));
+                    msg.hint(eco_format!(
+                        "use `<{s}>` or `label({})` to create a label",
+                        s.repr()
+                    ));
                 } else {
-                    msg.hint("use the label function to convert a string to a label");
+                    msg.hint(eco_format!("use `label({})` to create a label", s.repr()));
                 }
             }
         }

--- a/crates/typst/src/foundations/cast.rs
+++ b/crates/typst/src/foundations/cast.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 use std::hash::Hash;
 use std::ops::Add;
 
-use ecow::{eco_format, EcoString};
+use ecow::eco_format;
 use smallvec::SmallVec;
 use unicode_math_class::MathClass;
 
@@ -51,7 +51,7 @@ pub trait Reflect {
     /// );
     /// ```
     fn error(found: &Value) -> HintedString {
-        Self::input().error(found).into()
+        Self::input().error(found)
     }
 }
 
@@ -300,7 +300,7 @@ pub enum CastInfo {
 impl CastInfo {
     /// Produce an error message describing what was expected and what was
     /// found.
-    pub fn error(&self, found: &Value) -> EcoString {
+    pub fn error(&self, found: &Value) -> HintedString {
         let mut matching_type = false;
         let mut parts = vec![];
 
@@ -328,13 +328,20 @@ impl CastInfo {
             write!(msg, "{}", found.ty()).unwrap();
         }
 
+        let mut msg = HintedString::new(msg.into());
+
         if let Value::Int(i) = found {
-            if parts.iter().any(|p| p == "length") && !matching_type {
-                write!(msg, ": a length needs a unit - did you mean {i}pt?").unwrap();
+            if !matching_type && parts.iter().any(|p| p == "length") {
+                msg.hint(eco_format!("a length needs a unit - did you mean {i}pt?"));
+            }
+        }
+        if let Value::Str(_) = found {
+            if !matching_type && parts.iter().any(|p| p == "label") {
+                msg.hint("use the <label> syntax to create a label or the label function to convert a string to a label");
             }
         }
 
-        msg.into()
+        msg
     }
 
     /// Walk all contained non-union infos.

--- a/crates/typst/src/foundations/label.rs
+++ b/crates/typst/src/foundations/label.rs
@@ -78,7 +78,3 @@ impl From<Label> for PicoStr {
 
 /// Indicates that an element cannot be labelled.
 pub trait Unlabellable {}
-
-pub(crate) fn is_valid_in_label_literal(id: &str) -> bool {
-    !id.is_empty() && id.chars().all(typst_syntax::is_valid_in_label)
-}

--- a/crates/typst/src/foundations/label.rs
+++ b/crates/typst/src/foundations/label.rs
@@ -78,3 +78,7 @@ impl From<Label> for PicoStr {
 
 /// Indicates that an element cannot be labelled.
 pub trait Unlabellable {}
+
+pub(crate) fn is_valid_in_label_literal(id: &str) -> bool {
+    !id.is_empty() && id.chars().all(typst_syntax::is_valid_in_label)
+}

--- a/crates/typst/src/foundations/value.rs
+++ b/crates/typst/src/foundations/value.rs
@@ -610,11 +610,7 @@ macro_rules! primitive {
                 match value {
                     Value::$variant(v) => Ok(v),
                     $(Value::$other$(($binding))? => Ok($out),)*
-                    v => Err(eco_format!(
-                        "expected {}, found {}",
-                        Type::of::<Self>(),
-                        v.ty(),
-                    ).into()),
+                    v => Err(<Self as Reflect>::error(&v)),
                 }
             }
         }

--- a/tests/suite/layout/length.typ
+++ b/tests/suite/layout/length.typ
@@ -45,7 +45,8 @@
 }
 
 --- length-unit-hint ---
-// Error: 1:17-1:19 expected length, found integer: a length needs a unit - did you mean 12pt?
+// Error: 1:17-1:19 expected length, found integer
+// Hint: 1:17-1:19 a length needs a unit - did you mean 12pt?
 #set text(size: 12)
 
 --- length-ignore-em-pt-hint ---

--- a/tests/suite/layout/length.typ
+++ b/tests/suite/layout/length.typ
@@ -45,8 +45,8 @@
 }
 
 --- length-unit-hint ---
-// Error: 1:17-1:19 expected length, found integer
-// Hint: 1:17-1:19 a length needs a unit - did you mean 12pt?
+// Error: 17-19 expected length, found integer
+// Hint: 17-19 a length needs a unit - did you mean 12pt?
 #set text(size: 12)
 
 --- length-ignore-em-pt-hint ---

--- a/tests/suite/model/cite.typ
+++ b/tests/suite/model/cite.typ
@@ -114,3 +114,10 @@ B #cite(<netwok>) #cite(<arrgh>).
 @mcintosh_anxiety
 #show bibliography: none
 #bibliography("/assets/bib/works.bib", style: "chicago-author-date")
+
+--- cite-type-error-hint ---
+// Test hint for cast error from str to label
+// Error: 7-15 expected label, found string
+// Hint: 7-15 use the <label> syntax to create a label or the label function to convert a string to a label
+#cite("netwok")
+#bibliography("/assets/bib/works.bib")

--- a/tests/suite/model/cite.typ
+++ b/tests/suite/model/cite.typ
@@ -118,6 +118,13 @@ B #cite(<netwok>) #cite(<arrgh>).
 --- cite-type-error-hint ---
 // Test hint for cast error from str to label
 // Error: 7-15 expected label, found string
-// Hint: 7-15 use the <label> syntax to create a label or the label function to convert a string to a label
+// Hint: 7-15 use `<netwok>` to create a label or the label function to convert a string to a label
 #cite("netwok")
+#bibliography("/assets/bib/works.bib")
+
+--- cite-type-error-hint-invalid-literal ---
+// Test hint for cast error from str to label
+// Error: 7-15 expected label, found string
+// Hint: 7-15 use the label function to convert a string to a label
+#cite("%@&#*!")
 #bibliography("/assets/bib/works.bib")

--- a/tests/suite/model/cite.typ
+++ b/tests/suite/model/cite.typ
@@ -118,13 +118,11 @@ B #cite(<netwok>) #cite(<arrgh>).
 --- cite-type-error-hint ---
 // Test hint for cast error from str to label
 // Error: 7-15 expected label, found string
-// Hint: 7-15 use `<netwok>` to create a label or the label function to convert a string to a label
+// Hint: 7-15 use `<netwok>` or `label("netwok")` to create a label
 #cite("netwok")
-#bibliography("/assets/bib/works.bib")
 
 --- cite-type-error-hint-invalid-literal ---
 // Test hint for cast error from str to label
-// Error: 7-15 expected label, found string
-// Hint: 7-15 use the label function to convert a string to a label
-#cite("%@&#*!")
-#bibliography("/assets/bib/works.bib")
+// Error: 7-17 expected label, found string
+// Hint: 7-17 use `label("%@&#*!\\")` to create a label
+#cite("%@&#*!\\")


### PR DESCRIPTION
Closes #4329.

This also refactors `CastInfo::error` to return a hinted string and the `FromValue` implementation generated by the `primitive` macro to forward to `Reflect::error`.