### PR TITLE
fix a bug where setting quote(block: true, ...) would not prevent the…

### DIFF
--- a/crates/typst/src/model/quote.rs
+++ b/crates/typst/src/model/quote.rs
@@ -183,11 +183,6 @@ impl Show for Packed<QuoteElem> {
         }
 
         if block {
-            realized = BlockElem::new()
-                .with_body(Some(BlockChild::Content(realized)))
-                .pack()
-                .spanned(self.span());
-
             if let Some(attribution) = self.attribution(styles).as_ref() {
                 let mut seq = vec![TextElem::packed('—'), SpaceElem::new().pack()];
 
@@ -211,7 +206,14 @@ impl Show for Packed<QuoteElem> {
                 realized += weak_v + Content::sequence(seq).aligned(Alignment::END);
             }
 
+            realized = BlockElem::new()
+                .with_body(Some(BlockChild::Content(realized)))
+                .with_breakable(false)
+                .pack()
+                .spanned(self.span());
+            
             realized = PadElem::new(realized).pack();
+
         } else if let Some(Attribution::Label(label)) = self.attribution(styles) {
             realized += SpaceElem::new().pack()
                 + CiteElem::new(*label).pack().spanned(self.span());


### PR DESCRIPTION
Should fix #4246

This is my first PR so I don't really know what I'm doing, but this seems like the intended result.

There is a difference in behaviour between
```
#lorem(590)
#quote(block: true, attribution: [Somebody])[#lorem(50)]
```
and
```
#lorem(590)
#block(quote(block: true, attribution: [Somebody])[#lorem(50)])
```
though, as the latter one keeps the quote on the first page, while the first one puts it on the next page.