### PR TITLE
Add flox install

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Typst's CLI is available from different sources:
   - build and run a development version with
     `nix run github:typst/typst -- --version`.
 
+- Flox users can install Typst into their environment with `flox install typst`
+
 - Docker users can run a prebuilt image with
   `docker run -it ghcr.io/typst/typst:latest`.
 


### PR DESCRIPTION
`typst` is available in Flox, and seems to be working today!
Since Flox and Nix are related, I added the Flox install section below that of Nix.
If you have any questions about Flox, please let me know. 😊