### PR TITLE
Add `sys.target` export targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, merge_group]
 env:
   RUSTFLAGS: "-Dwarnings"
   RUSTDOCFLAGS: "-Dwarnings"
-  TYPST_TESTS_EXTENDED: true
+  TYPST_TESTS_ALL: true
 
 jobs:
   # This allows us to have one branch protection rule for the full test matrix.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2798,6 +2798,7 @@ dependencies = [
 name = "typst-tests"
 version = "0.11.0"
 dependencies = [
+ "bitflags 2.4.2",
  "clap",
  "comemo",
  "ecow",

--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -96,10 +96,6 @@ pub struct CompileCommand {
     #[clap(long = "make-deps", value_name = "PATH")]
     pub make_deps: Option<PathBuf>,
 
-    /// The format of the output file, inferred from the extension by default
-    #[arg(long = "format", short = 'f')]
-    pub format: Option<OutputFormat>,
-
     /// Opens the output file using the default viewer after compilation.
     /// Ignored if output is stdout
     #[arg(long = "open")]
@@ -156,8 +152,8 @@ pub struct QueryCommand {
     pub one: bool,
 
     /// The format to serialize in
-    #[clap(long = "format", default_value = "json")]
-    pub format: SerializationFormat,
+    #[clap(long = "output-format", default_value = "json")]
+    pub output_format: SerializationFormat,
 
     /// Whether to pretty-print the serialized output
     #[clap(long)]
@@ -177,6 +173,12 @@ pub struct SharedArgs {
     /// Path to input Typst file. Use `-` to read input from stdin
     #[clap(value_parser = input_value_parser)]
     pub input: Input,
+
+    /// The format of the output file, inferred from the extension by default
+    ///
+    /// This is visible through `sys.target`
+    #[arg(long = "format", short = 'f')]
+    pub format: Option<OutputFormat>,
 
     /// Configures the project root (for absolute paths)
     #[clap(long = "root", env = "TYPST_ROOT", value_name = "DIR")]
@@ -437,8 +439,9 @@ pub struct UpdateCommand {
 }
 
 /// Which format to use for the generated output file.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, ValueEnum)]
+#[derive(Debug, Copy, Clone, Default, Eq, PartialEq, Ord, PartialOrd, ValueEnum)]
 pub enum OutputFormat {
+    #[default]
     Pdf,
     Png,
     Svg,

--- a/crates/typst-cli/src/query.rs
+++ b/crates/typst-cli/src/query.rs
@@ -15,7 +15,8 @@ use crate::world::SystemWorld;
 
 /// Execute a query command.
 pub fn query(command: &QueryCommand) -> HintedStrResult<()> {
-    let mut world = SystemWorld::new(&command.common)?;
+    let mut world =
+        SystemWorld::new(&command.common, command.common.format.unwrap_or_default())?;
 
     // Reset everything and ensure that the main file is present.
     world.reset();
@@ -97,9 +98,9 @@ fn format(elements: Vec<Content>, command: &QueryCommand) -> StrResult<String> {
         let Some(value) = mapped.first() else {
             bail!("no such field found for element");
         };
-        serialize(value, command.format, command.pretty)
+        serialize(value, command.output_format, command.pretty)
     } else {
-        serialize(&mapped, command.format, command.pretty)
+        serialize(&mapped, command.output_format, command.pretty)
     }
 }
 

--- a/crates/typst-cli/src/watch.rs
+++ b/crates/typst-cli/src/watch.rs
@@ -30,7 +30,7 @@ pub fn watch(mut timer: Timer, mut command: CompileCommand) -> StrResult<()> {
     // Create the world that serves sources, files, and fonts.
     // Additionally, if any files do not exist, wait until they do.
     let mut world = loop {
-        match SystemWorld::new(&command.common) {
+        match SystemWorld::new(&command.common, command.output_format()?) {
             Ok(world) => break world,
             Err(
                 ref err @ (WorldCreationError::InputNotFound(ref path)

--- a/crates/typst/src/foundations/mod.rs
+++ b/crates/typst/src/foundations/mod.rs
@@ -76,6 +76,7 @@ use crate::diag::{bail, SourceResult, StrResult};
 use crate::engine::Engine;
 use crate::eval::EvalMode;
 use crate::syntax::Spanned;
+use crate::ExportTarget;
 
 /// Foundational types and functions.
 ///
@@ -85,7 +86,7 @@ use crate::syntax::Spanned;
 pub static FOUNDATIONS: Category;
 
 /// Hook up all `foundations` definitions.
-pub(super) fn define(global: &mut Scope, inputs: Dict) {
+pub(super) fn define(global: &mut Scope, inputs: Dict, target: ExportTarget) {
     global.category(FOUNDATIONS);
     global.define_type::<bool>();
     global.define_type::<i64>();
@@ -112,7 +113,7 @@ pub(super) fn define(global: &mut Scope, inputs: Dict) {
     global.define_func::<eval>();
     global.define_func::<style>();
     global.define_module(calc::module());
-    global.define_module(sys::module(inputs));
+    global.define_module(sys::module(inputs, target));
 }
 
 /// Fails with an error.

--- a/crates/typst/src/foundations/sys.rs
+++ b/crates/typst/src/foundations/sys.rs
@@ -1,9 +1,10 @@
 //! System-related things.
 
 use crate::foundations::{Dict, Module, Scope, Version};
+use crate::ExportTarget;
 
 /// A module with system-related things.
-pub fn module(inputs: Dict) -> Module {
+pub fn module(inputs: Dict, target: ExportTarget) -> Module {
     let mut scope = Scope::deduplicating();
     scope.define(
         "version",
@@ -14,5 +15,6 @@ pub fn module(inputs: Dict) -> Module {
         ]),
     );
     scope.define("inputs", inputs);
+    scope.define("target", target.as_str());
     Module::new("sys", scope)
 }

--- a/docs/reference/groups.yml
+++ b/docs/reference/groups.yml
@@ -134,6 +134,12 @@
     - The `sys.version` constant (of type [`version`]) that specifies
       the currently active Typst compiler version.
 
+    - The `sys.target` constant (of type [`str`]) that specifies the currently
+      active export target.
+
+      This value is one of `{"pdf"}`, `{"svg"}` or `{"raster"}` and can be used
+      to access target specific features.
+
     - The `sys.inputs` [dictionary], which makes external inputs
       available to the project. An input specified in the command line as
       `--input key=value` becomes available under `sys.inputs.key` as

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -18,6 +18,7 @@ typst-dev-assets = { workspace = true }
 typst-pdf = { workspace = true }
 typst-render = { workspace = true }
 typst-svg = { workspace = true }
+bitflags = { workspace = true }
 clap = { workspace = true }
 comemo = { workspace = true }
 ecow = { workspace = true }

--- a/tests/README.md
+++ b/tests/README.md
@@ -54,6 +54,13 @@ You may find more options in the help message:
 testit --help
 ```
 
+The options `--raster`, `--svg`, `--pdf` and `--all` control which export
+target is compiled and exported. If no export target is given, `--raster` is
+assumed. Tests which don't match the requested targets are filtered out.
+
+**The raster target is currently the only target for which the outputs are
+compared to references. Not running raster export means no comparison!**
+
 To make the integration tests go faster they don't generate PDFs by default.
 Pass the `--pdf` flag to generate those. Mind that PDFs are not tested
 automatically at the moment, so you should always check the output manually when
@@ -63,9 +70,14 @@ testit --pdf
 ```
 
 ## Writing tests
-The syntax for an individual test is `--- {name} ---` followed by some Typst
-code that should be tested. The name must be globally unique in the test suite,
-so that tests can be easily migrated across files.
+The syntax for an individual test is `--- {name} [: {targets}] ---` followed by
+some Typst code that should be tested. The name must be globally unique in the
+test suite, so that tests can be easily migrated across files.
+
+Targets specify for which target a test should be run and exported. Multiple
+targets can be specified using the `|` pipe operator like
+`--- name : PDF | RASTER ---`. If no target is specified, all targets are
+assumed.
 
 There are, broadly speaking, three kinds of tests:
 

--- a/tests/src/targets.rs
+++ b/tests/src/targets.rs
@@ -1,0 +1,64 @@
+use std::{fmt::Display, str::FromStr};
+
+use typst::ExportTarget;
+
+bitflags::bitflags! {
+    /// Bit flags for [`ExportTarget`].
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct ExportTargets: u8 {
+        /// The pdf export target.
+        const PDF = 1 << 0;
+        /// The SVG export target.
+        const SVG = 1 << 1;
+        /// The raster export target.
+        const RASTER = 1 << 2;
+    }
+}
+
+impl From<ExportTarget> for ExportTargets {
+    fn from(value: ExportTarget) -> Self {
+        match value {
+            ExportTarget::Pdf => Self::PDF,
+            ExportTarget::Svg => Self::SVG,
+            ExportTarget::Raster => Self::RASTER,
+            _ => todo!(),
+        }
+    }
+}
+
+impl TryFrom<ExportTargets> for ExportTarget {
+    type Error = ();
+
+    fn try_from(value: ExportTargets) -> Result<Self, Self::Error> {
+        Ok(match value {
+            x if x == ExportTargets::PDF => Self::Pdf,
+            x if x == ExportTargets::SVG => Self::Svg,
+            x if x == ExportTargets::RASTER => Self::Raster,
+            _ => return Err(()),
+        })
+    }
+}
+
+impl ExportTargets {
+    /// Turns self into an iterator of [`ExportTarget`], yielding one target for
+    /// each set bit.
+    pub fn iter_target(self) -> impl Iterator<Item = ExportTarget> {
+        self.iter_names().map(|(_, targets)| {
+            targets.try_into().expect("iter_names ensures unqiue bits")
+        })
+    }
+}
+
+impl FromStr for ExportTargets {
+    type Err = bitflags::parser::ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        bitflags::parser::from_str(s)
+    }
+}
+
+impl Display for ExportTargets {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        bitflags::parser::to_writer(self, f)
+    }
+}

--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -4,6 +4,7 @@ mod args;
 mod collect;
 mod logger;
 mod run;
+mod targets;
 mod world;
 
 use std::path::Path;
@@ -104,8 +105,8 @@ fn test() {
         // to `typst::utils::Deferred` yielding.
         tests.iter().par_bridge().for_each(|test| {
             logger.lock().start(test);
-            let result = std::panic::catch_unwind(|| run::run(test));
-            logger.lock().end(test, result);
+            let results = std::panic::catch_unwind(|| run::run(test));
+            logger.lock().end(test, results);
         });
 
         sender.send(()).unwrap();

--- a/tests/suite/sys/target.typ
+++ b/tests/suite/sys/target.typ
@@ -1,0 +1,12 @@
+--- export-target-pdf-success : PDF ---
+#if sys.target == "pdf" {
+  [Hello World]
+} else {
+  panic("This will never happen")
+}
+
+--- export-target-pdf-failure : PDF ---
+#if sys.target == "pdf" {
+  // Error: 3-18 panicked with: "Whoops"
+  panic("Whoops")
+}


### PR DESCRIPTION
This PR adds a `sys.target`, a string variable containing `pdf`, `svg` or `raster` depending on the export target.

It should be noted that, with this PR in its current stage, compilation is run 3 times per average test on `--extended`. It may be more sensible, but less intuitive to contributors, if we assume a default target of `raster` and then only override the target for those test which have an appropriate annotation.

### TODO
- [ ] allow custom export targets?
- [x] finalize design for CLI interface
- [x] write documentation
- [ ] allow contextual override

Related to #4174, partially resolves it.