### PR TITLE
Allow "imprecise" bounds for the compiler version

### DIFF
--- a/crates/typst-syntax/src/package.rs
+++ b/crates/typst-syntax/src/package.rs
@@ -242,16 +242,9 @@ impl PackageVersion {
     /// assert!(!v1_1_1.matches_eq(&SemVerBound::from_str("1.1.2").unwrap()));
     /// ```
     pub fn matches_eq(&self, bound: &VersionBound) -> bool {
-        if self.major != bound.major {
-            return false;
-        }
-        if bound.minor.map_or(false, |minor| self.minor != minor) {
-            return false;
-        }
-        if bound.patch.map_or(false, |patch| self.patch != patch) {
-            return false;
-        }
-        true
+        self.major == bound.major
+            && bound.minor.map_or(true, |minor| self.minor == minor)
+            && bound.patch.map_or(true, |patch| self.patch == patch)
     }
 
     /// Performs a `>` match with the given version bound. The match only succeeds if some version
@@ -278,15 +271,11 @@ impl PackageVersion {
         if self.major != bound.major {
             return self.major > bound.major;
         }
-        let Some(minor) = bound.minor else {
-            return false;
-        };
+        let Some(minor) = bound.minor else { return false };
         if self.minor != minor {
             return self.minor > minor;
         }
-        let Some(patch) = bound.patch else {
-            return false;
-        };
+        let Some(patch) = bound.patch else { return false };
         if self.patch != patch {
             return self.patch > patch;
         }
@@ -317,15 +306,11 @@ impl PackageVersion {
         if self.major != bound.major {
             return self.major < bound.major;
         }
-        let Some(minor) = bound.minor else {
-            return false;
-        };
+        let Some(minor) = bound.minor else { return false };
         if self.minor != minor {
             return self.minor < minor;
         }
-        let Some(patch) = bound.patch else {
-            return false;
-        };
+        let Some(patch) = bound.patch else { return false };
         if self.patch != patch {
             return self.patch < patch;
         }

--- a/crates/typst-syntax/src/package.rs
+++ b/crates/typst-syntax/src/package.rs
@@ -215,16 +215,17 @@ impl PackageVersion {
         }
     }
 
-    /// Performs an `==` match with the given version bound. Version elements missing in the bound
-    /// are ignored.
+    /// Performs an `==` match with the given version bound. Version elements
+    /// missing in the bound are ignored.
     pub fn matches_eq(&self, bound: &VersionBound) -> bool {
         self.major == bound.major
             && bound.minor.map_or(true, |minor| self.minor == minor)
             && bound.patch.map_or(true, |patch| self.patch == patch)
     }
 
-    /// Performs a `>` match with the given version bound. The match only succeeds if some version
-    /// element in the bound is actually greater than that of the version.
+    /// Performs a `>` match with the given version bound. The match only
+    /// succeeds if some version element in the bound is actually greater than
+    /// that of the version.
     pub fn matches_gt(&self, bound: &VersionBound) -> bool {
         if self.major != bound.major {
             return self.major > bound.major;
@@ -240,8 +241,9 @@ impl PackageVersion {
         false
     }
 
-    /// Performs a `<` match with the given version bound. The match only succeeds if some version
-    /// element in the bound is actually less than that of the version.
+    /// Performs a `<` match with the given version bound. The match only
+    /// succeeds if some version element in the bound is actually less than that
+    /// of the version.
     pub fn matches_lt(&self, bound: &VersionBound) -> bool {
         if self.major != bound.major {
             return self.major < bound.major;
@@ -257,14 +259,14 @@ impl PackageVersion {
         false
     }
 
-    /// Performs a `>=` match with the given versions. The match succeeds when either a `==` or `>`
-    /// match does.
+    /// Performs a `>=` match with the given versions. The match succeeds when
+    /// either a `==` or `>` match does.
     pub fn matches_ge(&self, bound: &VersionBound) -> bool {
         self.matches_eq(bound) || self.matches_gt(bound)
     }
 
-    /// Performs a `<=` match with the given versions. The match succeeds when either a `==` or `<`
-    /// match does.
+    /// Performs a `<=` match with the given versions. The match succeeds when
+    /// either a `==` or `<` match does.
     pub fn matches_le(&self, bound: &VersionBound) -> bool {
         self.matches_eq(bound) || self.matches_lt(bound)
     }

--- a/crates/typst-syntax/src/package.rs
+++ b/crates/typst-syntax/src/package.rs
@@ -40,7 +40,7 @@ pub struct PackageInfo {
     /// The path of the entrypoint into the package.
     pub entrypoint: EcoString,
     /// The minimum required compiler version for the package.
-    pub compiler: Option<SemVerBound>,
+    pub compiler: Option<VersionBound>,
 }
 
 impl PackageManifest {
@@ -241,7 +241,7 @@ impl PackageVersion {
     /// assert!(v1_1_1.matches_eq(&SemVerBound::from_str("1.1.1").unwrap()));
     /// assert!(!v1_1_1.matches_eq(&SemVerBound::from_str("1.1.2").unwrap()));
     /// ```
-    pub fn matches_eq(&self, bound: &SemVerBound) -> bool {
+    pub fn matches_eq(&self, bound: &VersionBound) -> bool {
         if self.major != bound.major {
             return false;
         }
@@ -274,7 +274,7 @@ impl PackageVersion {
     /// assert!(!v1_1_1.matches_gt(&SemVerBound::from_str("1.1.1").unwrap()));
     /// assert!(!v1_1_1.matches_gt(&SemVerBound::from_str("1.1.2").unwrap()));
     /// ```
-    pub fn matches_gt(&self, bound: &SemVerBound) -> bool {
+    pub fn matches_gt(&self, bound: &VersionBound) -> bool {
         if self.major != bound.major {
             return self.major > bound.major;
         }
@@ -313,7 +313,7 @@ impl PackageVersion {
     /// assert!(!v1_1_1.matches_lt(&SemVerBound::from_str("1.1.1").unwrap()));
     /// assert!(v1_1_1.matches_lt(&SemVerBound::from_str("1.1.2").unwrap()));
     /// ```
-    pub fn matches_lt(&self, bound: &SemVerBound) -> bool {
+    pub fn matches_lt(&self, bound: &VersionBound) -> bool {
         if self.major != bound.major {
             return self.major < bound.major;
         }
@@ -352,7 +352,7 @@ impl PackageVersion {
     /// assert!(v1_1_1.matches_ge(&SemVerBound::from_str("1.1.1").unwrap()));
     /// assert!(!v1_1_1.matches_ge(&SemVerBound::from_str("1.1.2").unwrap()));
     /// ```
-    pub fn matches_ge(&self, bound: &SemVerBound) -> bool {
+    pub fn matches_ge(&self, bound: &VersionBound) -> bool {
         self.matches_eq(bound) || self.matches_gt(bound)
     }
 
@@ -376,7 +376,7 @@ impl PackageVersion {
     /// assert!(v1_1_1.matches_le(&SemVerBound::from_str("1.1.1").unwrap()));
     /// assert!(v1_1_1.matches_le(&SemVerBound::from_str("1.1.2").unwrap()));
     /// ```
-    pub fn matches_le(&self, bound: &SemVerBound) -> bool {
+    pub fn matches_le(&self, bound: &VersionBound) -> bool {
         self.matches_eq(bound) || self.matches_lt(bound)
     }
 }
@@ -433,7 +433,7 @@ impl<'de> Deserialize<'de> for PackageVersion {
 
 /// A version bound for compatibility specification.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct SemVerBound {
+pub struct VersionBound {
     /// The bounds's major version.
     pub major: u32,
     /// The bounds's minor version.
@@ -442,7 +442,7 @@ pub struct SemVerBound {
     pub patch: Option<u32>,
 }
 
-impl FromStr for SemVerBound {
+impl FromStr for VersionBound {
     type Err = EcoString;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -469,13 +469,13 @@ impl FromStr for SemVerBound {
     }
 }
 
-impl Debug for SemVerBound {
+impl Debug for VersionBound {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         Display::fmt(self, f)
     }
 }
 
-impl Display for SemVerBound {
+impl Display for VersionBound {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{}", self.major)?;
         if let Some(minor) = self.minor {
@@ -488,13 +488,13 @@ impl Display for SemVerBound {
     }
 }
 
-impl Serialize for SemVerBound {
+impl Serialize for VersionBound {
     fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         s.collect_str(self)
     }
 }
 
-impl<'de> Deserialize<'de> for SemVerBound {
+impl<'de> Deserialize<'de> for VersionBound {
     fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
         let string = EcoString::deserialize(d)?;
         string.parse().map_err(serde::de::Error::custom)

--- a/crates/typst-syntax/src/package.rs
+++ b/crates/typst-syntax/src/package.rs
@@ -214,12 +214,6 @@ impl PackageVersion {
             patch: env!("CARGO_PKG_VERSION_PATCH").parse().unwrap(),
         }
     }
-}
-
-impl PackageVersion {
-    // the code in this impl block is based on https://github.com/dtolnay/semver/blob/1.0.23/src/eval.rs
-    // author: David Tolnay <https://github.com/dtolnay>
-    // licensed under Apache 2.0
 
     /// Performs an `==` match with the given version bound. Version elements missing in the bound
     /// are ignored.
@@ -483,5 +477,16 @@ impl<'de> Deserialize<'de> for VersionBound {
     fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
         let string = EcoString::deserialize(d)?;
         string.parse().map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_angle_unit_conversion() {
+        assert!((Angle::rad(2.0 * PI).to_deg() - 360.0) < 1e-4);
+        assert!((Angle::deg(45.0).to_rad() - std::f64::consts::FRAC_PI_4) < 1e-4);
     }
 }

--- a/crates/typst-syntax/src/package.rs
+++ b/crates/typst-syntax/src/package.rs
@@ -217,24 +217,6 @@ impl PackageVersion {
 
     /// Performs an `==` match with the given version bound. Version elements missing in the bound
     /// are ignored.
-    ///
-    /// ```
-    /// # use typst_syntax::package::{PackageVersion, SemVerBound};
-    /// # use std::str::FromStr;
-    /// let v1_1_1 = PackageVersion::from_str("1.1.1").unwrap();
-    ///
-    /// assert!(!v1_1_1.matches_eq(&SemVerBound::from_str("0").unwrap()));
-    /// assert!(v1_1_1.matches_eq(&SemVerBound::from_str("1").unwrap()));
-    /// assert!(!v1_1_1.matches_eq(&SemVerBound::from_str("2").unwrap()));
-    ///
-    /// assert!(!v1_1_1.matches_eq(&SemVerBound::from_str("1.0").unwrap()));
-    /// assert!(v1_1_1.matches_eq(&SemVerBound::from_str("1.1").unwrap()));
-    /// assert!(!v1_1_1.matches_eq(&SemVerBound::from_str("1.2").unwrap()));
-    ///
-    /// assert!(!v1_1_1.matches_eq(&SemVerBound::from_str("1.1.0").unwrap()));
-    /// assert!(v1_1_1.matches_eq(&SemVerBound::from_str("1.1.1").unwrap()));
-    /// assert!(!v1_1_1.matches_eq(&SemVerBound::from_str("1.1.2").unwrap()));
-    /// ```
     pub fn matches_eq(&self, bound: &VersionBound) -> bool {
         self.major == bound.major
             && bound.minor.map_or(true, |minor| self.minor == minor)
@@ -243,24 +225,6 @@ impl PackageVersion {
 
     /// Performs a `>` match with the given version bound. The match only succeeds if some version
     /// element in the bound is actually greater than that of the version.
-    ///
-    /// ```
-    /// # use typst_syntax::package::{PackageVersion, SemVerBound};
-    /// # use std::str::FromStr;
-    /// let v1_1_1 = PackageVersion::from_str("1.1.1").unwrap();
-    ///
-    /// assert!(v1_1_1.matches_gt(&SemVerBound::from_str("0").unwrap()));
-    /// assert!(!v1_1_1.matches_gt(&SemVerBound::from_str("1").unwrap()));
-    /// assert!(!v1_1_1.matches_gt(&SemVerBound::from_str("2").unwrap()));
-    ///
-    /// assert!(v1_1_1.matches_gt(&SemVerBound::from_str("1.0").unwrap()));
-    /// assert!(!v1_1_1.matches_gt(&SemVerBound::from_str("1.1").unwrap()));
-    /// assert!(!v1_1_1.matches_gt(&SemVerBound::from_str("1.2").unwrap()));
-    ///
-    /// assert!(v1_1_1.matches_gt(&SemVerBound::from_str("1.1.0").unwrap()));
-    /// assert!(!v1_1_1.matches_gt(&SemVerBound::from_str("1.1.1").unwrap()));
-    /// assert!(!v1_1_1.matches_gt(&SemVerBound::from_str("1.1.2").unwrap()));
-    /// ```
     pub fn matches_gt(&self, bound: &VersionBound) -> bool {
         if self.major != bound.major {
             return self.major > bound.major;
@@ -278,24 +242,6 @@ impl PackageVersion {
 
     /// Performs a `<` match with the given version bound. The match only succeeds if some version
     /// element in the bound is actually less than that of the version.
-    ///
-    /// ```
-    /// # use typst_syntax::package::{PackageVersion, SemVerBound};
-    /// # use std::str::FromStr;
-    /// let v1_1_1 = PackageVersion::from_str("1.1.1").unwrap();
-    ///
-    /// assert!(!v1_1_1.matches_lt(&SemVerBound::from_str("0").unwrap()));
-    /// assert!(!v1_1_1.matches_lt(&SemVerBound::from_str("1").unwrap()));
-    /// assert!(v1_1_1.matches_lt(&SemVerBound::from_str("2").unwrap()));
-    ///
-    /// assert!(!v1_1_1.matches_lt(&SemVerBound::from_str("1.0").unwrap()));
-    /// assert!(!v1_1_1.matches_lt(&SemVerBound::from_str("1.1").unwrap()));
-    /// assert!(v1_1_1.matches_lt(&SemVerBound::from_str("1.2").unwrap()));
-    ///
-    /// assert!(!v1_1_1.matches_lt(&SemVerBound::from_str("1.1.0").unwrap()));
-    /// assert!(!v1_1_1.matches_lt(&SemVerBound::from_str("1.1.1").unwrap()));
-    /// assert!(v1_1_1.matches_lt(&SemVerBound::from_str("1.1.2").unwrap()));
-    /// ```
     pub fn matches_lt(&self, bound: &VersionBound) -> bool {
         if self.major != bound.major {
             return self.major < bound.major;
@@ -313,48 +259,12 @@ impl PackageVersion {
 
     /// Performs a `>=` match with the given versions. The match succeeds when either a `==` or `>`
     /// match does.
-    ///
-    /// ```
-    /// # use typst_syntax::package::{PackageVersion, SemVerBound};
-    /// # use std::str::FromStr;
-    /// let v1_1_1 = PackageVersion::from_str("1.1.1").unwrap();
-    ///
-    /// assert!(v1_1_1.matches_ge(&SemVerBound::from_str("0").unwrap()));
-    /// assert!(v1_1_1.matches_ge(&SemVerBound::from_str("1").unwrap()));
-    /// assert!(!v1_1_1.matches_ge(&SemVerBound::from_str("2").unwrap()));
-    ///
-    /// assert!(v1_1_1.matches_ge(&SemVerBound::from_str("1.0").unwrap()));
-    /// assert!(v1_1_1.matches_ge(&SemVerBound::from_str("1.1").unwrap()));
-    /// assert!(!v1_1_1.matches_ge(&SemVerBound::from_str("1.2").unwrap()));
-    ///
-    /// assert!(v1_1_1.matches_ge(&SemVerBound::from_str("1.1.0").unwrap()));
-    /// assert!(v1_1_1.matches_ge(&SemVerBound::from_str("1.1.1").unwrap()));
-    /// assert!(!v1_1_1.matches_ge(&SemVerBound::from_str("1.1.2").unwrap()));
-    /// ```
     pub fn matches_ge(&self, bound: &VersionBound) -> bool {
         self.matches_eq(bound) || self.matches_gt(bound)
     }
 
     /// Performs a `<=` match with the given versions. The match succeeds when either a `==` or `<`
     /// match does.
-    ///
-    /// ```
-    /// # use typst_syntax::package::{PackageVersion, SemVerBound};
-    /// # use std::str::FromStr;
-    /// let v1_1_1 = PackageVersion::from_str("1.1.1").unwrap();
-    ///
-    /// assert!(!v1_1_1.matches_le(&SemVerBound::from_str("0").unwrap()));
-    /// assert!(v1_1_1.matches_le(&SemVerBound::from_str("1").unwrap()));
-    /// assert!(v1_1_1.matches_le(&SemVerBound::from_str("2").unwrap()));
-    ///
-    /// assert!(!v1_1_1.matches_le(&SemVerBound::from_str("1.0").unwrap()));
-    /// assert!(v1_1_1.matches_le(&SemVerBound::from_str("1.1").unwrap()));
-    /// assert!(v1_1_1.matches_le(&SemVerBound::from_str("1.2").unwrap()));
-    ///
-    /// assert!(!v1_1_1.matches_le(&SemVerBound::from_str("1.1.0").unwrap()));
-    /// assert!(v1_1_1.matches_le(&SemVerBound::from_str("1.1.1").unwrap()));
-    /// assert!(v1_1_1.matches_le(&SemVerBound::from_str("1.1.2").unwrap()));
-    /// ```
     pub fn matches_le(&self, bound: &VersionBound) -> bool {
         self.matches_eq(bound) || self.matches_lt(bound)
     }
@@ -482,11 +392,24 @@ impl<'de> Deserialize<'de> for VersionBound {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
 
     #[test]
-    fn test_angle_unit_conversion() {
-        assert!((Angle::rad(2.0 * PI).to_deg() - 360.0) < 1e-4);
-        assert!((Angle::deg(45.0).to_rad() - std::f64::consts::FRAC_PI_4) < 1e-4);
+    fn version_version_match() {
+        let v1_1_1 = PackageVersion::from_str("1.1.1").unwrap();
+
+        assert!(v1_1_1.matches_eq(&VersionBound::from_str("1").unwrap()));
+        assert!(v1_1_1.matches_eq(&VersionBound::from_str("1.1").unwrap()));
+        assert!(!v1_1_1.matches_eq(&VersionBound::from_str("1.2").unwrap()));
+
+        assert!(!v1_1_1.matches_gt(&VersionBound::from_str("1").unwrap()));
+        assert!(v1_1_1.matches_gt(&VersionBound::from_str("1.0").unwrap()));
+        assert!(!v1_1_1.matches_gt(&VersionBound::from_str("1.1").unwrap()));
+
+        assert!(!v1_1_1.matches_lt(&VersionBound::from_str("1").unwrap()));
+        assert!(!v1_1_1.matches_lt(&VersionBound::from_str("1.1").unwrap()));
+        assert!(v1_1_1.matches_lt(&VersionBound::from_str("1.2").unwrap()));
     }
 }


### PR DESCRIPTION
Fixes #4379. As suggested there, this is a direct implementation of the comparison logic without using a library. The comparisons are described and tested with doc tests, and I did a few manual end-to-end tests:

When compiling a file containing a single import to a local package, the following `compiler` field values in that packages have the following error messages:
- `compiler = "0.11.0"` - _no error_
- `compiler = "0.11"` - _no error_
- `compiler = "0.11.1"` - package requires typst 0.11.1 or newer (current version is 0.11.0)
- `compiler = "0.12.0"` - package requires typst 0.12.0 or newer (current version is 0.11.0)
- `compiler = "0.12"` - package requires typst 0.12 or newer (current version is 0.11.0)
- `compiler = "0.11.0.0"` - package manifest is malformed (version bound has unexpected fourth component: `0`)
- `compiler = "0.11.x"` - package manifest is malformed (`x` is not a valid patch version bound)
- `compiler = ""` - package manifest is malformed (`` is not a valid major version bound)

I didn't put "compiler" anywhere into the error messages, as the `SemVerBound` is not specific to that - so the error messages are only slightly improved, but the original error condition is removed. The remaining error messages contain a part of the version bound, so it's more likely that one will realize what field the error is about.

Some remarks regarding the code:
- the fields of `SemVerBound` are public, like with `PackageVersion`. It's possible to initialize an invalid value by giving a patch version but not a minor one, so it might make sense to change these fields to private and add a constructor.
- the error message for `compiler = "0.12"` says "typst 0.12 or newer", not "0.12.0 or newer". If that's considered a problem, I could add a conversion to `PackageVersion` for this.