### PR TITLE
Add hints to array destructuring error messages

### DIFF
--- a/crates/typst/src/eval/binding.rs
+++ b/crates/typst/src/eval/binding.rs
@@ -89,7 +89,6 @@ fn destructure_array<F>(
 where
     F: Fn(&mut Vm, ast::Expr, Value) -> SourceResult<()>,
 {
-    let destruct_len = destruct.items().count();
     let len = value.as_slice().len();
     let mut i = 0;
 
@@ -99,19 +98,19 @@ where
                 let Ok(v) = value.at(i as i64, None) else {
                     bail!(
                         pattern.span(), "not enough elements to destructure";
-                        hint: "the provided array has a length of {}", len
+                        hint: "the provided array has a length of {len}",
                     );
                 };
                 destructure_impl(vm, pattern, v, f)?;
                 i += 1;
             }
             ast::DestructuringItem::Spread(spread) => {
-                let sink_size = (1 + len).checked_sub(destruct_len);
+                let sink_size = (1 + len).checked_sub(destruct.items().count());
                 let sink = sink_size.and_then(|s| value.as_slice().get(i..i + s));
                 let (Some(sink_size), Some(sink)) = (sink_size, sink) else {
                     bail!(
                         spread.span(), "not enough elements to destructure";
-                        hint: "the provided array has a length of {}", len
+                        hint: "the provided array has a length of {len}",
                     );
                 };
                 if let Some(expr) = spread.sink_expr() {
@@ -129,20 +128,17 @@ where
         if i == 0 {
             bail!(
                 destruct.span(), "too many elements to destructure";
-                hint: "the provided array has a length of {}, but the pattern expects an empty array",
-                len
+                hint: "the provided array has a length of {len}, but the pattern expects an empty array",
             )
         } else if i == 1 {
             bail!(
                 destruct.span(), "too many elements to destructure";
-                hint: "the provided array has a length of {}, but the pattern expects a single element",
-                len
+                hint: "the provided array has a length of {len}, but the pattern expects a single element",
             );
         } else {
             bail!(
                 destruct.span(), "too many elements to destructure";
-                hint: "the provided array has a length of {}, but the pattern expects {} elements",
-                len, i
+                hint: "the provided array has a length of {len}, but the pattern expects {i} elements",
             );
         }
     }

--- a/crates/typst/src/eval/binding.rs
+++ b/crates/typst/src/eval/binding.rs
@@ -89,6 +89,7 @@ fn destructure_array<F>(
 where
     F: Fn(&mut Vm, ast::Expr, Value) -> SourceResult<()>,
 {
+    let destruct_len = destruct.items().count();
     let len = value.as_slice().len();
     let mut i = 0;
 
@@ -96,16 +97,22 @@ where
         match p {
             ast::DestructuringItem::Pattern(pattern) => {
                 let Ok(v) = value.at(i as i64, None) else {
-                    bail!(pattern.span(), "not enough elements to destructure");
+                    bail!(
+                        pattern.span(), "not enough elements to destructure";
+                        hint: "the provided array has a length of {}", len
+                    );
                 };
                 destructure_impl(vm, pattern, v, f)?;
                 i += 1;
             }
             ast::DestructuringItem::Spread(spread) => {
-                let sink_size = (1 + len).checked_sub(destruct.items().count());
+                let sink_size = (1 + len).checked_sub(destruct_len);
                 let sink = sink_size.and_then(|s| value.as_slice().get(i..i + s));
                 let (Some(sink_size), Some(sink)) = (sink_size, sink) else {
-                    bail!(spread.span(), "not enough elements to destructure");
+                    bail!(
+                        spread.span(), "not enough elements to destructure";
+                        hint: "the provided array has a length of {}", len
+                    );
                 };
                 if let Some(expr) = spread.sink_expr() {
                     f(vm, expr, Value::Array(sink.into()))?;
@@ -119,7 +126,25 @@ where
     }
 
     if i < len {
-        bail!(destruct.span(), "too many elements to destructure");
+        if i == 0 {
+            bail!(
+                destruct.span(), "too many elements to destructure";
+                hint: "the provided array has a length of {}, but the pattern expects an empty array",
+                len
+            )
+        } else if i == 1 {
+            bail!(
+                destruct.span(), "too many elements to destructure";
+                hint: "the provided array has a length of {}, but the pattern expects a single element",
+                len
+            );
+        } else {
+            bail!(
+                destruct.span(), "too many elements to destructure";
+                hint: "the provided array has a length of {}, but the pattern expects {} elements",
+                len, i
+            );
+        }
     }
 
     Ok(())

--- a/tests/suite/scripting/destructuring.typ
+++ b/tests/suite/scripting/destructuring.typ
@@ -119,12 +119,22 @@
 // Error: 7-14 expected pattern, found function call
 #let (a.at(0),) = (1,)
 
+--- destructuring-let-empty-array ---
+#let () = ()
+
+--- destructuring-let-empty-array-too-many-elements ---
+// Error: 6-8 too many elements to destructure
+// Hint: 6-8 the provided array has a length of 2, but the pattern expects an empty array
+#let () = (1, 2)
+
 --- destructuring-let-array-too-few-elements ---
 // Error: 13-14 not enough elements to destructure
+// Hint: 13-14 the provided array has a length of 2
 #let (a, b, c) = (1, 2)
 
 --- destructuring-let-array-too-few-elements-with-sink ---
 // Error: 7-10 not enough elements to destructure
+// Hint: 7-10 the provided array has a length of 2
 #let (..a, b, c, d) = (1, 2)
 
 --- destructuring-let-array-bool-invalid ---
@@ -183,6 +193,7 @@
 --- destructuring-let-array-trailing-placeholders ---
 // Trailing placeholders.
 // Error: 10-11 not enough elements to destructure
+// Hint: 10-11 the provided array has a length of 1
 #let (a, _, _, _, _) = (1,)
 #test(a, 1)
 
@@ -350,8 +361,10 @@
 
 --- issue-3275-destructuring-loop-over-2d-array-1 ---
 // Error: 10-11 not enough elements to destructure
+// Hint: 10-11 the provided array has a length of 1
 #for (x, y) in ((1,), (2,)) {}
 
 --- issue-3275-destructuring-loop-over-2d-array-2 ---
 // Error: 6-12 too many elements to destructure
+// Hint: 6-12 the provided array has a length of 3, but the pattern expects 2 elements
 #for (x, y) in ((1,2,3), (4,5,6)) {}


### PR DESCRIPTION
This small PR adds hints to array destructuring error messages indicating the length of the array. For example: "the provided array has a length of 3, but the pattern expects 2 elements".