### PR TITLE
docs: add reference for list of latex math symbols and typst equivalents

### DIFF
--- a/docs/guides/guide-for-latex-users.md
+++ b/docs/guides/guide-for-latex-users.md
@@ -499,6 +499,8 @@ their name. Some symbols are additionally available through shorthands, such as
 Refer to the [symbol pages]($reference/symbols) for a full list of the symbols.
 If a symbol is missing, you can also access it through a
 [Unicode escape sequence]($syntax/#escapes).
+A pretty complete list of LaTeX math symbols and their Typst equivalent can be
+found in the community-managed [typstfun PDF](http://mirrors.ctan.org/info/typstfun/typstfun.pdf).
 
 Alternate and related forms of symbols can often be selected by
 [appending a modifier]($symbol) after a period. For example,


### PR DESCRIPTION
I stumbled upon http://mirrors.ctan.org/info/typstfun/typstfun.pdf which I found pretty helpful in migrating from Latex to typst. Hence, I've added it to the docs.
Upstream repo: https://github.com/lvjr/typstfun