### PR TITLE
Add Galician & catalan translations

### DIFF
--- a/crates/typst/src/text/lang.rs
+++ b/crates/typst/src/text/lang.rs
@@ -24,6 +24,7 @@ const TRANSLATIONS: [(&str, &str); 31] = [
     translation!("et"),
     translation!("fi"),
     translation!("fr"),
+    translation!("gl"),
     translation!("gr"),
     translation!("hu"),
     translation!("it"),
@@ -67,6 +68,7 @@ impl Lang {
     pub const FILIPINO: Self = Self(*b"tl ", 2);
     pub const FINNISH: Self = Self(*b"fi ", 2);
     pub const FRENCH: Self = Self(*b"fr ", 2);
+    pub const GALICIAN: Self = Self(*b"gl ", 2);
     pub const GERMAN: Self = Self(*b"de ", 2);
     pub const GREEK: Self = Self(*b"gr ", 2);
     pub const HUNGARIAN: Self = Self(*b"hu ", 2);

--- a/crates/typst/src/text/lang.rs
+++ b/crates/typst/src/text/lang.rs
@@ -14,8 +14,9 @@ macro_rules! translation {
     };
 }
 
-const TRANSLATIONS: [(&str, &str); 31] = [
+const TRANSLATIONS: [(&str, &str); 33] = [
     translation!("ar"),
+    translation!("ca"),
     translation!("cs"),
     translation!("da"),
     translation!("de"),

--- a/crates/typst/translations/ca.txt
+++ b/crates/typst/translations/ca.txt
@@ -1,0 +1,7 @@
+figure = Figura
+table = Taula
+equation = Equació
+bibliography = Bibliografia
+heading = Secció
+outline = Índex
+raw = Llistat

--- a/crates/typst/translations/gl.txt
+++ b/crates/typst/translations/gl.txt
@@ -1,0 +1,7 @@
+figure = Figura
+table = Táboa
+equation = Ecuación
+bibliography = Bibliografía
+heading = Sección
+outline = Índice
+raw = Listado


### PR DESCRIPTION
This PR adds Galician translations to the Typst compiler. Furthermore, it recovers the Catalan translations from #3181 that got lost during the change to the custom key-value localization format in #3728.