### PR TITLE
Fix luma to CMYK conversion

### DIFF
--- a/crates/typst/src/visualize/color.rs
+++ b/crates/typst/src/visualize/color.rs
@@ -1721,7 +1721,7 @@ impl Cmyk {
     }
 
     fn from_luma(luma: Luma) -> Self {
-        let l = luma.luma;
+        let l = 1.0 - luma.luma;
         Cmyk::new(l * 0.75, l * 0.68, l * 0.67, l * 0.90)
     }
 

--- a/tests/suite/visualize/color.typ
+++ b/tests/suite/visualize/color.typ
@@ -117,7 +117,7 @@
 #test-repr(cmyk(4%, 5%, 6%, 7%).to-hex(), "#e0dcda")
 #test-repr(rgb(cmyk(4%, 5%, 6%, 7%)), rgb(87.84%, 86.27%, 85.49%, 100%))
 #test-repr(rgb(luma(40%)), rgb(40%, 40%, 40%))
-#test-repr(cmyk(luma(40)), cmyk(11.76%, 10.67%, 10.51%, 14.12%))
+#test-repr(cmyk(luma(40)), cmyk(63.24%, 57.33%, 56.49%, 75.88%))
 #test-repr(cmyk(rgb(1, 2, 3)), cmyk(66.67%, 33.33%, 0%, 98.82%))
 #test-repr(luma(rgb(1, 2, 3)), luma(0.73%))
 #test-repr(color.hsl(luma(40)), color.hsl(0deg, 0%, 15.69%))


### PR DESCRIPTION
The luma value is basically the "amount of white" but the CMYK values are rather an "amount of darkness" so it should be inverted. Previously `cmyk(black)` would return white (and the other way around).

This was also included in #2661 but then forgotten.