### PR TITLE
Open with (detached) custom viewers and raise error on failure

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -100,9 +100,11 @@ pub struct CompileCommand {
     #[arg(long = "format", short = 'f')]
     pub format: Option<OutputFormat>,
 
-    /// Opens the output file using the default viewer after compilation.
-    /// Ignored if output is stdout
-    #[arg(long = "open")]
+    /// Opens the output file with the default viewer or a specific program after
+    /// compilation
+    ///
+    /// Ignored if output is stdout.
+    #[arg(long = "open", value_name = "VIEWER")]
     pub open: Option<Option<String>>,
 
     /// The PPI (pixels per inch) to use for PNG export


### PR DESCRIPTION
Closes #4386 .

I just tested the behavior on my linux KDE desktop and not sure if it works on other platform (but I think it would work :smile: )

---

### Open without specific viewer

#### `typst compile --open` and the default resource openers failed

```console
$ PATH= ./target/debug/typst compile ../test.typ --open
error: failed to open file with any of these resource openers: xdg-open, gio, gnome-open, kde-open (No such file or directory (os error 2))
```

#### `typst watch --open` and the default openers failed

```console
$ PATH= ./target/debug/typst watch ../test.typ --open
watching ../test.typ
writing to ../test.pdf

[14:01:55] compiled successfully in 17.73ms

error: failed to open file with any of these resource openers: xdg-open, gio, gnome-open, kde-open (No such file or directory (os error 2))
```

### Open with specific viewer

#### `typst compile --open /path/nonexistent`

```console
$ ./target/debug/typst compile ../test.typ --open /path/nonexistent
error: failed to open file with /path/nonexistent (No such file or directory (os error 2))
```

#### `typst watch --open /path/nonexistent`

```console
$ ./target/debug/typst watch ../test.typ --open /path/nonexistent
watching ../test.typ
writing to ../test.pdf

[14:03:36] compiled successfully in 17.72ms

error: failed to open file with /path/nonexistent (No such file or directory (os error 2))
```