### PR TITLE
fix(array.slice): Clarify and correct function description

### DIFF
--- a/crates/typst/src/foundations/array.rs
+++ b/crates/typst/src/foundations/array.rs
@@ -259,7 +259,7 @@ impl Array {
             .ok_or_else(|| out_of_bounds_no_default(index, self.len()))
     }
 
-    /// Extracts a subslice of the array. Fails with an error if the start or
+    /// Extracts a subslice of the array. Fails with an error if the start or end
     /// index is out of bounds.
     #[func]
     pub fn slice(

--- a/crates/typst/src/foundations/bytes.rs
+++ b/crates/typst/src/foundations/bytes.rs
@@ -127,7 +127,7 @@ impl Bytes {
             .ok_or_else(|| out_of_bounds_no_default(index, self.len()))
     }
 
-    /// Extracts a subslice of the bytes. Fails with an error if the start or
+    /// Extracts a subslice of the bytes. Fails with an error if the start or end
     /// index is out of bounds.
     #[func]
     pub fn slice(


### PR DESCRIPTION
Updated the description of the `slice` function to explicitly mention both start and end index. This ensures the documentation accurately describes the behavior of the function.