### PR TITLE
Make typst-cli crate usable as library

### DIFF
--- a/crates/typst-cli/Cargo.toml
+++ b/crates/typst-cli/Cargo.toml
@@ -12,6 +12,11 @@ repository = { workspace = true }
 license = { workspace = true }
 readme = { workspace = true }
 
+[lib]
+name = "typst_cli"
+path = "src/lib.rs"
+doc = false
+
 [[bin]]
 name = "typst"
 path = "src/main.rs"

--- a/crates/typst-cli/src/lib.rs
+++ b/crates/typst-cli/src/lib.rs
@@ -1,0 +1,69 @@
+pub mod args;
+pub mod compile;
+pub mod download;
+pub mod fonts;
+pub mod init;
+pub mod package;
+pub mod query;
+pub mod terminal;
+pub mod timings;
+#[cfg(feature = "self-update")]
+pub mod update;
+pub mod watch;
+pub mod world;
+
+use std::cell::Cell;
+use std::io::{self, Write};
+use std::process::ExitCode;
+
+use clap::Parser;
+use codespan_reporting::term;
+use codespan_reporting::term::termcolor::WriteColor;
+use once_cell::sync::Lazy;
+
+use crate::args::CliArguments;
+
+/// Ensure a failure exit code.
+pub fn set_failed() {
+    EXIT.with(|cell| cell.set(ExitCode::FAILURE));
+}
+
+
+thread_local! {
+    /// The CLI's exit code.
+    pub static EXIT: Cell<ExitCode> = const { Cell::new(ExitCode::SUCCESS) };
+}
+
+/// The parsed commandline arguments.
+pub static ARGS: Lazy<CliArguments> = Lazy::new(CliArguments::parse);
+
+/// Used by `args.rs`.
+pub fn typst_version() -> &'static str {
+    env!("TYPST_VERSION")
+}
+
+/// Print an application-level error (independent from a source file).
+pub fn print_error(msg: &str) -> io::Result<()> {
+    let styles = term::Styles::default();
+
+    let mut output = terminal::out();
+    output.set_color(&styles.header_error)?;
+    write!(output, "error")?;
+
+    output.reset()?;
+    writeln!(output, ": {msg}")
+}
+
+#[cfg(not(feature = "self-update"))]
+pub mod update {
+    use crate::args::UpdateCommand;
+    use typst::diag::{bail, StrResult};
+
+    pub fn update(_: &UpdateCommand) -> StrResult<()> {
+        bail!(
+            "self-updating is not enabled for this executable, \
+             please update with the package manager or mechanism \
+             used for initial installation"
+        )
+    }
+}

--- a/crates/typst-cli/src/main.rs
+++ b/crates/typst-cli/src/main.rs
@@ -1,37 +1,10 @@
-mod args;
-mod compile;
-mod download;
-mod fonts;
-mod init;
-mod package;
-mod query;
-mod terminal;
-mod timings;
-#[cfg(feature = "self-update")]
-mod update;
-mod watch;
-mod world;
-
-use std::cell::Cell;
-use std::io::{self, Write};
 use std::process::ExitCode;
 
-use clap::Parser;
-use codespan_reporting::term;
-use codespan_reporting::term::termcolor::WriteColor;
-use once_cell::sync::Lazy;
 use typst::diag::HintedStrResult;
 
-use crate::args::{CliArguments, Command};
-use crate::timings::Timer;
-
-thread_local! {
-    /// The CLI's exit code.
-    static EXIT: Cell<ExitCode> = const { Cell::new(ExitCode::SUCCESS) };
-}
-
-/// The parsed commandline arguments.
-static ARGS: Lazy<CliArguments> = Lazy::new(CliArguments::parse);
+use typst_cli::{ARGS, EXIT, print_error, set_failed};
+use typst_cli::args::Command;
+use typst_cli::timings::Timer;
 
 /// Entry point.
 fn main() -> ExitCode {
@@ -50,49 +23,13 @@ fn dispatch() -> HintedStrResult<()> {
     let timer = Timer::new(&ARGS);
 
     match &ARGS.command {
-        Command::Compile(command) => crate::compile::compile(timer, command.clone())?,
-        Command::Watch(command) => crate::watch::watch(timer, command.clone())?,
-        Command::Init(command) => crate::init::init(command)?,
-        Command::Query(command) => crate::query::query(command)?,
-        Command::Fonts(command) => crate::fonts::fonts(command)?,
-        Command::Update(command) => crate::update::update(command)?,
+        Command::Compile(command) => typst_cli::compile::compile(timer, command.clone())?,
+        Command::Watch(command) => typst_cli::watch::watch(timer, command.clone())?,
+        Command::Init(command) => typst_cli::init::init(command)?,
+        Command::Query(command) => typst_cli::query::query(command)?,
+        Command::Fonts(command) => typst_cli::fonts::fonts(command)?,
+        Command::Update(command) => typst_cli::update::update(command)?,
     }
 
     Ok(())
-}
-
-/// Ensure a failure exit code.
-fn set_failed() {
-    EXIT.with(|cell| cell.set(ExitCode::FAILURE));
-}
-
-/// Used by `args.rs`.
-fn typst_version() -> &'static str {
-    env!("TYPST_VERSION")
-}
-
-/// Print an application-level error (independent from a source file).
-fn print_error(msg: &str) -> io::Result<()> {
-    let styles = term::Styles::default();
-
-    let mut output = terminal::out();
-    output.set_color(&styles.header_error)?;
-    write!(output, "error")?;
-
-    output.reset()?;
-    writeln!(output, ": {msg}")
-}
-
-#[cfg(not(feature = "self-update"))]
-mod update {
-    use crate::args::UpdateCommand;
-    use typst::diag::{bail, StrResult};
-
-    pub fn update(_: &UpdateCommand) -> StrResult<()> {
-        bail!(
-            "self-updating is not enabled for this executable, \
-             please update with the package manager or mechanism \
-             used for initial installation"
-        )
-    }
 }


### PR DESCRIPTION
Like others in #4452 i would like to use typst as library. This is the simplest way i found to do it, turning typst_cli into a library.