### PR TITLE
Add metadata for `cargo-binstall`

### DIFF
--- a/crates/typst-cli/Cargo.toml
+++ b/crates/typst-cli/Cargo.toml
@@ -85,3 +85,13 @@ vendor-openssl = ["openssl/vendored"]
 
 [lints]
 workspace = true
+
+# The following metadata is used by `cargo-binstall`, and should be synchronized
+# with `.github/workflows/release.yml`.
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/typst-{ target }{ archive-suffix }"
+bin-dir = "typst-{ target }/typst{ binary-ext }"
+pkg-fmt = "txz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-fmt = "zip"


### PR DESCRIPTION
Closes #4388 .

---

I tested this locally (x86_64 + linux + glibc) via:

```console
$ # in the root of this repo
$ cargo binstall typst-cli --manifest-path ./crates/typst-cli/Cargo.toml
```

Then, `cargo-binstall` downloaded the prebuilt artifacts for `x86_64-unknown-linux-musl`. This is because `cargo-binstall` finds a proper target-triple for us:

https://github.com/cargo-bins/cargo-binstall/blob/76814e4e8feaede87d8d112a4fad519d8eeaf81d/crates/bin/src/args.rs#L69-L73

---

To ensure it is working, we may need to test it locally for current prebuilt targets.
- [x] x86_64-unknown-linux-musl
- [ ] aarch64-unknown-linux-musl
- [ ] armv7-unknown-linux-musleabi
- [ ] x86_64-apple-darwin
- [ ] aarch64-apple-darwin
- [ ] x86_64-pc-windows-msvc

**I would appreciate it if you can help to test the untested targets above on your target-matched machine and report the result here to ensure everything works as expected.**