### PR TITLE
Statically link xz2

### DIFF
--- a/crates/typst-cli/Cargo.toml
+++ b/crates/typst-cli/Cargo.toml
@@ -53,7 +53,7 @@ tar = { workspace = true }
 tempfile = { workspace = true }
 toml = { workspace = true }
 ureq = { workspace = true }
-xz2 = { workspace = true, optional = true }
+xz2 = { workspace = true, optional = true, features = ["static"] }
 zip = { workspace = true, optional = true }
 
 # Explicitly depend on OpenSSL if applicable, so that we can add the


### PR DESCRIPTION
Fixes #4242.
This enables the static feature of xz2, to prevent it from dynamically linking a version of the library that might not exist on the target system.