### PR TITLE
Typed serialization (#3585)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,6 +612,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24e2389d65ab4fab27dc2a5de7b191e1f6617d1f1c8855c0dc569c94a4cbb18d"
+dependencies = [
+ "serde",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2537,6 +2547,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
+name = "typeid"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "059d83cc991e7a42fc37bd50941885db0888e34209f8cfd9aab07ddec03bc9cf"
+
+[[package]]
 name = "typst"
 version = "0.11.0"
 dependencies = [
@@ -2547,6 +2563,7 @@ dependencies = [
  "comemo",
  "csv",
  "ecow",
+ "erased-serde",
  "flate2",
  "fontdb",
  "hayagriva",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ same-file = "1"
 self-replace = "1.3.7"
 semver = "1"
 serde = { version = "1.0.184", features = ["derive"] }
+erased-serde = "0.4"
 serde_json = "1"
 serde_yaml = "0.9"
 shell-escape = "0.1.5"

--- a/crates/typst/Cargo.toml
+++ b/crates/typst/Cargo.toml
@@ -51,7 +51,8 @@ rayon = { workspace = true }
 regex = { workspace = true }
 roxmltree = { workspace = true }
 rustybuzz = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, features = ["rc", "derive"] }
+erased-serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 siphasher = { workspace = true }

--- a/crates/typst/src/foundations/args.rs
+++ b/crates/typst/src/foundations/args.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::fmt::{self, Debug, Formatter};
 
 use ecow::{eco_format, eco_vec, EcoString, EcoVec};
-use serde::{Serialize, Serializer};
 use serde::ser::SerializeMap;
+use serde::{Serialize, Serializer};
 
 use crate::diag::{bail, error, At, SourceDiagnostic, SourceResult};
 use crate::foundations::{
@@ -308,14 +308,18 @@ impl Serialize for Args {
     where
         S: Serializer,
     {
-        let (named, positional): (Vec<_>, Vec<_>) = self.items.iter().partition(|&it| it.name.is_some());
+        let (named, positional): (Vec<_>, Vec<_>) =
+            self.items.iter().partition(|&it| it.name.is_some());
 
         let mut map_ser = serializer.serialize_map(Some(3))?;
         map_ser.serialize_entry("type", "arguments")?;
 
         let positional_vec: Vec<_> = positional.iter().map(|it| &it.value.v).collect();
         map_ser.serialize_entry("positional", &positional_vec)?;
-        let named_map: HashMap<_, _> = named.iter().map(|it| (it.name.as_ref().unwrap(), &it.value.v)).collect();
+        let named_map: HashMap<_, _> = named
+            .iter()
+            .map(|it| (it.name.as_ref().unwrap(), &it.value.v))
+            .collect();
         map_ser.serialize_entry("named", &named_map)?;
         map_ser.end()
     }

--- a/crates/typst/src/foundations/auto.rs
+++ b/crates/typst/src/foundations/auto.rs
@@ -1,7 +1,7 @@
 use ecow::EcoString;
+use serde::{Serialize, Serializer};
 use std::fmt::{self, Debug, Formatter};
 use std::iter;
-use serde::{Serialize, Serializer};
 
 use crate::diag::HintedStrResult;
 use crate::foundations::{

--- a/crates/typst/src/foundations/auto.rs
+++ b/crates/typst/src/foundations/auto.rs
@@ -1,5 +1,7 @@
 use ecow::EcoString;
 use std::fmt::{self, Debug, Formatter};
+use std::iter;
+use serde::{Serialize, Serializer};
 
 use crate::diag::HintedStrResult;
 use crate::foundations::{
@@ -57,6 +59,15 @@ impl Debug for AutoValue {
 impl Repr for AutoValue {
     fn repr(&self) -> EcoString {
         "auto".into()
+    }
+}
+
+impl Serialize for AutoValue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_map::<&str, &str, _>(iter::once(("type", "auto")))
     }
 }
 

--- a/crates/typst/src/foundations/content.rs
+++ b/crates/typst/src/foundations/content.rs
@@ -1,7 +1,7 @@
 use std::any::TypeId;
 use std::fmt::{self, Debug, Formatter};
 use std::hash::{Hash, Hasher};
-use std::iter::{self, Sum};
+use std::iter::Sum;
 use std::marker::PhantomData;
 use std::ops::{Add, AddAssign, Deref, DerefMut};
 use std::sync::Arc;
@@ -705,7 +705,8 @@ impl Serialize for Content {
         S: Serializer,
     {
         serializer.collect_map(
-            iter::once(("func".into(), self.func().name().into_value()))
+            vec![("type".into(), "content".into_value()), ("func".into(), self.func().name().into_value())]
+                .into_iter()
                 .chain(self.fields()),
         )
     }

--- a/crates/typst/src/foundations/content.rs
+++ b/crates/typst/src/foundations/content.rs
@@ -705,9 +705,12 @@ impl Serialize for Content {
         S: Serializer,
     {
         serializer.collect_map(
-            vec![("type".into(), "content".into_value()), ("func".into(), self.func().name().into_value())]
-                .into_iter()
-                .chain(self.fields()),
+            vec![
+                ("type".into(), "content".into_value()),
+                ("func".into(), self.func().name().into_value()),
+            ]
+            .into_iter()
+            .chain(self.fields()),
         )
     }
 }

--- a/crates/typst/src/foundations/datetime.rs
+++ b/crates/typst/src/foundations/datetime.rs
@@ -3,8 +3,8 @@ use std::hash::Hash;
 use std::ops::{Add, Sub};
 
 use ecow::{eco_format, EcoString, EcoVec};
-use serde::{Serialize, Serializer};
 use serde::ser::SerializeMap;
+use serde::{Serialize, Serializer};
 use time::error::{Format, InvalidFormatDescription};
 use time::macros::format_description;
 use time::{format_description, Month, PrimitiveDateTime};
@@ -478,8 +478,11 @@ impl Serialize for Datetime {
             self.day().is_some(),
             self.hour().is_some(),
             self.minute().is_some(),
-            self.second().is_some()
-        ].into_iter().filter(|&x| x).count();
+            self.second().is_some(),
+        ]
+        .into_iter()
+        .filter(|&x| x)
+        .count();
 
         let mut map_ser = serializer.serialize_map(Some(size + 1))?;
         map_ser.serialize_entry("type", "datetime")?;

--- a/crates/typst/src/foundations/datetime.rs
+++ b/crates/typst/src/foundations/datetime.rs
@@ -3,6 +3,8 @@ use std::hash::Hash;
 use std::ops::{Add, Sub};
 
 use ecow::{eco_format, EcoString, EcoVec};
+use serde::{Serialize, Serializer};
+use serde::ser::SerializeMap;
 use time::error::{Format, InvalidFormatDescription};
 use time::macros::format_description;
 use time::{format_description, Month, PrimitiveDateTime};
@@ -462,6 +464,44 @@ impl Repr for Datetime {
             .collect::<EcoVec<_>>();
 
         eco_format!("datetime{}", &repr::pretty_array_like(&filtered, false))
+    }
+}
+
+impl Serialize for Datetime {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let size = [
+            self.year().is_some(),
+            self.month().is_some(),
+            self.day().is_some(),
+            self.hour().is_some(),
+            self.minute().is_some(),
+            self.second().is_some()
+        ].into_iter().filter(|&x| x).count();
+
+        let mut map_ser = serializer.serialize_map(Some(size + 1))?;
+        map_ser.serialize_entry("type", "datetime")?;
+        if let Some(year) = self.year() {
+            map_ser.serialize_entry("year", &year)?;
+        }
+        if let Some(month) = self.month() {
+            map_ser.serialize_entry("month", &month)?;
+        }
+        if let Some(day) = self.day() {
+            map_ser.serialize_entry("day", &day)?;
+        }
+        if let Some(hour) = self.hour() {
+            map_ser.serialize_entry("hour", &hour)?;
+        }
+        if let Some(minute) = self.minute() {
+            map_ser.serialize_entry("minute", &minute)?;
+        }
+        if let Some(second) = self.second() {
+            map_ser.serialize_entry("second", &second)?;
+        }
+        map_ser.end()
     }
 }
 

--- a/crates/typst/src/foundations/duration.rs
+++ b/crates/typst/src/foundations/duration.rs
@@ -2,6 +2,8 @@ use std::fmt::{self, Debug, Formatter};
 use std::ops::{Add, Div, Mul, Neg, Sub};
 
 use ecow::{eco_format, EcoString};
+use serde::ser::SerializeMap;
+use serde::Serialize;
 use time::ext::NumericalDuration;
 
 use crate::foundations::{func, repr, scope, ty, Repr};
@@ -151,6 +153,39 @@ impl Repr for Duration {
         }
 
         eco_format!("duration{}", &repr::pretty_array_like(&vec, false))
+    }
+}
+
+impl Serialize for Duration {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map_ser = serializer.serialize_map(Some(6))?;
+        map_ser.serialize_entry("type", "duration")?;
+
+        let mut tmp = self.0;
+
+        let weeks = tmp.whole_seconds() / 604_800.0 as i64;
+        map_ser.serialize_entry("weeks", &weeks)?;
+        tmp -= weeks.weeks();
+
+        let days = tmp.whole_days();
+        map_ser.serialize_entry("days", &days)?;
+        tmp -= days.days();
+
+        let hours = tmp.whole_hours();
+        map_ser.serialize_entry("hours", &hours)?;
+        tmp -= hours.hours();
+
+        let minutes = tmp.whole_minutes();
+        map_ser.serialize_entry("minutes", &minutes)?;
+        tmp -= minutes.minutes();
+
+        let seconds = tmp.whole_seconds();
+        map_ser.serialize_entry("seconds", &seconds)?;
+
+        map_ser.end()
     }
 }
 

--- a/crates/typst/src/foundations/label.rs
+++ b/crates/typst/src/foundations/label.rs
@@ -1,4 +1,5 @@
 use ecow::{eco_format, EcoString};
+use serde::Serialize;
 
 use crate::foundations::{func, scope, ty, Repr};
 use crate::utils::PicoStr;
@@ -67,6 +68,15 @@ impl Label {
 impl Repr for Label {
     fn repr(&self) -> EcoString {
         eco_format!("<{}>", self.as_str())
+    }
+}
+
+impl Serialize for Label {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_map::<&str, &str, _>(vec![("type", "label"), ("name", self.as_str())])
     }
 }
 

--- a/crates/typst/src/foundations/label.rs
+++ b/crates/typst/src/foundations/label.rs
@@ -76,7 +76,10 @@ impl Serialize for Label {
     where
         S: serde::Serializer,
     {
-        serializer.collect_map::<&str, &str, _>(vec![("type", "label"), ("name", self.as_str())])
+        serializer.collect_map::<&str, &str, _>(vec![
+            ("type", "label"),
+            ("name", self.as_str()),
+        ])
     }
 }
 

--- a/crates/typst/src/foundations/module.rs
+++ b/crates/typst/src/foundations/module.rs
@@ -2,6 +2,8 @@ use std::fmt::{self, Debug, Formatter};
 use std::sync::Arc;
 
 use ecow::{eco_format, EcoString};
+use serde::ser::SerializeMap;
+use serde::Serialize;
 
 use crate::diag::StrResult;
 use crate::foundations::{repr, ty, Content, Scope, Value};
@@ -116,6 +118,18 @@ impl Debug for Module {
 impl repr::Repr for Module {
     fn repr(&self) -> EcoString {
         eco_format!("<module {}>", self.name())
+    }
+}
+
+impl Serialize for Module {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map_ser = serializer.serialize_map(Some(2))?;
+        map_ser.serialize_entry("type", "module")?;
+        map_ser.serialize_entry("name", self.name())?;
+        map_ser.end()
     }
 }
 

--- a/crates/typst/src/foundations/plugin.rs
+++ b/crates/typst/src/foundations/plugin.rs
@@ -318,7 +318,7 @@ impl Serialize for Plugin {
     where
         S: Serializer,
     {
-        serializer.collect_map::<&str, &str, _>(vec![("type", "plugin"),])
+        serializer.collect_map::<&str, &str, _>(vec![("type", "plugin")])
         // Nothing useful here
     }
 }

--- a/crates/typst/src/foundations/plugin.rs
+++ b/crates/typst/src/foundations/plugin.rs
@@ -3,6 +3,7 @@ use std::hash::{Hash, Hasher};
 use std::sync::{Arc, Mutex};
 
 use ecow::{eco_format, EcoString};
+use serde::{Serialize, Serializer};
 use wasmi::{AsContext, AsContextMut};
 
 use crate::diag::{bail, At, SourceResult, StrResult};
@@ -309,6 +310,16 @@ impl Debug for Plugin {
 impl repr::Repr for Plugin {
     fn repr(&self) -> EcoString {
         "plugin(..)".into()
+    }
+}
+
+impl Serialize for Plugin {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_map::<&str, &str, _>(vec![("type", "plugin"),])
+        // Nothing useful here
     }
 }
 

--- a/crates/typst/src/foundations/selector.rs
+++ b/crates/typst/src/foundations/selector.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 
 use comemo::Tracked;
 use ecow::{eco_format, EcoString, EcoVec};
-use serde::{Serialize, Serializer};
 use serde::ser::SerializeMap;
+use serde::{Serialize, Serializer};
 use smallvec::SmallVec;
 
 use crate::diag::{bail, HintedStrResult, StrResult};
@@ -284,15 +284,22 @@ impl Serialize for Selector {
     {
         let size = match self {
             Self::Elem(_, dict) => {
-                if let Some(_) = dict { 4 } else { 3 }
+                if dict.is_some() {
+                    4
+                } else {
+                    3
+                }
             }
             Self::Before { selector: _, end: _, inclusive }
             | Self::After { selector: _, start: _, inclusive } => {
-                if !*inclusive { 5 } else { 4 }
+                if !*inclusive {
+                    5
+                } else {
+                    4
+                }
             }
-            _ => 3
+            _ => 3,
         };
-
 
         let mut map_ser = serializer.serialize_map(Some(size))?;
         map_ser.serialize_entry("type", "selector")?;
@@ -317,9 +324,13 @@ impl Serialize for Selector {
             }
             Self::Label(label) => ser_entries!(("func", "label"), ("label", label)),
             Self::Regex(regex) => ser_entries!(("func", "regex"), ("regex", regex)),
-            Self::Can(cap) => ser_entries!(("func", "can"), ("id", &eco_format!("{cap:?}"))),
+            Self::Can(cap) => {
+                ser_entries!(("func", "can"), ("id", &eco_format!("{cap:?}")))
+            }
             Self::Or(selectors) => ser_entries!(("func", "or"), ("variants", selectors)),
-            Self::And(selectors) => ser_entries!(("func", "and"), ("variants", selectors)),
+            Self::And(selectors) => {
+                ser_entries!(("func", "and"), ("variants", selectors))
+            }
             Self::Location(loc) => ser_entries!(("func", "location"), ("location", loc)),
             Self::Before { selector, end, inclusive } => {
                 ser_entries!(("func", "before"), ("selector", selector), ("end", end));

--- a/crates/typst/src/foundations/str.rs
+++ b/crates/typst/src/foundations/str.rs
@@ -5,7 +5,7 @@ use std::ops::{Add, AddAssign, Deref, Range};
 
 use comemo::Tracked;
 use ecow::EcoString;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::diag::{bail, At, SourceResult, StrResult};
@@ -32,6 +32,7 @@ pub use crate::__format_str as format_str;
 
 #[doc(hidden)]
 pub use ecow::eco_format;
+use serde::ser::SerializeMap;
 
 /// A sequence of Unicode codepoints.
 ///
@@ -895,6 +896,18 @@ impl Deref for Regex {
 impl Repr for Regex {
     fn repr(&self) -> EcoString {
         eco_format!("regex({})", self.0.as_str().repr())
+    }
+}
+
+impl Serialize for Regex {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map_ser = serializer.serialize_map(Some(2))?;
+        map_ser.serialize_entry("type", "regex")?;
+        map_ser.serialize_entry("regex", self.0.as_str())?;
+        map_ser.end()
     }
 }
 

--- a/crates/typst/src/foundations/ty.rs
+++ b/crates/typst/src/foundations/ty.rs
@@ -160,7 +160,7 @@ impl Serialize for Type {
     {
         let mut map_ser = serializer.serialize_map(Some(2))?;
         map_ser.serialize_entry("type", "type")?;
-        map_ser.serialize_entry("name", self.long_name())?;
+        map_ser.serialize_entry("name", self.short_name())?;
         map_ser.end()
     }
 }

--- a/crates/typst/src/foundations/ty.rs
+++ b/crates/typst/src/foundations/ty.rs
@@ -3,7 +3,8 @@ use std::fmt::{self, Debug, Display, Formatter};
 
 use ecow::{eco_format, EcoString};
 use once_cell::sync::Lazy;
-
+use serde::ser::SerializeMap;
+use serde::Serialize;
 use crate::diag::StrResult;
 use crate::foundations::{cast, func, Func, NativeFuncData, Repr, Scope, Value};
 use crate::utils::Static;
@@ -149,6 +150,18 @@ impl Debug for Type {
 impl Repr for Type {
     fn repr(&self) -> EcoString {
         self.long_name().into()
+    }
+}
+
+impl Serialize for Type {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map_ser = serializer.serialize_map(Some(2))?;
+        map_ser.serialize_entry("type", "type")?;
+        map_ser.serialize_entry("name", self.long_name())?;
+        map_ser.end()
     }
 }
 

--- a/crates/typst/src/foundations/ty.rs
+++ b/crates/typst/src/foundations/ty.rs
@@ -1,13 +1,13 @@
 use std::cmp::Ordering;
 use std::fmt::{self, Debug, Display, Formatter};
 
+use crate::diag::StrResult;
+use crate::foundations::{cast, func, Func, NativeFuncData, Repr, Scope, Value};
+use crate::utils::Static;
 use ecow::{eco_format, EcoString};
 use once_cell::sync::Lazy;
 use serde::ser::SerializeMap;
 use serde::Serialize;
-use crate::diag::StrResult;
-use crate::foundations::{cast, func, Func, NativeFuncData, Repr, Scope, Value};
-use crate::utils::Static;
 
 #[rustfmt::skip]
 #[doc(inline)]

--- a/crates/typst/src/foundations/value.rs
+++ b/crates/typst/src/foundations/value.rs
@@ -5,10 +5,10 @@ use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use ecow::{eco_format, EcoString};
+use erased_serde::Serialize as ErasedSerialize;
 use serde::de::value::{MapAccessDeserializer, SeqAccessDeserializer};
 use serde::de::{Error, MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use erased_serde::Serialize as ErasedSerialize;
 
 use crate::diag::{HintedStrResult, HintedString, StrResult};
 use crate::eval::ops;
@@ -94,7 +94,15 @@ impl Value {
     /// Create a new dynamic value.
     pub fn dynamic<T>(any: T) -> Self
     where
-        T: Debug + Repr + NativeType + PartialEq + Hash + ErasedSerialize + Sync + Send + 'static,
+        T: Debug
+            + Repr
+            + NativeType
+            + PartialEq
+            + Hash
+            + ErasedSerialize
+            + Sync
+            + Send
+            + 'static,
     {
         Self::Dyn(Dynamic::new(any))
     }
@@ -520,7 +528,15 @@ impl Dynamic {
     /// Create a new instance from any value that satisfies the required bounds.
     pub fn new<T>(any: T) -> Self
     where
-        T: Debug + Repr + NativeType + PartialEq + Hash + ErasedSerialize + Sync + Send + 'static,
+        T: Debug
+            + Repr
+            + NativeType
+            + PartialEq
+            + Hash
+            + ErasedSerialize
+            + Sync
+            + Send
+            + 'static,
     {
         Self(Arc::new(any))
     }
@@ -553,7 +569,7 @@ impl Repr for Dynamic {
     }
 }
 
-impl<'a> Serialize for dyn Bounds {
+impl Serialize for dyn Bounds {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -577,7 +593,15 @@ trait Bounds: Debug + Repr + ErasedSerialize + Sync + Send + 'static {
 
 impl<T> Bounds for T
 where
-    T: Debug + Repr + NativeType + PartialEq + Hash + ErasedSerialize + Sync + Send + 'static,
+    T: Debug
+        + Repr
+        + NativeType
+        + PartialEq
+        + Hash
+        + ErasedSerialize
+        + Sync
+        + Send
+        + 'static,
 {
     fn as_any(&self) -> &dyn Any {
         self

--- a/crates/typst/src/foundations/value.rs
+++ b/crates/typst/src/foundations/value.rs
@@ -8,6 +8,7 @@ use ecow::{eco_format, EcoString};
 use serde::de::value::{MapAccessDeserializer, SeqAccessDeserializer};
 use serde::de::{Error, MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use erased_serde::Serialize as ErasedSerialize;
 
 use crate::diag::{HintedStrResult, HintedString, StrResult};
 use crate::eval::ops;
@@ -93,7 +94,7 @@ impl Value {
     /// Create a new dynamic value.
     pub fn dynamic<T>(any: T) -> Self
     where
-        T: Debug + Repr + NativeType + PartialEq + Hash + Sync + Send + 'static,
+        T: Debug + Repr + NativeType + PartialEq + Hash + ErasedSerialize + Sync + Send + 'static,
     {
         Self::Dyn(Dynamic::new(any))
     }
@@ -357,17 +358,35 @@ impl Serialize for Value {
     {
         match self {
             Self::None => NoneValue.serialize(serializer),
+            Self::Auto => AutoValue.serialize(serializer),
             Self::Bool(v) => v.serialize(serializer),
             Self::Int(v) => v.serialize(serializer),
             Self::Float(v) => v.serialize(serializer),
+            Self::Length(v) => v.serialize(serializer),
+            Self::Angle(v) => v.serialize(serializer),
+            Self::Ratio(v) => v.serialize(serializer),
+            Self::Relative(v) => v.serialize(serializer),
+            Self::Fraction(v) => v.serialize(serializer),
+            Self::Color(v) => v.serialize(serializer),
+            Self::Gradient(v) => v.serialize(serializer),
+            Self::Pattern(v) => v.serialize(serializer),
+            Self::Symbol(v) => v.serialize(serializer),
+            Self::Version(v) => v.serialize(serializer),
             Self::Str(v) => v.serialize(serializer),
             Self::Bytes(v) => v.serialize(serializer),
-            Self::Symbol(v) => v.serialize(serializer),
+            Self::Label(v) => v.serialize(serializer),
+            Self::Datetime(v) => v.serialize(serializer),
+            Self::Duration(v) => v.serialize(serializer),
             Self::Content(v) => v.serialize(serializer),
             Self::Array(v) => v.serialize(serializer),
             Self::Dict(v) => v.serialize(serializer),
+            Self::Args(v) => v.serialize(serializer),
+            Self::Type(v) => v.serialize(serializer),
+            Self::Module(v) => v.serialize(serializer),
+            Self::Plugin(v) => v.serialize(serializer),
+            Self::Dyn(v) => v.serialize(serializer),
 
-            // Fall back to repr() for other things.
+            // Fall back to repr() for Styles and Func.
             other => serializer.serialize_str(&other.repr()),
         }
     }
@@ -493,7 +512,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
 }
 
 /// A value that is not part of the built-in enum.
-#[derive(Clone, Hash)]
+#[derive(Clone, Hash, Serialize)]
 #[allow(clippy::derived_hash_with_manual_eq)]
 pub struct Dynamic(Arc<dyn Bounds>);
 
@@ -501,7 +520,7 @@ impl Dynamic {
     /// Create a new instance from any value that satisfies the required bounds.
     pub fn new<T>(any: T) -> Self
     where
-        T: Debug + Repr + NativeType + PartialEq + Hash + Sync + Send + 'static,
+        T: Debug + Repr + NativeType + PartialEq + Hash + ErasedSerialize + Sync + Send + 'static,
     {
         Self(Arc::new(any))
     }
@@ -534,13 +553,22 @@ impl Repr for Dynamic {
     }
 }
 
+impl<'a> Serialize for dyn Bounds {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        erased_serde::serialize(self, serializer)
+    }
+}
+
 impl PartialEq for Dynamic {
     fn eq(&self, other: &Self) -> bool {
         self.0.dyn_eq(other)
     }
 }
 
-trait Bounds: Debug + Repr + Sync + Send + 'static {
+trait Bounds: Debug + Repr + ErasedSerialize + Sync + Send + 'static {
     fn as_any(&self) -> &dyn Any;
     fn dyn_eq(&self, other: &Dynamic) -> bool;
     fn dyn_ty(&self) -> Type;
@@ -549,7 +577,7 @@ trait Bounds: Debug + Repr + Sync + Send + 'static {
 
 impl<T> Bounds for T
 where
-    T: Debug + Repr + NativeType + PartialEq + Hash + Sync + Send + 'static,
+    T: Debug + Repr + NativeType + PartialEq + Hash + ErasedSerialize + Sync + Send + 'static,
 {
     fn as_any(&self) -> &dyn Any {
         self

--- a/crates/typst/src/foundations/version.rs
+++ b/crates/typst/src/foundations/version.rs
@@ -3,11 +3,11 @@ use std::fmt::{self, Display, Formatter, Write};
 use std::hash::Hash;
 use std::iter::repeat;
 
+use crate::diag::{bail, StrResult};
+use crate::foundations::{cast, func, repr, scope, ty, Repr};
 use ecow::{eco_format, EcoString, EcoVec};
 use serde::ser::SerializeMap;
 use serde::Serialize;
-use crate::diag::{bail, StrResult};
-use crate::foundations::{cast, func, repr, scope, ty, Repr};
 
 /// A version with an arbitrary number of components.
 ///

--- a/crates/typst/src/foundations/version.rs
+++ b/crates/typst/src/foundations/version.rs
@@ -4,7 +4,8 @@ use std::hash::Hash;
 use std::iter::repeat;
 
 use ecow::{eco_format, EcoString, EcoVec};
-
+use serde::ser::SerializeMap;
+use serde::Serialize;
 use crate::diag::{bail, StrResult};
 use crate::foundations::{cast, func, repr, scope, ty, Repr};
 
@@ -186,6 +187,18 @@ impl Repr for Version {
     fn repr(&self) -> EcoString {
         let parts: Vec<_> = self.0.iter().map(|v| eco_format!("{v}")).collect();
         eco_format!("version{}", &repr::pretty_array_like(&parts, false))
+    }
+}
+
+impl Serialize for Version {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map_ser = serializer.serialize_map(Some(2))?;
+        map_ser.serialize_entry("type", "version")?;
+        map_ser.serialize_entry("value", &self.0)?;
+        map_ser.end()
     }
 }
 

--- a/crates/typst/src/introspection/counter.rs
+++ b/crates/typst/src/introspection/counter.rs
@@ -3,8 +3,8 @@ use std::str::FromStr;
 
 use comemo::{Track, Tracked, TrackedMut};
 use ecow::{eco_format, eco_vec, EcoString, EcoVec};
-use serde::{Serialize, Serializer};
 use serde::ser::SerializeMap;
+use serde::{Serialize, Serializer};
 use smallvec::{smallvec, SmallVec};
 
 use crate::diag::{bail, At, HintedStrResult, SourceResult};
@@ -633,7 +633,8 @@ impl Serialize for CounterKey {
     where
         S: Serializer,
     {
-        let mut map_serializer = serializer.serialize_map(Some(if matches!(self, Self::Page) { 2 } else { 3 }))?;
+        let mut map_serializer = serializer
+            .serialize_map(Some(if matches!(self, Self::Page) { 2 } else { 3 }))?;
         map_serializer.serialize_entry("type", "counter-key")?;
         match self {
             Self::Page => {

--- a/crates/typst/src/introspection/location.rs
+++ b/crates/typst/src/introspection/location.rs
@@ -2,6 +2,7 @@ use std::fmt::{self, Debug, Formatter};
 use std::num::NonZeroUsize;
 
 use ecow::EcoString;
+use serde::{Serialize, Serializer};
 
 use crate::engine::Engine;
 use crate::foundations::{func, scope, ty, Repr};
@@ -102,6 +103,15 @@ impl Debug for Location {
 impl Repr for Location {
     fn repr(&self) -> EcoString {
         "..".into()
+    }
+}
+
+impl Serialize for Location {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer
+    {
+        serializer.serialize_str(&self.repr())
     }
 }
 

--- a/crates/typst/src/introspection/location.rs
+++ b/crates/typst/src/introspection/location.rs
@@ -109,7 +109,7 @@ impl Repr for Location {
 impl Serialize for Location {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer
+        S: Serializer,
     {
         serializer.serialize_str(&self.repr())
     }

--- a/crates/typst/src/introspection/state.rs
+++ b/crates/typst/src/introspection/state.rs
@@ -1,7 +1,7 @@
 use comemo::{Track, Tracked, TrackedMut};
 use ecow::{eco_format, eco_vec, EcoString, EcoVec};
-use serde::{Serialize, Serializer};
 use serde::ser::SerializeMap;
+use serde::{Serialize, Serializer};
 
 use crate::diag::{bail, At, SourceResult};
 use crate::engine::{Engine, Route, Sink, Traced};
@@ -388,7 +388,7 @@ impl Repr for State {
 impl Serialize for State {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer
+        S: Serializer,
     {
         let mut map_ser = serializer.serialize_map(Some(3))?;
         map_ser.serialize_entry("type", "state")?;

--- a/crates/typst/src/introspection/state.rs
+++ b/crates/typst/src/introspection/state.rs
@@ -1,5 +1,7 @@
 use comemo::{Track, Tracked, TrackedMut};
 use ecow::{eco_format, eco_vec, EcoString, EcoVec};
+use serde::{Serialize, Serializer};
+use serde::ser::SerializeMap;
 
 use crate::diag::{bail, At, SourceResult};
 use crate::engine::{Engine, Route, Sink, Traced};
@@ -380,6 +382,19 @@ impl State {
 impl Repr for State {
     fn repr(&self) -> EcoString {
         eco_format!("state({}, {})", self.key.repr(), self.init.repr())
+    }
+}
+
+impl Serialize for State {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer
+    {
+        let mut map_ser = serializer.serialize_map(Some(3))?;
+        map_ser.serialize_entry("type", "state")?;
+        map_ser.serialize_entry("key", &self.key)?;
+        map_ser.serialize_entry("init", &self.init)?;
+        map_ser.end()
     }
 }
 

--- a/crates/typst/src/layout/abs.rs
+++ b/crates/typst/src/layout/abs.rs
@@ -3,6 +3,8 @@ use std::iter::Sum;
 use std::ops::{Add, Div, Mul, Neg, Rem};
 
 use ecow::EcoString;
+use serde::ser::SerializeMap;
+use serde::Serialize;
 
 use crate::foundations::{cast, repr, Fold, Repr, Value};
 use crate::utils::{Numeric, Scalar};
@@ -151,6 +153,18 @@ impl Debug for Abs {
 impl Repr for Abs {
     fn repr(&self) -> EcoString {
         repr::format_float_with_unit(self.to_pt(), "pt")
+    }
+}
+
+impl Serialize for Abs {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map_ser = serializer.serialize_map(Some(2))?;
+        map_ser.serialize_entry("type", "length")?;
+        map_ser.serialize_entry("pts", &self.to_pt())?;
+        map_ser.end()
     }
 }
 

--- a/crates/typst/src/layout/abs.rs
+++ b/crates/typst/src/layout/abs.rs
@@ -163,7 +163,7 @@ impl Serialize for Abs {
     {
         let mut map_ser = serializer.serialize_map(Some(2))?;
         map_ser.serialize_entry("type", "length")?;
-        map_ser.serialize_entry("pts", &self.to_pt())?;
+        map_ser.serialize_entry("pt", &self.to_pt())?;
         map_ser.end()
     }
 }

--- a/crates/typst/src/layout/angle.rs
+++ b/crates/typst/src/layout/angle.rs
@@ -4,6 +4,8 @@ use std::iter::Sum;
 use std::ops::{Add, Div, Mul, Neg};
 
 use ecow::EcoString;
+use serde::ser::SerializeMap;
+use serde::Serialize;
 
 use crate::foundations::{func, repr, scope, ty, Repr};
 use crate::utils::{Numeric, Scalar};
@@ -138,6 +140,19 @@ impl Repr for Angle {
         repr::format_float_with_unit(self.to_deg(), "deg")
     }
 }
+
+impl Serialize for Angle {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map_ser = serializer.serialize_map(Some(2))?;
+        map_ser.serialize_entry("type", "angle")?;
+        map_ser.serialize_entry("deg", &self.to_deg())?;
+        map_ser.end()
+    }
+}
+
 
 impl Neg for Angle {
     type Output = Self;

--- a/crates/typst/src/layout/angle.rs
+++ b/crates/typst/src/layout/angle.rs
@@ -153,7 +153,6 @@ impl Serialize for Angle {
     }
 }
 
-
 impl Neg for Angle {
     type Output = Self;
 

--- a/crates/typst/src/layout/axes.rs
+++ b/crates/typst/src/layout/axes.rs
@@ -204,7 +204,9 @@ cast! {
 
 impl<T: Serialize> Serialize for Axes<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where S: Serializer {
+    where
+        S: Serializer,
+    {
         serializer.collect_seq(&[&self.x, &self.y])
     }
 }

--- a/crates/typst/src/layout/axes.rs
+++ b/crates/typst/src/layout/axes.rs
@@ -2,6 +2,8 @@ use std::any::Any;
 use std::fmt::{self, Debug, Formatter};
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, Deref, Not};
 
+use serde::{Serialize, Serializer};
+
 use crate::diag::bail;
 use crate::foundations::{array, cast, Array, Resolve, Smart, StyleChain};
 use crate::layout::{Abs, Dir, Length, Ratio, Rel, Size};
@@ -198,6 +200,13 @@ cast! {
     },
     "horizontal" => Self::X,
     "vertical" => Self::Y,
+}
+
+impl<T: Serialize> Serialize for Axes<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where S: Serializer {
+        serializer.collect_seq(&[&self.x, &self.y])
+    }
 }
 
 impl<T> Axes<Smart<T>> {

--- a/crates/typst/src/layout/dir.rs
+++ b/crates/typst/src/layout/dir.rs
@@ -1,5 +1,6 @@
 use ecow::EcoString;
-
+use serde::ser::SerializeMap;
+use serde::Serialize;
 use crate::foundations::{func, scope, ty, Repr};
 use crate::layout::{Axis, Side};
 
@@ -130,3 +131,16 @@ impl Repr for Dir {
         }
     }
 }
+
+impl Serialize for Dir {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map_ser = serializer.serialize_map(Some(2))?;
+        map_ser.serialize_entry("type", "direction")?;
+        map_ser.serialize_entry("value", &self.repr())?;
+        map_ser.end()
+    }
+}
+

--- a/crates/typst/src/layout/dir.rs
+++ b/crates/typst/src/layout/dir.rs
@@ -1,8 +1,8 @@
+use crate::foundations::{func, scope, ty, Repr};
+use crate::layout::{Axis, Side};
 use ecow::EcoString;
 use serde::ser::SerializeMap;
 use serde::Serialize;
-use crate::foundations::{func, scope, ty, Repr};
-use crate::layout::{Axis, Side};
 
 /// The four directions into which content can be laid out.
 ///
@@ -143,4 +143,3 @@ impl Serialize for Dir {
         map_ser.end()
     }
 }
-

--- a/crates/typst/src/layout/fr.rs
+++ b/crates/typst/src/layout/fr.rs
@@ -3,6 +3,8 @@ use std::iter::Sum;
 use std::ops::{Add, Div, Mul, Neg};
 
 use ecow::EcoString;
+use serde::ser::SerializeMap;
+use serde::Serialize;
 
 use crate::foundations::{repr, ty, Repr};
 use crate::layout::Abs;
@@ -80,6 +82,18 @@ impl Debug for Fr {
 impl Repr for Fr {
     fn repr(&self) -> EcoString {
         repr::format_float_with_unit(self.get(), "fr")
+    }
+}
+
+impl Serialize for Fr {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map_ser = serializer.serialize_map(Some(2))?;
+        map_ser.serialize_entry("type", "fraction")?;
+        map_ser.serialize_entry("value", &self.get())?;
+        map_ser.end()
     }
 }
 

--- a/crates/typst/src/layout/length.rs
+++ b/crates/typst/src/layout/length.rs
@@ -4,6 +4,8 @@ use std::ops::{Add, Div, Mul, Neg};
 
 use comemo::Tracked;
 use ecow::{eco_format, EcoString};
+use serde::ser::SerializeMap;
+use serde::Serialize;
 
 use crate::diag::{At, Hint, HintedStrResult, SourceResult};
 use crate::foundations::{func, scope, ty, Context, Fold, Repr, Resolve, StyleChain};
@@ -174,6 +176,19 @@ impl Repr for Length {
             (true, false) => self.em.repr(),
             (_, true) => self.abs.repr(),
         }
+    }
+}
+
+impl Serialize for Length {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map_ser = serializer.serialize_map(Some(3))?;
+        map_ser.serialize_entry("type", "length")?;
+        map_ser.serialize_entry("pt", &self.abs.to_pt())?;
+        map_ser.serialize_entry("em", &self.em.get())?;
+        map_ser.end()
     }
 }
 

--- a/crates/typst/src/layout/ratio.rs
+++ b/crates/typst/src/layout/ratio.rs
@@ -2,6 +2,8 @@ use std::fmt::{self, Debug, Formatter};
 use std::ops::{Add, Div, Mul, Neg};
 
 use ecow::EcoString;
+use serde::ser::SerializeMap;
+use serde::Serialize;
 
 use crate::foundations::{repr, ty, Repr};
 use crate::utils::{Numeric, Scalar};
@@ -77,6 +79,18 @@ impl Debug for Ratio {
 impl Repr for Ratio {
     fn repr(&self) -> EcoString {
         repr::format_float_with_unit(self.get() * 100.0, "%")
+    }
+}
+
+impl Serialize for Ratio {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map_ser = serializer.serialize_map(Some(2))?;
+        map_ser.serialize_entry("type", "ratio")?;
+        map_ser.serialize_entry("value", &self.get())?;
+        map_ser.end()
     }
 }
 

--- a/crates/typst/src/layout/rel.rs
+++ b/crates/typst/src/layout/rel.rs
@@ -3,6 +3,8 @@ use std::fmt::{self, Debug, Formatter};
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use ecow::{eco_format, EcoString};
+use serde::ser::SerializeMap;
+use serde::Serialize;
 
 use crate::foundations::{cast, ty, Fold, Repr, Resolve, StyleChain};
 use crate::layout::{Abs, Em, Length, Ratio};
@@ -101,6 +103,19 @@ impl<T: Numeric + Debug> Debug for Rel<T> {
 impl<T: Numeric + Repr> Repr for Rel<T> {
     fn repr(&self) -> EcoString {
         eco_format!("{} + {}", self.rel.repr(), self.abs.repr())
+    }
+}
+
+impl<T: Numeric + Serialize> Serialize for Rel<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map_ser = serializer.serialize_map(Some(3))?;
+        map_ser.serialize_entry("type", "relative")?;
+        map_ser.serialize_entry("rel", &self.rel)?;
+        map_ser.serialize_entry("abs", &self.abs)?;
+        map_ser.end()
     }
 }
 

--- a/crates/typst/src/model/bibliography.rs
+++ b/crates/typst/src/model/bibliography.rs
@@ -16,6 +16,7 @@ use hayagriva::{
 };
 use indexmap::IndexMap;
 use once_cell::sync::Lazy;
+use serde::{Serialize, Serializer};
 use smallvec::{smallvec, SmallVec};
 use typed_arena::Arena;
 
@@ -531,6 +532,15 @@ impl Repr for CslStyle {
             .as_ref()
             .map(|name| name.repr())
             .unwrap_or_else(|| "..".into())
+    }
+}
+
+impl Serialize for CslStyle {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer
+    {
+        serializer.serialize_str(&self.repr())
     }
 }
 

--- a/crates/typst/src/model/bibliography.rs
+++ b/crates/typst/src/model/bibliography.rs
@@ -538,7 +538,7 @@ impl Repr for CslStyle {
 impl Serialize for CslStyle {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer
+        S: Serializer,
     {
         serializer.serialize_str(&self.repr())
     }

--- a/crates/typst/src/visualize/color.rs
+++ b/crates/typst/src/visualize/color.rs
@@ -9,8 +9,8 @@ use palette::{
     Alpha, Darken, Desaturate, FromColor, Lighten, OklabHue, RgbHue, Saturate, ShiftHue,
 };
 use qcms::Profile;
-use serde::{Serialize, Serializer};
 use serde::ser::SerializeMap;
+use serde::{Serialize, Serializer};
 
 use crate::diag::{bail, At, SourceResult, StrResult};
 use crate::foundations::{
@@ -1578,10 +1578,11 @@ impl Repr for Color {
     }
 }
 
-
 impl Serialize for Color {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where S: Serializer {
+    where
+        S: Serializer,
+    {
         let components = match self {
             Self::Luma(c) => 1 + if c.alpha != 1.0 { 1 } else { 0 },
             Self::Oklab(c) => 3 + if c.alpha != 1.0 { 1 } else { 0 },
@@ -1643,7 +1644,8 @@ impl Serialize for Color {
             Self::Hsl(c) => {
                 map_ser.serialize_entry("func", "hsl")?;
                 map_ser.serialize_entry("hue", &hue_angle(c.hue.into_degrees()))?;
-                map_ser.serialize_entry("saturation", &Ratio::new(c.saturation.into()))?;
+                map_ser
+                    .serialize_entry("saturation", &Ratio::new(c.saturation.into()))?;
                 map_ser.serialize_entry("lightness", &Ratio::new(c.lightness.into()))?;
                 if c.alpha != 1.0 {
                     map_ser.serialize_entry("alpha", &Ratio::new(c.alpha.into()))?;
@@ -1652,7 +1654,8 @@ impl Serialize for Color {
             Self::Hsv(c) => {
                 map_ser.serialize_entry("func", "hsv")?;
                 map_ser.serialize_entry("hue", &hue_angle(c.hue.into_degrees()))?;
-                map_ser.serialize_entry("saturation", &Ratio::new(c.saturation.into()))?;
+                map_ser
+                    .serialize_entry("saturation", &Ratio::new(c.saturation.into()))?;
                 map_ser.serialize_entry("value", &Ratio::new(c.value.into()))?;
                 if c.alpha != 1.0 {
                     map_ser.serialize_entry("alpha", &Ratio::new(c.alpha.into()))?;

--- a/crates/typst/src/visualize/gradient.rs
+++ b/crates/typst/src/visualize/gradient.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 
 use ecow::EcoString;
 use kurbo::Vec2;
-use serde::{Serialize, Serializer};
 use serde::ser::SerializeMap;
+use serde::{Serialize, Serializer};
 
 use crate::diag::{bail, SourceResult};
 use crate::foundations::{
@@ -1058,7 +1058,9 @@ impl Repr for RadialGradient {
 
 impl Serialize for RadialGradient {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where S: Serializer {
+    where
+        S: Serializer,
+    {
         let mut map_ser = serializer.serialize_map(Some(8))?;
         map_ser.serialize_entry("type", "gradient")?;
         map_ser.serialize_entry("func", "radial")?;
@@ -1140,7 +1142,9 @@ impl Repr for ConicGradient {
 
 impl Serialize for ConicGradient {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where S: Serializer {
+    where
+        S: Serializer,
+    {
         let mut map_ser = serializer.serialize_map(Some(7))?;
         map_ser.serialize_entry("type", "gradient")?;
         map_ser.serialize_entry("func", "conic")?;

--- a/crates/typst/src/visualize/paint.rs
+++ b/crates/typst/src/visualize/paint.rs
@@ -1,6 +1,7 @@
 use std::fmt::{self, Debug, Formatter};
 
 use ecow::EcoString;
+use serde::Serialize;
 
 use crate::foundations::{cast, Repr, Smart};
 use crate::visualize::{Color, Gradient, Pattern, RelativeTo};
@@ -73,6 +74,19 @@ impl Repr for Paint {
             Self::Solid(color) => color.repr(),
             Self::Gradient(gradient) => gradient.repr(),
             Self::Pattern(pattern) => pattern.repr(),
+        }
+    }
+}
+
+impl Serialize for Paint {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Solid(color) => color.serialize(serializer),
+            Self::Gradient(gradient) => gradient.serialize(serializer),
+            Self::Pattern(pattern) => pattern.serialize(serializer),
         }
     }
 }

--- a/crates/typst/src/visualize/pattern.rs
+++ b/crates/typst/src/visualize/pattern.rs
@@ -2,8 +2,8 @@ use std::hash::Hash;
 use std::sync::Arc;
 
 use ecow::{eco_format, EcoString};
-use serde::{Serialize, Serializer};
 use serde::ser::SerializeMap;
+use serde::{Serialize, Serializer};
 
 use crate::diag::{bail, SourceResult};
 use crate::engine::Engine;
@@ -286,7 +286,10 @@ impl repr::Repr for Pattern {
 }
 
 impl Serialize for Pattern {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
         let size = 3 + if matches!(self.0.relative, Smart::Custom(_)) { 1 } else { 0 };
         let mut map_ser = serializer.serialize_map(Some(size))?;
         map_ser.serialize_entry("type", "pattern")?;

--- a/crates/typst/src/visualize/stroke.rs
+++ b/crates/typst/src/visualize/stroke.rs
@@ -1,6 +1,3 @@
-use ecow::EcoString;
-use serde::{Serialize, Serializer};
-use serde::ser::SerializeMap;
 use crate::diag::{HintedStrResult, SourceResult};
 use crate::foundations::{
     cast, dict, func, scope, ty, Args, Cast, Dict, Fold, FromValue, NoneValue, Repr,
@@ -9,6 +6,9 @@ use crate::foundations::{
 use crate::layout::{Abs, Length};
 use crate::utils::{Numeric, Scalar};
 use crate::visualize::{Color, Gradient, Paint, Pattern};
+use ecow::EcoString;
+use serde::ser::SerializeMap;
+use serde::{Serialize, Serializer};
 
 /// Defines how to draw a line.
 ///
@@ -334,7 +334,8 @@ impl<T: Numeric + Repr> Repr for Stroke<T> {
 impl<T: Numeric + Serialize> Serialize for Stroke<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer {
+        S: Serializer,
+    {
         let Self { paint, thickness, cap, join, dash, miter_limit } = &self;
 
         let size = [
@@ -344,7 +345,11 @@ impl<T: Numeric + Serialize> Serialize for Stroke<T> {
             matches!(&join, Smart::Custom(_)),
             matches!(&dash, Smart::Custom(_)),
             matches!(&miter_limit, Smart::Custom(_)),
-        ].iter().filter(|it| **it).count() + 1;
+        ]
+        .iter()
+        .filter(|it| **it)
+        .count()
+            + 1;
         let mut map_ser = serializer.serialize_map(Some(size))?;
         map_ser.serialize_entry("type", "stroke")?;
         if let Smart::Custom(paint) = &paint {
@@ -520,7 +525,10 @@ impl<T: Numeric + Repr, DT: Repr> Repr for DashPattern<T, DT> {
 }
 
 impl<T: Numeric + Serialize, DT: Serialize> Serialize for DashPattern<T, DT> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
         let mut map_ser = serializer.serialize_map(Some(2))?;
         // Don't serialize type, this is represented with just a Dict
         map_ser.serialize_entry("array", &self.array)?;
@@ -602,7 +610,10 @@ impl<T: Numeric + Repr> Repr for DashLength<T> {
 }
 
 impl<T: Numeric + Serialize> Serialize for DashLength<T> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
         match self {
             DashLength::LineWidth => serializer.serialize_str("dot"),
             DashLength::Length(v) => v.serialize(serializer),


### PR DESCRIPTION
Pretty much described in the issue (https://github.com/typst/typst/issues/3585). What is done:

- implemented `Serialize` for `Args`, `Auto`, `Datetime`, `Duration`, `Label`, `Selector`, `Regex`, `Type`, `Version`, `Counter`, `State`, `Abs`, `Align`, `Angle`, `Axes`, `Dir`, `Fr`, `Length`, `Ratio`, `Rel`, `Color`, `Gradient`, `Paint`, `Stroke`. The resulting way of serialization is as in the file I attached (the result of `query "<a>" --pretty` on typ file)
[serialization-test.txt](https://github.com/user-attachments/files/16029333/serialization-test.txt)
(Github doesn't seem to support attaching .typ)
[otuput.json](https://github.com/user-attachments/files/16029338/otuput.json)

- added stubs for types `Module`, `Plugin`, `Location`, `CslStyle`, `Pattern`. 
- added `erased_serde::Serialize` to `Bounds` for `Value::Dyn` to dispatch serialization of dynamic values.

