### PR TITLE
Add `--fill-transparent` option

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -109,6 +109,11 @@ pub struct CompileCommand {
     #[arg(long = "ppi", default_value_t = 144.0)]
     pub ppi: f32,
 
+    /// Don't fill the background with white below everything else
+    /// (only applies to PNG export).
+    #[arg(long = "fill-transparent")]
+    pub fill_transparent: bool,
+
     /// Produces performance timings of the compilation process (experimental)
     ///
     /// The resulting JSON file can be loaded into a tracing tool such as

--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -330,7 +330,9 @@ fn export_image_page(
 ) -> StrResult<()> {
     match fmt {
         ImageExportFormat::Png => {
-            let pixmap = typst_render::render(frame, command.ppi / 72.0, Color::WHITE);
+            let bg =
+                if command.fill_transparent { Color::TRANSPARENT } else { Color::WHITE };
+            let pixmap = typst_render::render(frame, command.ppi / 72.0, bg);
             let buf = pixmap
                 .encode_png()
                 .map_err(|err| eco_format!("failed to encode PNG file ({err})"))?;

--- a/crates/typst/src/visualize/color.rs
+++ b/crates/typst/src/visualize/color.rs
@@ -217,6 +217,7 @@ impl Color {
         MODULE.clone()
     };
 
+    pub const TRANSPARENT: Self = Self::Luma(Luma::new(0.0, 0.0));
     pub const BLACK: Self = Self::Luma(Luma::new(0.0, 1.0));
     pub const GRAY: Self = Self::Luma(Luma::new(0.6666666, 1.0));
     pub const WHITE: Self = Self::Luma(Luma::new(1.0, 1.0));


### PR DESCRIPTION
This PR adds a simple switch `--fill-transparent` (name to be bikeshed) to `typst compile` that changes the background to be transparent instead of white.

I don't see a reason why typst shouldn't be able to generate PNGs with a transparent background.

Cf. https://github.com/typst/typst/discussions/3914#discussioncomment-9076050