### PR TITLE
Add horizonal fractions

### DIFF
--- a/crates/typst/src/math/lr.rs
+++ b/crates/typst/src/math/lr.rs
@@ -251,7 +251,7 @@ pub fn norm(
     delimited(body, '‖', '‖', size)
 }
 
-fn delimited(
+pub(crate) fn delimited(
     body: Content,
     left: char,
     right: char,


### PR DESCRIPTION
- Add a `horizontal` parameter, which will layout fractions horizontally.
- Automatically surround the numerator/denominator with bracktes if they contain multiple elements
- Add `bracket-horizontal` (name could be changed) in order to switch off the behavior above, or force numerator and denominator to always be delimited

I'm not sure whether the way multiple elements are detected is the best way (or works in all expected cases). 
I'm also open to adding a way to support switching to horizontal mode if the math size would be to high otherwise (see https://discord.com/channels/1054443721975922748/1088371867913572452/1256637712182542377). 
Though that may be better in a separate pr.

