### PR TITLE
Conversion from int to bytes and back

### DIFF
--- a/crates/typst/src/foundations/int.rs
+++ b/crates/typst/src/foundations/int.rs
@@ -1,5 +1,6 @@
-use ecow::{eco_format, EcoString};
 use std::num::{NonZeroI64, NonZeroIsize, NonZeroU64, NonZeroUsize, ParseIntError};
+
+use ecow::{eco_format, EcoString};
 
 use crate::diag::StrResult;
 use crate::foundations::{cast, func, repr, scope, ty, Bytes, Repr, Str, Value};

--- a/crates/typst/src/foundations/int.rs
+++ b/crates/typst/src/foundations/int.rs
@@ -218,6 +218,7 @@ impl i64 {
     /// The bytes should be at most 8 bytes (64 bits) in size to fit in a 64-bit integer, otherwise an error will occur.
     ///
     /// If the signed parameter is true and the most significant bit is set,
+    /// the number will be treated as negative, filling the remaining bytes with 0xFF (two's complement).
     ///
     /// ```example
     /// #int.from-bytes(bytes((0, 0, 0, 0, 0, 0, 0, 1)))

--- a/crates/typst/src/foundations/int.rs
+++ b/crates/typst/src/foundations/int.rs
@@ -216,8 +216,11 @@ impl i64 {
     }
 
     /// Converts bytes to an integer.
-    ///
     /// Bytes should be 8 bytes (64 bits) in size.
+    /// 
+    /// ```example
+    /// #int.from-bytes(bytes((0, 0, 0, 0, 0, 0, 0, 1)), "little")
+    /// ```
     #[func]
     pub fn from_bytes(
         /// The bytes that should be converted to an integer.
@@ -237,6 +240,10 @@ impl i64 {
 
     /// Converts an integer to bytes.
     /// The integer is converted to 8 bytes or 64 bits in size.
+    /// 
+    /// ```example
+    /// #array(10000.to-bytes("big"))
+    /// ```
     #[func]
     pub fn to_bytes(
         self,

--- a/crates/typst/src/foundations/int.rs
+++ b/crates/typst/src/foundations/int.rs
@@ -1,6 +1,5 @@
-use std::num::{NonZeroI64, NonZeroIsize, NonZeroU64, NonZeroUsize, ParseIntError};
-
 use ecow::{eco_format, EcoString};
+use std::num::{NonZeroI64, NonZeroIsize, NonZeroU64, NonZeroUsize, ParseIntError};
 
 use crate::diag::StrResult;
 use crate::foundations::{cast, func, repr, scope, ty, Bytes, Repr, Str, Value};
@@ -145,7 +144,6 @@ impl i64 {
     #[func(title = "Bitwise Left Shift")]
     pub fn bit_lshift(
         self,
-
         /// The amount of bits to shift. Must not be negative.
         shift: u32,
     ) -> StrResult<i64> {
@@ -168,7 +166,6 @@ impl i64 {
     #[func(title = "Bitwise Right Shift")]
     pub fn bit_rshift(
         self,
-
         /// The amount of bits to shift. Must not be negative.
         ///
         /// Shifts larger than 63 are allowed and will cause the return value to
@@ -178,7 +175,6 @@ impl i64 {
         /// just applying this operation multiple times. Therefore, the shift will
         /// always succeed.
         shift: u32,
-
         /// Toggles whether a logical (unsigned) right shift should be performed
         /// instead of arithmetic right shift.
         /// If this is `true`, negative operands will not preserve their sign bit,
@@ -217,7 +213,7 @@ impl i64 {
 
     /// Converts bytes to an integer.
     /// Bytes should be 8 bytes (64 bits) in size.
-    /// 
+    ///
     /// ```example
     /// #int.from-bytes(bytes((0, 0, 0, 0, 0, 0, 0, 1)), "little")
     /// ```
@@ -240,7 +236,7 @@ impl i64 {
 
     /// Converts an integer to bytes.
     /// The integer is converted to 8 bytes or 64 bits in size.
-    /// 
+    ///
     /// ```example
     /// #array(10000.to-bytes("big"))
     /// ```
@@ -275,7 +271,7 @@ enum Endianness {
 
 cast! {
     Endianness,
-    v: Str => 
+    v: Str =>
         match v.as_str() {
             "big" => Ok(Self::Big),
             "little" => Ok(Self::Little),

--- a/crates/typst/src/foundations/int.rs
+++ b/crates/typst/src/foundations/int.rs
@@ -1,6 +1,7 @@
 use std::num::{NonZeroI64, NonZeroIsize, NonZeroU64, NonZeroUsize, ParseIntError};
 
 use ecow::{eco_format, EcoString};
+use typst_macros::Cast;
 
 use crate::diag::StrResult;
 use crate::foundations::{cast, func, repr, scope, ty, Bytes, Repr, Str, Value};
@@ -222,9 +223,7 @@ impl i64 {
     pub fn from_bytes(
         /// The bytes that should be converted to an integer.
         bytes: Bytes,
-        /// Endianness
-        /// - Little endian: the bytes are interpreted from the least significant to the most significant.
-        /// - Big endian: the bytes are interpreted from the most significant to the least significant.
+        /// Endianness of the conversion.
         endianness: Endianness,
     ) -> Result<i64, EcoString> {
         let array: [u8; 8] =
@@ -244,9 +243,7 @@ impl i64 {
     #[func]
     pub fn to_bytes(
         self,
-        /// Endianness
-        /// - Little endian: the bytes are interpreted from the least significant to the most significant.
-        /// - Big endian: the bytes are interpreted from the most significant to the least significant.
+        /// Endianness of the conversion.
         endianness: Endianness,
     ) -> Bytes {
         let array = match endianness {
@@ -263,21 +260,13 @@ impl Repr for i64 {
     }
 }
 
-/// The endianness of a bytes to and from int conversion.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+/// Represents the byte order used for converting integers to bytes and vice versa.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Cast)]
 enum Endianness {
+    /// Big-endian byte order: the highest-value byte is at the beginning of the bytes.
     Big,
+    /// Little-endian byte order: the lowest-value byte is at the beginning of the bytes.
     Little,
-}
-
-cast! {
-    Endianness,
-    v: Str =>
-        match v.as_str() {
-            "big" => Ok(Self::Big),
-            "little" => Ok(Self::Little),
-            _ => Err("invalid endianness"),
-        }?,
 }
 
 /// A value that can be cast to an integer.

--- a/tests/suite/foundations/int.typ
+++ b/tests/suite/foundations/int.typ
@@ -38,6 +38,24 @@
 #test(int(10.0).signum(), 1)
 #test(int(-10.0).signum(), -1)
 
+--- int-from-and-to-bytes ---
+// Test `int.from-bytes` and `int.to-bytes`.
+#test(int.from-bytes(bytes(())), 0)
+#test(int.from-bytes(bytes((1, 0, 0, 0, 0, 0, 0, 0)), endian: "little", signed: true), 1)
+#test(int.from-bytes(bytes((1, 0, 0, 0, 0, 0, 0, 0)), endian: "big", signed: true), 72057594037927936)
+#test(int.from-bytes(bytes((1, 0, 0, 0, 0, 0, 0, 0)), endian: "little", signed: false), 1)
+#test(int.from-bytes(bytes((255,)), endian: "big", signed: true), -1)
+#test(int.from-bytes(bytes((255,)), endian: "big", signed: false), 255)
+#test(int.from-bytes((-1000).to-bytes(endian: "big", size: 5), endian: "big", signed: true), -1000)
+#test(int.from-bytes((-1000).to-bytes(endian: "little", size: 5), endian: "little", signed: true), -1000)
+#test(int.from-bytes(1000.to-bytes(endian: "big", size: 5), endian: "big", signed: true), 1000)
+#test(int.from-bytes(1000.to-bytes(endian: "little", size: 5), endian: "little", signed: true), 1000)
+#test(int.from-bytes(1000.to-bytes(endian: "little", size: 5), endian: "little", signed: false), 1000)
+
+--- int-from-and-to-bytes-too-many ---
+// Error: 2-34 too many bytes to convert to a 64 bit number
+#int.from-bytes(bytes((0,) * 16))
+
 --- int-repr ---
 // Test the `repr` function with integers.
 #repr(12) \


### PR DESCRIPTION
Closes #2868.

Implements conversion from int to bytes and vice-versa.

Example:
```typ
#array(10000.to-bytes("big"))
#int.from-bytes(bytes((0, 0, 0, 0, 0, 0, 0, 1)), "little")
```
Output:
```
(0, 0, 0, 0, 0, 0, 39, 16)
72057594037927936
```

Maybe this should be extended to the float type as well? Waiting on implementation feedback.