### PR TITLE
Add missing keys to manifest types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2785,6 +2785,7 @@ dependencies = [
  "ecow",
  "once_cell",
  "serde",
+ "toml",
  "typst-utils",
  "unicode-ident",
  "unicode-math-class",

--- a/crates/typst-syntax/Cargo.toml
+++ b/crates/typst-syntax/Cargo.toml
@@ -17,14 +17,12 @@ typst-utils = { workspace = true }
 ecow = { workspace = true }
 once_cell = { workspace = true }
 serde = { workspace = true }
+toml = { workspace = true }
 unicode-ident = { workspace = true }
 unicode-math-class = { workspace = true }
 unicode-script = { workspace = true }
 unicode-segmentation = { workspace = true }
 unscanny = { workspace = true }
-
-[dev-dependencies]
-toml = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/typst-syntax/Cargo.toml
+++ b/crates/typst-syntax/Cargo.toml
@@ -23,5 +23,8 @@ unicode-script = { workspace = true }
 unicode-segmentation = { workspace = true }
 unscanny = { workspace = true }
 
+[dev-dependencies]
+toml = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/typst-syntax/src/package.rs
+++ b/crates/typst-syntax/src/package.rs
@@ -1,37 +1,69 @@
 //! Package manifest parsing.
 
+use std::collections::BTreeMap;
 use std::fmt::{self, Debug, Display, Formatter};
 use std::str::FromStr;
 
 use ecow::{eco_format, EcoString};
+use serde::de::IgnoredAny;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use unscanny::Scanner;
 
 use crate::is_ident;
 
+/// A type alias for a map of key-value pairs used to collect unknown fields
+/// where values are completely discarded.
+pub type UnknownFields = BTreeMap<EcoString, IgnoredAny>;
+
 /// A parsed package manifest.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+///
+/// The `unknown_fields` contains fields which were found but not expected.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PackageManifest {
     /// Details about the package itself.
     pub package: PackageInfo,
     /// Details about the template, if the package is one.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub template: Option<TemplateInfo>,
+    /// The tools section for third-party configuration.
+    #[serde(default, skip_serializing)]
+    pub tool: Option<ToolInfo>,
+    /// All parsed but unknown fields, this can be used for validation.
+    #[serde(flatten, skip_serializing)]
+    pub unknown_fields: UnknownFields,
+}
+
+/// The `[tool]` key in the manifest.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ToolInfo {
+    /// Any fields parsed in the tool section.
+    #[serde(flatten, skip_serializing)]
+    pub unknown_fields: UnknownFields,
 }
 
 /// The `[template]` key in the manifest.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+///
+/// The `unknown_fields` contains fields which were found but not expected.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TemplateInfo {
-    /// The path of the starting point within the package.
+    /// The directory within the package that contains the files that should be
+    /// copied into the user's new project directory.
     pub path: EcoString,
-    /// The path of the entrypoint relative to the starting point's `path`.
+    /// A path relative to the template's path that points to the file serving
+    /// as the compilation target.
     pub entrypoint: EcoString,
+    /// A path relative to the package's root that points to a PNG or lossless
+    /// WebP thumbnail for the template.
+    pub thumbnail: EcoString,
+    /// All parsed but unknown fields, this can be used for validation.
+    #[serde(flatten, skip_serializing)]
+    pub unknown_fields: UnknownFields,
 }
 
 /// The `[package]` key in the manifest.
 ///
-/// More fields are specified, but they are not relevant to the compiler.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+/// The `unknown_fields` contains fields which were found but not expected.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PackageInfo {
     /// The name of the package within its namespace.
     pub name: EcoString,
@@ -39,8 +71,42 @@ pub struct PackageInfo {
     pub version: PackageVersion,
     /// The path of the entrypoint into the package.
     pub entrypoint: EcoString,
+    /// A list of the package's authors.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub authors: Vec<EcoString>,
+    ///  The package's license.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub license: Option<EcoString>,
+    /// A short description of the package.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<EcoString>,
+    /// A link to the package's web presence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub homepage: Option<EcoString>,
+    /// A link to the repository where this package is developed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repository: Option<EcoString>,
+    /// An array of search keywords for the package.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub keywords: Vec<EcoString>,
+    /// An array with up to three of the predefined categories to help users
+    /// discover the package.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub categories: Vec<EcoString>,
+    /// An array of disciplines defining the target audience for which the
+    /// package is useful.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub disciplines: Vec<EcoString>,
     /// The minimum required compiler version for the package.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub compiler: Option<VersionBound>,
+    /// An array of globs specifying files that should not be part of the
+    /// published bundle.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub exclude: Vec<EcoString>,
+    /// All parsed but unknown fields, this can be used for validation.
+    #[serde(flatten, skip_serializing)]
+    pub unknown_fields: UnknownFields,
 }
 
 impl PackageManifest {
@@ -422,5 +488,57 @@ mod tests {
         assert!(!v1_1_1.matches_lt(&VersionBound::from_str("1").unwrap()));
         assert!(!v1_1_1.matches_lt(&VersionBound::from_str("1.1").unwrap()));
         assert!(v1_1_1.matches_lt(&VersionBound::from_str("1.2").unwrap()));
+    }
+
+    #[test]
+    fn minimal_manifest() {
+        assert_eq!(
+            toml::from_str::<PackageManifest>(
+                r#"
+                [package]
+                name = "package"
+                version = "0.1.0"
+                entrypoint = "src/lib.typ"
+            "#
+            ),
+            Ok(PackageManifest {
+                package: PackageInfo {
+                    name: "package".into(),
+                    version: PackageVersion { major: 0, minor: 1, patch: 0 },
+                    entrypoint: "src/lib.typ".into(),
+                    authors: vec![],
+                    license: None,
+                    description: None,
+                    homepage: None,
+                    repository: None,
+                    keywords: vec![],
+                    categories: vec![],
+                    disciplines: vec![],
+                    compiler: None,
+                    exclude: vec![],
+                    unknown_fields: BTreeMap::new(),
+                },
+                template: None,
+                tool: None,
+                unknown_fields: BTreeMap::new(),
+            })
+        );
+    }
+
+    #[test]
+    fn unknown_keys() {
+        let manifest: PackageManifest = toml::from_str(
+            r#"
+            [package]
+            name = "package"
+            version = "0.1.0"
+            entrypoint = "src/lib.typ"
+
+            [unknown]
+        "#,
+        )
+        .unwrap();
+
+        assert!(manifest.unknown_fields.contains_key("unknown"));
     }
 }


### PR DESCRIPTION
This PR is the first step towards #4452 and adds the missing keys used in the `typst/package` bundler to the `typst-syntax` manifest types as fully optional. I opted to make `authors`, `license` and `description` optional too, as these are only relevant for the universe itself, but not necessarily for the compiler or other tooling.

I've also added a `unknown_fields` map which collects the field names which were parsed but not expected, this can be used by downstream tooling for diagnostics on misspelled fields. This also means that manifests are no longer `Eq` or `Hash` as these ignored values are not parsed and can't be compared.

Ideally a downstream consumer would be able to actually get values out of these unknown keys to support custom keys and such, but to enable this we'd have to take a hard dependency on `toml` to add its `Table` and actually deserialize the values in question. A similar thing applies to `ToolInfo`, in both cases we expect to only ever parse toml documents and `Tables` can be used to deserialize directly after the fact. See here: https://github.com/tingerrr/typst-project/blob/e19fb3d68b10fce7d2366f4e5969edac6e2f7d34/src/manifest/tool.rs#L11-L39

I think without getting any values out of them, people will end up recreating the manifest structs 1:1 to parse their own tool's config or company internal keys, which is what we're trying to prevent.