### PR TITLE
Go from `String` to `&str` when passing font names to SVG code

### DIFF
--- a/crates/typst/src/visualize/image/mod.rs
+++ b/crates/typst/src/visualize/image/mod.rs
@@ -196,7 +196,7 @@ fn layout_image(
         format,
         elem.alt(styles),
         engine.world,
-        &families(styles).map(|s| s.into()).collect::<Vec<_>>(),
+        &families(styles).collect::<Vec<_>>(),
     )
     .at(span)?;
 
@@ -360,7 +360,7 @@ impl Image {
         format: ImageFormat,
         alt: Option<EcoString>,
         world: Tracked<dyn World + '_>,
-        families: &[String],
+        families: &[&str],
     ) -> StrResult<Image> {
         let kind = match format {
             ImageFormat::Raster(format) => {

--- a/crates/typst/src/visualize/image/svg.rs
+++ b/crates/typst/src/visualize/image/svg.rs
@@ -195,7 +195,7 @@ impl FontResolver<'_> {
                 // We don't support generic families at the moment.
                 _ => None,
             })
-            .chain(self.families.into_iter().map(|s| *s))
+            .chain(self.families.iter().copied())
             .filter_map(|named| self.book.select(&named.to_lowercase(), variant))
             .find_map(|index| self.get_or_load(index, db))
     }

--- a/crates/typst/src/visualize/image/svg.rs
+++ b/crates/typst/src/visualize/image/svg.rs
@@ -40,7 +40,7 @@ impl SvgImage {
     pub fn with_fonts(
         data: Bytes,
         world: Tracked<dyn World + '_>,
-        families: &[String],
+        families: &[&str],
     ) -> StrResult<SvgImage> {
         let book = world.book();
         let resolver = Mutex::new(FontResolver::new(world, book, families));
@@ -142,7 +142,7 @@ struct FontResolver<'a> {
     /// The world we use to load fonts.
     world: Tracked<'a, dyn World + 'a>,
     /// The active list of font families at the location of the SVG.
-    families: &'a [String],
+    families: &'a [&'a str],
     /// A mapping from Typst font indices to fontdb IDs.
     to_id: HashMap<usize, Option<fontdb::ID>>,
     /// The reverse mapping.
@@ -156,7 +156,7 @@ impl<'a> FontResolver<'a> {
     fn new(
         world: Tracked<'a, dyn World + 'a>,
         book: &'a FontBook,
-        families: &'a [String],
+        families: &'a [&'a str],
     ) -> Self {
         Self {
             book,
@@ -191,11 +191,11 @@ impl FontResolver<'_> {
         font.families()
             .iter()
             .filter_map(|family| match family {
-                usvg::FontFamily::Named(named) => Some(named),
+                usvg::FontFamily::Named(named) => Some(named.as_str()),
                 // We don't support generic families at the moment.
                 _ => None,
             })
-            .chain(self.families)
+            .chain(self.families.into_iter().map(|s| *s))
             .filter_map(|named| self.book.select(&named.to_lowercase(), variant))
             .find_map(|index| self.get_or_load(index, db))
     }


### PR DESCRIPTION
The name says it all, it serves no purpose (other than bloating my PR count 😎). I can't measure any difference, perhaps on some specific SVG heavy documents it might but it's unlikely. Anyway, less allocations = more vroom vroom