### PR TITLE
Add arctg and arcctg predefined operators

### DIFF
--- a/crates/typst/src/math/op.rs
+++ b/crates/typst/src/math/op.rs
@@ -17,7 +17,7 @@ use crate::text::TextElem;
 /// ```
 ///
 /// # Predefined Operators { #predefined }
-/// Typst predefines the operators `arccos`, `arcsin`, `arctan`, `arg`, `cos`,
+/// Typst predefines the operators `arccos`, `arcctg`, `arcsin`, `arctan`, `arctg`, `arg`, `cos`,
 /// `cosh`, `cot`, `coth`, `csc`, `csch`, `ctg`, `deg`, `det`, `dim`, `exp`,
 /// `gcd`, `hom`, `id`, `im`, `inf`, `ker`, `lg`, `lim`, `liminf`, `limsup`,
 /// `ln`, `log`, `max`, `min`, `mod`, `Pr`, `sec`, `sech`, `sin`, `sinc`,
@@ -86,8 +86,10 @@ macro_rules! ops {
 
 ops! {
     arccos,
+    arcctg,
     arcsin,
     arctan,
+    arctg,
     arg,
     cos,
     cosh,


### PR DESCRIPTION
We already have tangent and cotangent in the tg/ctg notation, and we have inverse trig functions with arc prefix, so it would make sense to have arctg and arcctg.

These functions are commonly used where I am from.

There are more trig function with missing inverse versions (cot, sec, csc), so maybe it would make sense to add them too, but I don't know how often they are used if at all.