### PR TITLE
Mark synthesized prime symbol frame text-like

### DIFF
--- a/crates/typst/src/math/attach.rs
+++ b/crates/typst/src/math/attach.rs
@@ -143,7 +143,7 @@ impl LayoutMath for Packed<PrimesElem> {
                         prime.clone(),
                     )
                 }
-                ctx.push(FrameFragment::new(ctx, styles, frame));
+                ctx.push(FrameFragment::new(ctx, styles, frame).with_text_like(true));
             }
         }
         Ok(())


### PR DESCRIPTION
The pre-built prime symbols are `GlyphFragment` and the character is non-`MathClass::Large`, and therefore are text-like: https://github.com/typst/typst/blob/34990f7f0e25d51a76520edc1101df606013973f/crates/typst/src/math/attach.rs#L120-L128 https://github.com/typst/typst/blob/34990f7f0e25d51a76520edc1101df606013973f/crates/typst/src/math/fragment.rs#L146-L147 and equivalently the manually-synthesized prime symbol should also be text-like.