### PR TITLE
Change the signature of `World::main`

### DIFF
--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -192,8 +192,8 @@ impl World for SystemWorld {
         &self.book
     }
 
-    fn main(&self) -> Source {
-        self.source(self.main).unwrap()
+    fn main(&self) -> FileId {
+        self.main
     }
 
     fn source(&self, id: FileId) -> FileResult<Source> {

--- a/crates/typst-ide/src/lib.rs
+++ b/crates/typst-ide/src/lib.rs
@@ -139,8 +139,8 @@ mod tests {
             &self.base.book
         }
 
-        fn main(&self) -> Source {
-            self.main.clone()
+        fn main(&self) -> FileId {
+            self.main.id()
         }
 
         fn source(&self, id: FileId) -> FileResult<Source> {

--- a/crates/typst-syntax/src/file.rs
+++ b/crates/typst-syntax/src/file.rs
@@ -91,6 +91,11 @@ impl FileId {
         Self::new(self.package().cloned(), self.vpath().join(path))
     }
 
+    /// The same file location, but with a different extension.
+    pub fn with_extension(&self, extension: &str) -> Self {
+        Self::new(self.package().cloned(), self.vpath().with_extension(extension))
+    }
+
     /// Construct from a raw number.
     pub(crate) const fn from_raw(v: u16) -> Self {
         Self(v)

--- a/crates/typst-syntax/src/path.rs
+++ b/crates/typst-syntax/src/path.rs
@@ -85,6 +85,11 @@ impl VirtualPath {
             Self::new(path)
         }
     }
+
+    /// The same path, but with a different extension.
+    pub fn with_extension(&self, extension: &str) -> Self {
+        Self(self.0.with_extension(extension))
+    }
 }
 
 impl Debug for VirtualPath {

--- a/crates/typst/src/lib.rs
+++ b/crates/typst/src/lib.rs
@@ -439,10 +439,6 @@ fn hint_invalid_main_file(
                 extension.to_string_lossy()
             ));
         };
-
-        if path.with_extension("typ").exists() {
-            diagnostic.hint("check if you meant to use the `.typ` extension instead");
-        }
     }
 
     eco_vec![diagnostic]

--- a/crates/typst/src/lib.rs
+++ b/crates/typst/src/lib.rs
@@ -60,10 +60,12 @@ use std::collections::HashSet;
 use std::ops::{Deref, Range};
 
 use comemo::{Track, Tracked, Validate};
-use ecow::{EcoString, EcoVec};
+use ecow::{eco_format, eco_vec, EcoString, EcoVec};
 use typst_timing::{timed, TimingScope};
 
-use crate::diag::{warning, FileResult, SourceDiagnostic, SourceResult, Warned};
+use crate::diag::{
+    warning, FileError, FileResult, SourceDiagnostic, SourceResult, Warned,
+};
 use crate::engine::{Engine, Route, Sink, Traced};
 use crate::foundations::{
     Array, Bytes, Datetime, Dict, Module, Scope, StyleChain, Styles, Value,
@@ -107,6 +109,9 @@ fn compile_inner(
 ) -> SourceResult<Document> {
     let library = world.library();
     let styles = StyleChain::new(&library.styles);
+    let main = world
+        .source(world.main())
+        .map_err(|err| hint_invalid_main_file(err, world.main()))?;
 
     // First evaluate the main source file into a module.
     let content = crate::eval::eval(
@@ -114,7 +119,7 @@ fn compile_inner(
         traced,
         sink.track_mut(),
         Route::default().track(),
-        &world.main(),
+        &main,
     )?
     .content();
 
@@ -203,8 +208,8 @@ pub trait World: Send + Sync {
     /// Metadata about all known fonts.
     fn book(&self) -> &LazyHash<FontBook>;
 
-    /// Access the main source file.
-    fn main(&self) -> Source;
+    /// Get the file id of the main source file.
+    fn main(&self) -> FileId;
 
     /// Try to access the specified source file.
     fn source(&self, id: FileId) -> FileResult<Source>;
@@ -246,7 +251,7 @@ macro_rules! delegate_for_ptr {
                 self.deref().book()
             }
 
-            fn main(&self) -> Source {
+            fn main(&self) -> FileId {
                 self.deref().main()
             }
 
@@ -401,4 +406,43 @@ fn prelude(global: &mut Scope) {
     global.define("top", Alignment::TOP);
     global.define("horizon", Alignment::HORIZON);
     global.define("bottom", Alignment::BOTTOM);
+}
+
+/// Adds useful hints when the main source file couldn't be read
+/// and returns the final diagnostic.
+fn hint_invalid_main_file(
+    file_error: FileError,
+    input: FileId,
+) -> EcoVec<SourceDiagnostic> {
+    let is_utf8_error = matches!(file_error, FileError::InvalidUtf8);
+    let mut diagnostic =
+        SourceDiagnostic::error(Span::detached(), EcoString::from(file_error));
+
+    // Attempt to provide helpful hints for UTF-8 errors.
+    // Perhaps the user mistyped the filename.
+    // For example, they could have written "file.pdf" instead of
+    // "file.typ".
+    if is_utf8_error {
+        let path = input.vpath().as_rootless_path();
+        let extension = path.extension();
+
+        if let Some(extension) = extension {
+            if extension == "typ" {
+                // No hints if the file is already a .typ file.
+                // The file is indeed just invalid.
+                return eco_vec![diagnostic];
+            }
+
+            diagnostic.hint(eco_format!(
+                "a file with the `.{}` extension is not usually a Typst file",
+                extension.to_string_lossy()
+            ));
+        };
+
+        if path.with_extension("typ").exists() {
+            diagnostic.hint("check if you meant to use the `.typ` extension instead");
+        }
+    }
+
+    eco_vec![diagnostic]
 }

--- a/crates/typst/src/lib.rs
+++ b/crates/typst/src/lib.rs
@@ -109,9 +109,10 @@ fn compile_inner(
 ) -> SourceResult<Document> {
     let library = world.library();
     let styles = StyleChain::new(&library.styles);
-    let main = world
-        .source(world.main())
-        .map_err(|err| hint_invalid_main_file(err, world.main()))?;
+
+    // Fetch the main source file once.
+    let main = world.main();
+    let main = world.source(main).map_err(|err| hint_invalid_main_file(err, main))?;
 
     // First evaluate the main source file into a module.
     let content = crate::eval::eval(

--- a/docs/src/html.rs
+++ b/docs/src/html.rs
@@ -6,7 +6,7 @@ use heck::{ToKebabCase, ToTitleCase};
 use pulldown_cmark as md;
 use serde::{Deserialize, Serialize};
 use typed_arena::Arena;
-use typst::diag::{FileResult, StrResult};
+use typst::diag::{FileError, FileResult, StrResult};
 use typst::foundations::{Bytes, Datetime};
 use typst::layout::{Abs, Point, Size};
 use typst::syntax::{FileId, Source, VirtualPath};
@@ -467,8 +467,12 @@ impl World for DocWorld {
         self.0.id()
     }
 
-    fn source(&self, _: FileId) -> FileResult<Source> {
-        Ok(self.0.clone())
+    fn source(&self, id: FileId) -> FileResult<Source> {
+        if id == self.0.id() {
+            Ok(self.0.clone())
+        } else {
+            Err(FileError::NotFound(id.vpath().as_rootless_path().into()))
+        }
     }
 
     fn file(&self, id: FileId) -> FileResult<Bytes> {

--- a/docs/src/html.rs
+++ b/docs/src/html.rs
@@ -463,8 +463,8 @@ impl World for DocWorld {
         &FONTS.0
     }
 
-    fn main(&self) -> Source {
-        self.0.clone()
+    fn main(&self) -> FileId {
+        self.0.id()
     }
 
     fn source(&self, _: FileId) -> FileResult<Source> {

--- a/tests/fuzz/src/compile.rs
+++ b/tests/fuzz/src/compile.rs
@@ -43,12 +43,16 @@ impl World for FuzzWorld {
         self.source.id()
     }
 
-    fn source(&self, src: FileId) -> FileResult<Source> {
-        Err(FileError::NotFound(src.vpath().as_rootless_path().into()))
+    fn source(&self, id: FileId) -> FileResult<Source> {
+        if id == self.source.id() {
+            Ok(self.source.clone())
+        } else {
+            Err(FileError::NotFound(id.vpath().as_rootless_path().into()))
+        }
     }
 
-    fn file(&self, src: FileId) -> FileResult<Bytes> {
-        Err(FileError::NotFound(src.vpath().as_rootless_path().into()))
+    fn file(&self, id: FileId) -> FileResult<Bytes> {
+        Err(FileError::NotFound(id.vpath().as_rootless_path().into()))
     }
 
     fn font(&self, _: usize) -> Option<Font> {

--- a/tests/fuzz/src/compile.rs
+++ b/tests/fuzz/src/compile.rs
@@ -39,8 +39,8 @@ impl World for FuzzWorld {
         &self.book
     }
 
-    fn main(&self) -> Source {
-        self.source.clone()
+    fn main(&self) -> FileId {
+        self.source.id()
     }
 
     fn source(&self, src: FileId) -> FileResult<Source> {

--- a/tests/src/world.rs
+++ b/tests/src/world.rs
@@ -43,8 +43,8 @@ impl World for TestWorld {
         &self.base.book
     }
 
-    fn main(&self) -> Source {
-        self.main.clone()
+    fn main(&self) -> FileId {
+        self.main.id()
     }
 
     fn source(&self, id: FileId) -> FileResult<Source> {


### PR DESCRIPTION
The current `World::main` cannot process the case when the main source file may be gone or invalid at some time well. For example, `typst-cli` has to always add an extra checking before trapped into `typst::compile`.

Therefore, we would like to change the the signature of `World::main` to `fn main(&self) -> FileId`. This decouples the world APIs a bit and makes it impossible to have a mismatch between `world.main()` and `world.source(world.main().id())` (which would be a logic error). The PR itself also proves it actually makes life of downstreams simpler.