### PR TITLE
Let test error hide line number if it's zero

### DIFF
--- a/tests/src/collect.rs
+++ b/tests/src/collect.rs
@@ -48,7 +48,11 @@ impl FilePos {
 
 impl Display for FilePos {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{}:{}", self.path.display(), self.line)
+        if self.line > 0 {
+            write!(f, "{}:{}", self.path.display(), self.line)
+        } else {
+            write!(f, "{}", self.path.display())
+        }
     }
 }
 


### PR DESCRIPTION
An error complaining about a dangling reference file displays something like `tests/ref/math-attach-horizontal-align.png:0`. Instead, it should display the file path without the `:0` part.

If a file is textual, the line number always starts at 1 so it's okay to ignore the line number when displaying if it's zero.