### PR TITLE
Remove `place.flush` from global scope

### DIFF
--- a/crates/typst/src/layout/mod.rs
+++ b/crates/typst/src/layout/mod.rs
@@ -106,7 +106,6 @@ pub fn define(global: &mut Scope) {
     global.define_elem::<ColumnsElem>();
     global.define_elem::<ColbreakElem>();
     global.define_elem::<PlaceElem>();
-    global.define_elem::<FlushElem>();
     global.define_elem::<AlignElem>();
     global.define_elem::<PadElem>();
     global.define_elem::<RepeatElem>();

--- a/crates/typst/src/layout/place.rs
+++ b/crates/typst/src/layout/place.rs
@@ -46,7 +46,7 @@ pub struct PlaceElem {
     /// Floating elements are positioned at the top or bottom of the page,
     /// displacing in-flow content. They are always placed in the in-flow
     /// order relative to each other, as well as before any content following
-    /// a later [`flush`] element.
+    /// a later [`place.flush`] element.
     ///
     /// ```example
     /// #set page(height: 150pt)


### PR DESCRIPTION
Was added to both `place` and the global scope by accident in #4141.