### PR TITLE
Short-circuit on None's when laying out AttachElem

### DIFF
--- a/crates/typst/src/math/attach.rs
+++ b/crates/typst/src/math/attach.rs
@@ -349,6 +349,10 @@ fn attach_top_and_bottom(
     t: Option<MathFragment>,
     b: Option<MathFragment>,
 ) -> (Frame, Abs) {
+    if t.is_none() && b.is_none() {
+        return (base.into_frame(), Abs::zero());
+    }
+
     let upper_gap_min = scaled!(ctx, styles, upper_limit_gap_min);
     let upper_rise_min = scaled!(ctx, styles, upper_limit_baseline_rise_min);
     let lower_gap_min = scaled!(ctx, styles, lower_limit_gap_min);
@@ -398,6 +402,10 @@ fn compute_shifts_up_and_down(
     base: &MathFragment,
     [tl, tr, bl, br]: [&Option<MathFragment>; 4],
 ) -> (Abs, Abs) {
+    if [tl, tr, bl, br].iter().all(|e| e.is_none()) {
+        return (Abs::zero(), Abs::zero());
+    }
+
     let sup_shift_up = if EquationElem::cramped_in(styles) {
         scaled!(ctx, styles, superscript_shift_up_cramped)
     } else {


### PR DESCRIPTION
If [`attach_top_and_bottom()`](https://github.com/typst/typst/blob/ab5cebc57c8345f397c3f0a1ed0c024dc6811e2f/crates/typst/src/math/attach.rs#L345) is fed with `t = None, b = None`, then this function should do not the thrown-away work, e.g. querying `upper_limit_gap_min` from the font data's [Math Constant Table](https://learn.microsoft.com/en-us/typography/opentype/spec/math#mathconstants-table). This function should be short-circuited.

Likewise, if [`compute_shifts_up_and_down()`](https://github.com/typst/typst/blob/ab5cebc57c8345f397c3f0a1ed0c024dc6811e2f/crates/typst/src/math/attach.rs#L395C4-L395C30) is fed with `tl = None, tr = None, bl = None, br = None`, this function should be short-circuited too.