### PR TITLE
Add file-exists function

### DIFF
--- a/crates/typst/src/loading/file-exists.rs
+++ b/crates/typst/src/loading/file-exists.rs
@@ -1,0 +1,40 @@
+use ecow::EcoString;
+
+use crate::diag::{At, SourceResult};
+use crate::engine::Engine;
+use crate::foundations::func;
+use crate::syntax::Spanned;
+use crate::World;
+
+/// Checks whether a file exists at a path.
+///
+/// It does not check for encoding errors.
+///
+/// # Example
+/// ```example
+/// An example for safely reading a file: \
+/// #if file-exists("example.html") {
+///     let text = read("example.html")
+///     raw(text, lang: "html")
+/// }
+/// ```
+#[func(title = "file-exists")]
+pub fn file_exists(
+    /// The engine.
+    engine: &mut Engine,
+    /// Path to a file.
+    path: Spanned<EcoString>,
+) -> SourceResult<bool> {
+    let Spanned { v: path, span } = path;
+    let resolved_path = match span.resolve_path(&path).at(span) {
+        Err(_) => return Ok(false),
+        Ok(id) => id,
+    };
+    //since all loading functions should use internal caching and
+    //most often the file is read afterwards the penalty of reading should
+    //not be big.
+    match engine.world.file(resolved_path).at(span) {
+        Err(_) => Ok(false),
+        Ok(_) => Ok(true),
+    }
+}

--- a/crates/typst/src/loading/mod.rs
+++ b/crates/typst/src/loading/mod.rs
@@ -4,6 +4,8 @@
 mod cbor_;
 #[path = "csv.rs"]
 mod csv_;
+#[path = "file-exists.rs"]
+mod file_exists_;
 #[path = "json.rs"]
 mod json_;
 #[path = "read.rs"]
@@ -17,6 +19,7 @@ mod yaml_;
 
 pub use self::cbor_::*;
 pub use self::csv_::*;
+pub use self::file_exists_::*;
 pub use self::json_::*;
 pub use self::read_::*;
 pub use self::toml_::*;
@@ -42,6 +45,7 @@ pub(super) fn define(global: &mut Scope) {
     global.define_func::<yaml>();
     global.define_func::<cbor>();
     global.define_func::<xml>();
+    global.define_func::<file_exists>();
 }
 
 /// A value that can be read from a file.

--- a/tests/suite/loading/file-exists.typ
+++ b/tests/suite/loading/file-exists.typ
@@ -1,0 +1,12 @@
+--- file-exists-text ---
+// Test reading plain text files
+#let data = file-exists("/assets/text/hello.txt")
+#test(data, true)
+
+--- file-exists-file-not-found ---
+#let data = file-exists("/assets/text/missing.txt")
+#test(data, false)
+
+--- file-exists-invalid-utf-8 ---
+#let data = file-exists("/assets/text/bad.txt")
+#test(data, true)


### PR DESCRIPTION
When a read call to a non existent file is made, the compilation errors (as it should). This is why issue #2025 ask for a function to check for file existence.

`file-exists` is a simple implementation of that. It uses the `engine.world.file` functionality that should then cache for the upcoming read.

*The function naming is debatable and is just a proposal.* 
`exists` is too generic but alternatives `fexists` could work. Since this is most likely a temporary solution that will be deprecated once a more stable path type is necessary.   