### PR TITLE
Update nixpkgs input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -39,11 +39,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1706371002,
-        "narHash": "sha256-dwuorKimqSYgyu8Cw6ncKhyQjUDOyuXoxDTVmAXq88s=",
+        "lastModified": 1720957393,
+        "narHash": "sha256-oedh2RwpjEa+TNxhg5Je9Ch6d3W1NKi7DbRO1ziHemA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c002c6aa977ad22c60398daaa9be52f2203d0006",
+        "rev": "693bc46d169f5af9c992095736e82c3488bf7dbb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
I'm currently unable to build main from the nix flake. I was getting the error `error: package 'wasmi_core v0.34.0' cannot be built because it requires rustc 1.77 or newer, while the currently active rustc version is 1.75.0`, so after a quick check it seems this occurred after [#4523](https://github.com/typst/typst/pull/4523) was merged.

This PR bumps the underlying rustc package to `1.78`, which resolves the failing build on `main`.