### PR TITLE
Bail out of reparse in `expr_with_paren` if we land on a different char

### DIFF
--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -1102,19 +1102,17 @@ fn expr_with_paren(p: &mut Parser, atomic: bool) {
     if p.at(SyntaxKind::Arrow) {
         p.restore(checkpoint);
         params(p);
-        if p.current() != SyntaxKind::Arrow {
+        if !p.expect(SyntaxKind::Arrow) {
             return;
         }
-        p.eat();
         code_expr(p);
         p.wrap(m, SyntaxKind::Closure);
     } else if p.at(SyntaxKind::Eq) && kind != SyntaxKind::Parenthesized {
         p.restore(checkpoint);
         destructuring_or_parenthesized(p, true, &mut HashSet::new());
-        if p.current() != SyntaxKind::Eq {
+        if !p.expect(SyntaxKind::Eq) {
             return;
         }
-        p.eat();
         code_expr(p);
         p.wrap(m, SyntaxKind::DestructAssignment);
     } else {

--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -1102,13 +1102,17 @@ fn expr_with_paren(p: &mut Parser, atomic: bool) {
     if p.at(SyntaxKind::Arrow) {
         p.restore(checkpoint);
         params(p);
-        p.assert(SyntaxKind::Arrow);
+        if p.current() != SyntaxKind::Arrow {
+            return;
+        }
         code_expr(p);
         p.wrap(m, SyntaxKind::Closure);
     } else if p.at(SyntaxKind::Eq) && kind != SyntaxKind::Parenthesized {
         p.restore(checkpoint);
         destructuring_or_parenthesized(p, true, &mut HashSet::new());
-        p.assert(SyntaxKind::Eq);
+        if p.current() != SyntaxKind::Eq {
+            return;
+        }
         code_expr(p);
         p.wrap(m, SyntaxKind::DestructAssignment);
     } else {

--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -1105,6 +1105,7 @@ fn expr_with_paren(p: &mut Parser, atomic: bool) {
         if p.current() != SyntaxKind::Arrow {
             return;
         }
+        p.eat();
         code_expr(p);
         p.wrap(m, SyntaxKind::Closure);
     } else if p.at(SyntaxKind::Eq) && kind != SyntaxKind::Parenthesized {
@@ -1113,6 +1114,7 @@ fn expr_with_paren(p: &mut Parser, atomic: bool) {
         if p.current() != SyntaxKind::Eq {
             return;
         }
+        p.eat();
         code_expr(p);
         p.wrap(m, SyntaxKind::DestructAssignment);
     } else {

--- a/tests/suite/syntax/bugs.typ
+++ b/tests/suite/syntax/bugs.typ
@@ -1,0 +1,20 @@
+--- issue-4571-panic-when-compiling-invalid-file ---
+// Test that trying to parse the following does not result in a panic.
+
+// Error: 1:9-10 unclosed delimiter
+// Error: 1:22 expected pattern
+// Error: 1:23-24 unexpected star
+// Error: 2:1-2:2 the character `#` is not valid in code
+// Error: 2:2-2:8 expected pattern, found keyword `import`
+// Hint: 2:2-2:8 keyword `import` is not allowed as an identifier; try `import_` instead
+// Error: 2:9-2:20 expected identifier, found string
+// Error: 3:1-3:2 the character `#` is not valid in code
+// Error: 3:2-3:5 expected pattern, found keyword `let`
+// Hint: 3:2-3:5 keyword `let` is not allowed as an identifier; try `let_` instead
+// Error: 4:3-4:4 unexpected equals sign
+// Error: 4:5-4:6 unclosed delimiter
+#import (hntle-clues: *
+#import "/util.typ": qrlink
+#let auton(
+) = {
+

--- a/tests/suite/syntax/bugs.typ
+++ b/tests/suite/syntax/bugs.typ
@@ -13,6 +13,7 @@
 // Hint: 3:2-3:5 keyword `let` is not allowed as an identifier; try `let_` instead
 // Error: 4:3-4:4 unexpected equals sign
 // Error: 4:5-4:6 unclosed delimiter
+// Error: 4:6 expected equals sign
 #import (hntle-clues: *
 #import "/util.typ": qrlink
 #let auton(


### PR DESCRIPTION
Fixes #4571.

As I mentioned in [my comment](https://github.com/typst/typst/issues/4571#issuecomment-2233743137), I’m not sure if this is the solution we want to implement. Even then, we might want to be checking that the *positions* agree instead of checking that the next token is what we expect.