### PR TITLE
Explanation of void return in the functions documentation

### DIFF
--- a/crates/typst/src/foundations/func.rs
+++ b/crates/typst/src/foundations/func.rs
@@ -80,6 +80,10 @@ pub use typst_macros::func;
 /// optionally specify a return value. If no explicit return value is given, the
 /// body evaluates to the result of joining all expressions preceding the
 /// `return`.
+/// 
+/// Functions that don't return any meaningful value return the [`none`]($none) value. 
+/// Their return type is not explicitly specified in their documentation.
+/// Example of this is [`array.push`]($array.push). 
 ///
 /// ```example
 /// #let alert(body, fill: red) = {

--- a/crates/typst/src/foundations/func.rs
+++ b/crates/typst/src/foundations/func.rs
@@ -81,9 +81,9 @@ pub use typst_macros::func;
 /// body evaluates to the result of joining all expressions preceding the
 /// `return`.
 ///
-/// Functions that don't return any meaningful value return the [`none`]($none) value.
-/// Their return type is not explicitly specified in their documentation.
-/// Example of this is [`array.push`]($array.push).
+/// Functions that don't return any meaningful value return [`none`] instead.
+/// The return type of such functions is not explicitly specified in the
+/// documentation. (An example of this is [`array.push`]).
 ///
 /// ```example
 /// #let alert(body, fill: red) = {

--- a/crates/typst/src/foundations/func.rs
+++ b/crates/typst/src/foundations/func.rs
@@ -80,10 +80,10 @@ pub use typst_macros::func;
 /// optionally specify a return value. If no explicit return value is given, the
 /// body evaluates to the result of joining all expressions preceding the
 /// `return`.
-/// 
-/// Functions that don't return any meaningful value return the [`none`]($none) value. 
+///
+/// Functions that don't return any meaningful value return the [`none`]($none) value.
 /// Their return type is not explicitly specified in their documentation.
-/// Example of this is [`array.push`]($array.push). 
+/// Example of this is [`array.push`]($array.push).
 ///
 /// ```example
 /// #let alert(body, fill: red) = {


### PR DESCRIPTION
Solving #3056 in accordance with [this comment](https://github.com/typst/typst/issues/3056#issuecomment-1880735386). 
The returning of `none` for "void" function is now mentioned in the documentation for the [Function Type](https://typst.app/docs/reference/foundations/function/).