### PR TITLE
Add font exceptions for Kaiti SC and Kaiti TC

### DIFF
--- a/crates/typst/src/text/font/exceptions.rs
+++ b/crates/typst/src/text/font/exceptions.rs
@@ -323,12 +323,12 @@ static EXCEPTION_MAP: phf::Map<&'static str, Exception> = phf::phf_map! {
         .family("Latin Modern Sans 12"),
     "LMSans17-Oblique" => Exception::new()
         .family("Latin Modern Sans 17"),
-    // STKaiti is a set of Kai fonts on Mac systems. However, their weight values
-    // need to be corrected according to their PostScript names.
-    "STKaitiSC-Regular" => Exception::new().family("Kaiti SC").weight(400),
-    "STKaitiTC-Regular" => Exception::new().family("Kaiti TC").weight(400),
-    "STKaitiSC-Bold" => Exception::new().family("Kaiti SC").weight(700),
-    "STKaitiTC-Bold" => Exception::new().family("Kaiti TC").weight(700),
-    "STKaitiSC-Black" => Exception::new().family("Kaiti SC").weight(900),
-    "STKaitiTC-Black" => Exception::new().family("Kaiti TC").weight(900),
+    // STKaiti is a set of Kai fonts. Their weight values need to be corrected
+    // according to their PostScript names.
+    "STKaitiSC-Regular" => Exception::new().weight(400),
+    "STKaitiTC-Regular" => Exception::new().weight(400),
+    "STKaitiSC-Bold" => Exception::new().weight(700),
+    "STKaitiTC-Bold" => Exception::new().weight(700),
+    "STKaitiSC-Black" => Exception::new().weight(900),
+    "STKaitiTC-Black" => Exception::new().weight(900),
 };

--- a/crates/typst/src/text/font/exceptions.rs
+++ b/crates/typst/src/text/font/exceptions.rs
@@ -44,12 +44,14 @@ pub fn find_exception(postscript_name: &str) -> Option<&'static Exception> {
 
 /// A map which keys are PostScript name and values are override entries.
 static EXCEPTION_MAP: phf::Map<&'static str, Exception> = phf::phf_map! {
-    // The old version of Arial-Black, published by Microsoft in 1996 in their "core fonts for the web" project, has a wrong weight of 400.
+    // The old version of Arial-Black, published by Microsoft in 1996 in their
+    // "core fonts for the web" project, has a wrong weight of 400.
     // See https://corefonts.sourceforge.net/.
     "Arial-Black" => Exception::new()
         .weight(900),
-    // Archivo Narrow is different from Archivo and Archivo Black. Since Archivo Black seems
-    // identical to Archivo weight 900, only differentiate between Archivo and Archivo Narrow.
+    // Archivo Narrow is different from Archivo and Archivo Black. Since Archivo Black
+    // seems identical to Archivo weight 900, only differentiate between Archivo and
+    // Archivo Narrow.
     "ArchivoNarrow-Regular" => Exception::new()
         .family("Archivo Narrow"),
     "ArchivoNarrow-Italic" => Exception::new()
@@ -321,4 +323,12 @@ static EXCEPTION_MAP: phf::Map<&'static str, Exception> = phf::phf_map! {
         .family("Latin Modern Sans 12"),
     "LMSans17-Oblique" => Exception::new()
         .family("Latin Modern Sans 17"),
+    // STKaiti is a set of Kai fonts on Mac systems. However, their weight values
+    // need to be corrected according to their PostScript names.
+    "STKaitiSC-Regular" => Exception::new().family("Kaiti SC").weight(400),
+    "STKaitiTC-Regular" => Exception::new().family("Kaiti TC").weight(400),
+    "STKaitiSC-Bold" => Exception::new().family("Kaiti SC").weight(700),
+    "STKaitiTC-Bold" => Exception::new().family("Kaiti TC").weight(700),
+    "STKaitiSC-Black" => Exception::new().family("Kaiti SC").weight(900),
+    "STKaitiTC-Black" => Exception::new().family("Kaiti TC").weight(900),
 };

--- a/crates/typst/src/text/font/variant.rs
+++ b/crates/typst/src/text/font/variant.rs
@@ -79,6 +79,8 @@ impl From<usvg::FontStyle> for FontStyle {
 #[serde(transparent)]
 pub struct FontWeight(pub(super) u16);
 
+/// Font weight names and numbers:
+/// https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-weight#common_weight_name_mapping
 impl FontWeight {
     /// Thin weight (100).
     pub const THIN: Self = Self(100);

--- a/crates/typst/src/text/font/variant.rs
+++ b/crates/typst/src/text/font/variant.rs
@@ -79,8 +79,8 @@ impl From<usvg::FontStyle> for FontStyle {
 #[serde(transparent)]
 pub struct FontWeight(pub(super) u16);
 
-/// Font weight names and numbers:
-/// https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-weight#common_weight_name_mapping
+/// Font weight names and numbers.
+/// See `<https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-weight#common_weight_name_mapping>`
 impl FontWeight {
     /// Thin weight (100).
     pub const THIN: Self = Self(100);


### PR DESCRIPTION
Fixes #4532. Tested on macOS:

```typ
#text("测试", font: "Kaiti SC", weight: "regular")
#text("测试", font: "Kaiti SC", weight: "bold")
#text("测试", font: "Kaiti SC", weight: "black")
```

| | Output PDF |
|:--|:--|
|Before|<img width="200" alt="Screenshot 2024-07-24 at 22 42 24" src="https://github.com/user-attachments/assets/7d110a2a-9b68-460d-a250-cf0b6d434086">|
|After|<img width="200" alt="Screenshot 2024-07-24 at 22 41 32" src="https://github.com/user-attachments/assets/e8281f64-e134-4918-b10c-a14415094bb4">|
