### PR TITLE
Export `ty` and `scope` macros before mod decls to sidestep a rust-analyzer issue

### DIFF
--- a/crates/typst/src/foundations/mod.rs
+++ b/crates/typst/src/foundations/mod.rs
@@ -4,6 +4,8 @@ pub mod calc;
 pub mod repr;
 pub mod sys;
 
+pub use typst_macros::{scope, ty};
+
 mod args;
 mod array;
 mod auto;


### PR DESCRIPTION
While we are waiting on a fix to address https://github.com/rust-lang/rust-analyzer/issues/17630, this small edit makes rust-analyzer happy.

Tested on VSCode with rust-analyzer [v0.3.2045](https://github.com/rust-lang/rust-analyzer/releases/tag/2024-07-22).