### PR TITLE
Add timezone to PDF's default timestamp and consolidate logic

### DIFF
--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -190,13 +190,13 @@ fn export_pdf(document: &Document, command: &CompileCommand) -> StrResult<()> {
 /// timestamps do not have timezone; the datetime from the CLI command is
 /// parsed from a UNIX timestamp and it assumed the UTC timezone.
 fn make_pdf_timestamp(
-    document_date_config: Smart<Option<Datetime>>,
-    command_override: Option<chrono::DateTime<chrono::Utc>>,
+    document_datetime: Smart<Option<Datetime>>,
+    command_datetime: Option<chrono::DateTime<chrono::Utc>>,
 ) -> Option<Timestamp> {
-    match document_date_config {
+    match document_datetime {
         Smart::Custom(None) => None,
         Smart::Custom(Some(datetime)) => Some(Timestamp::new(datetime)),
-        Smart::Auto => match command_override.and_then(chrono_to_datetime) {
+        Smart::Auto => match command_datetime.and_then(chrono_to_datetime) {
             Some(datetime) => Timestamp::new(datetime).with_timezone_offset(0),
             None => {
                 let now = chrono::Local::now();

--- a/crates/typst-pdf/src/catalog.rs
+++ b/crates/typst-pdf/src/catalog.rs
@@ -13,12 +13,10 @@ use typst::text::Lang;
 use crate::WithEverything;
 use crate::{hash_base64, outline, page::PdfPageLabel};
 
-#[derive(Debug, Clone, Copy)]
 pub struct Timestamp {
-    // The timestamp in UTC.
     pub datetime: Datetime,
-    // The local timezone minus the UTC, in hour and remaining minutes. If None,
-    // the PDF timestamp will not have a timezone suffix.
+    // The local timezone minus the UTC, in hours and remaining minutes. If None,
+    // the PDF timestamps will not have a timezone suffix.
     pub timezone_offset: Option<(i8, u8)>,
 }
 

--- a/crates/typst-pdf/src/lib.rs
+++ b/crates/typst-pdf/src/lib.rs
@@ -20,7 +20,7 @@ use std::ops::{Deref, DerefMut};
 
 use base64::Engine;
 use pdf_writer::{Chunk, Pdf, Ref};
-use typst::foundations::{Datetime, Smart};
+use typst::foundations::Smart;
 use typst::layout::{Abs, Em, PageRanges, Transform};
 use typst::model::Document;
 use typst::text::Font;
@@ -41,6 +41,8 @@ use crate::resources::{
     alloc_resources_refs, write_resource_dictionaries, Resources, ResourcesRefs,
 };
 
+pub use crate::catalog::Timestamp;
+
 /// Export a document into a PDF file.
 ///
 /// Returns the raw bytes making up the PDF file.
@@ -57,9 +59,8 @@ use crate::resources::{
 /// hash of the document's title and author is used instead (which is reasonably
 /// unique and stable).
 ///
-/// The `timestamp`, if given, is expected to be the creation date of the
-/// document as a UTC datetime. It will only be used if `set document(date: ..)`
-/// is `auto`.
+/// The `timestamp`, if given, is expected to be the creation datetime of the
+/// document.
 ///
 /// The `page_ranges` option specifies which ranges of pages should be exported
 /// in the PDF. When `None`, all pages should be exported.
@@ -67,7 +68,7 @@ use crate::resources::{
 pub fn pdf(
     document: &Document,
     ident: Smart<&str>,
-    timestamp: Option<Datetime>,
+    timestamp: Option<Timestamp>,
     page_ranges: Option<PageRanges>,
 ) -> Vec<u8> {
     PdfBuilder::new(document, page_ranges)
@@ -344,11 +345,11 @@ impl<S> PdfBuilder<S> {
     fn export_with<P>(
         mut self,
         ident: Smart<&str>,
-        timestamp: Option<Datetime>,
+        timestamp: Option<Timestamp>,
         process: P,
     ) -> Vec<u8>
     where
-        P: Fn(S, Smart<&str>, Option<Datetime>, &mut Pdf, &mut Ref),
+        P: Fn(S, Smart<&str>, Option<Timestamp>, &mut Pdf, &mut Ref),
     {
         process(self.state, ident, timestamp, &mut self.pdf, &mut self.alloc);
         self.pdf.finish()


### PR DESCRIPTION
TL;DR: Fixes #3948, i.e. let the default timestamp include a timezone suffix.

## The instant in time

The PDF's timestamp represents an absolute instant in time, unrelated to the choice of timezone.

Though not called for by issue #3948, this PR consolidates (but does _not_ change) the logic of deciding the PDF timestamps in `make_pdf_timestamp()`. Originally, the decision relies on a series of fallback decision-making in multiple files, across the `typst-cli` and `typst-pdf` crates, and made it challenging to reason about.

In summary, the fallback decisions follow this precedence, which is preserved by this PR:
* (a) respect [`document.date`](https://typst.app/docs/reference/model/document/#parameters-date) (either a `datetime(...)` or `none`),
* (b) if (a) is the default value `auto`, the UNIX timestamp provided through the CLI command,
* (c) if (b) is absent, the current time.

## The timezone

The same instant in time has multiple representations depending on the choice of timezone. This PR changes the timezone as requested by issue #3948.

| | Status quo | After this PR |
|:--|:--|:--|
|`#set document(date: none)`| no timestamp | same |
|`#set document(date: datetime(...))`| no timezone suffix<br>e.g. `20200101` | same |
|`--creation-timestamp=(UNIX time)`| with a UTC suffix<br>e.g. `20230101050000Z` | same |
|Default (i.e. use the current time)| with a UTC suffix<br>e.g. `20240727195902Z` | with the local timezone suffix<br>e.g. `20240727150651-04'00` |

## Testing

(note: I could use `hexdump` but it's hard to `grep` the results, so I resorted to `strings`, which is also available on most *nix systems)

### (1) Timestamp disabled by `#set document(date: none)`
```typ
// test.typ
#set document(date: none)
PDF
```
`strings test.pdf` shows there's no creation or modification timestamp in the generated PDF's binary file.

### (2) Timestamp specified by `#set document(date: datetime(...))`
```typ
// test.typ
#set document(date: datetime(year: 2020, month: 1, day: 1))
PDF
```
`strings test.pdf | grep Date` shows
```txt
  /CreationDate (D:20200101)
  /ModDate (D:20200101)
...<xmp:CreateDate>2020-01-01</xmp:CreateDate><xmp:ModifyDate>2020-01-01</xmp:ModifyDate>...
```

### (3) Timestamp specified by CLI `--creation-timestamp=1672549200`
i.e. Sun Jan 01 2023 05:00:00 GMT+0000
```typ
// test.typ
PDF
```
`strings test.pdf | grep Date` shows
```txt
  /CreationDate (D:20230101050000Z)
  /ModDate (D:20230101050000Z)
...<xmp:CreateDate>2023-01-01T05:00:00Z</xmp:CreateDate><xmp:ModifyDate>2023-01-01T05:00:00Z</xmp:ModifyDate>...
```

### (4) Default (i.e. `document.date` is `auto`)
```typ
// test.typ
PDF
```
`strings test.pdf | grep Date` shows
```txt
  /CreationDate (D:20240727150651-04'00)
  /ModDate (D:20240727150651-04'00)
...<xmp:CreateDate>2024-07-27T15:06:51-04:00</xmp:CreateDate><xmp:ModifyDate>2024-07-27T15:06:51-04:00</xmp:ModifyDate>...
```