### PR TITLE
Automatically get footnote numbering in counter display

### DIFF
--- a/crates/typst/src/introspection/counter.rs
+++ b/crates/typst/src/introspection/counter.rs
@@ -373,7 +373,7 @@ impl Counter {
                 } else if func == EquationElem::elem() {
                     EquationElem::numbering_in(styles).clone()
                 } else if func == FootnoteElem::elem() {
-                    FootnoteElem::numbering_in(styles).clone().into()
+                    Some(FootnoteElem::numbering_in(styles).clone())
                 } else {
                     None
                 }

--- a/crates/typst/src/introspection/counter.rs
+++ b/crates/typst/src/introspection/counter.rs
@@ -15,7 +15,7 @@ use crate::foundations::{
 use crate::introspection::{Introspector, Locatable, Location};
 use crate::layout::{Frame, FrameItem, PageElem};
 use crate::math::EquationElem;
-use crate::model::{FigureElem, HeadingElem, Numbering, NumberingPattern};
+use crate::model::{FigureElem, FootnoteElem, HeadingElem, Numbering, NumberingPattern};
 use crate::syntax::Span;
 use crate::utils::NonZeroExt;
 use crate::World;
@@ -372,6 +372,8 @@ impl Counter {
                     FigureElem::numbering_in(styles).clone()
                 } else if func == EquationElem::elem() {
                     EquationElem::numbering_in(styles).clone()
+                } else if func == FootnoteElem::elem() {
+                    FootnoteElem::numbering_in(styles).clone().into()
                 } else {
                     None
                 }


### PR DESCRIPTION
When using `counter(footnote).display()`, the numbering should be automatically retrieved from the current `footnote.numbering` value, similar to how it is done for equations, figures and headings.

Note that (as for the other countable elements) this doesn't work when the display function is called in a show rule and the numbering is explicitly set on the element, as it will always get the numbering value from the style chain.