### PR TITLE
Fix crash when local package  is missing and make OpenSSL optional in typst-kit

### DIFF
--- a/crates/typst-kit/Cargo.toml
+++ b/crates/typst-kit/Cargo.toml
@@ -28,7 +28,7 @@ ureq = { workspace = true, optional = true }
 # Explicitly depend on OpenSSL if applicable, so that we can add the
 # `openssl/vendored` feature to it if `vendor-openssl` is enabled.
 [target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios", target_os = "watchos", target_os = "tvos")))'.dependencies]
-openssl = { workspace = true }
+openssl = { workspace = true, optional = true }
 
 [features]
 default = ["fonts", "packages"]
@@ -37,7 +37,7 @@ default = ["fonts", "packages"]
 fonts = ["dep:fontdb", "fontdb/memmap", "fontdb/fontconfig"]
 
 # Add generic downloading utilities
-downloads = ["dep:env_proxy", "dep:native-tls", "dep:ureq"]
+downloads = ["dep:env_proxy", "dep:native-tls", "dep:ureq", "openssl"]
 
 # Add package downloading utilities, implies `downloads`
 packages = ["downloads", "dep:dirs", "dep:flate2", "dep:tar"]

--- a/crates/typst-kit/Cargo.toml
+++ b/crates/typst-kit/Cargo.toml
@@ -37,7 +37,7 @@ default = ["fonts", "packages"]
 fonts = ["dep:fontdb", "fontdb/memmap", "fontdb/fontconfig"]
 
 # Add generic downloading utilities
-downloads = ["dep:env_proxy", "dep:native-tls", "dep:ureq", "openssl"]
+downloads = ["dep:env_proxy", "dep:native-tls", "dep:ureq", "dep:openssl"]
 
 # Add package downloading utilities, implies `downloads`
 packages = ["downloads", "dep:dirs", "dep:flate2", "dep:tar"]

--- a/crates/typst-kit/src/package.rs
+++ b/crates/typst-kit/src/package.rs
@@ -85,9 +85,11 @@ impl PackageStorage {
             }
 
             // Download from network if it doesn't exist yet.
-            self.download_package(spec, &dir, progress)?;
-            if dir.exists() {
-                return Ok(dir);
+            if spec.namespace == "preview" {
+                self.download_package(spec, &dir, progress)?;
+                if dir.exists() {
+                    return Ok(dir);
+                }
             }
         }
 


### PR DESCRIPTION
This PR attempts to resolve  https://github.com/typst/typst/issues/4718 by reverting the change identified by @PgBiel . 
Not sure if someone is already working on it - if yes (or if the way I've done it is not right), feel free to close this PR.

It also makes the OpenSLL dependency in typst-kit optional as suggested by @laurmaedje [here](https://github.com/typst/typst/pull/4540).