### PR TITLE
Fix lexer on sth followed by comments

### DIFF
--- a/crates/typst-syntax/src/lexer.rs
+++ b/crates/typst-syntax/src/lexer.rs
@@ -503,7 +503,10 @@ impl Lexer<'_> {
     }
 
     fn space_or_end(&self) -> bool {
-        self.s.done() || self.s.at(char::is_whitespace)
+        self.s.done()
+            || self.s.at(char::is_whitespace)
+            || self.s.at("//")
+            || self.s.at("/*")
     }
 }
 

--- a/tests/suite/syntax/comment.typ
+++ b/tests/suite/syntax/comment.typ
@@ -34,6 +34,41 @@ Second part
 First part          //
 Second part
 
+--- issue-4632-sth-followed-by-comment ---
+// Test heading markers followed by comments.
+#test([
+  =// Comment
+  =/* Comment */
+], [
+  =
+  =
+])
+
+// Test list markers followed by comments.
+#test([
+  -// Comment
+  -/* Comment */
+], [
+  -
+  -
+])
+
+// Test enum markers followed by comments.
+#test([
+  +// Comment
+  +/* Comment */
+
+  1.// Comment
+  2./* Comment */
+], [
+  +
+  +
+
+  1.
+  2.
+])
+
+
 --- comment-block-unclosed ---
 // End should not appear without start.
 // Error: 7-9 unexpected end of block comment


### PR DESCRIPTION
Fixes #4632.

I adjusted the function `space_or_end` for the fix. As this function is private, so only some  syntax nodes are affected in lexing process. They are
1. `SyntaxKind::HeadingMarker`
2. `SyntaxKind::ListMarker`
3. `SyntaxKind::EnumMarker`
4. `SyntaxKind::TermMarker`

I believe, when dealing with these syntax nodes (except for term-marker), comments after them **should be treated as spaces**. And, apparently, we don't need to deal with term-markers (`/`) followed by comments (`//` or `/*`). Thus I think my adjustment does no harm to the lexer and fixes the issue correctly.