### PR TITLE
Add benchmarking of test suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,7 +353,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -420,7 +420,7 @@ checksum = "c8936e42f9b4f5bdfaf23700609ac1f11cb03ad4c1ec128a4ee4fd0903e228db"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -541,7 +541,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -573,7 +573,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -620,7 +620,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -880,6 +880,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b24ad5637230df201ab1034d593f1d09bf7f2a9274f2e8897638078579f4265"
 
 [[package]]
+name = "iai-callgrind"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cb8104440b95df18524edb6b37c59c412a4eaee28eb52cf5c893fddc79eab30"
+dependencies = [
+ "bincode",
+ "iai-callgrind-macros",
+ "iai-callgrind-runner",
+]
+
+[[package]]
+name = "iai-callgrind-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065a2a6ff103151860ce6f416eac6667e87dd7d866e7f5ebfd10f70c0e98c090"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.70",
+]
+
+[[package]]
+name = "iai-callgrind-runner"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61a004e04c161d16fcbfec3419c5cfc2589dbf8f45429cc7d16fdee1c4af386"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1024,7 +1056,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -1463,7 +1495,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -1530,7 +1562,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -1609,7 +1641,7 @@ dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -1695,7 +1727,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -1782,6 +1814,30 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -2136,7 +2192,7 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -2302,7 +2358,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -2342,6 +2398,16 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f0209b68b3613b093e0ec905354eccaedcfe83b8cb37cbdeae64026c3064c16"
@@ -2359,7 +2425,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -2445,7 +2511,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -2784,7 +2850,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -2869,6 +2935,7 @@ dependencies = [
  "clap",
  "comemo",
  "ecow",
+ "iai-callgrind",
  "once_cell",
  "oxipng",
  "parking_lot",
@@ -3132,7 +3199,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.70",
  "wasm-bindgen-shared",
 ]
 
@@ -3154,7 +3221,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.70",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3500,7 +3567,7 @@ checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.70",
  "synstructure",
 ]
 
@@ -3521,7 +3588,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -3541,7 +3608,7 @@ checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.70",
  "synstructure",
 ]
 
@@ -3577,7 +3644,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.70",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,9 +881,9 @@ checksum = "3b24ad5637230df201ab1034d593f1d09bf7f2a9274f2e8897638078579f4265"
 
 [[package]]
 name = "iai-callgrind"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a78ccb3312d22603d4ee8498216d338f15d5b2d959cf4438ba780eedfad8914"
+checksum = "283f598a969822c70af13aae1272ba09c97014c7344d3b24652e5b1d7b771c36"
 dependencies = [
  "bincode",
  "iai-callgrind-macros",
@@ -906,9 +906,9 @@ dependencies = [
 
 [[package]]
 name = "iai-callgrind-runner"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f0e43cd457ebe0085b420ca96c6467270beaf09a33ebc50bc8717becf721b1"
+checksum = "fb92a65def0d3a0ef41029c411dc2ecdd3518708c062f8bd576fd4143be1c56b"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,9 +881,9 @@ checksum = "3b24ad5637230df201ab1034d593f1d09bf7f2a9274f2e8897638078579f4265"
 
 [[package]]
 name = "iai-callgrind"
-version = "0.12.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cb8104440b95df18524edb6b37c59c412a4eaee28eb52cf5c893fddc79eab30"
+checksum = "0a78ccb3312d22603d4ee8498216d338f15d5b2d959cf4438ba780eedfad8914"
 dependencies = [
  "bincode",
  "iai-callgrind-macros",
@@ -892,21 +892,23 @@ dependencies = [
 
 [[package]]
 name = "iai-callgrind-macros"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065a2a6ff103151860ce6f416eac6667e87dd7d866e7f5ebfd10f70c0e98c090"
+checksum = "04e2ff2e86bdba764b66d94b65f2caa03da60d971a6930fdc2e67f12582c5bb8"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
+ "serde",
+ "serde_json",
  "syn 2.0.70",
 ]
 
 [[package]]
 name = "iai-callgrind-runner"
-version = "0.12.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61a004e04c161d16fcbfec3419c5cfc2589dbf8f45429cc7d16fdee1c4af386"
+checksum = "53f0e43cd457ebe0085b420ca96c6467270beaf09a33ebc50bc8717becf721b1"
 dependencies = [
  "serde",
 ]
@@ -2932,6 +2934,7 @@ dependencies = [
 name = "typst-tests"
 version = "0.11.0"
 dependencies = [
+ "base64",
  "clap",
  "comemo",
  "ecow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,6 +138,10 @@ opt-level = 2
 lto = "thin"
 codegen-units = 1
 
+[profile.bench]
+debug = true
+strip = false
+
 [profile.release.package."typst-cli"]
 strip = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ fs_extra = "1.3"
 hayagriva = "0.5.3"
 heck = "0.5"
 hypher = "0.1.4"
+iai-callgrind = "0.12.0"
 icu_properties = { version = "1.4", features = ["serde"] }
 icu_provider = { version = "1.4", features = ["sync"] }
 icu_provider_adapters = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ fs_extra = "1.3"
 hayagriva = "0.5.3"
 heck = "0.5"
 hypher = "0.1.4"
-iai-callgrind = "0.12.0"
+iai-callgrind = "0.12.2"
 icu_properties = { version = "1.4", features = ["serde"] }
 icu_provider = { version = "1.4", features = ["sync"] }
 icu_provider_adapters = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ fs_extra = "1.3"
 hayagriva = "0.5.3"
 heck = "0.5"
 hypher = "0.1.4"
-iai-callgrind = "0.12.2"
+iai-callgrind = "0.12.3"
 icu_properties = { version = "1.4", features = ["serde"] }
 icu_provider = { version = "1.4", features = ["sync"] }
 icu_provider_adapters = "1.4"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -11,6 +11,11 @@ name = "tests"
 path = "src/tests.rs"
 harness = false
 
+[[bench]]
+name = "benches"
+path = "src/benches.rs"
+harness = false
+
 [dependencies]
 typst = { workspace = true }
 typst-assets = { workspace = true, features = ["fonts"] }
@@ -21,6 +26,7 @@ typst-svg = { workspace = true }
 clap = { workspace = true }
 comemo = { workspace = true }
 ecow = { workspace = true }
+iai-callgrind = { workspace = true }
 once_cell = { workspace = true }
 oxipng = { workspace = true }
 parking_lot = { workspace = true }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -6,14 +6,20 @@ authors = { workspace = true }
 edition = { workspace = true }
 publish = false
 
+[lib]
+crate-type = ["lib"]
+
+[[bin]]
+name = "prepare-benches"
+path = "src/benches.rs"
+
 [[test]]
 name = "tests"
 path = "src/tests.rs"
 harness = false
 
 [[bench]]
-name = "benches"
-path = "src/benches.rs"
+name = "tests"
 harness = false
 
 [dependencies]
@@ -23,6 +29,7 @@ typst-dev-assets = { workspace = true }
 typst-pdf = { workspace = true }
 typst-render = { workspace = true }
 typst-svg = { workspace = true }
+base64 = { workspace = true }
 clap = { workspace = true }
 comemo = { workspace = true }
 ecow = { workspace = true }

--- a/tests/benches/tests.rs
+++ b/tests/benches/tests.rs
@@ -1,15 +1,28 @@
 use base64::Engine;
-use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+use ecow::EcoString;
+use iai_callgrind::{
+    library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig,
+};
 use typst::syntax::{FileId, Source, VirtualPath};
 use typst_tests::world::TestWorld;
 
-fn benchmark_setup(line: String) -> TestWorld {
-    let source = String::from_utf8(
+fn source_from_line(line: &str) -> Result<String, EcoString> {
+    let Some(content) = line.split_ascii_whitespace().nth(1) else {
+        return Ok(String::new());
+    };
+    String::from_utf8(
         base64::engine::general_purpose::STANDARD
-            .decode(line.split_ascii_whitespace().nth(1).unwrap())
-            .unwrap(),
+            .decode(content)
+            .map_err::<EcoString, _>(|e| typst::diag::error!("Invalid base64: {e}"))?,
     )
-    .unwrap();
+    .map_err::<EcoString, _>(|e| {
+        typst::diag::error!("Invalid UTF-8 of decoded content: {e}")
+    })
+}
+
+fn benchmark_setup(line: String) -> TestWorld {
+    let source =
+        source_from_line(&line).unwrap_or_else(|e| panic!("Malformed line {line}: {e}"));
     TestWorld::new(Source::new(FileId::new_fake(VirtualPath::new("stdin")), source))
 }
 
@@ -19,8 +32,13 @@ fn benchmark_function(world: TestWorld) {
     let output = typst::compile(&world);
     let _ = std::hint::black_box(output);
 }
+
 library_benchmark_group!(
     name = main_group;
     benchmarks = benchmark_function
 );
-main!(library_benchmark_groups = main_group);
+
+main!(
+    config = LibraryBenchmarkConfig::default().truncate_description(Some(100));
+    library_benchmark_groups = main_group
+);

--- a/tests/benches/tests.rs
+++ b/tests/benches/tests.rs
@@ -1,0 +1,26 @@
+use base64::Engine;
+use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+use typst::syntax::{FileId, Source, VirtualPath};
+use typst_tests::world::TestWorld;
+
+fn benchmark_setup(line: String) -> TestWorld {
+    let source = String::from_utf8(
+        base64::engine::general_purpose::STANDARD
+            .decode(line.split_ascii_whitespace().nth(1).unwrap())
+            .unwrap(),
+    )
+    .unwrap();
+    TestWorld::new(Source::new(FileId::new_fake(VirtualPath::new("stdin")), source))
+}
+
+#[library_benchmark]
+#[benches::my_id(file = "tests/store/fixtures", setup = benchmark_setup)]
+fn benchmark_function(world: TestWorld) {
+    let output = typst::compile(&world);
+    let _ = std::hint::black_box(output);
+}
+library_benchmark_group!(
+    name = main_group;
+    benchmarks = benchmark_function
+);
+main!(library_benchmark_groups = main_group);

--- a/tests/src/benches.rs
+++ b/tests/src/benches.rs
@@ -1,9 +1,8 @@
-//! Typst's test runner.
+//! Typst's benchmark runner.
 
 mod args;
 mod collect;
 mod constants;
-mod custom;
 mod logger;
 mod run;
 mod world;
@@ -12,9 +11,11 @@ use std::path::Path;
 use std::time::Duration;
 
 use clap::Parser;
+use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use rayon::iter::{ParallelBridge, ParallelIterator};
+use std::hint::black_box;
 
 use crate::args::{CliArguments, Command};
 use crate::logger::Logger;
@@ -26,7 +27,7 @@ fn main() {
     setup();
 
     match &ARGS.command {
-        None => test(),
+        None => bench(),
         Some(Command::Clean) => std::fs::remove_dir_all(constants::STORE_PATH).unwrap(),
     }
 }
@@ -50,7 +51,7 @@ fn setup() {
     }
 }
 
-fn test() {
+fn bench() {
     let (tests, skipped) = crate::collect::collect_or_exit();
 
     let selected = tests.len();
@@ -85,7 +86,7 @@ fn test() {
         // to `typst::utils::Deferred` yielding.
         tests.iter().par_bridge().for_each(|test| {
             logger.lock().start(test);
-            let result = std::panic::catch_unwind(|| run::run(test));
+            let result = std::panic::catch_unwind(|| run::bench(test));
             logger.lock().end(test, result);
         });
 

--- a/tests/src/benches.rs
+++ b/tests/src/benches.rs
@@ -11,11 +11,9 @@ use std::path::Path;
 use std::time::Duration;
 
 use clap::Parser;
-use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use rayon::iter::{ParallelBridge, ParallelIterator};
-use std::hint::black_box;
 
 use crate::args::{CliArguments, Command};
 use crate::logger::Logger;
@@ -86,7 +84,7 @@ fn bench() {
         // to `typst::utils::Deferred` yielding.
         tests.iter().par_bridge().for_each(|test| {
             logger.lock().start(test);
-            let result = std::panic::catch_unwind(|| run::bench(test));
+            let result = std::panic::catch_unwind(|| run::run(test));
             logger.lock().end(test, result);
         });
 

--- a/tests/src/collect.rs
+++ b/tests/src/collect.rs
@@ -18,6 +18,20 @@ pub fn collect() -> Result<(Vec<Test>, usize), Vec<TestParseError>> {
     Collector::new().collect()
 }
 
+/// Like [`collect`], but prints all errors and exits if this didn’t succeed.
+pub fn collect_or_exit() -> (Vec<Test>, usize) {
+    match crate::collect::collect() {
+        Ok(output) => output,
+        Err(errors) => {
+            eprintln!("failed to collect tests");
+            for error in errors {
+                eprintln!("❌ {error}");
+            }
+            std::process::exit(1);
+        }
+    }
+}
+
 /// A single test.
 pub struct Test {
     pub pos: FilePos,

--- a/tests/src/collect.rs
+++ b/tests/src/collect.rs
@@ -139,7 +139,9 @@ impl Collector {
 
     /// Walks through all test files and collects the tests.
     fn walk_files(&mut self) {
-        for entry in walkdir::WalkDir::new(crate::SUITE_PATH).sort_by_file_name() {
+        for entry in
+            walkdir::WalkDir::new(crate::constants::SUITE_PATH).sort_by_file_name()
+        {
             let entry = entry.unwrap();
             let path = entry.path();
             if !path.extension().is_some_and(|ext| ext == "typ") {
@@ -158,7 +160,8 @@ impl Collector {
     /// Walks through all reference images and ensure that a test exists for
     /// each one.
     fn walk_references(&mut self) {
-        for entry in walkdir::WalkDir::new(crate::REF_PATH).sort_by_file_name() {
+        for entry in walkdir::WalkDir::new(crate::constants::REF_PATH).sort_by_file_name()
+        {
             let entry = entry.unwrap();
             let path = entry.path();
             if !path.extension().is_some_and(|ext| ext == "png") {
@@ -177,7 +180,7 @@ impl Collector {
             };
 
             let len = path.metadata().unwrap().len() as usize;
-            if !self.large.contains(name) && len > crate::REF_LIMIT {
+            if !self.large.contains(name) && len > crate::constants::REF_LIMIT {
                 self.errors.push(TestParseError {
                     pos: pos.clone(),
                     message: format!(

--- a/tests/src/collect.rs
+++ b/tests/src/collect.rs
@@ -9,6 +9,8 @@ use typst::syntax::package::PackageVersion;
 use typst::syntax::{is_id_continue, is_ident, is_newline, FileId, Source, VirtualPath};
 use unscanny::Scanner;
 
+use crate::constants;
+
 /// Collects all tests from all files.
 ///
 /// Returns:
@@ -153,9 +155,7 @@ impl Collector {
 
     /// Walks through all test files and collects the tests.
     fn walk_files(&mut self) {
-        for entry in
-            walkdir::WalkDir::new(crate::constants::SUITE_PATH).sort_by_file_name()
-        {
+        for entry in walkdir::WalkDir::new(constants::SUITE_PATH).sort_by_file_name() {
             let entry = entry.unwrap();
             let path = entry.path();
             if !path.extension().is_some_and(|ext| ext == "typ") {
@@ -174,8 +174,7 @@ impl Collector {
     /// Walks through all reference images and ensure that a test exists for
     /// each one.
     fn walk_references(&mut self) {
-        for entry in walkdir::WalkDir::new(crate::constants::REF_PATH).sort_by_file_name()
-        {
+        for entry in walkdir::WalkDir::new(constants::REF_PATH).sort_by_file_name() {
             let entry = entry.unwrap();
             let path = entry.path();
             if !path.extension().is_some_and(|ext| ext == "png") {
@@ -194,12 +193,12 @@ impl Collector {
             };
 
             let len = path.metadata().unwrap().len() as usize;
-            if !self.large.contains(name) && len > crate::constants::REF_LIMIT {
+            if !self.large.contains(name) && len > constants::REF_LIMIT {
                 self.errors.push(TestParseError {
                     pos: pos.clone(),
                     message: format!(
                         "reference image size exceeds {}, but the test is not marked as `// LARGE`",
-                        FileSize(crate::REF_LIMIT),
+                        FileSize(constants::REF_LIMIT),
                     ),
                 });
             }

--- a/tests/src/constants.rs
+++ b/tests/src/constants.rs
@@ -1,0 +1,13 @@
+//! Paths and other constants used for the test runner.
+
+/// The directory where the test suite is located.
+pub const SUITE_PATH: &str = "tests/suite";
+
+/// The directory where the full test results are stored.
+pub const STORE_PATH: &str = "tests/store";
+
+/// The directory where the reference images are stored.
+pub const REF_PATH: &str = "tests/ref";
+
+/// The maximum size of reference images that aren't marked as `// LARGE`.
+pub const REF_LIMIT: usize = 20 * 1024;

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,0 +1,14 @@
+use args::CliArguments;
+use clap::Parser;
+use once_cell::sync::Lazy;
+
+pub mod args;
+pub mod collect;
+pub mod constants;
+pub mod custom;
+pub mod logger;
+pub mod run;
+pub mod world;
+
+/// The parsed command line arguments.
+pub static ARGS: Lazy<CliArguments> = Lazy::new(CliArguments::parse);

--- a/tests/src/run.rs
+++ b/tests/src/run.rs
@@ -12,6 +12,7 @@ use typst::visualize::Color;
 use typst::WorldExt;
 
 use crate::collect::{FileSize, NoteKind, Test};
+use crate::constants;
 use crate::world::TestWorld;
 
 /// Runs a single test.
@@ -144,8 +145,9 @@ impl<'a> Runner<'a> {
 
     /// Check that the document output is correct.
     fn check_document(&mut self, document: Option<&Document>) {
-        let live_path = format!("{}/render/{}.png", crate::STORE_PATH, self.test.name);
-        let ref_path = format!("{}/{}.png", crate::REF_PATH, self.test.name);
+        let live_path =
+            format!("{}/render/{}.png", constants::STORE_PATH, self.test.name);
+        let ref_path = format!("{}/{}.png", constants::REF_PATH, self.test.name);
         let has_ref = Path::new(&ref_path).exists();
 
         let Some(document) = document else {
@@ -185,14 +187,16 @@ impl<'a> Runner<'a> {
 
         // Write PDF if requested.
         if crate::ARGS.pdf() {
-            let pdf_path = format!("{}/pdf/{}.pdf", crate::STORE_PATH, self.test.name);
+            let pdf_path =
+                format!("{}/pdf/{}.pdf", constants::STORE_PATH, self.test.name);
             let pdf = typst_pdf::pdf(document, Smart::Auto, None, None);
             std::fs::write(pdf_path, pdf).unwrap();
         }
 
         // Write SVG if requested.
         if crate::ARGS.svg() {
-            let svg_path = format!("{}/svg/{}.svg", crate::STORE_PATH, self.test.name);
+            let svg_path =
+                format!("{}/svg/{}.svg", constants::STORE_PATH, self.test.name);
             let svg = typst_svg::svg_merged(document, Abs::pt(5.0));
             std::fs::write(svg_path, svg).unwrap();
         }
@@ -220,9 +224,9 @@ impl<'a> Runner<'a> {
                 let opts = oxipng::Options::max_compression();
                 let data = pixmap.encode_png().unwrap();
                 let ref_data = oxipng::optimize_from_memory(&data, &opts).unwrap();
-                if !self.test.large && ref_data.len() > crate::constants::REF_LIMIT {
+                if !self.test.large && ref_data.len() > constants::REF_LIMIT {
                     log!(self, "reference image would exceed maximum size");
-                    log!(self, "  maximum   | {}", FileSize(crate::REF_LIMIT));
+                    log!(self, "  maximum   | {}", FileSize(constants::REF_LIMIT));
                     log!(self, "  size      | {}", FileSize(ref_data.len()));
                     log!(self, "please try to minimize the size of the test (smaller pages, less text, etc.)");
                     log!(self, "if you think the test cannot be reasonably minimized, mark it as `// LARGE`");

--- a/tests/src/run.rs
+++ b/tests/src/run.rs
@@ -220,7 +220,7 @@ impl<'a> Runner<'a> {
                 let opts = oxipng::Options::max_compression();
                 let data = pixmap.encode_png().unwrap();
                 let ref_data = oxipng::optimize_from_memory(&data, &opts).unwrap();
-                if !self.test.large && ref_data.len() > crate::REF_LIMIT {
+                if !self.test.large && ref_data.len() > crate::constants::REF_LIMIT {
                     log!(self, "reference image would exceed maximum size");
                     log!(self, "  maximum   | {}", FileSize(crate::REF_LIMIT));
                     log!(self, "  size      | {}", FileSize(ref_data.len()));

--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -1,26 +1,13 @@
 //! Typst's test runner.
 
-mod args;
-mod collect;
-mod constants;
-mod custom;
-mod logger;
-mod run;
-mod world;
-
 use std::path::Path;
 use std::time::Duration;
 
-use clap::Parser;
-use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use rayon::iter::{ParallelBridge, ParallelIterator};
-
-use crate::args::{CliArguments, Command};
-use crate::logger::Logger;
-
-/// The parsed command line arguments.
-static ARGS: Lazy<CliArguments> = Lazy::new(CliArguments::parse);
+use typst_tests::args::Command;
+use typst_tests::logger::Logger;
+use typst_tests::{constants, run, ARGS};
 
 fn main() {
     setup();
@@ -51,7 +38,7 @@ fn setup() {
 }
 
 fn test() {
-    let (tests, skipped) = crate::collect::collect_or_exit();
+    let (tests, skipped) = typst_tests::collect::collect_or_exit();
 
     let selected = tests.len();
     if ARGS.list {

--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -2,6 +2,7 @@
 
 mod args;
 mod collect;
+mod constants;
 mod custom;
 mod logger;
 mod run;
@@ -21,24 +22,12 @@ use crate::logger::Logger;
 /// The parsed command line arguments.
 static ARGS: Lazy<CliArguments> = Lazy::new(CliArguments::parse);
 
-/// The directory where the test suite is located.
-const SUITE_PATH: &str = "tests/suite";
-
-/// The directory where the full test results are stored.
-const STORE_PATH: &str = "tests/store";
-
-/// The directory where the reference images are stored.
-const REF_PATH: &str = "tests/ref";
-
-/// The maximum size of reference images that aren't marked as `// LARGE`.
-const REF_LIMIT: usize = 20 * 1024;
-
 fn main() {
     setup();
 
     match &ARGS.command {
         None => test(),
-        Some(Command::Clean) => std::fs::remove_dir_all(STORE_PATH).unwrap(),
+        Some(Command::Clean) => std::fs::remove_dir_all(constants::STORE_PATH).unwrap(),
     }
 }
 
@@ -49,7 +38,7 @@ fn setup() {
 
     // Create the storage.
     for ext in ["render", "pdf", "svg"] {
-        std::fs::create_dir_all(Path::new(STORE_PATH).join(ext)).unwrap();
+        std::fs::create_dir_all(Path::new(constants::STORE_PATH).join(ext)).unwrap();
     }
 
     // Set up the thread pool.


### PR DESCRIPTION
See #680.

Currently uses `iai-callgrind` on the integration test cases, though we could add `criterion`-based benchmarks or dedicated benchmarks as well.

Due to limitations in `iai-callgrind`, running the benchmarks requires running `cargo run --bin prepare-benches` first to generate the fixture file – see iai-callgrind/iai-callgrind#207 for more details. Otherwise, the benchmarking code Works™, though it takes a good part of an hour to run through the whole test suite.