### PR TITLE
Improve documents for the `--font-path` arg & `TYPST_FONT_PATHS` env

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -385,7 +385,10 @@ pub struct FontsCommand {
 /// Common arguments to customize available fonts
 #[derive(Debug, Clone, Parser)]
 pub struct FontArgs {
-    /// Adds additional directories to search for fonts
+    /// Adds additional directories that are recursively searched for fonts
+    ///
+    /// If multiple paths are specified, they are separated by the system's path
+    /// separator (`:` on Unix-like systems and `;` on Windows).
     #[clap(
         long = "font-path",
         env = "TYPST_FONT_PATHS",


### PR DESCRIPTION
Closes #1708.