### PR TITLE
Add checkmark ballot symbols

### DIFF
--- a/crates/typst/src/symbols/sym.rs
+++ b/crates/typst/src/symbols/sym.rs
@@ -476,7 +476,7 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
     yen: '¥',
 
     // Miscellaneous.
-    ballot: ['☐', x: '☒'],
+    ballot: ['☐', x: '☒', check: '☑', check.heavy: '🗹'],
     checkmark: ['✓', light: '🗸', heavy: '✔'],
     crossmark: ['✗', heavy: '✘'],
     floral: ['❦', l: '☙', r: '❧'],

--- a/crates/typst/src/symbols/sym.rs
+++ b/crates/typst/src/symbols/sym.rs
@@ -476,7 +476,7 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
     yen: '¥',
 
     // Miscellaneous.
-    ballot: ['☐', x: '☒', check: '☑', check.heavy: '🗹'],
+    ballot: ['☐', cross: '☒', check: '☑', check.heavy: '🗹'],
     checkmark: ['✓', light: '🗸', heavy: '✔'],
     crossmark: ['✗', heavy: '✘'],
     floral: ['❦', l: '☙', r: '❧'],


### PR DESCRIPTION
This small PR adds the two checkmarked ballot symbols as `ballot.check` and `ballot.check.heavy`.

Unicode calls `ballot.check.heavy` "BALLOT BOX WITH BOLD CHECK", but I think using "heavy" is more consistent here.

Another question is whether we should rename `ballot.x` to `ballot.cross` for more consistency.

I also debated whether to add U+237B ⍻ NOT CHECK MARK, but decided not to because it seems to be an old and unused symbol.[^1]

[^1]: https://en.wiktionary.org/wiki/%E2%8D%BB