### PR TITLE
Add double parentheses, braces and shell variants

### DIFF
--- a/crates/typst/src/symbols/sym.rs
+++ b/crates/typst/src/symbols/sym.rs
@@ -41,7 +41,7 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
     paren: [l: '(', l.double: '⦅', r: ')', r.double: '⦆', t: '⏜', b: '⏝'],
     brace: [l: '{', l.double: '⦃', r: '}', r.double: '⦄', t: '⏞', b: '⏟'],
     bracket: [l: '[', l.double: '⟦', r: ']', r.double: '⟧', t: '⎴', b: '⎵'],
-    shell: [l: '〔', r: '〕', t: '⏠', b: '⏡'],
+    shell: [l: '❲', l.double: '⟬', r: '❳', r.double: '⟭', t: '⏠', b: '⏡'],
     bar: [v: '|', v.double: '‖', v.triple: '⦀', v.broken: '¦', v.circle: '⦶', h: '―'],
     fence: [l: '⧘', l.double: '⧚', r: '⧙', r.double: '⧛', dotted: '⦙'],
     angle: [

--- a/crates/typst/src/symbols/sym.rs
+++ b/crates/typst/src/symbols/sym.rs
@@ -38,8 +38,8 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
     ],
 
     // Delimiters.
-    paren: [l: '(', r: ')', t: '⏜', b: '⏝'],
-    brace: [l: '{', r: '}', t: '⏞', b: '⏟'],
+    paren: [l: '(', l.double: '⦅', r: ')', r.double: '⦆', t: '⏜', b: '⏝'],
+    brace: [l: '{', l.double: '⦃', r: '}', r.double: '⦄', t: '⏞', b: '⏟'],
     bracket: [l: '[', l.double: '⟦', r: ']', r.double: '⟧', t: '⎴', b: '⎵'],
     shell: [l: '〔', r: '〕', t: '⏠', b: '⏡'],
     bar: [v: '|', v.double: '‖', v.triple: '⦀', v.broken: '¦', v.circle: '⦶', h: '―'],


### PR DESCRIPTION
This PR adds `{paren,brace,shell}.{l,r}.double` and updates `shell.{l,r}` to use the right codepoints (see original comment below).

## Original comment

I did not add double variants for `shell` because there are two of them, and I'm unsure which one to choose:
- U+27EC ⟬ MATHEMATICAL LEFT WHITE TORTOISE SHELL BRACKET and U+27ED ⟭ MATHEMATICAL RIGHT WHITE TORTOISE SHELL BRACKET, from Miscellaneous Mathematical Symbols-A, or
- U+3018 〘 LEFT WHITE TORTOISE SHELL BRACKET and U+3019 〙 RIGHT WHITE TORTOISE SHELL BRACKET, from CJK Symbols and Punctuation.

Note that Unicode also defines two main regular tortoise shell variants (`shell` currently uses the second one):
- U+2772 ❲ LIGHT LEFT TORTOISE SHELL BRACKET ORNAMENT and U+2773 ❳ LIGHT RIGHT TORTOISE SHELL BRACKET ORNAMENT in the "Dingbats" block, and
- U+3014 〔 LEFT TORTOISE SHELL BRACKET and U+3015 〕 RIGHT TORTOISE SHELL BRACKET in the "CJK Symbols and Punctuation" block.

I think we should use the codepoints from Miscellaneous Mathematical Symbols-A and Dingbats rather than CJK symbols (meaning we should also change `shell.l` and `shell.r`) because they seem to be more appropriate for use as math symbols.

As a comparison, here is how those characters render in the webapp (the first line is text mode, and the other two lines are in math mode):
![image](https://github.com/user-attachments/assets/01c7bdee-9172-4062-976c-f3d0f9b36ac6)

<details>
<summary>Source code</summary>

```typ
#set align(center)

#let tortoise = symbol(
  ("dingbats.l", "❲"),
  ("dingbats.r", "❳"),
  ("math.l.double", "⟬"),
  ("math.r.double", "⟭"),
  ("cjk.l", "〔"),
  ("cjk.r", "〕"),
  ("cjk.l.double", "〘"),
  ("cjk.r.double", "〙"),
)

#tortoise.dingbats.l
Dingbats
#tortoise.dingbats.r
and
#tortoise.cjk.l
CJK
#tortoise.cjk.r

$
  tortoise.dingbats.l
  "Dingbats"
  tortoise.dingbats.r
  +
  tortoise.cjk.l
  "CJK"
  tortoise.cjk.r
$

$
  tortoise.math.l.double
  "Mathematical"
  tortoise.math.r.double
  +
  tortoise.cjk.l.double
  "CJK"
  tortoise.cjk.r.double
$
```
</details>

