### PR TITLE
Add miscellaneous symbols from Miscellaneous Mathematical Symbols-B

### DIFF
--- a/crates/typst/src/symbols/sym.rs
+++ b/crates/typst/src/symbols/sym.rs
@@ -444,7 +444,7 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
     // Function and category theory.
     compose: '∘',
     convolve: '∗',
-    multimap: '⊸',
+    multimap: ['⊸', double: '⧟'],
 
     // Number theory.
     divides: ['∣', not: '∤'],

--- a/crates/typst/src/symbols/sym.rs
+++ b/crates/typst/src/symbols/sym.rs
@@ -186,10 +186,12 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
         circle.arrow: '⟴',
         circle.big: '⨁',
         dot: '∔',
+        double: '⧺',
         minus: '±',
         small: '﹢',
         square: '⊞',
         triangle: '⨹',
+        triple: '⧻',
     ],
     minus: [
         '−',

--- a/crates/typst/src/symbols/sym.rs
+++ b/crates/typst/src/symbols/sym.rs
@@ -453,6 +453,10 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
     convolve: '∗',
     multimap: ['⊸', double: '⧟'],
 
+    // Game theory.
+    tiny: '⧾',
+    miny: '⧿',
+
     // Number theory.
     divides: ['∣', not: '∤'],
 

--- a/crates/typst/src/symbols/sym.rs
+++ b/crates/typst/src/symbols/sym.rs
@@ -395,7 +395,12 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
     ],
 
     // Calculus.
-    infinity: '∞',
+    infinity: [
+        '∞',
+        bar: '⧞',
+        incomplete: '⧜',
+        tie: '⧝',
+    ],
     oo: '∞',
     diff: '∂', // Deprecation planned
     partial: '∂',

--- a/crates/typst/src/symbols/sym.rs
+++ b/crates/typst/src/symbols/sym.rs
@@ -638,6 +638,7 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
         #[call(crate::math::accent::arrow)] r: '→',
         r.long.bar: '⟼',
         r.bar: '↦',
+        r.colon: '⧴',
         r.curve: '⤷',
         r.dashed: '⇢',
         r.dotted: '⤑',

--- a/crates/typst/src/symbols/sym.rs
+++ b/crates/typst/src/symbols/sym.rs
@@ -649,7 +649,6 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
         #[call(crate::math::accent::arrow)] r: '→',
         r.long.bar: '⟼',
         r.bar: '↦',
-        r.colon: '⧴',
         r.curve: '⤷',
         r.dashed: '⇢',
         r.dotted: '⤑',


### PR DESCRIPTION
This PR adds multiple unrelated symbols from the "Miscellaneous Mathematical Symbols-B" Unicode block.

As far as I can tell, `arrow.r.colon` does not have equivalent Unicode codepoints for other arrow directions, even outside Miscellaneous Mathematical Symbols-B. Maybe it should be named `colon.arrow` instead, similarly to `colon.eq`.

I added variants to `infinity`, but not to `oo`. I can add them to `oo` as well if you want.
