### PR TITLE
Add new variants to `parallel` symbol

### DIFF
--- a/crates/typst/src/symbols/sym.rs
+++ b/crates/typst/src/symbols/sym.rs
@@ -455,7 +455,7 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
     // Geometry.
     parallel: [
         '∥',
-        sruck: '⫲',
+        struck: '⫲',
         circle: '⦷',
         eq: '⋕',
         equiv: '⩨',

--- a/crates/typst/src/symbols/sym.rs
+++ b/crates/typst/src/symbols/sym.rs
@@ -453,7 +453,18 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
     wreath: '≀',
 
     // Geometry.
-    parallel: ['∥', circle: '⦷', not: '∦'],
+    parallel: [
+        '∥',
+        bar: '⫲',
+        circle: '⦷',
+        eq: '⋕',
+        equiv: '⩨',
+        not: '∦',
+        slanted.eq: '⧣',
+        slanted.eq.tilde: '⧤',
+        slanted.equiv: '⧥',
+        tilde: '⫳',
+    ],
     perp: ['⟂', circle: '⦹'],
 
     // Miscellaneous Technical.

--- a/crates/typst/src/symbols/sym.rs
+++ b/crates/typst/src/symbols/sym.rs
@@ -455,7 +455,7 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
     // Geometry.
     parallel: [
         '∥',
-        bar: '⫲',
+        sruck: '⫲',
         circle: '⦷',
         eq: '⋕',
         equiv: '⩨',


### PR DESCRIPTION
This PR adds new variants to the `parallel` symbol.

I'm not sure `bar` and `tilde` are the right variant names for U+2AF2 ⫲ PARALLEL WITH HORIZONTAL STROKE and U+2AF3 ⫳ PARALLEL WITH TILDE OPERATOR. The `tilde` variant name is inconsistent with `slanted.eq.tilde`, where the tilde is above the symbol instead of striking through it. The `bar` variant name is inconsistent with the `emptyset.bar` symbol added in #4826, where the bar is added above the symbol. I am unaware of any similar precedent.

Additionally, maybe `parallel.eq` should be named `eq.parallel` instead, and similarly for other `*.eq.*` and `*.equiv.*` variants.