### PR TITLE
Small improvements to the test runner

### DIFF
--- a/tests/src/args.rs
+++ b/tests/src/args.rs
@@ -46,6 +46,9 @@ pub struct CliArguments {
     /// Displays the syntax tree.
     #[arg(long)]
     pub syntax: bool,
+    /// Displays only one line per test, hiding details about failures.
+    #[arg(short, long)]
+    pub compact: bool,
     /// Prevents the terminal from being cleared of test names.
     #[arg(short, long)]
     pub verbose: bool,

--- a/tests/src/logger.rs
+++ b/tests/src/logger.rs
@@ -70,8 +70,10 @@ impl<'a> Logger<'a> {
         self.print(move |out| {
             if !result.errors.is_empty() {
                 writeln!(out, "❌ {test}")?;
-                for line in result.errors.lines() {
-                    writeln!(out, "  {line}")?;
+                if !crate::ARGS.compact {
+                    for line in result.errors.lines() {
+                        writeln!(out, "  {line}")?;
+                    }
                 }
             } else if crate::ARGS.verbose || !result.infos.is_empty() {
                 writeln!(out, "✅ {test}")?;

--- a/tests/src/run.rs
+++ b/tests/src/run.rs
@@ -157,6 +157,10 @@ impl<'a> Runner<'a> {
         };
 
         let skippable = match document.pages.as_slice() {
+            [] => {
+                log!(self, "document has zero pages");
+                return;
+            }
             [page] => skippable(page),
             _ => false,
         };
@@ -231,7 +235,7 @@ impl<'a> Runner<'a> {
                 std::fs::write(&ref_path, &ref_data).unwrap();
                 log!(
                     into: self.result.infos,
-                    "Updated reference image ({ref_path}, {})",
+                    "updated reference image ({ref_path}, {})",
                     FileSize(ref_data.len()),
                 );
             }
@@ -414,6 +418,7 @@ fn render_links(canvas: &mut sk::Pixmap, ts: sk::Transform, frame: &Frame) {
 fn skippable(page: &Page) -> bool {
     page.frame.width().approx_eq(Abs::pt(120.0))
         && page.frame.height().approx_eq(Abs::pt(20.0))
+        && page.fill.is_auto()
         && skippable_frame(&page.frame)
 }
 


### PR DESCRIPTION
- Detects if there are zero pages instead of panicking during rendering
- Doesn't skip otherwise skippable pages with fill anymore
- New `-c` or `--compact` mode for just one line per test. Makes it easier to go through a large number of failures.