### PR TITLE
Refactor depth checks and apply them in math

### DIFF
--- a/crates/typst/src/eval/call.rs
+++ b/crates/typst/src/eval/call.rs
@@ -30,9 +30,7 @@ impl Eval for ast::FuncCall<'_> {
         let args = self.args();
         let trailing_comma = args.trailing_comma();
 
-        if !vm.engine.route.within(Route::MAX_CALL_DEPTH) {
-            bail!(span, "maximum function call depth exceeded");
-        }
+        vm.engine.route.check_call_depth().at(span)?;
 
         // Try to evaluate as a call to an associated function or field.
         let (callee, args) = if let ast::Expr::FieldAccess(access) = callee {

--- a/crates/typst/src/layout/flow.rs
+++ b/crates/typst/src/layout/flow.rs
@@ -7,7 +7,7 @@ use std::num::NonZeroUsize;
 
 use comemo::{Track, Tracked, TrackedMut};
 
-use crate::diag::{bail, SourceResult};
+use crate::diag::{bail, At, SourceResult};
 use crate::engine::{Engine, Route, Sink, Traced};
 use crate::foundations::{
     Content, NativeElement, Packed, Resolve, Smart, StyleChain, Styles,
@@ -724,12 +724,7 @@ fn layout_fragment_impl(
         route: Route::extend(route),
     };
 
-    if !engine.route.within(Route::MAX_LAYOUT_DEPTH) {
-        bail!(
-            content.span(), "maximum layout depth exceeded";
-            hint: "try to reduce the amount of nesting in your layout",
-        );
-    }
+    engine.route.check_layout_depth().at(content.span())?;
 
     // If we are in a `PageElem`, this might already be a realized flow.
     let arenas = Arenas::default();

--- a/crates/typst/src/math/mod.rs
+++ b/crates/typst/src/math/mod.rs
@@ -42,7 +42,7 @@ use self::fragment::*;
 use self::row::*;
 use self::spacing::*;
 
-use crate::diag::SourceResult;
+use crate::diag::{At, SourceResult};
 use crate::foundations::{
     category, Category, Content, Module, Resolve, Scope, SequenceElem, StyleChain,
     StyledElem,
@@ -239,6 +239,9 @@ impl LayoutMath for Content {
         if let Some((tag, realized)) =
             process(ctx.engine, &mut ctx.locator, self, styles)?
         {
+            ctx.engine.route.increase();
+            ctx.engine.route.check_show_depth().at(self.span())?;
+
             if let Some(tag) = &tag {
                 ctx.push(MathFragment::Tag(tag.clone()));
             }
@@ -246,6 +249,8 @@ impl LayoutMath for Content {
             if let Some(tag) = tag {
                 ctx.push(MathFragment::Tag(tag.with_kind(TagKind::End)));
             }
+
+            ctx.engine.route.decrease();
             return Ok(());
         }
 

--- a/crates/typst/src/realize/mod.rs
+++ b/crates/typst/src/realize/mod.rs
@@ -15,8 +15,8 @@ pub use self::process::process;
 
 use std::mem;
 
-use crate::diag::{bail, SourceResult};
-use crate::engine::{Engine, Route};
+use crate::diag::{bail, At, SourceResult};
+use crate::engine::Engine;
 use crate::foundations::{
     Content, ContextElem, NativeElement, Packed, SequenceElem, Smart, StyleChain,
     StyleVec, StyledElem, Styles,
@@ -139,12 +139,7 @@ impl<'a, 'v> Builder<'a, 'v> {
             process(self.engine, self.locator, content, styles)?
         {
             self.engine.route.increase();
-            if !self.engine.route.within(Route::MAX_SHOW_RULE_DEPTH) {
-                bail!(
-                    content.span(), "maximum show rule depth exceeded";
-                    hint: "check whether the show rule matches its own output"
-                );
-            }
+            self.engine.route.check_show_depth().at(content.span())?;
 
             if let Some(tag) = &tag {
                 self.accept(self.arenas.store(TagElem::packed(tag.clone())), styles)?;

--- a/tests/suite/scripting/recursion.typ
+++ b/tests/suite/scripting/recursion.typ
@@ -53,3 +53,9 @@
 // Hint: 22-25 check whether the show rule matches its own output
 #show math.equation: $x$
 $ x $
+
+--- recursion-show-math-realize ---
+// Error: 22-33 maximum show rule depth exceeded
+// Hint: 22-33 check whether the show rule matches its own output
+#show heading: it => heading[it]
+$ #heading[hi] $


### PR DESCRIPTION
Brings all the checking into one place. So there's no need to copy paste it into math as well. Fixes #2996.