### PR TITLE
Add `at` method to `arguments`

### DIFF
--- a/crates/typst/src/foundations/args.rs
+++ b/crates/typst/src/foundations/args.rs
@@ -309,7 +309,7 @@ impl Args {
     ) -> StrResult<Value> {
         match &key {
             ArgumentKey::Index(index) => self.to_pos().at(*index, default).ok(),
-            ArgumentKey::Name(name) => self.to_named().at(name, default).ok(),
+            ArgumentKey::Name(name) => self.to_named().at(name.clone(), default).ok(),
         }
         .ok_or_else(|| missing_key_no_default(key))
     }

--- a/crates/typst/src/foundations/args.rs
+++ b/crates/typst/src/foundations/args.rs
@@ -1,11 +1,10 @@
 use std::fmt::{self, Debug, Formatter};
 
 use ecow::{eco_format, eco_vec, EcoString, EcoVec};
-use typst_macros::cast;
 
 use crate::diag::{bail, error, At, SourceDiagnostic, SourceResult, StrResult};
 use crate::foundations::{
-    func, repr, scope, ty, Array, Dict, FromValue, IntoValue, Repr, Str, Value,
+    cast, func, repr, scope, ty, Array, Dict, FromValue, IntoValue, Repr, Str, Value,
 };
 use crate::syntax::{Span, Spanned};
 

--- a/tests/suite/scripting/arguments.typ
+++ b/tests/suite/scripting/arguments.typ
@@ -1,0 +1,18 @@
+// Test arguments.
+
+--- arguments-at ---
+#let args = arguments(0, 1, a: 2, 3)
+#test(args.at(0), 0)
+#test(args.at(1), 1)
+#test(args.at(2), 3)
+#test(args.at("a"), 2)
+
+--- arguments-at-invalid-index ---
+#let args = arguments(0, 1, a: 2, 3)
+// Error: 2-12 arguments do not contain key 4 and no default value was specified
+#args.at(4)
+
+--- arguments-at-invalid-name ---
+#let args = arguments(0, 1, a: 2, 3)
+// Error: 2-14 arguments do not contain key "b" and no default value was specified
+#args.at("b")


### PR DESCRIPTION
This PR adds an `at` method to `arguments`, which corresponds to `arguments.pos(..).at` or `arguments.named(..).at` depending on the type of the parameter. This is just a convenience method, it doesn't allow anything new, but makes the `arguments` type more useful by itself.