### PR TITLE
Added `purge` CLI command

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -62,6 +62,9 @@ pub enum Command {
     /// Self update the Typst CLI
     #[cfg_attr(not(feature = "self-update"), doc = " (disabled)")]
     Update(UpdateCommand),
+
+    /// Purge the package cache
+    Purge(PurgeCommand),
 }
 
 /// Compiles an input file into a supported output format
@@ -175,6 +178,21 @@ pub struct QueryCommand {
 pub enum SerializationFormat {
     Json,
     Yaml,
+}
+
+/// Purge the package cache, removing all downloaded packages
+///
+/// This command is useful when the package cache is corrupted or
+/// when you want to free up disk space.
+#[derive(Debug, Clone, Parser)]
+pub struct PurgeCommand {
+    /// Arguments related to storage of packages in the system
+    #[clap(flatten)]
+    pub package_storage_args: PackageStorageArgs,
+
+    /// Whether to also remove the local packages directory
+    #[clap(long, required = false, action = ArgAction::SetTrue)]
+    pub local: bool,
 }
 
 /// Common arguments of compile, watch, and query.

--- a/crates/typst-cli/src/main.rs
+++ b/crates/typst-cli/src/main.rs
@@ -56,6 +56,7 @@ fn dispatch() -> HintedStrResult<()> {
         Command::Query(command) => crate::query::query(command)?,
         Command::Fonts(command) => crate::fonts::fonts(command)?,
         Command::Update(command) => crate::update::update(command)?,
+        Command::Purge(command) => crate::package::purge(command)?,
     }
 
     Ok(())

--- a/crates/typst-cli/src/package.rs
+++ b/crates/typst-cli/src/package.rs
@@ -1,6 +1,7 @@
+use typst::diag::PackageResult;
 use typst_kit::package::PackageStorage;
 
-use crate::args::PackageStorageArgs;
+use crate::args::{PackageStorageArgs, PurgeCommand};
 use crate::download;
 
 /// Returns a new package storage for the given args.
@@ -10,4 +11,19 @@ pub fn storage(args: &PackageStorageArgs) -> PackageStorage {
         args.package_path.clone(),
         download::downloader(),
     )
+}
+
+/// Purges the package cache.
+pub fn purge(command: &PurgeCommand) -> PackageResult<()> {
+    let storage = storage(&command.package_storage_args);
+
+    storage.purge_cache()?;
+    println!("Purged package cache");
+
+    if command.local {
+        storage.purge_local()?;
+        println!("Purged local packages");
+    }
+
+    Ok(())
 }

--- a/crates/typst-kit/src/package.rs
+++ b/crates/typst-kit/src/package.rs
@@ -178,4 +178,28 @@ impl PackageStorage {
             PackageError::MalformedArchive(Some(eco_format!("{err}")))
         })
     }
+
+    /// Purge the package cache.
+    pub fn purge_cache(&self) -> PackageResult<()> {
+        if let Some(cache_dir) = &self.package_cache_path {
+            if cache_dir.exists() {
+                fs::remove_dir_all(cache_dir)
+                    .map_err(|err| PackageError::Other(Some(eco_format!("{err}"))))?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Purge the local package storage.
+    pub fn purge_local(&self) -> PackageResult<()> {
+        if let Some(packages_dir) = &self.package_path {
+            if packages_dir.exists() {
+                fs::remove_dir_all(packages_dir)
+                    .map_err(|err| PackageError::Other(Some(eco_format!("{err}"))))?;
+            }
+        }
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
Adds a `purge` command to clean the package cache, can optionally specify the `--local` flag to also clear out the local package storage.

Closes #4441