### PR TITLE
Line::{stretchability, shrinkability}: return +0.0 when empty

### DIFF
--- a/crates/typst/src/layout/inline/line.rs
+++ b/crates/typst/src/layout/inline/line.rs
@@ -76,7 +76,7 @@ impl<'a> Line<'a> {
             .iter()
             .filter_map(Item::text)
             .map(|s| s.stretchability())
-            // Don’t use sum because it returns -0.0 for an empty iter
+            // Use fold instead of sum because sum returns -0.0 for an empty iter
             .fold(Abs::zero(), |acc, x| acc + x)
     }
 
@@ -86,7 +86,7 @@ impl<'a> Line<'a> {
             .iter()
             .filter_map(Item::text)
             .map(|s| s.shrinkability())
-            // Don’t use sum because it returns -0.0 for an empty iter
+            // Use fold instead of sum because sum returns -0.0 for an empty iter
             .fold(Abs::zero(), |acc, x| acc + x)
     }
 

--- a/crates/typst/src/layout/inline/line.rs
+++ b/crates/typst/src/layout/inline/line.rs
@@ -76,7 +76,8 @@ impl<'a> Line<'a> {
             .iter()
             .filter_map(Item::text)
             .map(|s| s.stretchability())
-            .sum()
+            // Don’t use sum because it returns -0.0 for an empty iter
+            .fold(Abs::zero(), |acc, x| acc + x)
     }
 
     /// How much the line can shrink.
@@ -85,7 +86,8 @@ impl<'a> Line<'a> {
             .iter()
             .filter_map(Item::text)
             .map(|s| s.shrinkability())
-            .sum()
+            // Don’t use sum because it returns -0.0 for an empty iter
+            .fold(Abs::zero(), |acc, x| acc + x)
     }
 
     /// Whether the line has items with negative width.

--- a/crates/typst/src/layout/inline/line.rs
+++ b/crates/typst/src/layout/inline/line.rs
@@ -72,21 +72,21 @@ impl<'a> Line<'a> {
 
     /// How much the line can stretch.
     pub fn stretchability(&self) -> Abs {
+        // Use fold instead of sum because sum returns -0.0 for an empty iter
         self.items
             .iter()
             .filter_map(Item::text)
             .map(|s| s.stretchability())
-            // Use fold instead of sum because sum returns -0.0 for an empty iter
             .fold(Abs::zero(), |acc, x| acc + x)
     }
 
     /// How much the line can shrink.
     pub fn shrinkability(&self) -> Abs {
+        // Use fold instead of sum because sum returns -0.0 for an empty iter
         self.items
             .iter()
             .filter_map(Item::text)
             .map(|s| s.shrinkability())
-            // Use fold instead of sum because sum returns -0.0 for an empty iter
             .fold(Abs::zero(), |acc, x| acc + x)
     }
 


### PR DESCRIPTION
Fixes #4877.

rustc 2024-08-22 changed `<f64 as Sum>::sum` to return -0.0 for an empty iterator (rust-lang/rust#129321). When -0.0 is passed as the stretchability or shrinkability parameter of `linebreak::raw_ratio`, the ratio value becomes negative infinity and does not hit the `ratio > 1.0` check. This causes -inf to be returned as the line ratio from `ratio_and_cost`, leading to the `active` variable being incremented too early in `linebreak_optimized_bounded` and the entire line breaking process being skipped.