### PR TITLE
Make `jump_from_cursor` return a vector of `Position`

### DIFF
--- a/crates/typst-ide/src/jump.rs
+++ b/crates/typst-ide/src/jump.rs
@@ -113,25 +113,30 @@ pub fn jump_from_cursor(
     document: &Document,
     source: &Source,
     cursor: usize,
-) -> Option<Position> {
+) -> Vec<Position> {
     fn is_text(node: &LinkedNode) -> bool {
         node.get().kind() == SyntaxKind::Text
     }
 
     let root = LinkedNode::new(source.root());
-    let node = root
+    let Some(node) = root
         .leaf_at(cursor, Side::Before)
         .filter(is_text)
-        .or_else(|| root.leaf_at(cursor, Side::After).filter(is_text))?;
+        .or_else(|| root.leaf_at(cursor, Side::After).filter(is_text))
+    else {
+        return vec![];
+    };
 
     let span = node.span();
-    for (i, page) in document.pages.iter().enumerate() {
-        if let Some(point) = find_in_frame(&page.frame, span) {
-            return Some(Position { page: NonZeroUsize::new(i + 1).unwrap(), point });
-        }
-    }
-
-    None
+    document
+        .pages
+        .iter()
+        .enumerate()
+        .filter_map(|(i, page)| {
+            find_in_frame(&page.frame, span)
+                .map(|point| Position { page: NonZeroUsize::new(i + 1).unwrap(), point })
+        })
+        .collect()
 }
 
 /// Find the position of a span in a frame.
@@ -226,8 +231,8 @@ mod tests {
         let world = TestWorld::new(text);
         let doc = typst::compile(&world).output.unwrap();
         let pos = jump_from_cursor(&doc, &world.main, cursor);
-        assert_eq!(pos.is_some(), expected.is_some());
-        if let (Some(pos), Some(expected)) = (pos, expected) {
+        assert_eq!(!pos.is_empty(), expected.is_some());
+        if let (Some(pos), Some(expected)) = (pos.first(), expected) {
             assert_eq!(pos.page, expected.page);
             assert_approx_eq!(pos.point.x, expected.point.x);
             assert_approx_eq!(pos.point.y, expected.point.y);


### PR DESCRIPTION
Sorry @laurmaedje but as we say in French: "thing promised, thing owed" 😂 

First step in fixing a bug in the webapp where writing to headings jumps you to the contents table: shortly discussed on discord -> https://discord.com/channels/1054443721975922748/1088371919725793360/1280530856615608413