### PR TITLE
Pop stylechain head in outline

### DIFF
--- a/crates/typst/src/foundations/styles.rs
+++ b/crates/typst/src/foundations/styles.rs
@@ -702,6 +702,11 @@ impl<'a> StyleChain<'a> {
         *self = self.tail.copied().unwrap_or_default();
     }
 
+    /// The tail of the chain.
+    pub fn tail(&self) -> Option<Self> {
+        self.tail.copied()
+    }
+
     /// Determine the shared trunk of a collection of style chains.
     pub fn trunk(iter: impl IntoIterator<Item = Self>) -> Option<Self> {
         // Determine shared style depth and first span.

--- a/crates/typst/src/model/outline.rs
+++ b/crates/typst/src/model/outline.rs
@@ -209,13 +209,15 @@ impl Show for Packed<OutlineElem> {
         let mut ancestors: Vec<&Content> = vec![];
         let elems = engine.introspector.query(&self.target(styles).0);
 
+        // Compute the style chain before the outline `ShowSet` is applied.
+        let pre = styles.tail().unwrap_or_default();
         for elem in &elems {
             let Some(entry) = OutlineEntry::from_outlinable(
                 engine,
                 self.span(),
                 elem.clone(),
                 self.fill(styles),
-                styles,
+                pre,
             )?
             else {
                 continue;


### PR DESCRIPTION
Fixes #4646

When building outline, always the same `Styles` gets added to the `StyleChain` at the head, I just added a piece of code that "pops" it, fixing the bug where the wrong style chain was provided to outline entries.

EDIT: this would still only involve giving the style chain at the place where the outline is defined, not where the heading is defined. There is definitely a discussion to be had of which behavior is preferable 