### PR TITLE
Clarify the path argument of the image element

### DIFF
--- a/crates/typst/src/foundations/plugin.rs
+++ b/crates/typst/src/foundations/plugin.rs
@@ -156,7 +156,7 @@ impl Plugin {
         engine: &mut Engine,
         /// Path to a WebAssembly file.
         ///
-        /// For detailed description see [Paths]($syntax/#paths).
+        /// For more details, see the [Paths section]($syntax/#paths).
         path: Spanned<EcoString>,
     ) -> SourceResult<Plugin> {
         let Spanned { v: path, span } = path;

--- a/crates/typst/src/foundations/plugin.rs
+++ b/crates/typst/src/foundations/plugin.rs
@@ -155,6 +155,8 @@ impl Plugin {
         /// The engine.
         engine: &mut Engine,
         /// Path to a WebAssembly file.
+        ///
+        /// For detailed description see [Paths]($syntax/#paths).
         path: Spanned<EcoString>,
     ) -> SourceResult<Plugin> {
         let Spanned { v: path, span } = path;

--- a/crates/typst/src/loading/cbor.rs
+++ b/crates/typst/src/loading/cbor.rs
@@ -23,7 +23,7 @@ pub fn cbor(
     engine: &mut Engine,
     /// Path to a CBOR file.
     ///
-    /// For detailed description see [Paths]($syntax/#paths).
+    /// For more details, see the [Paths section]($syntax/#paths).
     path: Spanned<EcoString>,
 ) -> SourceResult<Value> {
     let Spanned { v: path, span } = path;

--- a/crates/typst/src/loading/cbor.rs
+++ b/crates/typst/src/loading/cbor.rs
@@ -22,6 +22,8 @@ pub fn cbor(
     /// The engine.
     engine: &mut Engine,
     /// Path to a CBOR file.
+    ///
+    /// For detailed description see [Paths]($syntax/#paths).
     path: Spanned<EcoString>,
 ) -> SourceResult<Value> {
     let Spanned { v: path, span } = path;

--- a/crates/typst/src/loading/csv.rs
+++ b/crates/typst/src/loading/csv.rs
@@ -30,7 +30,7 @@ pub fn csv(
     engine: &mut Engine,
     /// Path to a CSV file.
     ///
-    /// For detailed description see [Paths]($syntax/#paths).
+    /// For more details, see the [Paths section]($syntax/#paths).
     path: Spanned<EcoString>,
     /// The delimiter that separates columns in the CSV file.
     /// Must be a single ASCII character.

--- a/crates/typst/src/loading/csv.rs
+++ b/crates/typst/src/loading/csv.rs
@@ -29,6 +29,8 @@ pub fn csv(
     /// The engine.
     engine: &mut Engine,
     /// Path to a CSV file.
+    ///
+    /// For detailed description see [Paths]($syntax/#paths).
     path: Spanned<EcoString>,
     /// The delimiter that separates columns in the CSV file.
     /// Must be a single ASCII character.

--- a/crates/typst/src/loading/json.rs
+++ b/crates/typst/src/loading/json.rs
@@ -55,7 +55,7 @@ pub fn json(
     engine: &mut Engine,
     /// Path to a JSON file.
     ///
-    /// For detailed description see [Paths]($syntax/#paths).
+    /// For more details, see the [Paths section]($syntax/#paths).
     path: Spanned<EcoString>,
 ) -> SourceResult<Value> {
     let Spanned { v: path, span } = path;

--- a/crates/typst/src/loading/json.rs
+++ b/crates/typst/src/loading/json.rs
@@ -54,6 +54,8 @@ pub fn json(
     /// The engine.
     engine: &mut Engine,
     /// Path to a JSON file.
+    ///
+    /// For detailed description see [Paths]($syntax/#paths).
     path: Spanned<EcoString>,
 ) -> SourceResult<Value> {
     let Spanned { v: path, span } = path;

--- a/crates/typst/src/loading/read.rs
+++ b/crates/typst/src/loading/read.rs
@@ -28,7 +28,7 @@ pub fn read(
     engine: &mut Engine,
     /// Path to a file.
     ///
-    /// For detailed description see [Paths]($syntax/#paths).
+    /// For more details, see the [Paths section]($syntax/#paths).
     path: Spanned<EcoString>,
     /// The encoding to read the file with.
     ///

--- a/crates/typst/src/loading/read.rs
+++ b/crates/typst/src/loading/read.rs
@@ -27,6 +27,8 @@ pub fn read(
     /// The engine.
     engine: &mut Engine,
     /// Path to a file.
+    ///
+    /// For detailed description see [Paths]($syntax/#paths).
     path: Spanned<EcoString>,
     /// The encoding to read the file with.
     ///

--- a/crates/typst/src/loading/toml.rs
+++ b/crates/typst/src/loading/toml.rs
@@ -33,7 +33,7 @@ pub fn toml(
     engine: &mut Engine,
     /// Path to a TOML file.
     ///
-    /// For detailed description see [Paths]($syntax/#paths).
+    /// For more details, see the [Paths section]($syntax/#paths).
     path: Spanned<EcoString>,
 ) -> SourceResult<Value> {
     let Spanned { v: path, span } = path;

--- a/crates/typst/src/loading/toml.rs
+++ b/crates/typst/src/loading/toml.rs
@@ -32,6 +32,8 @@ pub fn toml(
     /// The engine.
     engine: &mut Engine,
     /// Path to a TOML file.
+    ///
+    /// For detailed description see [Paths]($syntax/#paths).
     path: Spanned<EcoString>,
 ) -> SourceResult<Value> {
     let Spanned { v: path, span } = path;

--- a/crates/typst/src/loading/xml.rs
+++ b/crates/typst/src/loading/xml.rs
@@ -62,7 +62,7 @@ pub fn xml(
     engine: &mut Engine,
     /// Path to an XML file.
     ///
-    /// For detailed description see [Paths]($syntax/#paths).
+    /// For more details, see the [Paths section]($syntax/#paths).
     path: Spanned<EcoString>,
 ) -> SourceResult<Value> {
     let Spanned { v: path, span } = path;

--- a/crates/typst/src/loading/xml.rs
+++ b/crates/typst/src/loading/xml.rs
@@ -61,6 +61,8 @@ pub fn xml(
     /// The engine.
     engine: &mut Engine,
     /// Path to an XML file.
+    ///
+    /// For detailed description see [Paths]($syntax/#paths).
     path: Spanned<EcoString>,
 ) -> SourceResult<Value> {
     let Spanned { v: path, span } = path;

--- a/crates/typst/src/loading/yaml.rs
+++ b/crates/typst/src/loading/yaml.rs
@@ -45,7 +45,7 @@ pub fn yaml(
     engine: &mut Engine,
     /// Path to a YAML file.
     ///
-    /// For detailed description see [Paths]($syntax/#paths).
+    /// For more details, see the [Paths section]($syntax/#paths).
     path: Spanned<EcoString>,
 ) -> SourceResult<Value> {
     let Spanned { v: path, span } = path;

--- a/crates/typst/src/loading/yaml.rs
+++ b/crates/typst/src/loading/yaml.rs
@@ -44,6 +44,8 @@ pub fn yaml(
     /// The engine.
     engine: &mut Engine,
     /// Path to a YAML file.
+    ///
+    /// For detailed description see [Paths]($syntax/#paths).
     path: Spanned<EcoString>,
 ) -> SourceResult<Value> {
     let Spanned { v: path, span } = path;

--- a/crates/typst/src/visualize/image/mod.rs
+++ b/crates/typst/src/visualize/image/mod.rs
@@ -56,7 +56,7 @@ use crate::World;
 pub struct ImageElem {
     /// Path to an image file
     ///
-    /// For detailed description see [Paths]($syntax/#paths).
+    /// For more details, see the [Paths section]($syntax/#paths).
     #[required]
     #[parse(
         let Spanned { v: path, span } =

--- a/crates/typst/src/visualize/image/mod.rs
+++ b/crates/typst/src/visualize/image/mod.rs
@@ -54,7 +54,9 @@ use crate::World;
 /// [gh-svg]: https://github.com/typst/typst/issues?q=is%3Aopen+is%3Aissue+label%3Asvg
 #[elem(scope, Show, LocalName, Figurable)]
 pub struct ImageElem {
-    /// Path to an image file, relative to the input file by default; if starting with `/`, it's relative to the `--root` path.
+    /// Path to an image file
+    ///
+    /// For detailed description see [Paths]($syntax/#paths).
     #[required]
     #[parse(
         let Spanned { v: path, span } =

--- a/crates/typst/src/visualize/image/mod.rs
+++ b/crates/typst/src/visualize/image/mod.rs
@@ -54,7 +54,7 @@ use crate::World;
 /// [gh-svg]: https://github.com/typst/typst/issues?q=is%3Aopen+is%3Aissue+label%3Asvg
 #[elem(scope, Show, LocalName, Figurable)]
 pub struct ImageElem {
-    /// Path to an image file.
+    /// Path to an image file, relative to the input file by default; if starting with `/`, it's relative to the `--root` path.
     #[required]
     #[parse(
         let Spanned { v: path, span } =

--- a/docs/reference/syntax.md
+++ b/docs/reference/syntax.md
@@ -169,26 +169,47 @@ I got an ice cream for
 ```
 
 ## Paths
-Typst supports several directives that require a file path to reference external
-resources such as images, imports, data loading, and others. Understanding how
-to correctly specify paths for these directives is essential to ensure that
-Typst can locate and load the required files during compilation.
+Typst has various features that require a file path to reference external
+resources such as images, Typst files, or data files. Paths are represented as
+[strings]($str). There are two kinds of paths: Relative and absolute.
 
-A **relative path** starts from the location of the Typst file where the
-directive is invoked. For example:
-```typ
-#image("images/logo.png")
-```
+- A **relative path** searches from the location of the Typst file where the
+  feature is invoked. It is the default:
+  ```typ
+  #image("images/logo.png")
+  ```
 
-When a path begins with `/`, it is treated as an absolute path relative to the
-project root. For example:
-```typ
-#image("/assets/logo.png")
-```
+- An **absolute path** searches from the _root_ of the project. It starts with a
+  leading `/`:
+  ```typ
+  #image("/assets/logo.png")
+  ```
 
-Typst allows customization of the project root through the CLI option `--root`.
-By default, the project root is the directory from which Typst is run.
-If you want to set a specific folder as the root of your project, you can use:
+### Project root
+By default, the project root is the parent directory of the main Typst file.
+For security reasons, you cannot read any files outside of the root directory.
+
+If you want to set a specific folder as the root of your project, you can use
+the CLI's `--root` flag. Make sure that the main file is contained in the
+folder's subtree!
 ```bash
-typst compile --root <path-to-project-root> file.typ
+typst compile --root .. file.typ
 ```
+
+In the web app, the project itself is the root directory. You can always read
+all files within it, no matter which one is previewed (via the eye toggle next
+to each Typst file in the file panel).
+
+### Paths and packages
+A package can only load files from its own directory. Within it, absolute paths
+point to the package root, rather than the project root. For this reason, it
+cannot directly load files from the project directory. If a package needs
+resources from the project (such as a logo image), you must pass the already
+loaded image, e.g. as a named parameter `{logo: image("mylogo.svg")}`. Note that
+you can then still customize the image's appearance with a set rule within the
+package.
+
+In the future, paths might become a
+[distinct type from strings](https://github.com/typst/typst/issues/971), so that
+they can retain knowledge of where they were constructed. This way, resources
+could be loaded from a different root.

--- a/docs/reference/syntax.md
+++ b/docs/reference/syntax.md
@@ -167,3 +167,28 @@ sequence: `[\u{1f600}]`. The same kind of escape sequences also work in
 I got an ice cream for
 \$1.50! \u{1f600}
 ```
+
+## Paths { #paths }
+Typst supports several directives that require a file path to reference external
+resources such as images, imports, data loading, and others. Understanding how
+to correctly specify paths for these directives is essential to ensure that
+Typst can locate and load the required files during compilation.
+
+A **relative path** starts from the location of the Typst file where the
+directive is invoked. For example:
+```example
+#image("images/logo.png")
+```
+
+When a path begins with `/`, it is treated as an absolute path relative to the
+project root. For example:
+```example
+#image("/assets/logo.png")
+```
+
+Typst allows customization of the project root through the CLI option `--root`.
+By default, the project root is the directory from which Typst is run.
+If you want to set a specific folder as the root of your project, you can use:
+```example
+typst compile --root <path-to-project-root> file.typ
+```

--- a/docs/reference/syntax.md
+++ b/docs/reference/syntax.md
@@ -176,19 +176,19 @@ Typst can locate and load the required files during compilation.
 
 A **relative path** starts from the location of the Typst file where the
 directive is invoked. For example:
-```example
+```typ
 #image("images/logo.png")
 ```
 
 When a path begins with `/`, it is treated as an absolute path relative to the
 project root. For example:
-```example
+```typ
 #image("/assets/logo.png")
 ```
 
 Typst allows customization of the project root through the CLI option `--root`.
 By default, the project root is the directory from which Typst is run.
 If you want to set a specific folder as the root of your project, you can use:
-```example
+```typ
 typst compile --root <path-to-project-root> file.typ
 ```

--- a/docs/reference/syntax.md
+++ b/docs/reference/syntax.md
@@ -168,7 +168,7 @@ I got an ice cream for
 \$1.50! \u{1f600}
 ```
 
-## Paths { #paths }
+## Paths
 Typst supports several directives that require a file path to reference external
 resources such as images, imports, data loading, and others. Understanding how
 to correctly specify paths for these directives is essential to ensure that

--- a/docs/reference/syntax.md
+++ b/docs/reference/syntax.md
@@ -189,6 +189,6 @@ project root. For example:
 Typst allows customization of the project root through the CLI option `--root`.
 By default, the project root is the directory from which Typst is run.
 If you want to set a specific folder as the root of your project, you can use:
-```typ
+```bash
 typst compile --root <path-to-project-root> file.typ
 ```


### PR DESCRIPTION
Add clarification that by default the path argument is relative to the input file location, but with the `/` symbol as the first character it become relative to the `--root` path.

The feature is mentioned in the https://github.com/typst/typst/issues/2608#issuecomment-1799021131 comment but absent on the documentation page.