### PR TITLE
Fix typo in `block.clip` documentation

### DIFF
--- a/crates/typst/src/layout/container.rs
+++ b/crates/typst/src/layout/container.rs
@@ -439,8 +439,8 @@ pub struct BlockElem {
 
     /// Whether to clip the content inside the block.
     ///
-    /// Clipping is useful when the block's content is larger than the box itself,
-    /// as any content that exceeds the box's bounds will be hidden.
+    /// Clipping is useful when the block's content is larger than the block itself,
+    /// as any content that exceeds the block's bounds will be hidden.
     ///
     /// ```example
     /// #block(


### PR DESCRIPTION
Fixes a typo in the documentation for `block.clip` added in #4870 