### PR TITLE
Terminate tests when stuck for 10s

### DIFF
--- a/tests/src/logger.rs
+++ b/tests/src/logger.rs
@@ -100,9 +100,10 @@ impl<'a> Logger<'a> {
         self.failed == 0
     }
 
-    /// Refresh the status.
-    pub fn refresh(&mut self) {
+    /// Refresh the status. Returns whether we still seem to be making progress.
+    pub fn refresh(&mut self) -> bool {
         self.print(|_| Ok(())).unwrap();
+        self.last_change.elapsed() < Duration::from_secs(10)
     }
 
     /// Refresh the status print.

--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -94,7 +94,10 @@ fn test() {
         // Regularly refresh the logger in case we make no progress.
         scope.spawn(move || {
             while receiver.recv_timeout(Duration::from_millis(500)).is_err() {
-                logger.lock().refresh();
+                if !logger.lock().refresh() {
+                    eprintln!("tests seem to be stuck");
+                    std::process::exit(1);
+                }
             }
         });
 


### PR DESCRIPTION
When clicking "Run" in the VS Code test-helper while working on code with loops, it's easy to leak test processes that spin the CPU.