### PR TITLE
Document caveat re large Typst projects

### DIFF
--- a/docs/guides/guide-for-latex-users.md
+++ b/docs/guides/guide-for-latex-users.md
@@ -670,3 +670,8 @@ applicable, contains possible workarounds.
   break will be created if this spot would be a natural page break anyways. You
   can also use `[#v(1fr)]` to distribute space on your page. It works quite
   similar to LaTeX's `\vfill`.
+
+- **Boilerplate for large scale projects.** LaTeX definitions are available in
+  included files. This is not the case in Typst, where you'll need your definitions
+  in a file of its own, and manually `import` them into each of your project's
+  `include`d files. Alternatively your Typst project can be in one very large file.

--- a/docs/guides/guide-for-latex-users.md
+++ b/docs/guides/guide-for-latex-users.md
@@ -674,9 +674,18 @@ applicable, contains possible workarounds.
 - **Separation of `import` and `include` behaviours.** `\include`ing a file in LaTeX
   has two behaviours that have been separated in Typst: imports LaTeX macros,
   and adds the document content to the parent file. In Typst: `#import`ing will
-  add definitions to the parent file, but not add document content;
-  `#include`ing will add document content to the parent file, but will not import
-  definitions. The syntax for including document content is simply `#include "file.typ"`,
+  add definitions (equivalent to LaTeX macros) to the parent file,
+  but not add document content; `#include`ing will add document content
+  to the parent file, but will not import definitions.
+  The syntax for including document content is simply `#include "file.typ"`,
   but the syntax for importing definitions provides more flexibility:
   `#import "file.typ": *` will import all of `file.typ`'s definitions;
   `#import "file.typ": x, y, template` will import only the named definitions.
+  It is of particular note for those familiar with LaTeX that
+  in LaTeX, a file only needs to be `\include`d once;
+  in Typst, your global definitions
+  and global setups need to be placed in a separate file,
+  and that file is then `#import`ed and/or `#include`d
+  into all of your project's nested files in addition to the main file.
+  This requirement and design improves the robustness, predictability,
+  and performance of Typst, as every file is well-defined in isolation.

--- a/docs/guides/guide-for-latex-users.md
+++ b/docs/guides/guide-for-latex-users.md
@@ -671,7 +671,12 @@ applicable, contains possible workarounds.
   can also use `[#v(1fr)]` to distribute space on your page. It works quite
   similar to LaTeX's `\vfill`.
 
-- **Boilerplate for large scale projects.** LaTeX definitions are available in
-  included files. This is not the case in Typst, where you'll need your definitions
-  in a file of its own, and manually `import` them into each of your project's
-  `include`d files. Alternatively your Typst project can be in one very large file.
+- **Separation between `import` and `include`.** LaTeX macro definitions in files are
+  automatically available in documents which `\include` those files' contents. In Typst,
+  including a file's contents (done through `#include "file.typ"`) is separate from
+  importing its definitions, which must be done with a separate
+  `#import "file.typ": definitions` command. With it, you can either list the definitions
+  to import individually, which is more usual when they are few (e.g.
+  `#import "file.typ": x, y, template`), or, to fully mimic LaTeX's behavior, you may use a
+  wildcard import to import all definitions available in another file
+  (e.g. `#import "file.typ": *`).

--- a/docs/guides/guide-for-latex-users.md
+++ b/docs/guides/guide-for-latex-users.md
@@ -686,6 +686,6 @@ applicable, contains possible workarounds.
   in Typst, your global definitions
   and global setups need to be placed in a separate file,
   and that file is then `#import`ed and/or `#include`d
-  into all of your project's nested files in addition to the main file.
+  into the files that make use of these definitions.
   This requirement and design improves the robustness, predictability,
   and performance of Typst, as every file is well-defined in isolation.

--- a/docs/guides/guide-for-latex-users.md
+++ b/docs/guides/guide-for-latex-users.md
@@ -671,12 +671,12 @@ applicable, contains possible workarounds.
   can also use `[#v(1fr)]` to distribute space on your page. It works quite
   similar to LaTeX's `\vfill`.
 
-- **Separation between `import` and `include`.** LaTeX macro definitions in files are
-  automatically available in documents which `\include` those files' contents. In Typst,
-  including a file's contents (done through `#include "file.typ"`) is separate from
-  importing its definitions, which must be done with a separate
-  `#import "file.typ": definitions` command. With it, you can either list the definitions
-  to import individually, which is more usual when they are few (e.g.
-  `#import "file.typ": x, y, template`), or, to fully mimic LaTeX's behavior, you may use a
-  wildcard import to import all definitions available in another file
-  (e.g. `#import "file.typ": *`).
+- **Separation of `import` and `include` behaviours.** `\include`ing a file in LaTeX
+  has two behaviours that have been separated in Typst: imports LaTeX macros,
+  and adds the document content to the parent file. In Typst: `#import`ing will
+  add definitions to the parent file, but not add document content;
+  `#include`ing will add document content to the parent file, but will not import
+  definitions. The syntax for including document content is simply `#include "file.typ"`,
+  but the syntax for importing definitions provides more flexibility:
+  `#import "file.typ": *` will import all of `file.typ`'s definitions;
+  `#import "file.typ": x, y, template` will import only the named definitions.


### PR DESCRIPTION
Documenting a sorely needed caveat for LaTeX users who are used to having their definitions available in any included file, especially for large scale Typst projects with many (possibly nested) `include`s.

Addresses #595, #754, #4194 in the documentation.