### PR TITLE
Only scan for color glyphs in `is_color_glyph`.

### DIFF
--- a/crates/typst/src/text/font/color.rs
+++ b/crates/typst/src/text/font/color.rs
@@ -23,8 +23,10 @@ pub fn is_color_glyph(font: &Font, g: &Glyph) -> bool {
     // PNG glyphs but the sbix table can also contain JPEG
     // and TIFF glyphs.
     if let Some(sbix) = ttf.tables().sbix {
-        if sbix.best_strike(pixels_per_em).is_some() {
-            return true;
+        if let Some(strike) = sbix.best_strike(pixels_per_em) {
+            if strike.get(glyph_id).is_some() {
+                return true;
+            }
         }
     }
 


### PR DESCRIPTION
This will prevent typst from picking up (unsupported) monochrome bitmaps in Windows system fonts e.g. Cambria Math and SimSun and the resulting panic (see #4335).  One path leading to panic is eliminated, however:

- unwrap is supplemented with an explicit panic that provides some debugging info.  Longer-term it would be nice to have access to logging context from `draw_raster_glyph` and to bubble up some error handling.
- unsupported color glyphs (e.g. JPEG and TIFF) will still cause a panic in PNG generation