### PR TITLE
Add warning when SVG with foreign object is included

### DIFF
--- a/crates/typst/src/loading/mod.rs
+++ b/crates/typst/src/loading/mod.rs
@@ -54,7 +54,7 @@ pub enum Readable {
 }
 
 impl Readable {
-    fn as_slice(&self) -> &[u8] {
+    pub(crate) fn as_slice(&self) -> &[u8] {
         match self {
             Readable::Bytes(v) => v,
             Readable::Str(v) => v.as_bytes(),

--- a/crates/typst/src/loading/mod.rs
+++ b/crates/typst/src/loading/mod.rs
@@ -22,6 +22,7 @@ pub use self::read_::*;
 pub use self::toml_::*;
 pub use self::xml_::*;
 pub use self::yaml_::*;
+use image::EncodableLayout;
 
 use crate::foundations::{cast, category, Bytes, Category, Scope, Str};
 
@@ -54,10 +55,17 @@ pub enum Readable {
 }
 
 impl Readable {
-    pub(crate) fn as_slice(&self) -> &[u8] {
+    fn as_slice(&self) -> &[u8] {
         match self {
             Readable::Bytes(v) => v,
             Readable::Str(v) => v.as_bytes(),
+        }
+    }
+
+    pub(crate) fn as_str(&self) -> Option<&str> {
+        match self {
+            Readable::Str(v) => Some(v.as_str()),
+            Readable::Bytes(v) => std::str::from_utf8(v.as_bytes()).ok(),
         }
     }
 }

--- a/crates/typst/src/loading/mod.rs
+++ b/crates/typst/src/loading/mod.rs
@@ -22,7 +22,6 @@ pub use self::read_::*;
 pub use self::toml_::*;
 pub use self::xml_::*;
 pub use self::yaml_::*;
-use image::EncodableLayout;
 
 use crate::foundations::{cast, category, Bytes, Category, Scope, Str};
 
@@ -65,7 +64,7 @@ impl Readable {
     pub(crate) fn as_str(&self) -> Option<&str> {
         match self {
             Readable::Str(v) => Some(v.as_str()),
-            Readable::Bytes(v) => std::str::from_utf8(v.as_bytes()).ok(),
+            Readable::Bytes(v) => std::str::from_utf8(v).ok(),
         }
     }
 }

--- a/crates/typst/src/visualize/image/mod.rs
+++ b/crates/typst/src/visualize/image/mod.rs
@@ -200,9 +200,12 @@ fn layout_image(
             .windows(needle.len())
             .any(|s| s == needle)
         {
-            engine.sink.warn(warning!(span, "image contains foreign object";
-            hint: "svg images with foreign objects might render incorrectly in typst";
-            hint: "see https://github.com/typst/typst/issues/1421 for more information"));
+            engine.sink.warn(warning!(
+                span,
+                "image contains foreign object";
+                hint: "SVG images with foreign objects might render incorrectly in typst";
+                hint: "see https://github.com/typst/typst/issues/1421 for more information"
+            ));
         }
     }
 

--- a/crates/typst/src/visualize/image/mod.rs
+++ b/crates/typst/src/visualize/image/mod.rs
@@ -198,8 +198,7 @@ fn layout_image(
         if data
             .as_slice()
             .windows(needle.len())
-            .position(|s| s == needle)
-            .is_some()
+            .any(|s| s == needle)
         {
             engine.sink.warn(warning!(span, "image contains foreign object";
             hint: "svg images with foreign objects might render incorrectly in typst";

--- a/crates/typst/src/visualize/image/mod.rs
+++ b/crates/typst/src/visualize/image/mod.rs
@@ -191,7 +191,8 @@ fn layout_image(
         Smart::Auto => determine_format(elem.path().as_str(), data).at(span)?,
     };
 
-    // Warn the user if the image contains a foreign object.
+    // Warn the user if the image contains a foreign object. Not perfect
+    // because the svg could also be encoded, but that's an edge case.
     if format == ImageFormat::Vector(VectorFormat::Svg) {
         let needle = b"foreignObject";
         if data

--- a/crates/typst/src/visualize/image/mod.rs
+++ b/crates/typst/src/visualize/image/mod.rs
@@ -194,7 +194,7 @@ fn layout_image(
     // Warn the user if the image contains a foreign object. Not perfect
     // because the svg could also be encoded, but that's an edge case.
     if format == ImageFormat::Vector(VectorFormat::Svg) {
-        let needle = b"foreignObject";
+        let needle = b"<foreignObject";
         if data
             .as_slice()
             .windows(needle.len())

--- a/crates/typst/src/visualize/image/mod.rs
+++ b/crates/typst/src/visualize/image/mod.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use comemo::Tracked;
 use ecow::EcoString;
 
-use crate::diag::{bail, At, SourceResult, StrResult};
+use crate::diag::{bail, warning, At, SourceResult, StrResult};
 use crate::engine::Engine;
 use crate::foundations::{
     cast, elem, func, scope, Bytes, Cast, Content, NativeElement, Packed, Show, Smart,
@@ -30,7 +30,6 @@ use crate::syntax::{Span, Spanned};
 use crate::text::{families, LocalName};
 use crate::utils::LazyHash;
 use crate::visualize::Path;
-use crate::warning;
 use crate::World;
 
 /// A raster or vector graphic.

--- a/crates/typst/src/visualize/image/mod.rs
+++ b/crates/typst/src/visualize/image/mod.rs
@@ -194,7 +194,7 @@ fn layout_image(
     // because the svg could also be encoded, but that's an edge case.
     if format == ImageFormat::Vector(VectorFormat::Svg) {
         let has_foreign_object =
-            data.as_str().map(|s| s.contains("<foreignObject")).unwrap_or(false);
+            data.as_str().is_some_and(|s| s.contains("<foreignObject"));
 
         if has_foreign_object {
             engine.sink.warn(warning!(

--- a/crates/typst/src/visualize/image/mod.rs
+++ b/crates/typst/src/visualize/image/mod.rs
@@ -193,12 +193,10 @@ fn layout_image(
     // Warn the user if the image contains a foreign object. Not perfect
     // because the svg could also be encoded, but that's an edge case.
     if format == ImageFormat::Vector(VectorFormat::Svg) {
-        let needle = b"<foreignObject";
-        if data
-            .as_slice()
-            .windows(needle.len())
-            .any(|s| s == needle)
-        {
+        let has_foreign_object =
+            data.as_str().map(|s| s.contains("<foreignObject")).unwrap_or(false);
+
+        if has_foreign_object {
             engine.sink.warn(warning!(
                 span,
                 "image contains foreign object";


### PR DESCRIPTION
A bit unfortunate to have to search every SVG like this (I'm also not sure if this might be very unefficient, if so I'm open for suggestions on how to improve it), but I think it's good to have a warning, so we can finally close #1421 since there isn't much we can do from our side.

I tested it manually to confirm that it works.