### PR TITLE
Don't include "update" in help output if self-update disabled

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -60,7 +60,6 @@ pub enum Command {
     Fonts(FontsCommand),
 
     /// Self update the Typst CLI
-    #[cfg_attr(not(feature = "self-update"), doc = " (disabled)")]
     #[cfg_attr(not(feature = "self-update"), clap(hide = true))]
     Update(UpdateCommand),
 }

--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -61,6 +61,7 @@ pub enum Command {
 
     /// Self update the Typst CLI
     #[cfg_attr(not(feature = "self-update"), doc = " (disabled)")]
+    #[cfg_attr(not(feature = "self-update"), clap(hide = true))]
     Update(UpdateCommand),
 }
 


### PR DESCRIPTION
Very minor change, but it makes the help output very slightly cleaner when self-updates are disabled by hiding an option that doesn't do anything.
This has no effect at all if self-update is enabled (the output remains exactly the same as before).

Old (current) `--help` output with self-update disabled:
```
The Typst compiler

Usage: typst [OPTIONS] <COMMAND>

Commands:
  compile  Compiles an input file into a supported output format [aliases: c]
  watch    Watches an input file and recompiles on changes [aliases: w]
  init     Initializes a new project from a template
  query    Processes an input file to extract provided metadata
  fonts    Lists all discovered fonts in system and custom font paths
  update   Self update the Typst CLI (disabled)
  help     Print this message or the help of the given subcommand(s)

Options:
      --color[=<WHEN>]  Set when to use color. auto = use color if a capable terminal is detected [default: auto] [possible values: auto, always, never]
      --cert <CERT>     Path to a custom CA certificate to use when making network requests [env: TYPST_CERT=]
  -h, --help            Print help
  -V, --version         Print version
  ```

New `--help` output with self-update disabled:
```
The Typst compiler

Usage: typst [OPTIONS] <COMMAND>

Commands:
  compile  Compiles an input file into a supported output format [aliases: c]
  watch    Watches an input file and recompiles on changes [aliases: w]
  init     Initializes a new project from a template
  query    Processes an input file to extract provided metadata
  fonts    Lists all discovered fonts in system and custom font paths
  help     Print this message or the help of the given subcommand(s)

Options:
      --color[=<WHEN>]  Set when to use color. auto = use color if a capable terminal is detected [default: auto] [possible values: auto, always, never]
      --cert <CERT>     Path to a custom CA certificate to use when making network requests [env: TYPST_CERT=]
  -h, --help            Print help
  -V, --version         Print version
```

(Unchanged) Output of `update --help` with self-update disabled:
```
Self update the Typst CLI (disabled)

Usage: typst update [OPTIONS] [VERSION]

Arguments:
  [VERSION]  Which version to update to (defaults to latest)

Options:
      --force               Forces a downgrade to an older version (required for downgrading)
      --revert              Reverts to the version from before the last update (only possible if `typst update` has previously ran)
      --backup-path <FILE>  Custom path to the backup file created on update and used by `--revert`, defaults to system-dependent location [env: TYPST_UPDATE_BACKUP_PATH=]
  -h, --help                Print help
```