### PR TITLE
Do not surface warnings from non-last layout iterations

### DIFF
--- a/crates/typst/src/engine.rs
+++ b/crates/typst/src/engine.rs
@@ -156,6 +156,11 @@ impl Sink {
     pub fn values(self) -> EcoVec<(Value, Option<Styles>)> {
         self.values
     }
+
+    /// Extend from another sink.
+    pub fn extend_from_sink(&mut self, other: Sink) {
+        self.extend(other.delayed, other.warnings, other.values);
+    }
 }
 
 #[comemo::track]
@@ -181,7 +186,7 @@ impl Sink {
         }
     }
 
-    /// Extend from another sink.
+    /// Extend from parts of another sink.
     fn extend(
         &mut self,
         delayed: EcoVec<SourceDiagnostic>,

--- a/tests/suite/foundations/context.typ
+++ b/tests/suite/foundations/context.typ
@@ -76,3 +76,16 @@
 // Warning: 2-44 `counter.display` without context is deprecated
 // Hint: 2-44 use it in a `context` expression instead
 #counter(heading).display(n => test(n, 10))
+
+--- context-delayed-warning ---
+// Ensure that the warning that triggers in the first layout iteration is not
+// surfaced since it goes away in the second one. Just like errors in show
+// rules.
+#show heading: none
+
+= A <a>
+#context {
+  let n = query(<a>).len()
+  let fonts = ("nope", "Roboto")
+  set text(font: fonts.at(n))
+}


### PR DESCRIPTION
Warnings from earlier layout iterations are not surfaced anymore when they go away in the last one. Just like errors in show rules.