### PR TITLE
Add float to bytes conversion and vice-versa

### DIFF
--- a/crates/typst/src/foundations/float.rs
+++ b/crates/typst/src/foundations/float.rs
@@ -120,31 +120,24 @@ impl f64 {
     pub fn from_bytes(
         /// The bytes that should be converted to a float.
         ///
-        /// Must be of a length of exactly 8 so that the result fits into a 64-bit float.
+        /// Must be of length exactly 8 so that the result fits into a 64-bit
+        /// float.
         bytes: Bytes,
         /// The endianness of the conversion.
         #[named]
         #[default(Endianness::Little)]
         endian: Endianness,
     ) -> StrResult<f64> {
-        // Ensure the input is exactly 8 bytes long
-        if bytes.len() != 8 {
-            bail!("bytes must have a length of 8");
-        }
-
-        // Convert slice to an array of length 8. This cannot fail because length
-        // of bytes is ensured to be 8
-        let buffer: [u8; 8] = match bytes.as_ref().try_into() {
+        // Convert slice to an array of length 8.
+        let buf: [u8; 8] = match bytes.as_ref().try_into() {
             Ok(buffer) => buffer,
-            Err(_) => unreachable!(),
+            Err(_) => bail!("bytes must have a length of exactly 8"),
         };
 
-        let result = match endian {
-            Endianness::Little => f64::from_le_bytes(buffer),
-            Endianness::Big => f64::from_be_bytes(buffer),
-        };
-
-        Ok(result)
+        Ok(match endian {
+            Endianness::Little => f64::from_le_bytes(buf),
+            Endianness::Big => f64::from_be_bytes(buf),
+        })
     }
 
     /// Converts a float to bytes.
@@ -161,12 +154,12 @@ impl f64 {
         #[default(Endianness::Little)]
         endian: Endianness,
     ) -> Bytes {
-        let array = match endian {
+        match endian {
             Endianness::Little => self.to_le_bytes(),
             Endianness::Big => self.to_be_bytes(),
-        };
-
-        Bytes::from(array.as_ref())
+        }
+        .as_slice()
+        .into()
     }
 }
 

--- a/crates/typst/src/foundations/float.rs
+++ b/crates/typst/src/foundations/float.rs
@@ -3,7 +3,9 @@ use std::num::ParseFloatError;
 use ecow::{eco_format, EcoString};
 
 use crate::diag::StrResult;
-use crate::foundations::{bail, cast, func, repr, scope, ty, Bytes, Endianness, Repr, Str};
+use crate::foundations::{
+    bail, cast, func, repr, scope, ty, Bytes, Endianness, Repr, Str,
+};
 use crate::layout::Ratio;
 
 /// A floating-point number.

--- a/crates/typst/src/foundations/int.rs
+++ b/crates/typst/src/foundations/int.rs
@@ -341,7 +341,7 @@ impl Repr for i64 {
     }
 }
 
-/// Represents the byte order used for converting integers to bytes and vice versa.
+/// Represents the byte order used for converting integers and floats to bytes and vice versa.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Cast)]
 pub enum Endianness {
     /// Big-endian byte order: the highest-value byte is at the beginning of the bytes.

--- a/crates/typst/src/foundations/int.rs
+++ b/crates/typst/src/foundations/int.rs
@@ -341,12 +341,15 @@ impl Repr for i64 {
     }
 }
 
-/// Represents the byte order used for converting integers and floats to bytes and vice versa.
+/// Represents the byte order used for converting integers and floats to bytes
+/// and vice versa.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Cast)]
 pub enum Endianness {
-    /// Big-endian byte order: the highest-value byte is at the beginning of the bytes.
+    /// Big-endian byte order: The highest-value byte is at the beginning of the
+    /// bytes.
     Big,
-    /// Little-endian byte order: the lowest-value byte is at the beginning of the bytes.
+    /// Little-endian byte order: The lowest-value byte is at the beginning of
+    /// the bytes.
     Little,
 }
 

--- a/tests/suite/foundations/float.typ
+++ b/tests/suite/foundations/float.typ
@@ -50,7 +50,7 @@
 #test(1.0.to-bytes(endian: "big"), bytes((63, 240, 0, 0, 0, 0, 0, 0)))
 
 --- float-from-bytes-bad-length ---
-// Error: 2-54 bytes must have a length of 8
+// Error: 2-54 bytes must have a length of exactly 8
 #float.from-bytes(bytes((0, 0, 0, 0, 0, 0, 0, 1, 0)))
 
 --- float-repr ---

--- a/tests/suite/foundations/float.typ
+++ b/tests/suite/foundations/float.typ
@@ -42,6 +42,17 @@
 #test(float(-calc.inf).signum(), -1.0)
 #test(float(float.nan).signum().is-nan(), true)
 
+--- float-from-and-to-bytes ---
+// Test float `from-bytes()` and `to-bytes()`.
+#test(float.from-bytes(bytes((0, 0, 0, 0, 0, 0, 240, 63))), 1.0)
+#test(float.from-bytes(bytes((63, 240, 0, 0, 0, 0, 0, 0)), endian: "big"), 1.0)
+#test(1.0.to-bytes(), bytes((0, 0, 0, 0, 0, 0, 240, 63)))
+#test(1.0.to-bytes(endian: "big"), bytes((63, 240, 0, 0, 0, 0, 0, 0)))
+
+--- float-from-bytes-bad-length ---
+// Error: 2-54 bytes must have a length of 8
+#float.from-bytes(bytes((0, 0, 0, 0, 0, 0, 0, 1, 0)))
+
 --- float-repr ---
 // Test the `repr` function with floats.
 #repr(12.0) \


### PR DESCRIPTION
Adds float to bytes conversion and vice-versa. Useful when using plugins.

**Example:**

```typst
#float.from-bytes(bytes((0, 0, 0, 0, 0, 0, 240, 63)))
// 1.0
#array(1.0.to-bytes())
// (0, 0, 0, 0, 0, 0, 240, 63)
```

I followed the implementation of #4490.