### PR TITLE
Improve scripting reference `Methods` example

### DIFF
--- a/docs/reference/scripting.md
+++ b/docs/reference/scripting.md
@@ -273,9 +273,9 @@ of each type lists it's scoped functions. You cannot currently define your own
 methods.
 
 ```example
-#let array = (1, 2, 3, 4)
-#array.pop() \
-#array.len() \
+#let values = (1, 2, 3, 4)
+#values.pop() \
+#values.len() \
 
 #("a, b, c"
     .split(", ")


### PR DESCRIPTION
The [Methods](https://typst.app/docs/reference/scripting/#methods) section talks about a **method call** that calls a function scoped to a value's type. It's structure is `value.method(..args)` and the equivalent full function call is `type(value).method(value, ..args)`. Setting the value name to `array` in this context is unnecessarily confusing as that is the same name as it's type, `array`.

This change makes clear that a method call is being used here.