### PR TITLE
Upload artifacts on CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,28 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace --no-run
       - run: cargo test --workspace --no-fail-fast
+      - if: failure()
+        name: Upload rendered test output
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-artifacts-${{ matrix.os }}
+          path: tests/store/render/**
+          retention-days: 3
+
+      - if: failure()
+        name: Update test artifacts
+        run: |
+          : Update test artifacts
+          cargo test --all --test tests -- --update
+          echo 'updated_artifacts=1' >> "$GITHUB_ENV"
+
+      - if: failure() && env.updated_artifacts
+        name: Upload updated reference output (for use if the test changes are desired)
+        uses: actions/upload-artifact@v4
+        with:
+          name: updated-artifacts-${{ matrix.os }}
+          path: tests/ref/**
+          retention-days: 3
 
   checks:
     name: Check clippy, formatting, and documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,26 +34,23 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace --no-run
       - run: cargo test --workspace --no-fail-fast
-      - if: failure()
-        name: Upload rendered test output
+      - name: Upload rendered test output
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: test-artifacts-${{ matrix.os }}
+          name: tests-rendered-${{ matrix.os }}
           path: tests/store/render/**
           retention-days: 3
-
-      - if: failure()
-        name: Update test artifacts
+      - name: Update test artifacts
+        if: failure()
         run: |
-          : Update test artifacts
-          cargo test --all --test tests -- --update
+          cargo test --workspace --test tests -- --update
           echo 'updated_artifacts=1' >> "$GITHUB_ENV"
-
-      - if: failure() && env.updated_artifacts
-        name: Upload updated reference output (for use if the test changes are desired)
+      - name: Upload updated reference output (for use if the test changes are desired)
+        if: failure() && env.updated_artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: updated-artifacts-${{ matrix.os }}
+          name: tests-updated-${{ matrix.os }}
           path: tests/ref/**
           retention-days: 3
 


### PR DESCRIPTION
While working on #5020 it was frustrating not having access to the rendered content. As GitHub workflows already do the work of generating the images, it seemed helpful to provide them in an artifact.

Note it's possible to specify [`retention-days: 1`](https://github.com/actions/upload-artifact?tab=readme-ov-file#retention-period) or similar (for some things, I use that value myself). I was lazy in drafting this so haven't set a value.

This is just a proposal, I'm happy to adjust it...