### PR TITLE
Fix two doc typos

### DIFF
--- a/crates/typst/src/introspection/state.rs
+++ b/crates/typst/src/introspection/state.rs
@@ -71,7 +71,7 @@ use crate::World;
 /// # Managing state in Typst { #state-in-typst }
 /// So what do we do instead? We use Typst's state management system. Calling
 /// the `state` function with an identifying string key and an optional initial
-/// value gives you a state value which exposes a few function. The two most
+/// value gives you a state value which exposes a few functions. The two most
 /// important ones are `get` and `update`:
 ///
 /// - The [`get`]($state.get) function retrieves the current value of the state.

--- a/crates/typst/src/visualize/pattern.rs
+++ b/crates/typst/src/visualize/pattern.rs
@@ -19,7 +19,7 @@ use crate::World;
 /// pattern is repeated in a grid-like fashion, covering the entire area of an
 /// element that is filled or stroked. The pattern is defined by a tile size and
 /// a body defining the content of each cell. You can also add horizontal or
-/// vertical spacing between the cells of the patterng.
+/// vertical spacing between the cells of the pattern.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
Just two small typos in the documentation.