### PR TITLE
Fix example in table.rs

### DIFF
--- a/crates/typst/src/model/table.rs
+++ b/crates/typst/src/model/table.rs
@@ -62,7 +62,7 @@ use crate::visualize::{Paint, Stroke};
 ///   inset: 10pt,
 ///   align: horizon,
 ///   table.header(
-///     [], [*Area*], [*Parameters*],
+///     [], [*Volume*], [*Parameters*],
 ///   ),
 ///   image("cylinder.svg"),
 ///   $ pi h (D^2 - d^2) / 4 $,


### PR DESCRIPTION
The formulas given in the table are volume formulas not areas at https://typst.app/docs/reference/model/table/#example.
As typst is used by scientists I felt like it was somewhat important but I didn't find any open PR modifying `table.rs` to slip into.

As it is a really minor fix feel free to integrate it to already opened spelling/typo/doc PRs such as #5020 or #5032 