### PR TITLE
Implement symbol Proposal 21 (iteration 1)

### DIFF
--- a/crates/typst/src/symbols/sym.rs
+++ b/crates/typst/src/symbols/sym.rs
@@ -341,18 +341,18 @@ pub(crate) const SYM: &[(&str, Symbol)] = symbols! {
     // Set theory.
     emptyset: [
         '∅',
+        arrow.r: '⦳',
+        arror.l: '⦴',
         bar: '⦱',
         circle: '⦲',
-        larrow: '⦴',
-        rarrow: '⦳',
         rev: '⦰',
     ],
     nothing: [
         '∅',
+        arrow.r: '⦳',
+        arror.l: '⦴',
         bar: '⦱',
         circle: '⦲',
-        larrow: '⦴',
-        rarrow: '⦳',
         rev: '⦰',
     ],
     without: '∖',


### PR DESCRIPTION
This PR implements Proposal 21 (iteration 1) from [the Symbols document](https://typst.app/project/riXtMSim5zLCo7DWngIFbT).

This was accepted by @reknih [on Discord](https://discord.com/channels/1054443721975922748/1277628305142452306/1284579940800659468) some time ago and originally introduced in #4958. Merging this before 0.12 does not cause any breaking change, whereas merging it after 0.12 would be a breaking change.