### PR TITLE
Revert return type change in floor, ceil, trunc, quo

### DIFF
--- a/crates/typst/src/foundations/int.rs
+++ b/crates/typst/src/foundations/int.rs
@@ -368,7 +368,7 @@ cast! {
     v: Str => Self(parse_int(&v).map_err(|_| eco_format!("invalid integer: {}", v))?),
 }
 
-fn convert_float_to_int(f: f64) -> StrResult<i64> {
+pub fn convert_float_to_int(f: f64) -> StrResult<i64> {
     if f <= i64::MIN as f64 - 1.0 || f >= i64::MAX as f64 + 1.0 {
         Err(eco_format!("number too large"))
     } else {

--- a/tests/suite/foundations/calc.typ
+++ b/tests/suite/foundations/calc.typ
@@ -122,10 +122,10 @@
 #test(calc.quo(1, 1), 1)
 #test(calc.quo(5, 3), 1)
 #test(calc.quo(5, -3), -1)
-#test(calc.quo(22.5, 10), 2.0)
-#test(calc.quo(9, 4.5), 2.0)
-#test(calc.quo(decimal("22.5"), 10), decimal("2"))
-#test(calc.quo(decimal("9"), decimal("4.5")), decimal("2"))
+#test(calc.quo(22.5, 10), 2)
+#test(calc.quo(9, 4.5), 2)
+#test(calc.quo(decimal("22.5"), 10), 2)
+#test(calc.quo(decimal("9"), decimal("4.5")), 2)
 
 --- calc-quo-divisor-zero-1 ---
 // Error: 14-15 divisor must not be zero
@@ -307,29 +307,29 @@
 // Error: 2-41 the result is too large
 #calc.lcm(15486487489457, 4874879896543)
 
---- calc-rounding-larger-than-max-int ---
+--- calc-round-larger-than-max-int ---
 #test(calc.round(decimal("9223372036854775809.5")), decimal("9223372036854775810"))
 #test(calc.round(9223372036854775809.5), 9223372036854775810.0)
-#test(calc.floor(decimal("9223372036854775809.5")), decimal("9223372036854775809"))
-#test(calc.floor(9223372036854775809.5), 9223372036854775809.0)
-#test(calc.ceil(decimal("9223372036854775809.5")), decimal("9223372036854775810"))
-#test(calc.ceil(9223372036854775809.5), 9223372036854775810.0)
-#test(calc.trunc(decimal("9223372036854775809.5")), decimal("9223372036854775809"))
-#test(calc.trunc(9223372036854775809.5), 9223372036854775809.0)
-#test(calc.quo(decimal("9223372036854775809.5"), 1), decimal("9223372036854775809"))
-#test(calc.quo(9223372036854775809.5, 1), 9223372036854775809.0)
 
---- calc-rounding-smaller-than-min-int ---
+--- calc-floor-float-larger-than-max-int ---
+// Error: 2-35 the result is too large
+#calc.floor(9223372036854775809.5)
+
+--- calc-floor-decimal-larger-than-max-int ---
+// Error: 2-46 the result is too large
+#calc.floor(decimal("9223372036854775809.5"))
+
+--- calc-round-smaller-than-min-int ---
 #test(calc.round(decimal("-9223372036854775809.5")), decimal("-9223372036854775810"))
 #test(calc.round(-9223372036854775809.5), -9223372036854775810.0)
-#test(calc.floor(decimal("-9223372036854775809.5")), decimal("-9223372036854775810"))
-#test(calc.floor(-9223372036854775809.5), -9223372036854775810.0)
-#test(calc.ceil(decimal("-9223372036854775809.5")), decimal("-9223372036854775809"))
-#test(calc.ceil(-9223372036854775809.5), -9223372036854775809.0)
-#test(calc.trunc(decimal("-9223372036854775809.5")), decimal("-9223372036854775809"))
-#test(calc.trunc(-9223372036854775809.5), -9223372036854775809.0)
-#test(calc.quo(decimal("-9223372036854775809.5"), 1), decimal("-9223372036854775810"))
-#test(calc.quo(-9223372036854775809.5, 1), -9223372036854775810.0)
+
+--- calc-floor-float-smaller-than-min-int ---
+// Error: 2-36 the result is too large
+#calc.floor(-9223372036854775809.5)
+
+--- calc-floor-decimal-smaller-than-min-int ---
+// Error: 2-47 the result is too large
+#calc.floor(decimal("-9223372036854775809.5"))
 
 --- calc-min-nothing ---
 // Error: 2-12 expected at least one value


### PR DESCRIPTION
Reverts the change made in https://github.com/typst/typst/pull/4900 to the return types of `calc.floor`, `calc.ceil`, `calc.trunc` and `calc.quo`.

**Before (with that PR):** with `float` they return `float`, with `decimal` they return `decimal`.
**After (with this PR):** they always return `int`. If the resulting value doesn't fit into an `int`, throws an error.

Note that this still differs from 0.11.1, which would previously saturate the resulting value as the maximum integer instead of throwing an error.

# Explanation

The change was made because large floats and decimals might not fit into an integer.

The change is being reversed as the breaking change affects many packages, and could not make sense if larger integer values are ever allowed in the future.