### PR TITLE
Do not write empty destination name tree root

### DIFF
--- a/crates/typst-pdf/src/catalog.rs
+++ b/crates/typst-pdf/src/catalog.rs
@@ -139,16 +139,15 @@ pub fn write_catalog(
     catalog.viewer_preferences().direction(dir);
     catalog.metadata(meta_ref);
 
-    // Write the named destination tree.
-    let mut name_dict = catalog.names();
-    let mut dests_name_tree = name_dict.destinations();
-    let mut names = dests_name_tree.names();
-    for &(name, dest_ref, ..) in &ctx.references.named_destinations.dests {
-        names.insert(Str(name.as_str().as_bytes()), dest_ref);
+    // Write the named destination tree if there are any entries.
+    if !ctx.references.named_destinations.dests.is_empty() {
+        let mut name_dict = catalog.names();
+        let mut dests_name_tree = name_dict.destinations();
+        let mut names = dests_name_tree.names();
+        for &(name, dest_ref, ..) in &ctx.references.named_destinations.dests {
+            names.insert(Str(name.as_str().as_bytes()), dest_ref);
+        }
     }
-    names.finish();
-    dests_name_tree.finish();
-    name_dict.finish();
 
     // Insert the page labels.
     if !page_labels.is_empty() {


### PR DESCRIPTION
I checked our test corpus against the [Arlington PDF model](https://github.com/pdf-association/arlington-pdf-model) using a [veraPDF dev build](https://pdfa.org/development-preview-pdf-file-checker-based-on-the-arlington-pdf-model). While doing so, I noticed that all test cases without named destinations fail because they write a name tree with an empty root `Names` array.

The Arlington model checks `size > 0 && size % 2 == 0` for name tree name arrays and claims that an empty `Names` array is in violation of clause 7.9.6 of the ISO 3200-1 PDF 1.7 spec.

I updated the code to only write the name tree if there are named destinations.