### PR TITLE
Fix reference documentation mathematical error

### DIFF
--- a/crates/typst/src/model/reference.rs
+++ b/crates/typst/src/model/reference.rs
@@ -49,7 +49,7 @@ use crate::text::TextElem;
 /// == Performance <perf>
 /// @slow demonstrates what slow
 /// software looks like.
-/// $ O(n) = 2^n $ <slow>
+/// $ T(n) = O(2^n) $ <slow>
 ///
 /// #bibliography("works.bib")
 /// ```


### PR DESCRIPTION
This is a minor nitpick and not crucial to the docs, but is an easy fix so I figured I might as well. `O(n) = 2^n` is somewhat unclear and not mathematically correct, and `T(n)` is common notation for the time complexity of an algorithm.