### PR TITLE
PDF export diagnostics

### DIFF
--- a/crates/typst-cli/src/fonts.rs
+++ b/crates/typst-cli/src/fonts.rs
@@ -1,11 +1,10 @@
-use typst::diag::StrResult;
 use typst::text::FontVariant;
 use typst_kit::fonts::Fonts;
 
 use crate::args::FontsCommand;
 
 /// Execute a font listing command.
-pub fn fonts(command: &FontsCommand) -> StrResult<()> {
+pub fn fonts(command: &FontsCommand) {
     let fonts = Fonts::searcher()
         .include_system_fonts(!command.font_args.ignore_system_fonts)
         .search_with(&command.font_args.font_paths);
@@ -19,6 +18,4 @@ pub fn fonts(command: &FontsCommand) -> StrResult<()> {
             }
         }
     }
-
-    Ok(())
 }

--- a/crates/typst-cli/src/main.rs
+++ b/crates/typst-cli/src/main.rs
@@ -54,7 +54,7 @@ fn dispatch() -> HintedStrResult<()> {
         Command::Watch(command) => crate::watch::watch(timer, command.clone())?,
         Command::Init(command) => crate::init::init(command)?,
         Command::Query(command) => crate::query::query(command)?,
-        Command::Fonts(command) => crate::fonts::fonts(command)?,
+        Command::Fonts(command) => crate::fonts::fonts(command),
         Command::Update(command) => crate::update::update(command)?,
     }
 

--- a/crates/typst-cli/src/update.rs
+++ b/crates/typst-cli/src/update.rs
@@ -28,7 +28,7 @@ pub fn update(command: &UpdateCommand) -> StrResult<()> {
 
         if version < &Version::new(0, 8, 0) {
             eprintln!(
-                "Note: Versions older than 0.8.0 will not have \
+                "note: versions older than 0.8.0 will not have \
                  the update command available."
             );
         }

--- a/crates/typst-pdf/src/extg.rs
+++ b/crates/typst-pdf/src/extg.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use pdf_writer::Ref;
+use typst::diag::SourceResult;
 
 use crate::{PdfChunk, WithGlobalRefs};
 
@@ -28,7 +29,7 @@ impl ExtGState {
 /// Embed all used external graphics states into the PDF.
 pub fn write_graphic_states(
     context: &WithGlobalRefs,
-) -> (PdfChunk, HashMap<ExtGState, Ref>) {
+) -> SourceResult<(PdfChunk, HashMap<ExtGState, Ref>)> {
     let mut chunk = PdfChunk::new();
     let mut out = HashMap::new();
     context.resources.traverse(&mut |resources| {
@@ -44,7 +45,9 @@ pub fn write_graphic_states(
                 .non_stroking_alpha(external_gs.fill_opacity as f32 / 255.0)
                 .stroking_alpha(external_gs.stroke_opacity as f32 / 255.0);
         }
-    });
 
-    (chunk, out)
+        Ok(())
+    })?;
+
+    Ok((chunk, out))
 }

--- a/crates/typst-pdf/src/gradient.rs
+++ b/crates/typst-pdf/src/gradient.rs
@@ -3,12 +3,10 @@ use std::f32::consts::{PI, TAU};
 use std::sync::Arc;
 
 use ecow::eco_format;
-use pdf_writer::{
-    types::{ColorSpaceOperand, FunctionShadingType},
-    writers::StreamShadingType,
-    Filter, Finish, Name, Ref,
-};
-
+use pdf_writer::types::{ColorSpaceOperand, FunctionShadingType};
+use pdf_writer::writers::StreamShadingType;
+use pdf_writer::{Filter, Finish, Name, Ref};
+use typst::diag::SourceResult;
 use typst::layout::{Abs, Angle, Point, Quadrant, Ratio, Transform};
 use typst::utils::Numeric;
 use typst::visualize::{
@@ -38,7 +36,7 @@ pub struct PdfGradient {
 /// This is performed once after writing all pages.
 pub fn write_gradients(
     context: &WithGlobalRefs,
-) -> (PdfChunk, HashMap<PdfGradient, Ref>) {
+) -> SourceResult<(PdfChunk, HashMap<PdfGradient, Ref>)> {
     let mut chunk = PdfChunk::new();
     let mut out = HashMap::new();
     context.resources.traverse(&mut |resources| {
@@ -161,9 +159,11 @@ pub fn write_gradients(
 
             shading_pattern.matrix(transform_to_array(*transform));
         }
-    });
 
-    (chunk, out)
+        Ok(())
+    })?;
+
+    Ok((chunk, out))
 }
 
 /// Writes an exponential or stitched function that expresses the gradient.
@@ -249,7 +249,7 @@ impl PaintEncode for Gradient {
         ctx: &mut content::Builder,
         on_text: bool,
         transforms: content::Transforms,
-    ) {
+    ) -> SourceResult<()> {
         ctx.reset_fill_color_space();
 
         let index = register_gradient(ctx, self, on_text, transforms);
@@ -258,6 +258,7 @@ impl PaintEncode for Gradient {
 
         ctx.content.set_fill_color_space(ColorSpaceOperand::Pattern);
         ctx.content.set_fill_pattern(None, name);
+        Ok(())
     }
 
     fn set_as_stroke(
@@ -265,7 +266,7 @@ impl PaintEncode for Gradient {
         ctx: &mut content::Builder,
         on_text: bool,
         transforms: content::Transforms,
-    ) {
+    ) -> SourceResult<()> {
         ctx.reset_stroke_color_space();
 
         let index = register_gradient(ctx, self, on_text, transforms);
@@ -274,6 +275,7 @@ impl PaintEncode for Gradient {
 
         ctx.content.set_stroke_color_space(ColorSpaceOperand::Pattern);
         ctx.content.set_stroke_pattern(None, name);
+        Ok(())
     }
 }
 

--- a/crates/typst-pdf/src/named_destination.rs
+++ b/crates/typst-pdf/src/named_destination.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
-use pdf_writer::{writers::Destination, Ref};
+use pdf_writer::writers::Destination;
+use pdf_writer::Ref;
+use typst::diag::SourceResult;
 use typst::foundations::{Label, NativeElement};
 use typst::introspection::Location;
 use typst::layout::Abs;
@@ -34,7 +36,7 @@ impl Renumber for NamedDestinations {
 /// destination objects.
 pub fn write_named_destinations(
     context: &WithGlobalRefs,
-) -> (PdfChunk, NamedDestinations) {
+) -> SourceResult<(PdfChunk, NamedDestinations)> {
     let mut chunk = PdfChunk::new();
     let mut out = NamedDestinations::default();
     let mut seen = HashSet::new();
@@ -74,5 +76,5 @@ pub fn write_named_destinations(
         }
     }
 
-    (chunk, out)
+    Ok((chunk, out))
 }

--- a/crates/typst-pdf/src/outline.rs
+++ b/crates/typst-pdf/src/outline.rs
@@ -1,7 +1,6 @@
 use std::num::NonZeroUsize;
 
 use pdf_writer::{Finish, Pdf, Ref, TextStr};
-
 use typst::foundations::{NativeElement, Packed, StyleChain};
 use typst::layout::Abs;
 use typst::model::HeadingElem;
@@ -25,7 +24,7 @@ pub(crate) fn write_outline(
     let elements = ctx.document.introspector.query(&HeadingElem::elem().select());
 
     for elem in elements.iter() {
-        if let Some(page_ranges) = &ctx.exported_pages {
+        if let Some(page_ranges) = &ctx.options.page_ranges {
             if !page_ranges
                 .includes_page(ctx.document.introspector.page(elem.location().unwrap()))
             {

--- a/crates/typst-pdf/src/resources.rs
+++ b/crates/typst-pdf/src/resources.rs
@@ -12,14 +12,19 @@ use std::hash::Hash;
 use ecow::{eco_format, EcoString};
 use pdf_writer::{Dict, Finish, Name, Ref};
 use subsetter::GlyphRemapper;
-use typst::text::Lang;
-use typst::{text::Font, utils::Deferred, visualize::Image};
+use typst::diag::{SourceResult, StrResult};
+use typst::syntax::Span;
+use typst::text::{Font, Lang};
+use typst::utils::Deferred;
+use typst::visualize::Image;
 
-use crate::{
-    color::ColorSpaces, color_font::ColorFontMap, extg::ExtGState, gradient::PdfGradient,
-    image::EncodedImage, pattern::PatternRemapper, PdfChunk, Renumber, WithEverything,
-    WithResources,
-};
+use crate::color::ColorSpaces;
+use crate::color_font::ColorFontMap;
+use crate::extg::ExtGState;
+use crate::gradient::PdfGradient;
+use crate::image::EncodedImage;
+use crate::pattern::PatternRemapper;
+use crate::{PdfChunk, Renumber, WithEverything, WithResources};
 
 /// All the resources that have been collected when traversing the document.
 ///
@@ -58,7 +63,7 @@ pub struct Resources<R = Ref> {
     /// Deduplicates images used across the document.
     pub images: Remapper<Image>,
     /// Handles to deferred image conversions.
-    pub deferred_images: HashMap<usize, Deferred<EncodedImage>>,
+    pub deferred_images: HashMap<usize, (Deferred<StrResult<EncodedImage>>, Span)>,
     /// Deduplicates gradients used across the document.
     pub gradients: Remapper<PdfGradient>,
     /// Deduplicates patterns used across the document.
@@ -159,17 +164,18 @@ impl Resources<()> {
 impl<R> Resources<R> {
     /// Run a function on this resource dictionary and all
     /// of its sub-resources.
-    pub fn traverse<P>(&self, process: &mut P)
+    pub fn traverse<P>(&self, process: &mut P) -> SourceResult<()>
     where
-        P: FnMut(&Self),
+        P: FnMut(&Self) -> SourceResult<()>,
     {
-        process(self);
+        process(self)?;
         if let Some(color_fonts) = &self.color_fonts {
-            color_fonts.resources.traverse(process)
+            color_fonts.resources.traverse(process)?;
         }
         if let Some(patterns) = &self.patterns {
-            patterns.resources.traverse(process)
+            patterns.resources.traverse(process)?;
         }
+        Ok(())
     }
 }
 
@@ -196,7 +202,9 @@ impl Renumber for ResourcesRefs {
 }
 
 /// Allocate references for all resource dictionaries.
-pub fn alloc_resources_refs(context: &WithResources) -> (PdfChunk, ResourcesRefs) {
+pub fn alloc_resources_refs(
+    context: &WithResources,
+) -> SourceResult<(PdfChunk, ResourcesRefs)> {
     let mut chunk = PdfChunk::new();
     /// Recursively explore resource dictionaries and assign them references.
     fn refs_for(resources: &Resources<()>, chunk: &mut PdfChunk) -> ResourcesRefs {
@@ -214,7 +222,7 @@ pub fn alloc_resources_refs(context: &WithResources) -> (PdfChunk, ResourcesRefs
     }
 
     let refs = refs_for(&context.resources, &mut chunk);
-    (chunk, refs)
+    Ok((chunk, refs))
 }
 
 /// Write the resource dictionaries that will be referenced by all pages.
@@ -224,7 +232,7 @@ pub fn alloc_resources_refs(context: &WithResources) -> (PdfChunk, ResourcesRefs
 /// feature breaks PDF merging with Apple Preview.
 ///
 /// Also write resource dictionaries for Type3 fonts and patterns.
-pub fn write_resource_dictionaries(ctx: &WithEverything) -> (PdfChunk, ()) {
+pub fn write_resource_dictionaries(ctx: &WithEverything) -> SourceResult<(PdfChunk, ())> {
     let mut chunk = PdfChunk::new();
     let mut used_color_spaces = ColorSpaces::default();
 
@@ -287,11 +295,13 @@ pub fn write_resource_dictionaries(ctx: &WithEverything) -> (PdfChunk, ()) {
         resources
             .colors
             .write_color_spaces(color_spaces, &ctx.globals.color_functions);
-    });
+
+        Ok(())
+    })?;
 
     used_color_spaces.write_functions(&mut chunk, &ctx.globals.color_functions);
 
-    (chunk, ())
+    Ok((chunk, ()))
 }
 
 /// Assigns new, consecutive PDF-internal indices to items.

--- a/crates/typst/src/foundations/str.rs
+++ b/crates/typst/src/foundations/str.rs
@@ -636,7 +636,7 @@ impl Repr for EcoString {
     }
 }
 
-impl Repr for &str {
+impl Repr for str {
     fn repr(&self) -> EcoString {
         let mut r = EcoString::with_capacity(self.len() + 2);
         r.push('"');

--- a/tests/src/run.rs
+++ b/tests/src/run.rs
@@ -5,11 +5,11 @@ use std::path::Path;
 use ecow::eco_vec;
 use tiny_skia as sk;
 use typst::diag::{SourceDiagnostic, Warned};
-use typst::foundations::Smart;
 use typst::layout::{Abs, Frame, FrameItem, Page, Transform};
 use typst::model::Document;
 use typst::visualize::Color;
 use typst::WorldExt;
+use typst_pdf::PdfOptions;
 
 use crate::collect::{FileSize, NoteKind, Test};
 use crate::world::TestWorld;
@@ -190,7 +190,7 @@ impl<'a> Runner<'a> {
         // Write PDF if requested.
         if crate::ARGS.pdf() {
             let pdf_path = format!("{}/pdf/{}.pdf", crate::STORE_PATH, self.test.name);
-            let pdf = typst_pdf::pdf(document, Smart::Auto, None, None);
+            let pdf = typst_pdf::pdf(document, &PdfOptions::default()).unwrap();
             std::fs::write(pdf_path, pdf).unwrap();
         }
 


### PR DESCRIPTION
The PDF export can now produce errors just like normal compilation (though no warnings for now, this can be added in the future). The PDF export configuration was encapsulated into a struct.