### PR TITLE
Hint for `show par: set block(spacing: ..)`

### DIFF
--- a/crates/typst/src/foundations/styles.rs
+++ b/crates/typst/src/foundations/styles.rs
@@ -488,6 +488,11 @@ impl Recipe {
         &self.transform
     }
 
+    /// The recipe's span.
+    pub fn span(&self) -> Span {
+        self.span
+    }
+
     /// Apply the recipe to the given content.
     pub fn apply(
         &self,

--- a/tests/suite/model/par.typ
+++ b/tests/suite/model/par.typ
@@ -106,3 +106,9 @@ Lorem ipsum dolor #metadata(none) nonumy eirmod tempor.
 #h(0pt) #box[] <a>
 
 #context test(query(<a>).len(), 1)
+
+--- show-par-set-block-hint ---
+// Warning: 2-36 `show par: set block(spacing: ..)` has no effect anymore
+// Hint: 2-36 this is specific to paragraphs as they are not considered blocks anymore
+// Hint: 2-36 write `set par(spacing: ..)` instead
+#show par: set block(spacing: 12pt)


### PR DESCRIPTION
```
warning: `show par: set block(spacing: ..)` has no effect anymore
   ┌─ hi.typ:18:1
   │
18 │ #show par: set block(spacing: 12pt)
   │  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   │
   = hint: write `set par(spacing: ..)` instead
   = hint: this is specific to paragraphs as they are not considered blocks anymore
```