### PR TITLE
Check that an output format is available before compiling

### DIFF
--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -82,6 +82,9 @@ impl CompileCommand {
 
 /// Execute a compilation command.
 pub fn compile(mut timer: Timer, mut command: CompileCommand) -> StrResult<()> {
+    // Only meant for input validation
+    _ = command.output_format()?;
+
     let mut world =
         SystemWorld::new(&command.common).map_err(|err| eco_format!("{err}"))?;
     timer.record(&mut world, |world| compile_once(world, &mut command, false))??;


### PR DESCRIPTION
Resolves the main issue in #5042.

It's important to place the call to `.output_format()` before initialising the World as it can cause a noticeable delay before displaying the error.
Dropping the OutputFormat only to recalculate it moments later is a little goofy, but it's a very cheap calculation and the visual overhead of passing yet another argument around justifies the cost I think.
