### PR TITLE
Prevent double allocation due to `Content::sequence`

### DIFF
--- a/crates/typst/src/foundations/content.rs
+++ b/crates/typst/src/foundations/content.rs
@@ -245,16 +245,14 @@ impl Content {
 
     /// Create a new sequence element from multiples elements.
     pub fn sequence(iter: impl IntoIterator<Item = Self>) -> Self {
-        let mut iter = iter.into_iter();
-        let Some(first) = iter.next() else { return Self::empty() };
-        let Some(second) = iter.next() else { return first };
-        SequenceElem::new(
-            std::iter::once(first)
-                .chain(std::iter::once(second))
-                .chain(iter)
-                .collect(),
-        )
-        .into()
+        let vec: Vec<_> = iter.into_iter().collect();
+        if vec.is_empty() {
+            Self::empty()
+        } else if vec.len() == 1 {
+            vec.into_iter().next().unwrap()
+        } else {
+            SequenceElem::new(vec).into()
+        }
     }
 
     /// Whether the contained element is of type `T`.


### PR DESCRIPTION
Often, the `iter` will already come from a `Vec` and then we just rebuild it for no reason. The rare case where it's not from a `Vec` and of length 1 doesn't feel like worth the trouble of preventing the allocation.