### PR TITLE
Fix default ignorables

### DIFF
--- a/crates/typst-pdf/src/content.rs
+++ b/crates/typst-pdf/src/content.rs
@@ -425,7 +425,7 @@ fn write_text(ctx: &mut Builder, pos: Point, text: &TextItem) -> SourceResult<()
                 bail!(
                     g.span.0,
                     "the text {} could not be displayed with any font",
-                    text.text[g.range()].repr()
+                    TextItemView::full(text).glyph_text(g).repr(),
                 );
             }
         }
@@ -493,9 +493,7 @@ fn write_normal_text(
 
     let glyph_set = ctx.resources.glyph_sets.entry(text.item.font.clone()).or_default();
     for g in text.glyphs() {
-        let t = text.text();
-        let segment = &t[g.range()];
-        glyph_set.entry(g.id).or_insert_with(|| segment.into());
+        glyph_set.entry(g.id).or_insert_with(|| text.glyph_text(&g));
     }
 
     let fill_transform = ctx.state.transforms(Size::zero(), pos);
@@ -640,9 +638,7 @@ fn write_color_glyphs(
 
         ctx.content.show(Str(&[index]));
 
-        glyph_set
-            .entry(glyph.id)
-            .or_insert_with(|| text.text()[glyph.range()].into());
+        glyph_set.entry(glyph.id).or_insert_with(|| text.glyph_text(&glyph));
     }
     ctx.content.end_text();
 

--- a/crates/typst-pdf/src/content.rs
+++ b/crates/typst-pdf/src/content.rs
@@ -441,7 +441,7 @@ fn write_text(ctx: &mut Builder, pos: Point, text: &TextItem) -> SourceResult<()
         || tables.svg.is_some()
         || tables.colr.is_some();
     if !has_color_glyphs {
-        write_normal_text(ctx, pos, TextItemView::all_of(text))?;
+        write_normal_text(ctx, pos, TextItemView::full(text))?;
         return Ok(());
     }
 
@@ -449,9 +449,9 @@ fn write_text(ctx: &mut Builder, pos: Point, text: &TextItem) -> SourceResult<()
         text.glyphs.iter().filter(|g| is_color_glyph(&text.font, g)).count();
 
     if color_glyph_count == text.glyphs.len() {
-        write_color_glyphs(ctx, pos, TextItemView::all_of(text))?;
+        write_color_glyphs(ctx, pos, TextItemView::full(text))?;
     } else if color_glyph_count == 0 {
-        write_normal_text(ctx, pos, TextItemView::all_of(text))?;
+        write_normal_text(ctx, pos, TextItemView::full(text))?;
     } else {
         // Otherwise we need to split it in smaller text runs
         let mut offset = 0;

--- a/crates/typst/src/layout/inline/collect.rs
+++ b/crates/typst/src/layout/inline/collect.rs
@@ -8,7 +8,8 @@ use crate::layout::{
 };
 use crate::syntax::Span;
 use crate::text::{
-    LinebreakElem, SmartQuoteElem, SmartQuoter, SmartQuotes, SpaceElem, TextElem,
+    is_default_ignorable, LinebreakElem, SmartQuoteElem, SmartQuoter, SmartQuotes,
+    SpaceElem, TextElem,
 };
 use crate::utils::Numeric;
 

--- a/crates/typst/src/layout/inline/mod.rs
+++ b/crates/typst/src/layout/inline/mod.rs
@@ -10,7 +10,7 @@ use comemo::{Track, Tracked, TrackedMut};
 use self::collect::{collect, Item, Segment, SpanMapper};
 use self::finalize::finalize;
 use self::line::{commit, line, Line};
-use self::linebreak::{is_default_ignorable, linebreak, Breakpoint};
+use self::linebreak::{linebreak, Breakpoint};
 use self::prepare::{prepare, Preparation};
 use self::shaping::{
     cjk_punct_style, is_of_cj_script, shape_range, ShapedGlyph, ShapedText,

--- a/crates/typst/src/layout/inline/shaping.rs
+++ b/crates/typst/src/layout/inline/shaping.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use az::SaturatingAs;
 use ecow::EcoString;
-use rustybuzz::{ShapePlan, UnicodeBuffer};
+use rustybuzz::{BufferFlags, ShapePlan, UnicodeBuffer};
 use ttf_parser::Tag;
 use unicode_bidi::{BidiInfo, Level as BidiLevel};
 use unicode_script::{Script, UnicodeScript};
@@ -773,6 +773,12 @@ fn shape_segment<'a>(
         _ => unimplemented!("vertical text layout"),
     });
     buffer.guess_segment_properties();
+
+    // By default, Harfbuzz will create zero-width space glyphs for default
+    // ignorables. This is probably useful for GUI apps that want noticable
+    // effects on the cursor for those, but for us it's not useful and hurts
+    // text extraction.
+    buffer.set_flags(BufferFlags::REMOVE_DEFAULT_IGNORABLES);
 
     // Prepare the shape plan. This plan depends on direction, script, language,
     // and features, but is independent from the text and can thus be memoized.

--- a/crates/typst/src/layout/inline/shaping.rs
+++ b/crates/typst/src/layout/inline/shaping.rs
@@ -15,8 +15,8 @@ use crate::engine::Engine;
 use crate::foundations::{Smart, StyleChain};
 use crate::layout::{Abs, Dir, Em, Frame, FrameItem, Point, Size};
 use crate::text::{
-    decorate, families, features, variant, Font, FontVariant, Glyph, Lang, Region,
-    TextElem, TextItem,
+    decorate, families, features, is_default_ignorable, variant, Font, FontVariant,
+    Glyph, Lang, Region, TextElem, TextItem,
 };
 use crate::utils::SliceExt;
 use crate::World;
@@ -725,8 +725,11 @@ fn shape_segment<'a>(
     text: &str,
     mut families: impl Iterator<Item = &'a str> + Clone,
 ) {
-    // Fonts dont have newlines and tabs.
-    if text.chars().all(|c| c == '\n' || c == '\t') {
+    // Don't try shaping newlines, tabs, or default ignorables.
+    if text
+        .chars()
+        .all(|c| c == '\n' || c == '\t' || is_default_ignorable(c))
+    {
         return;
     }
 

--- a/crates/typst/src/text/item.rs
+++ b/crates/typst/src/text/item.rs
@@ -5,7 +5,7 @@ use ecow::EcoString;
 
 use crate::layout::{Abs, Em};
 use crate::syntax::Span;
-use crate::text::{Font, Lang, Region};
+use crate::text::{is_default_ignorable, Font, Lang, Region};
 use crate::visualize::{FixedStroke, Paint};
 
 /// A run of shaped text.
@@ -104,9 +104,13 @@ impl<'a> TextItemView<'a> {
         })
     }
 
-    /// The plain text that this slice represents
-    pub fn text(&self) -> &str {
-        &self.item.text[self.text_range()]
+    /// The plain text for the given glyph. This is an approximation since
+    /// glyphs do not correspond 1-1 with codepoints.
+    pub fn glyph_text(&self, glyph: &Glyph) -> EcoString {
+        self.item.text[glyph.range()]
+            .chars()
+            .filter(|&c| !is_default_ignorable(c))
+            .collect()
     }
 
     /// The total width of this text slice

--- a/crates/typst/src/text/item.rs
+++ b/crates/typst/src/text/item.rs
@@ -78,7 +78,7 @@ pub struct TextItemView<'a> {
 
 impl<'a> TextItemView<'a> {
     /// Build a TextItemView for the whole contents of a TextItem.
-    pub fn all_of(text: &'a TextItem) -> Self {
+    pub fn full(text: &'a TextItem) -> Self {
         Self::from_glyph_range(text, 0..text.glyphs.len())
     }
 
@@ -87,23 +87,21 @@ impl<'a> TextItemView<'a> {
         TextItemView { item: text, glyph_range }
     }
 
-    /// Obtains a glyph in this slice, remapping the range that it represents in
-    /// the original text so that it is relative to the start of the slice
-    pub fn glyph_at(&self, index: usize) -> Glyph {
-        let g = &self.item.glyphs[self.glyph_range.start + index];
-        let base = self.text_range().start as u16;
-        Glyph {
-            range: g.range.start - base..g.range.end - base,
-            ..*g
-        }
-    }
-
     /// Returns an iterator over the glyphs of the slice.
     ///
     /// The range of text that each glyph represents is remapped to be relative
     /// to the start of the slice.
     pub fn glyphs(&self) -> impl Iterator<Item = Glyph> + '_ {
-        (0..self.glyph_range.len()).map(|index| self.glyph_at(index))
+        let first = self.item.glyphs[self.glyph_range.start].range();
+        let last = self.item.glyphs[self.glyph_range.end - 1].range();
+        let base = first.start.min(last.start) as u16;
+        (0..self.glyph_range.len()).map(move |index| {
+            let g = &self.item.glyphs[self.glyph_range.start + index];
+            Glyph {
+                range: g.range.start - base..g.range.end - base,
+                ..*g
+            }
+        })
     }
 
     /// The plain text that this slice represents
@@ -118,13 +116,5 @@ impl<'a> TextItemView<'a> {
             .map(|g| g.x_advance)
             .sum::<Em>()
             .at(self.item.size)
-    }
-
-    /// The range of text in the original TextItem that this slice corresponds
-    /// to.
-    fn text_range(&self) -> Range<usize> {
-        let first = self.item.glyphs[self.glyph_range.start].range();
-        let last = self.item.glyphs[self.glyph_range.end - 1].range();
-        first.start.min(last.start)..first.end.max(last.end)
     }
 }


### PR DESCRIPTION
Since https://github.com/typst/typst/pull/4585, we use the text that glyphs were shaped from for the PDF CMap. However, this creates an undesirable effect in combination with default ignorable codepoints such as BiDi overrides or zero-width joiners.

Consider this code snippet:
```typ
A#sym.zwj B C
```

Harfbuzz will produce an empty space glyph with zero advance width for the ZWJ and put it into one cluster with the "A". As a result, Typst sees two glyphs within the cluster range 0..4. Because of this clustering, it assigns the range 0..0 to A and 0..4 to the ZWJ. As a result, the CMap entry in the PDF for the space glyphs becomes totally wrong.

What this PR does:
- Enable `REMOVE_DEFAULT_IGNORABLES` in Harfbuzz. This way, we don't get zero-advance space glyphs at all anymore. I assume that this is not the default because of GUI apps, where cursor movement shall be affected. @behdad Is this correct or does this have other relevant effects?
- Filter out default ignorables when creating CMap entries for the PDF. Text extraction can still fail, to truly fix it we need `/ActualText` support.
- Ignores default ignorables when scanning for segments that need font fallback. We currently shape full segments of text, even containing linebreaks, as one (but other segment properties are ensured to be uniform). With this change, default ignorables can be soaked up into the cluster of a newline's tofu, which broke a check. I think shaping newlines is probably wrong and we should maybe rather split shape runs at newlines? But that's left as future work.

Fixes #5091