### PR TITLE
Fix panic for empty breakable block equations

### DIFF
--- a/crates/typst/src/math/equation.rs
+++ b/crates/typst/src/math/equation.rs
@@ -379,6 +379,12 @@ fn layout_equation_block(
             equation_builder.size.y = height;
         }
 
+        // Ensure that there is at least one frame, even for empty equations.
+        if equation_builders.is_empty() {
+            equation_builders
+                .push(MathRunFrameBuilder { frames: vec![], size: Size::zero() });
+        }
+
         equation_builders
     } else {
         vec![full_equation_builder]

--- a/tests/suite/math/multiline.typ
+++ b/tests/suite/math/multiline.typ
@@ -147,10 +147,14 @@ $ a + b $
 Shouldn't overflow:
 $ a + b $
 
+--- issue-5113-pagebreaking-empty ---
+// Test empty breakable equations.
+#show math.equation: set block(breakable: true)
+#math.equation(block: true, [])
+
 --- issue-1948-math-text-break ---
 // Test text with linebreaks in math.
 $ x := "a\nb\nc\nd\ne" $
-
 
 --- issue-4829-math-pagebreaking-wrong-number ---
 // Test numbering of empty regions of broken equations.


### PR DESCRIPTION
Fixes #5113 

An empty equation now returns an empty frame instead of no frame at all, so that the 1-1 region to frame contract is maintained.

(Something like this may have been the real reason why I did https://github.com/typst/typst/pull/5078#issuecomment-2384865773 initially, but I should have documented that somewhere.)