### PR TITLE
Fix "thumbnail" key in manifest files not being optional

### DIFF
--- a/crates/typst-syntax/src/package.rs
+++ b/crates/typst-syntax/src/package.rs
@@ -86,7 +86,8 @@ pub struct TemplateInfo {
     pub entrypoint: EcoString,
     /// A path relative to the package's root that points to a PNG or lossless
     /// WebP thumbnail for the template.
-    pub thumbnail: EcoString,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thumbnail: Option<EcoString>,
     /// All parsed but unknown fields, this can be used for validation.
     #[serde(flatten, skip_serializing)]
     pub unknown_fields: UnknownFields,


### PR DESCRIPTION
As per [the `packages` repository's README](https://github.com/typst/packages/blob/2b56fa0f972c616b1481c4572e897f3c9782f853/README.md), the key is only required when uploading to the official registry.

This otherwise creates a regression in v0.12.0-rc1.