### PR TITLE
Fix excluded PDF pages being written

### DIFF
--- a/crates/typst-pdf/src/page.rs
+++ b/crates/typst-pdf/src/page.rs
@@ -106,10 +106,12 @@ pub fn write_page_tree(ctx: &WithRefs) -> SourceResult<(PdfChunk, Ref)> {
         );
     }
 
+    let page_kids = ctx.globals.pages.iter().filter_map(Option::as_ref).copied();
+
     chunk
         .pages(page_tree_ref)
-        .count(ctx.pages.len() as i32)
-        .kids(ctx.globals.pages.iter().filter_map(Option::as_ref).copied());
+        .count(page_kids.clone().count() as i32)
+        .kids(page_kids);
 
     Ok((chunk, page_tree_ref))
 }


### PR DESCRIPTION
Fixes #5129

**Test case used:** the example code in the issue with `typst c --pages=1,2 code.typ code.pdf`

Starting with #4039, only pages 1 and 2 would remain, but due to a regression in #4154, the other, excluded pages would still be written, but empty.

This PR fixes it by fixing the page count in the page tree writing function.