### PR TITLE
Increase page height in place example

### DIFF
--- a/crates/typst/src/layout/place.rs
+++ b/crates/typst/src/layout/place.rs
@@ -23,7 +23,7 @@ use crate::layout::{Alignment, Em, Length, Rel};
 ///
 /// # Examples
 /// ```example
-/// #set page(height: 60pt)
+/// #set page(height: 120pt)
 /// Hello, world!
 ///
 /// #rect(


### PR DESCRIPTION
Small follow-up to #5031: this example was meant to produce a single page, and I see on https://staging.typst.app/docs/reference/layout/place/#examples that 60pt is too small for that. 120pt is enough in local testing, I hope it would work for the HTML docs too (there seem to be some differences).

Also maybe the `set page` line should be hidden using `>>>`?