### PR TITLE
A few decimal docs fixes

### DIFF
--- a/crates/typst/src/foundations/calc.rs
+++ b/crates/typst/src/foundations/calc.rs
@@ -92,7 +92,7 @@ cast! {
 /// Raises a value to some exponent.
 ///
 /// ```example
-/// #calc.pow(2, 3)
+/// #calc.pow(2, 3) \
 /// #calc.pow(decimal("2.5"), 2)
 /// ```
 #[func(title = "Power")]
@@ -969,7 +969,7 @@ pub fn div_euclid(
 /// #calc.rem-euclid(7, -3) \
 /// #calc.rem-euclid(-7, 3) \
 /// #calc.rem-euclid(-7, -3) \
-/// #calc.rem-euclid(1.75, 0.5)
+/// #calc.rem-euclid(1.75, 0.5) \
 /// #calc.rem-euclid(decimal("1.75"), decimal("0.5"))
 /// ```
 #[func(title = "Euclidean Remainder")]

--- a/crates/typst/src/foundations/decimal.rs
+++ b/crates/typst/src/foundations/decimal.rs
@@ -33,9 +33,10 @@ use crate::World;
 /// constructing a decimal from a [floating-point number]($float), while
 /// supported, **is an imprecise conversion and therefore discouraged.** A
 /// warning will be raised if Typst detects that there was an accidental `float`
-/// to `decimal` cast through its constructor (e.g. if writing `{decimal(3.14)}`
-/// - note the lack of double quotes, indicating this is an accidental `float`
-/// cast and therefore imprecise).
+/// to `decimal` cast through its constructor, e.g. if writing `{decimal(3.14)}`
+/// (note the lack of double quotes, indicating this is an accidental `float`
+/// cast and therefore imprecise). It is recommended to use strings for
+/// constant decimal values instead (e.g. `decimal("3.14")`).
 ///
 /// The precision of a `float` to `decimal` cast can be slightly improved by
 /// rounding the result to 15 digits with [`calc.round`]($calc.round), but there
@@ -258,6 +259,7 @@ impl Decimal {
     #[func(constructor)]
     pub fn construct(
         engine: &mut Engine,
+        /// The value that should be converted to a decimal.
         value: Spanned<ToDecimal>,
     ) -> SourceResult<Decimal> {
         match value.v {


### PR DESCRIPTION
Fixes the following weirdnesses:

![random list in the text](https://github.com/user-attachments/assets/72e7d426-a6ca-4223-8982-71bbcb582e2a)
![missing linebreak in calc.pow](https://github.com/user-attachments/assets/74c81387-9fc0-41a2-a87c-788f42c85e20)
![missing linebreak in rem-euclid](https://github.com/user-attachments/assets/980e816d-2722-4c6c-898d-352ba43b220a)
![missing value description](https://github.com/user-attachments/assets/02667610-1f9e-4363-9717-de9c82f45737)

There is another one which is going to be fixed by #5136 ("refer to the limits below" instead of "above").