### PR TITLE
Fix warning in proc macro

### DIFF
--- a/crates/typst-macros/src/scope.rs
+++ b/crates/typst-macros/src/scope.rs
@@ -163,6 +163,7 @@ fn rewrite_primitive_base(item: &syn::ItemImpl, ident_ext: &syn::Ident) -> Token
 
     let self_ty = &item.self_ty;
     quote! {
+        #[allow(non_camel_case_types)]
         trait #ident_ext {
             #(#sigs)*
         }


### PR DESCRIPTION
The warning was kinda spurious and maybe only with rust-analyzer, but it doesn't hurt in any case.