### PR TITLE
Error for parent-scoped figures without placement

### DIFF
--- a/crates/typst/src/model/figure.rs
+++ b/crates/typst/src/model/figure.rs
@@ -351,6 +351,12 @@ impl Show for Packed<FigureElem> {
                 .with_float(true)
                 .pack()
                 .spanned(self.span());
+        } else if self.scope(styles) == PlacementScope::Parent {
+            bail!(
+                self.span(),
+                "parent-scoped placement is only available for floating figures";
+                hint: "you can enable floating placement with `figure(placement: auto, ..)`"
+            );
         }
 
         Ok(realized)

--- a/tests/suite/model/figure.typ
+++ b/tests/suite/model/figure.typ
@@ -77,6 +77,11 @@ We can clearly see that @fig-cylinder and
 
 #lines(15)
 
+--- figure-scope-without-placement ---
+// Error: 2-27 parent-scoped placement is only available for floating figures
+// Hint: 2-27 you can enable floating placement with `figure(placement: auto, ..)`
+#figure(scope: "parent")[]
+
 --- figure-theorem ---
 // Testing show rules with figures with a simple theorem display
 #show figure.where(kind: "theorem"): it => {


### PR DESCRIPTION
Parent scope is only supported for floating figures. This is now reflected through an error instead of failing silently.