### PR TITLE
Fix hint for destructuring to an array with at least 1 element

### DIFF
--- a/crates/typst/src/eval/binding.rs
+++ b/crates/typst/src/eval/binding.rs
@@ -195,6 +195,7 @@ fn wrong_number_of_elements(
 
     let quantifier = if len > count { "too many" } else { "not enough" };
     let expected = match (spread, count) {
+        (true, 1) => "at least 1 element".into(),
         (true, c) => eco_format!("at least {c} elements"),
         (false, 0) => "an empty array".into(),
         (false, 1) => "a single element".into(),

--- a/tests/suite/scripting/destructuring.typ
+++ b/tests/suite/scripting/destructuring.typ
@@ -137,6 +137,11 @@
 // Hint: 6-20 the provided array has a length of 2, but the pattern expects at least 3 elements
 #let (..a, b, c, d) = (1, 2)
 
+--- destructuring-let-array-too-few-elements-with-sink-1-element ---
+// Error: 6-14 not enough elements to destructure
+// Hint: 6-14 the provided array has a length of 0, but the pattern expects at least 1 element
+#let (..a, b) = ()
+
 --- destructuring-let-array-bool-invalid ---
 // Error: 6-12 cannot destructure boolean
 #let (a, b) = true


### PR DESCRIPTION
Addendum to #5139, fixing “at least 1 elements” to “at least 1 element”.