### PR TITLE
Fix hashing of equal decimals with different scales

### DIFF
--- a/crates/typst/src/foundations/decimal.rs
+++ b/crates/typst/src/foundations/decimal.rs
@@ -92,22 +92,6 @@ use crate::World;
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Decimal(rust_decimal::Decimal);
 
-impl Hash for Decimal {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        // `rust_decimal`'s Hash implementation normalizes decimals before
-        // hashing them. This means decimals with different scales but
-        // equivalent value not only compare equal but also hash equally.
-        // Here, we hash all bytes explicitly to ensure the scale is also
-        // considered. This means that 123.314 == 123.31400, but
-        // 123.314.hash() != 123.31400.hash().
-        //
-        // Note that this implies that equal decimals can have different
-        // hashes, which might generate problems with certain data structures,
-        // such as HashSet and HashMap.
-        self.0.serialize().hash(state);
-    }
-}
-
 impl Decimal {
     pub const ZERO: Self = Self(rust_decimal::Decimal::ZERO);
     pub const ONE: Self = Self(rust_decimal::Decimal::ONE);
@@ -384,6 +368,22 @@ impl Neg for Decimal {
 
     fn neg(self) -> Self {
         Self(-self.0)
+    }
+}
+
+impl Hash for Decimal {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // `rust_decimal`'s Hash implementation normalizes decimals before
+        // hashing them. This means decimals with different scales but
+        // equivalent value not only compare equal but also hash equally. Here,
+        // we hash all bytes explicitly to ensure the scale is also considered.
+        // This means that 123.314 == 123.31400, but 123.314.hash() !=
+        // 123.31400.hash().
+        //
+        // Note that this implies that equal decimals can have different hashes,
+        // which might generate problems with certain data structures, such as
+        // HashSet and HashMap.
+        self.0.serialize().hash(state);
     }
 }
 

--- a/crates/typst/src/foundations/decimal.rs
+++ b/crates/typst/src/foundations/decimal.rs
@@ -406,44 +406,24 @@ cast! {
 
 #[cfg(test)]
 mod tests {
-    use std::hash::{DefaultHasher, Hash, Hasher};
     use std::str::FromStr;
 
     use super::Decimal;
+    use crate::utils::hash128;
 
     #[test]
-    fn test_equal_decimals_with_equal_scales_hash_identically() {
-        let decimal_first = Decimal::from_str("3.14").unwrap();
-        let decimal_second = Decimal::from_str("3.14").unwrap();
-
-        assert_eq!(decimal_first, decimal_second);
-
-        let mut hasher_first = DefaultHasher::new();
-        decimal_first.hash(&mut hasher_first);
-        let hash_first = hasher_first.finish();
-
-        let mut hasher_second = DefaultHasher::new();
-        decimal_second.hash(&mut hasher_second);
-        let hash_second = hasher_second.finish();
-
-        assert_eq!(hash_first, hash_second);
+    fn test_decimals_with_equal_scales_hash_identically() {
+        let a = Decimal::from_str("3.14").unwrap();
+        let b = Decimal::from_str("3.14").unwrap();
+        assert_eq!(a, b);
+        assert_eq!(hash128(&a), hash128(&b));
     }
 
     #[test]
-    fn test_equal_decimals_with_different_scales_hash_differently() {
-        let decimal_short = Decimal::from_str("3.140").unwrap();
-        let decimal_long = Decimal::from_str("3.14000").unwrap();
-
-        assert_eq!(decimal_short, decimal_long);
-
-        let mut hasher_short = DefaultHasher::new();
-        decimal_short.hash(&mut hasher_short);
-        let hash_short = hasher_short.finish();
-
-        let mut hasher_long = DefaultHasher::new();
-        decimal_long.hash(&mut hasher_long);
-        let hash_long = hasher_long.finish();
-
-        assert_ne!(hash_short, hash_long);
+    fn test_decimals_with_different_scales_hash_differently() {
+        let a = Decimal::from_str("3.140").unwrap();
+        let b = Decimal::from_str("3.14000").unwrap();
+        assert_eq!(a, b);
+        assert_ne!(hash128(&a), hash128(&b));
     }
 }

--- a/tests/suite/foundations/decimal.typ
+++ b/tests/suite/foundations/decimal.typ
@@ -31,6 +31,13 @@
 // Error: 10-19 float is not a valid decimal: float.nan
 #decimal(float.nan)
 
+--- decimal-scale-is-observable ---
+// Ensure equal decimals with different scales produce different strings.
+#let f1(x) = str(x)
+#let f2(x) = f1(x)
+#test(f2(decimal("3.140")), "3.140")
+#test(f2(decimal("3.14000")), "3.14000")
+
 --- decimal-repr ---
 // Test the `repr` function with decimals.
 #test(repr(decimal("12.0")), "decimal(\"12.0\")")


### PR DESCRIPTION
Decimals of equal value but different scales (e.g. `3.14` and `3.14000`) are treated as equal and had the same hash, but this produced problems as the scale is observable through `str()` and `repr()`, meaning function calls can produce different results depending on the scales of received decimals, but that wouldn't matter to comemo since they hashed the same, so, after calling `f("3.14")`, a call to `f("3.14000")` would then always (wrongly) produce the same result  and vice-versa.

This is fixed by considering the scale when hashing as well (we consider all bytes).

One alternative could be to ensure the scale is not observable by normalizing the decimal (trimming trailing zeroes and replacing `-0` with `0`) on each `str()` and `repr()`. To be honest, I'm having a hard time justifying keeping the scale observable... but, in principle, it can be nice to keep a consistent scale across all of your decimals (e.g. for finance, you'd always create and display decimals with 3 digits, even though operations such as division can increase that). Not 100% sure that's a strong enough reason though, as in principle this only matters when displaying the decimal (at which point you'd be able to, say, use oxifmt to ensure you have a precision of 3 digits), not when doing calculations with it.

**Edit:** I think there is a strong enough argument to override the Hash implementation regardless of whether the scale is observable, given Rust code can still somehow observe the scale.