### PR TITLE
Fix the order to match the text

### DIFF
--- a/docs/tutorial/2-formatting.md
+++ b/docs/tutorial/2-formatting.md
@@ -103,13 +103,13 @@ Let's add a few more styles to our document. We want larger margins and a serif
 font. For the purposes of the example, we'll also set another page size.
 
 ```example
-#set text(
-  font: "New Computer Modern",
-  size: 10pt
-)
 #set page(
   paper: "a6",
   margin: (x: 1.8cm, y: 1.5cm),
+)
+#set text(
+  font: "New Computer Modern",
+  size: 10pt
 )
 #set par(
   justify: true,


### PR DESCRIPTION
The text says "First is the page set rule.", so it should also come first in the example.