### PR TITLE
(Re-)implement rounding with negative digits

### DIFF
--- a/crates/typst-utils/src/lib.rs
+++ b/crates/typst-utils/src/lib.rs
@@ -17,7 +17,7 @@ pub use self::deferred::Deferred;
 pub use self::duration::format_duration;
 pub use self::hash::LazyHash;
 pub use self::pico::PicoStr;
-pub use self::round::round_with_precision;
+pub use self::round::{round_int_with_precision, round_with_precision};
 pub use self::scalar::Scalar;
 
 use std::fmt::{Debug, Formatter};

--- a/crates/typst-utils/src/round.rs
+++ b/crates/typst-utils/src/round.rs
@@ -166,27 +166,27 @@ mod tests {
     #[test]
     fn test_round_with_precision_negative_1() {
         let round = |value| rp(value, -1);
-        assert_eq!(0.0, round(0.0));
-        assert_eq!(-0.0, round(-0.0));
-        assert_eq!(0.0, round(0.4));
-        assert_eq!(-0.0, round(-0.4));
-        assert_eq!(1230.0, round(1234.5));
-        assert_eq!(-1230.0, round(-1234.5));
-        assert_eq!(1250.0, round(1245.232));
-        assert_eq!(-1250.0, round(-1245.232));
+        assert_eq!(round(0.0), 0.0);
+        assert_eq!(round(-0.0), -0.0);
+        assert_eq!(round(0.4), 0.0);
+        assert_eq!(round(-0.4), -0.0);
+        assert_eq!(round(1234.5), 1230.0);
+        assert_eq!(round(-1234.5), -1230.0);
+        assert_eq!(round(1245.232), 1250.0);
+        assert_eq!(round(-1245.232), -1250.0);
     }
 
     #[test]
     fn test_round_with_precision_negative_2() {
         let round = |value| rp(value, -2);
-        assert_eq!(0.0, round(0.0));
-        assert_eq!(-0.0, round(-0.0));
-        assert_eq!(0.0, round(0.4));
-        assert_eq!(-0.0, round(-0.4));
-        assert_eq!(1200.0, round(1243.232));
-        assert_eq!(-1200.0, round(-1243.232));
-        assert_eq!(1300.0, round(1253.232));
-        assert_eq!(-1300.0, round(-1253.232));
+        assert_eq!(round(0.0), 0.0);
+        assert_eq!(round(-0.0), -0.0);
+        assert_eq!(round(0.4), 0.0);
+        assert_eq!(round(-0.4), -0.0);
+        assert_eq!(round(1243.232), 1200.0);
+        assert_eq!(round(-1243.232), -1200.0);
+        assert_eq!(round(1253.232), 1300.0);
+        assert_eq!(round(-1253.232), -1300.0);
     }
 
     #[test]
@@ -196,8 +196,8 @@ mod tests {
         let max_digits = f64::DIGITS as i16;
 
         // Special cases.
-        assert_eq!(round(f64::INFINITY), f64::INFINITY,);
-        assert_eq!(round(f64::NEG_INFINITY), f64::NEG_INFINITY,);
+        assert_eq!(round(f64::INFINITY), f64::INFINITY);
+        assert_eq!(round(f64::NEG_INFINITY), f64::NEG_INFINITY);
         assert!(round(f64::NAN).is_nan());
 
         // Max
@@ -221,8 +221,8 @@ mod tests {
         let max_down = max_digits - 1;
 
         // Special cases.
-        assert_eq!(f64::INFINITY, rp(f64::INFINITY, -1));
-        assert_eq!(f64::NEG_INFINITY, rp(f64::NEG_INFINITY, -1));
+        assert_eq!(rp(f64::INFINITY, -1), f64::INFINITY);
+        assert_eq!(rp(f64::NEG_INFINITY, -1), f64::NEG_INFINITY);
         assert!(rp(f64::NAN, -1).is_nan());
 
         // Max
@@ -248,8 +248,8 @@ mod tests {
         // Max - 1
         assert_eq!(rp(f64::MAX, -max_down), f64::INFINITY);
         assert_eq!(rp(f64::MIN, -max_down), f64::NEG_INFINITY);
-        assert_eq!(2.0 * exp10(max_down), rp(1.66 * exp10(max_down), -(max_down)));
-        assert_eq!(-2.0 * exp10(max_down), rp(-1.66 * exp10(max_down), -(max_down)));
+        assert_eq!(rp(1.66 * exp10(max_down), -max_down), 2.0 * exp10(max_down));
+        assert_eq!(rp(-1.66 * exp10(max_down), -max_down), -2.0 * exp10(max_down));
         assert_eq!(rp(1234.5678, -max_down), 0.0);
         assert_eq!(rp(-1234.5678, -max_down), -0.0);
 
@@ -267,10 +267,10 @@ mod tests {
 
     #[test]
     fn test_round_int_with_precision_positive() {
-        assert_eq!(Some(0), rip(0, 0));
-        assert_eq!(Some(10), rip(10, 0));
-        assert_eq!(Some(23), rip(23, 235));
-        assert_eq!(Some(i64::MAX), rip(i64::MAX, 235));
+        assert_eq!(rip(0, 0), Some(0));
+        assert_eq!(rip(10, 0), Some(10));
+        assert_eq!(rip(23, 235), Some(23));
+        assert_eq!(rip(i64::MAX, 235), Some(i64::MAX));
     }
 
     #[test]

--- a/crates/typst-utils/src/round.rs
+++ b/crates/typst-utils/src/round.rs
@@ -1,8 +1,17 @@
 /// Returns value with `n` digits after floating point where `n` is `precision`.
-/// Standard rounding rules apply (if `n+1`th digit >= 5, round up).
+/// Standard rounding rules apply (if `n+1`th digit >= 5, round away from zero).
+///
+/// If `precision` is negative, returns value with `n` less significant integer
+/// digits before floating point where `n` is `-precision`. Standard rounding
+/// rules apply to the first remaining significant digit (if `n`th digit from
+/// the floating point >= 5, round away from zero).
 ///
 /// If rounding the `value` will have no effect (e.g., it's infinite or NaN),
 /// returns `value` unchanged.
+///
+/// Note that rounding with negative precision may return plus or minus
+/// infinity if the result would overflow or underflow (respectively) the range
+/// of floating-point numbers.
 ///
 /// # Examples
 ///
@@ -10,8 +19,11 @@
 /// # use typst_utils::round_with_precision;
 /// let rounded = round_with_precision(-0.56553, 2);
 /// assert_eq!(-0.57, rounded);
+///
+/// let rounded_negative = round_with_precision(823543.0, -3);
+/// assert_eq!(824000.0, rounded_negative);
 /// ```
-pub fn round_with_precision(value: f64, precision: u8) -> f64 {
+pub fn round_with_precision(value: f64, precision: i16) -> f64 {
     // Don't attempt to round the float if that wouldn't have any effect.
     // This includes infinite or NaN values, as well as integer values
     // with a filled mantissa (which can't have a fractional part).
@@ -23,14 +35,27 @@ pub fn round_with_precision(value: f64, precision: u8) -> f64 {
     // `value * offset` multiplication) does not.
     if value.is_infinite()
         || value.is_nan()
-        || value.abs() >= (1_i64 << f64::MANTISSA_DIGITS) as f64
-        || precision as u32 >= f64::DIGITS
+        || precision >= 0 && value.abs() >= (1_i64 << f64::MANTISSA_DIGITS) as f64
+        || precision >= f64::DIGITS as i16
     {
         return value;
     }
-    let offset = 10_f64.powi(precision.into());
-    assert!((value * offset).is_finite(), "{value} * {offset} is not finite!");
-    (value * offset).round() / offset
+    // Floats cannot have more than this amount of base-10 integer digits.
+    if precision < -(f64::MAX_10_EXP as i16) {
+        // Multiply by zero to ensure sign is kept.
+        return value * 0.0;
+    }
+    if precision > 0 {
+        let offset = 10_f64.powi(precision.into());
+        assert!((value * offset).is_finite(), "{value} * {offset} is not finite!");
+        (value * offset).round() / offset
+    } else {
+        // Divide instead of multiplying by a negative exponent given that
+        // `f64::MAX_10_EXP` is larger than `f64::MIN_10_EXP` in absolute value
+        // (|308| > |-307|), allowing for the precision of -308 to be used.
+        let offset = 10_f64.powi((-precision).into());
+        (value / offset).round() * offset
+    }
 }
 
 #[cfg(test)]
@@ -88,7 +113,7 @@ mod tests {
         assert!(round(f64::NAN).is_nan());
 
         let max_int = (1_i64 << f64::MANTISSA_DIGITS) as f64;
-        let f64_digits = f64::DIGITS as u8;
+        let f64_digits = f64::DIGITS as i16;
 
         // max
         assert_eq!(max_int, round(max_int));
@@ -101,5 +126,137 @@ mod tests {
         assert_eq!(max_int - 1f64, round_with_precision(max_int - 1f64, f64_digits));
         assert_eq!(max_int, round_with_precision(max_int, f64_digits - 1));
         assert_eq!(max_int - 1f64, round_with_precision(max_int - 1f64, f64_digits - 1));
+    }
+
+    #[test]
+    fn test_round_with_precision_negative_1() {
+        let round = |value| round_with_precision(value, -1);
+        assert_eq!(0.0, round(0.0));
+        assert_eq!(-0.0, round(-0.0));
+        assert_eq!(0.0, round(0.4));
+        assert_eq!(-0.0, round(-0.4));
+        assert_eq!(1230.0, round(1234.5));
+        assert_eq!(-1230.0, round(-1234.5));
+        assert_eq!(1250.0, round(1245.232));
+        assert_eq!(-1250.0, round(-1245.232));
+    }
+
+    #[test]
+    fn test_round_with_precision_negative_2() {
+        let round = |value| round_with_precision(value, -2);
+        assert_eq!(0.0, round(0.0));
+        assert_eq!(-0.0, round(-0.0));
+        assert_eq!(0.0, round(0.4));
+        assert_eq!(-0.0, round(-0.4));
+        assert_eq!(1200.0, round(1243.232));
+        assert_eq!(-1200.0, round(-1243.232));
+        assert_eq!(1300.0, round(1253.232));
+        assert_eq!(-1300.0, round(-1253.232));
+    }
+
+    #[test]
+    fn test_round_with_precision_fuzzy_negative() {
+        let round = |value| round_with_precision(value, -1);
+        assert_eq!(f64::INFINITY, round(f64::INFINITY));
+        assert_eq!(f64::NEG_INFINITY, round(f64::NEG_INFINITY));
+        assert!(round(f64::NAN).is_nan());
+
+        let max_int_digits = f64::MAX_10_EXP as i16;
+        let ten_exp = |exponent: i16| 10_f64.powi(exponent.into());
+
+        // max
+        assert_eq!(f64::INFINITY, round_with_precision(f64::MAX, -max_int_digits));
+        assert_eq!(f64::NEG_INFINITY, round_with_precision(f64::MIN, -max_int_digits));
+        assert_eq!(
+            f64::INFINITY,
+            round_with_precision(1.66 * ten_exp(max_int_digits), -max_int_digits)
+        );
+        assert_eq!(
+            f64::NEG_INFINITY,
+            round_with_precision(-1.66 * ten_exp(max_int_digits), -max_int_digits)
+        );
+        assert_eq!(
+            0.0,
+            round_with_precision(1.66 * ten_exp(max_int_digits - 1), -max_int_digits)
+        );
+        assert_eq!(
+            -0.0,
+            round_with_precision(-1.66 * ten_exp(max_int_digits - 1), -max_int_digits)
+        );
+        assert_eq!(0.0, round_with_precision(1234.5678, -max_int_digits));
+        assert_eq!(-0.0, round_with_precision(-1234.5678, -max_int_digits));
+
+        // max - 1
+        assert_eq!(f64::INFINITY, round_with_precision(f64::MAX, -(max_int_digits - 1)));
+        assert_eq!(
+            f64::NEG_INFINITY,
+            round_with_precision(f64::MIN, -(max_int_digits - 1))
+        );
+        assert_eq!(
+            // Must be approx equal to 1.7e308.
+            //
+            // Using some division and flooring to avoid weird results due to
+            // imprecision.
+            17.0,
+            (round_with_precision(1.66 * ten_exp(max_int_digits), -(max_int_digits - 1))
+                / ten_exp(max_int_digits - 1))
+            .floor()
+        );
+        assert_eq!(
+            // Must be approx equal to -1.7e308.
+            //
+            // Using some division and flooring to avoid weird results due to
+            // imprecision.
+            -17.0,
+            (round_with_precision(
+                -1.66 * ten_exp(max_int_digits),
+                -(max_int_digits - 1)
+            ) / ten_exp(max_int_digits - 1))
+            .floor()
+        );
+        assert_eq!(
+            2.0 * ten_exp(max_int_digits - 1),
+            round_with_precision(
+                1.66 * ten_exp(max_int_digits - 1),
+                -(max_int_digits - 1)
+            )
+        );
+        assert_eq!(
+            -2.0 * ten_exp(max_int_digits - 1),
+            round_with_precision(
+                -1.66 * ten_exp(max_int_digits - 1),
+                -(max_int_digits - 1)
+            )
+        );
+        assert_eq!(0.0, round_with_precision(1234.5678, -(max_int_digits - 1)));
+        assert_eq!(-0.0, round_with_precision(-1234.5678, -(max_int_digits - 1)));
+
+        // max + 1
+        assert_eq!(0.0, round_with_precision(f64::MAX, -(max_int_digits + 1)));
+        assert_eq!(-0.0, round_with_precision(f64::MIN, -(max_int_digits + 1)));
+        assert_eq!(
+            0.0,
+            round_with_precision(1.66 * ten_exp(max_int_digits), -(max_int_digits + 1))
+        );
+        assert_eq!(
+            -0.0,
+            round_with_precision(-1.66 * ten_exp(max_int_digits), -(max_int_digits + 1))
+        );
+        assert_eq!(
+            0.0,
+            round_with_precision(
+                1.66 * ten_exp(max_int_digits - 1),
+                -(max_int_digits + 1)
+            )
+        );
+        assert_eq!(
+            -0.0,
+            round_with_precision(
+                -1.66 * ten_exp(max_int_digits - 1),
+                -(max_int_digits + 1)
+            )
+        );
+        assert_eq!(0.0, round_with_precision(1234.5678, -(max_int_digits + 1)));
+        assert_eq!(-0.0, round_with_precision(-1234.5678, -(max_int_digits + 1)));
     }
 }

--- a/crates/typst-utils/src/round.rs
+++ b/crates/typst-utils/src/round.rs
@@ -191,22 +191,21 @@ mod tests {
 
     #[test]
     fn test_round_with_precision_fuzzy() {
-        let round = |value| rp(value, 0);
         let max_int = (1_i64 << f64::MANTISSA_DIGITS) as f64;
         let max_digits = f64::DIGITS as i16;
 
         // Special cases.
-        assert_eq!(round(f64::INFINITY), f64::INFINITY);
-        assert_eq!(round(f64::NEG_INFINITY), f64::NEG_INFINITY);
-        assert!(round(f64::NAN).is_nan());
+        assert_eq!(rp(f64::INFINITY, 0), f64::INFINITY);
+        assert_eq!(rp(f64::NEG_INFINITY, 0), f64::NEG_INFINITY);
+        assert!(rp(f64::NAN, 0).is_nan());
 
         // Max
-        assert_eq!(round(max_int), max_int);
+        assert_eq!(rp(max_int, 0), max_int);
         assert_eq!(rp(0.123456, max_digits), 0.123456);
         assert_eq!(rp(max_int, max_digits), max_int);
 
         // Max - 1
-        assert_eq!(round(max_int - 1.0), max_int - 1.0);
+        assert_eq!(rp(max_int - 1.0, 0), max_int - 1.0);
         assert_eq!(rp(0.123456, max_digits - 1), 0.123456);
         assert_eq!(rp(max_int - 1.0, max_digits), max_int - 1.0);
         assert_eq!(rp(max_int, max_digits - 1), max_int);

--- a/crates/typst-utils/src/round.rs
+++ b/crates/typst-utils/src/round.rs
@@ -348,8 +348,8 @@ mod tests {
         assert_eq!(Some(0), round(3));
         assert_eq!(Some(0), round(5));
         assert_eq!(Some(0), round(13));
-        assert_eq!(Some(1200), round(1243));
-        assert_eq!(Some(-1200), round(-1243));
+        assert_eq!(Some(1200), round(1245));
+        assert_eq!(Some(-1200), round(-1245));
         assert_eq!(Some(1300), round(1253));
         assert_eq!(Some(-1300), round(-1253));
         assert_eq!(Some(i64::MAX - 7), round(i64::MAX));

--- a/crates/typst/src/foundations/calc.rs
+++ b/crates/typst/src/foundations/calc.rs
@@ -4,6 +4,7 @@ use std::cmp;
 use std::cmp::Ordering;
 
 use az::SaturatingAs;
+use ecow::EcoString;
 
 use crate::diag::{bail, At, HintedString, SourceResult, StrResult};
 use crate::eval::ops;
@@ -714,9 +715,12 @@ pub fn fract(
     }
 }
 
-/// Rounds a number to the nearest integer.
+/// Rounds a number to the nearest integer away from zero.
 ///
 /// Optionally, a number of decimal places can be specified.
+///
+/// If the number of digits is negative, its absolute value will indicate the
+/// amount of significant integer digits to remove before the decimal point.
 ///
 /// Note that this function will return the same type as the operand. That is,
 /// applying `round` to a [`float`] will return a `float`, and to a [`decimal`],
@@ -725,29 +729,57 @@ pub fn fract(
 /// `float` or `decimal` is larger than the maximum 64-bit signed integer or
 /// smaller than the minimum integer.
 ///
+/// In addition, this function can error if there is an attempt to round beyond
+/// the maximum or minimum integer or `decimal`. If the number is a `float`,
+/// such an attempt will cause `{float.inf}` or `{-float.inf}` to be returned
+/// for maximum and minimum respectively.
+///
 /// ```example
 /// #assert(calc.round(3) == 3)
 /// #assert(calc.round(3.14) == 3)
 /// #assert(calc.round(3.5) == 4.0)
+/// #assert(calc.round(3333.45, digits: -2) == 3300.0)
+/// #assert(calc.round(-48953.45, digits: -3) == -49000.0)
+/// #assert(calc.round(3333, digits: -2) == 3300)
+/// #assert(calc.round(-48953, digits: -3) == -49000)
 /// #assert(calc.round(decimal("-6.5")) == decimal("-7"))
 /// #assert(calc.round(decimal("7.123456789"), digits: 6) == decimal("7.123457"))
+/// #assert(calc.round(decimal("3333.45"), digits: -2) == decimal("3300"))
+/// #assert(calc.round(decimal("-48953.45"), digits: -3) == decimal("-49000"))
 /// #calc.round(3.1415, digits: 2)
 /// ```
 #[func]
 pub fn round(
     /// The number to round.
     value: DecNum,
-    /// The number of decimal places. Must not be negative.
+    /// If positive, the number of decimal places.
+    ///
+    /// If negative, the number of significant integer digits that should be
+    /// removed before the decimal point.
     #[named]
     #[default(0)]
-    digits: u32,
-) -> DecNum {
+    digits: i64,
+) -> StrResult<DecNum> {
     match value {
-        DecNum::Int(n) => DecNum::Int(n),
-        DecNum::Float(n) => {
-            DecNum::Float(round_with_precision(n, digits.saturating_as::<u8>()))
+        DecNum::Int(n) => {
+            if digits >= 0 {
+                Ok(DecNum::Int(n))
+            } else {
+                // Round into integer digits using decimals.
+                Decimal::from(n)
+                    .round(digits.saturating_as::<i32>())
+                    .and_then(|n| i64::try_from(n).ok())
+                    .map(DecNum::Int)
+                    .ok_or_else(too_large)
+                    .map_err(EcoString::from)
+            }
         }
-        DecNum::Decimal(n) => DecNum::Decimal(n.round(digits)),
+        DecNum::Float(n) => {
+            Ok(DecNum::Float(round_with_precision(n, digits.saturating_as::<i16>())))
+        }
+        DecNum::Decimal(n) => Ok(DecNum::Decimal(
+            n.round(digits.saturating_as::<i32>()).ok_or_else(too_large)?,
+        )),
     }
 }
 

--- a/crates/typst/src/foundations/decimal.rs
+++ b/crates/typst/src/foundations/decimal.rs
@@ -482,6 +482,10 @@ mod tests {
             Decimal::from_str("312.55553").unwrap().round(3)
         );
         assert_eq!(
+            Some(Decimal::from_str("312.556").unwrap()),
+            Decimal::from_str("312.5555300000").unwrap().round(3)
+        );
+        assert_eq!(
             Some(Decimal::from_str("-312.556").unwrap()),
             Decimal::from_str("-312.55553").unwrap().round(3)
         );
@@ -504,6 +508,10 @@ mod tests {
         assert_eq!(
             Some(Decimal::from_str("4600").unwrap()),
             Decimal::from_str("4596.55553").unwrap().round(-1)
+        );
+        assert_eq!(
+            Some(Decimal::from_str("4600").unwrap()),
+            Decimal::from_str("4596.555530000000").unwrap().round(-1)
         );
         assert_eq!(
             Some(Decimal::from_str("-5000").unwrap()),

--- a/crates/typst/src/foundations/decimal.rs
+++ b/crates/typst/src/foundations/decimal.rs
@@ -146,11 +146,55 @@ impl Decimal {
     /// Rounds this decimal up to the specified amount of digits with the
     /// traditional rounding rules, using the "midpoint away from zero"
     /// strategy (6.5 -> 7, -6.5 -> -7).
-    pub fn round(self, digits: u32) -> Self {
-        Self(self.0.round_dp_with_strategy(
-            digits,
-            rust_decimal::RoundingStrategy::MidpointAwayFromZero,
-        ))
+    ///
+    /// If given a negative amount of digits, rounds to integer digits instead
+    /// with the same rounding strategy. For example, rounding to -3 digits
+    /// will turn 34567.89 into 35000.00 and -34567.89 into -35000.00.
+    ///
+    /// Note that this can return `None` when using negative digits where the
+    /// rounded number would overflow the available range for decimals.
+    pub fn round(self, digits: i32) -> Option<Self> {
+        if let Ok(positive_digits) = u32::try_from(digits) {
+            Some(Self(self.0.round_dp_with_strategy(
+                positive_digits,
+                rust_decimal::RoundingStrategy::MidpointAwayFromZero,
+            )))
+        } else {
+            // We received negative digits, so we round into integer digits.
+            let mut num = self.0;
+            let old_scale = num.scale();
+            let digits = -digits as u32;
+
+            // Same as dividing by 10^digits.
+            match num.set_scale(old_scale + digits) {
+                Ok(_) => {}
+                Err(rust_decimal::Error::ScaleExceedsMaximumPrecision(_)) => {
+                    // Scaling more than any possible amount of integer digits.
+                    let mut zero = rust_decimal::Decimal::ZERO;
+                    zero.set_sign_negative(self.is_negative());
+                    return Some(Self(zero));
+                }
+                Err(_) => return None,
+            }
+
+            // Round to this integer digit.
+            num = num.round_dp_with_strategy(
+                0,
+                rust_decimal::RoundingStrategy::MidpointAwayFromZero,
+            );
+
+            let Some(ten_to_digits) =
+                rust_decimal::Decimal::TEN.checked_powi(digits as i64)
+            else {
+                // Scaling more than any possible amount of integer digits.
+                let mut zero = rust_decimal::Decimal::ZERO;
+                zero.set_sign_negative(self.is_negative());
+                return Some(Self(zero));
+            };
+
+            // Multiply by 10^digits again, which can overflow and fail.
+            num.checked_mul(ten_to_digits).map(Self)
+        }
     }
 
     /// Attempts to add two decimals.
@@ -425,5 +469,54 @@ mod tests {
         let b = Decimal::from_str("3.14000").unwrap();
         assert_eq!(a, b);
         assert_ne!(hash128(&a), hash128(&b));
+    }
+
+    #[test]
+    fn test_decimal_positive_round() {
+        assert_eq!(
+            Some(Decimal::from_str("313.00000").unwrap()),
+            Decimal::from_str("312.55553").unwrap().round(0)
+        );
+        assert_eq!(
+            Some(Decimal::from_str("312.556").unwrap()),
+            Decimal::from_str("312.55553").unwrap().round(3)
+        );
+        assert_eq!(
+            Some(Decimal::from_str("-312.556").unwrap()),
+            Decimal::from_str("-312.55553").unwrap().round(3)
+        );
+        assert_eq!(
+            Some(Decimal::from_str("312.55553").unwrap()),
+            Decimal::from_str("312.55553").unwrap().round(28)
+        );
+        assert_eq!(
+            Some(Decimal::from_str("312.55553").unwrap()),
+            Decimal::from_str("312.55553").unwrap().round(2341)
+        );
+        assert_eq!(
+            Some(Decimal::from_str("-312.55553").unwrap()),
+            Decimal::from_str("-312.55553").unwrap().round(2341)
+        );
+    }
+
+    #[test]
+    fn test_decimal_negative_round() {
+        assert_eq!(
+            Some(Decimal::from_str("4600").unwrap()),
+            Decimal::from_str("4596.55553").unwrap().round(-1)
+        );
+        assert_eq!(
+            Some(Decimal::from_str("-5000").unwrap()),
+            Decimal::from_str("-4596.55553").unwrap().round(-3)
+        );
+        assert_eq!(
+            Some(Decimal::ZERO),
+            Decimal::from_str("4596.55553").unwrap().round(-28)
+        );
+        assert_eq!(
+            Some(-Decimal::ZERO),
+            Decimal::from_str("-4596.55553").unwrap().round(-2341)
+        );
+        assert_eq!(None, Decimal(rust_decimal::Decimal::MAX).round(-1));
     }
 }

--- a/crates/typst/src/foundations/repr.rs
+++ b/crates/typst/src/foundations/repr.rs
@@ -85,7 +85,7 @@ pub fn format_float(
     unit: &str,
 ) -> EcoString {
     if let Some(p) = precision {
-        value = round_with_precision(value, p);
+        value = round_with_precision(value, p as i16);
     }
     // Debug for f64 always prints a decimal separator, while Display only does
     // when necessary.

--- a/tests/suite/foundations/calc.typ
+++ b/tests/suite/foundations/calc.typ
@@ -4,18 +4,23 @@
 #test(type(calc.round(3.1415, digits: 2)), float)
 #test(type(calc.round(5, digits: 2)), int)
 #test(type(calc.round(decimal("3.1415"), digits: 2)), decimal)
+#test(type(calc.round(314.15, digits: -2)), float)
+#test(type(calc.round(523, digits: -2)), int)
+#test(type(calc.round(decimal("314.15"), digits: -2)), decimal)
 
 --- calc-round-large-inputs ---
 #test(calc.round(31114, digits: 4000000000), 31114)
 #test(calc.round(9223372036854775807, digits: 12), 9223372036854775807)
+#test(calc.round(9223372036854775807, digits: -20), 0)
 #test(calc.round(238959235.129590203, digits: 4000000000), 238959235.129590203)
 #test(calc.round(1.7976931348623157e+308, digits: 12), 1.7976931348623157e+308)
+#test(calc.round(1.7976931348623157e+308, digits: -308), float.inf)
+#test(calc.round(-1.7976931348623157e+308, digits: -308), -float.inf)
+#test(calc.round(12.34, digits: -312), 0.0)
 #test(calc.round(decimal("238959235.129590203"), digits: 4000000000), decimal("238959235.129590203"))
 #test(calc.round(decimal("79228162514264337593543950335"), digits: 12), decimal("79228162514264337593543950335"))
-
---- calc-round-negative-digits ---
-// Error: 29-31 number must be at least zero
-#calc.round(243.32, digits: -2)
+#test(calc.round(decimal("79228162514264337593543950335"), digits: -50), decimal("0"))
+#test(calc.round(decimal("-79228162514264337593543950335"), digits: -2), decimal("-79228162514264337593543950300"))
 
 --- calc-abs ---
 // Test the `abs` function.
@@ -330,6 +335,22 @@
 --- calc-floor-decimal-smaller-than-min-int ---
 // Error: 2-47 the result is too large
 #calc.floor(decimal("-9223372036854775809.5"))
+
+--- calc-round-int-too-large ---
+// Error: 2-45 the result is too large
+#calc.round(9223372036854775807, digits: -1)
+
+--- calc-round-int-negative-too-large ---
+// Error: 2-46 the result is too large
+#calc.round(-9223372036854775807, digits: -1)
+
+--- calc-round-decimal-too-large ---
+// Error: 2-66 the result is too large
+#calc.round(decimal("79228162514264337593543950335"), digits: -1)
+
+--- calc-round-decimal-negative-too-large ---
+// Error: 2-67 the result is too large
+#calc.round(decimal("-79228162514264337593543950335"), digits: -1)
 
 --- calc-min-nothing ---
 // Error: 2-12 expected at least one value


### PR DESCRIPTION
Closes #5155

Implements rounding with negative digits for floats, decimals and ints. ~~(for those, I just chose to re-use the decimal impl, since it doesn't use any imprecise operations).~~ (**EDIT:** Using fully separate procedures for each type now.)

I'd suggest some good amount of scrutiny before merging. :sweat_smile:

In principle, all seems good to me though.

## Some important details

- `calc.round` can now error if rounding decimals or ints above the max / min.
- `calc.round` can now return +inf or -inf if rounding floats above max / min (respectively).