### PR TITLE
Use `set page(columns: n)` in tutorial

### DIFF
--- a/docs/guides/guide-for-latex-users.md
+++ b/docs/guides/guide-for-latex-users.md
@@ -325,64 +325,65 @@ function. The following example illustrates how it works:
 >>>   abstract: [],
 >>>   doc,
 >>> ) = {
->>>  set text(font: "Libertinus Serif", 11pt)
->>>  set par(justify: true)
->>>  set page(
->>>    "us-letter",
->>>    margin: auto,
->>>    header: align(
->>>      right + horizon,
->>>      title
->>>    ),
->>>    numbering: "1",
->>>    columns: 2
->>>  )
+>>>   set text(font: "Libertinus Serif", 11pt)
+>>>   set par(justify: true)
+>>>   set page(
+>>>     "us-letter",
+>>>     margin: auto,
+>>>     header: align(
+>>>       right + horizon,
+>>>       title
+>>>     ),
+>>>     numbering: "1",
+>>>     columns: 2
+>>>   )
 >>>
->>>  show heading.where(
->>>    level: 1
->>>  ): it => block(
->>>    align(center,
->>>      text(
->>>        13pt,
->>>        weight: "regular",
->>>        smallcaps(it.body),
->>>      )
->>>    ),
->>>  )
->>>  show heading.where(
->>>    level: 2
->>>  ): it => box(
->>>    text(
->>>      11pt,
->>>      weight: "regular",
->>>      style: "italic",
->>>      it.body + [.],
->>>    )
->>>  )
+>>>   show heading.where(
+>>>     level: 1
+>>>   ): it => block(
+>>>     align(center,
+>>>       text(
+>>>         13pt,
+>>>         weight: "regular",
+>>>         smallcaps(it.body),
+>>>       )
+>>>     ),
+>>>   )
+>>>   show heading.where(
+>>>     level: 2
+>>>   ): it => box(
+>>>     text(
+>>>       11pt,
+>>>       weight: "regular",
+>>>       style: "italic",
+>>>       it.body + [.],
+>>>     )
+>>>   )
 >>>
->>>  place(top, float: true, {
->>>    set align(center)
->>>    text(17pt, title)
+>>>   place(top, float: true, scope: "parent", {
+>>>     set align(center)
+>>>     text(17pt, title)
 >>>
->>>    let count = calc.min(authors.len(), 3)
->>>    grid(
->>>      columns: (1fr,) * count,
->>>      row-gutter: 24pt,
->>>      ..authors.map(author => [
->>>        #author.name \
->>>        #author.affiliation \
->>>        #link("mailto:" + author.email)
->>>      ]),
->>>    )
+>>>     let count = calc.min(authors.len(), 3)
+>>>     grid(
+>>>       columns: (1fr,) * count,
+>>>       row-gutter: 24pt,
+>>>       ..authors.map(author => [
+>>>         #author.name \
+>>>         #author.affiliation \
+>>>         #link("mailto:" + author.email)
+>>>       ]),
+>>>     )
 >>>
->>>    par(justify: false)[
->>>      *Abstract* \
->>>      #abstract
->>>    ]
->>> })
+>>>     par(justify: false)[
+>>>       *Abstract* \
+>>>       #abstract
+>>>     ]
+>>>   })
 >>>
->>>  set align(left)
->>>}
+>>>   set align(left)
+>>>   doc
+>>> }
 <<< #import "conf.typ": conf
 #show: conf.with(
   title: [
@@ -406,6 +407,7 @@ function. The following example illustrates how it works:
 Let's get started writing this
 article by putting insightful
 paragraphs right here!
+>>> #lorem(500)
 ```
 
 The [`{import}`]($scripting/#modules) statement makes [functions]($function)
@@ -415,12 +417,24 @@ as a conference article. We use a show rule to apply it to the document and also
 configure some metadata of the article. After applying the show rule, we can
 start writing our article right away!
 
-You can also use templates from Typst Universe, which is Typst's equivalent of
-CTAN using an import statement like this: `[#import
+You can also use templates from Typst Universe (which is Typst's equivalent of
+CTAN) using an import statement like this: `[#import
 "@preview/elsearticle:0.2.1": elsearticle]`. Check the documentation of an
 individual template to learn the name of its template function. Templates and
 packages from Typst Universe are automatically downloaded when you first use
 them.
+
+In the web app, you can choose to create a project from a template on Typst
+Universe or even create your own using the template wizard. Locally, you can use
+the `typst init` CLI to create a new project from a template. Check out [the
+list of templates]($universe/search/?kind=templates) published on Typst
+Universe. You can also take a look at the [`awesome-typst`
+repository](https://github.com/qjcg/awesome-typst) to find community templates
+that aren't available through Universe.
+
+You can also [create your own, custom templates.]($tutorial/making-a-template)
+They are shorter and more readable than the corresponding LaTeX `.sty` files by
+orders of magnitude, so give it a try!
 
 <div class="info-box">
 
@@ -436,18 +450,6 @@ result as an argument. The `.with` part is a _method_ that takes the `conf`
 function and pre-configures some if its arguments before passing it on to the
 show rule.
 </div>
-
-In the web app, you can choose to create a project from a template on Typst
-Universe or even create your own using the template wizard. Locally, you can use
-the `typst init` CLI to create a new project from a template. Check out [the
-list of templates]($universe/search/?kind=templates) published on Typst
-Universe. You can also take a look at the [`awesome-typst`
-repository](https://github.com/qjcg/awesome-typst) to find community templates
-that aren't available through Universe.
-
-You can also [create your own, custom templates.]($tutorial/making-a-template)
-They are shorter and more readable than the corresponding LaTeX `.sty` files by
-orders of magnitude, so give it a try!
 
 ## How do I load packages? { #packages }
 Typst is "batteries included," so the equivalent of many popular LaTeX packages

--- a/docs/guides/guide-for-latex-users.md
+++ b/docs/guides/guide-for-latex-users.md
@@ -335,6 +335,7 @@ function. The following example illustrates how it works:
 >>>      title
 >>>    ),
 >>>    numbering: "1",
+>>>    columns: 2
 >>>  )
 >>>
 >>>  show heading.where(
@@ -359,27 +360,28 @@ function. The following example illustrates how it works:
 >>>    )
 >>>  )
 >>>
->>>  set align(center)
->>>  text(17pt, title)
+>>>  place(top, float: true, {
+>>>    set align(center)
+>>>    text(17pt, title)
 >>>
->>>  let count = calc.min(authors.len(), 3)
->>>  grid(
->>>    columns: (1fr,) * count,
->>>    row-gutter: 24pt,
->>>    ..authors.map(author => [
->>>      #author.name \
->>>      #author.affiliation \
->>>      #link("mailto:" + author.email)
->>>    ]),
->>>  )
+>>>    let count = calc.min(authors.len(), 3)
+>>>    grid(
+>>>      columns: (1fr,) * count,
+>>>      row-gutter: 24pt,
+>>>      ..authors.map(author => [
+>>>        #author.name \
+>>>        #author.affiliation \
+>>>        #link("mailto:" + author.email)
+>>>      ]),
+>>>    )
 >>>
->>>  par(justify: false)[
->>>    *Abstract* \
->>>    #abstract
->>>  ]
+>>>    par(justify: false)[
+>>>      *Abstract* \
+>>>      #abstract
+>>>    ]
+>>> })
 >>>
 >>>  set align(left)
->>>  columns(2, doc)
 >>>}
 <<< #import "conf.typ": conf
 #show: conf.with(
@@ -406,12 +408,19 @@ article by putting insightful
 paragraphs right here!
 ```
 
-The [`{import}`]($scripting/#modules) statement makes
-[functions]($function) (and other definitions) from another file available.
-In this example, it imports the `conf` function from the `conf.typ` file. This
-function formats a document as a conference article. We use a show rule to apply
-it to the document and also configure some metadata of the article. After
-applying the show rule, we can start writing our article right away!
+The [`{import}`]($scripting/#modules) statement makes [functions]($function)
+(and other definitions) from another file available. In this example, it imports
+the `conf` function from the `conf.typ` file. This function formats a document
+as a conference article. We use a show rule to apply it to the document and also
+configure some metadata of the article. After applying the show rule, we can
+start writing our article right away!
+
+You can also use templates from Typst Universe, which is Typst's equivalent of
+CTAN using an import statement like this: `[#import
+"@preview/elsearticle:0.2.1": elsearticle]`. Check the documentation of an
+individual template to learn the name of its template function. Templates and
+packages from Typst Universe are automatically downloaded when you first use
+them.
 
 <div class="info-box">
 
@@ -428,13 +437,13 @@ function and pre-configures some if its arguments before passing it on to the
 show rule.
 </div>
 
-In the web app, you can choose from predefined templates or even
-create your own using the template wizard. Locally, you can use the
-`typst init` CLI to create a new project from a template. Check out
-[the list of templates]($universe/search/?kind=templates) published on Typst
-Universe, our official package ecosystem. You can also take a look at the
-[`awesome-typst` repository](https://github.com/qjcg/awesome-typst) to find
-community templates that aren't yet available as packages.
+In the web app, you can choose to create a project from a template on Typst
+Universe or even create your own using the template wizard. Locally, you can use
+the `typst init` CLI to create a new project from a template. Check out [the
+list of templates]($universe/search/?kind=templates) published on Typst
+Universe. You can also take a look at the [`awesome-typst`
+repository](https://github.com/qjcg/awesome-typst) to find community templates
+that aren't available through Universe.
 
 You can also [create your own, custom templates.]($tutorial/making-a-template)
 They are shorter and more readable than the corresponding LaTeX `.sty` files by

--- a/docs/guides/page-setup.md
+++ b/docs/guides/page-setup.md
@@ -432,7 +432,7 @@ frequently used for [figures]($figure.placement).
 
 ### Use columns anywhere in your document { #columns-anywhere }
 To create columns within a nested layout, e.g. within a rectangle, you can use
-the [`columns` function]($columns) directly. However, it should really only be
+the [`columns` function]($columns) directly. However, it really should only be
 used within nested layouts. At the page-level, the page set rule is preferrable
 because it has better interactions with things like page-level floats,
 footnotes, and line numbers.

--- a/docs/src/html.rs
+++ b/docs/src/html.rs
@@ -427,7 +427,7 @@ fn code_block(resolver: &dyn Resolver, lang: &str, text: &str) -> Html {
         document.pages.truncate(1);
     }
 
-    let hash = typst::utils::hash128(text);
+    let hash = typst::utils::hash128(&(lang, text));
     resolver.example(hash, highlighted, &document)
 }
 

--- a/docs/tutorial/3-advanced.md
+++ b/docs/tutorial/3-advanced.md
@@ -10,7 +10,7 @@ base a conference paper on it! The report will of course have to comply with the
 conference's style guide. Let's see how we can achieve that.
 
 Before we start, let's create a team, invite your supervisor and add them to the
-team. You can do this by going back to the app dashboard with the back icon in 
+team. You can do this by going back to the app dashboard with the back icon in
 the top left corner of the editor. Then, choose the plus icon in the left
 toolbar and create a team. Finally, click on the new team and go to its settings
 by clicking 'manage team' next to the team name. Now you can invite your
@@ -248,17 +248,31 @@ on another title, we can easily change it in one place.
 
 ## Adding columns and headings { #columns-and-headings }
 The paper above unfortunately looks like a wall of lead. To fix that, let's add
-some headings and switch our paper to a two-column layout. The [`columns`]
-function takes a number and content, and layouts the content into the specified
-number of columns. Since we want everything after the abstract to be in two
-columns, we need to apply the column function to our whole document.
+some headings and switch our paper to a two-column layout. Fortunately, that's
+easy to do: We just need to amend our `page` set rule with the `columns`
+argument.
 
-Instead of wrapping the whole document in a giant function call, we can use an
-"everything" show rule. To write such a show rule, put a colon directly behind
-the show keyword and then provide a function. This function is given the rest of
-the document as a parameter. We have called the parameter `rest` here, but you
-are free to choose any name. The function can then do anything with this
-content. In our case, it passes it on to the `columns` function.
+By adding `{columns: 2}` to the argument list, we have wrapped the whole
+document in two columns. However, that would also affect the title and authors
+overview. To keep them spanning the whole page, we can wrap them in a function
+call to [`{place}`]($place). Place expects an alignment and the content it
+should place as positional arguments. Using the named `{scope}` argument, we can
+decide if the items should be placed relative to the current column or its
+parent (the page). There is one more thing to configure: If no other arguments
+are provided, `{place}` takes its content out of the flow of the document and
+positions it over the other content without affecting the layout of other
+content in its container:
+
+```example
+#place(top + center, square())
+#lorem(30)
+```
+
+If we did not use the `{place}` function, the square would be on its own line,
+but here, it overlaps the few lines of text following it. Likewise, that text
+acts like as if there was no square. To change this behavior, we can pass the
+argument `{float: true}` to ensure that the space taken up by the placed item at
+the top or bottom of the page is not occupied by any other content.
 
 ```example:single
 >>> #let title = [
@@ -268,45 +282,51 @@ content. In our case, it passes it on to the `columns` function.
 >>>
 >>> #set text(font: "Libertinus Serif", 11pt)
 >>> #set par(justify: true)
->>> #set page(
->>>   "us-letter",
->>>   margin: auto,
->>>   header: align(
->>>     right + horizon,
->>>     title
->>>   ),
->>>   numbering: "1",
->>> )
 >>>
->>> #align(center, text(
->>>   17pt,
->>>   weight: "bold",
->>>   title,
->>> ))
->>>
->>> #grid(
->>>   columns: (1fr, 1fr),
->>>   align(center)[
->>>     Therese Tungsten \
->>>     Artos Institute \
->>>     #link("mailto:tung@artos.edu")
->>>   ],
->>>   align(center)[
->>>     Dr. John Doe \
->>>     Artos Institute \
->>>     #link("mailto:doe@artos.edu")
->>>   ]
->>> )
->>>
->>> #align(center)[
->>>   #set par(justify: false)
->>>   *Abstract* \
->>>   #lorem(80)
->>> ]
->>> #v(4mm)
-<<< ...
+#set page(
+  "us-letter",
+  margin: auto,
+  header: align(
+    right + horizon,
+    title
+  ),
+  numbering: "1",
+  columns: 2,
+)
 
-#show: rest => columns(2, rest)
+#place(
+  top,
+  float: true,
+  scope: "parent",
+  clearance: 4mm,
+)[
+>>>  #align(center, text(
+>>>    17pt,
+>>>    weight: "bold",
+>>>    title,
+>>>  ))
+>>>
+>>>  #grid(
+>>>    columns: (1fr, 1fr),
+>>>    align(center)[
+>>>      Therese Tungsten \
+>>>      Artos Institute \
+>>>      #link("mailto:tung@artos.edu")
+>>>    ],
+>>>    align(center)[
+>>>      Dr. John Doe \
+>>>      Artos Institute \
+>>>      #link("mailto:doe@artos.edu")
+>>>    ]
+>>>  )
+<<<   ...
+
+  #align(center)[
+    #set par(justify: false)
+    *Abstract* \
+    #lorem(80)
+  ]
+]
 
 = Introduction
 #lorem(300)
@@ -314,6 +334,10 @@ content. In our case, it passes it on to the `columns` function.
 = Related Work
 #lorem(200)
 ```
+
+In this example, we also used the `clearance` argument of the `{place}`
+function to provide the space between it and the body instead of using the
+[`{v}`]($v) function.
 
 Now there is only one thing left to do: Style our headings. We need to make them
 centered and use small capitals. Because the `heading` function does not offer
@@ -335,6 +359,7 @@ a way to set any of that, we need to write our own heading show rule.
 >>>     title
 >>>   ),
 >>>   numbering: "1",
+>>>   columns: 2,
 >>> )
 #show heading: it => [
   #set align(center)
@@ -344,34 +369,38 @@ a way to set any of that, we need to write our own heading show rule.
 
 <<< ...
 >>>
->>> #align(center, text(
->>>   17pt,
->>>   weight: "bold",
->>>   title,
->>> ))
+>>> #place(
+>>>   top,
+>>>   float: true,
+>>>   scope: "parent",
+>>>   clearance: 4mm,
+>>> )[
+>>>   #align(center, text(
+>>>     17pt,
+>>>     weight: "bold",
+>>>     title,
+>>>   ))
 >>>
->>> #grid(
->>>   columns: (1fr, 1fr),
->>>   align(center)[
->>>     Therese Tungsten \
->>>     Artos Institute \
->>>     #link("mailto:tung@artos.edu")
->>>   ],
->>>   align(center)[
->>>     Dr. John Doe \
->>>     Artos Institute \
->>>     #link("mailto:doe@artos.edu")
+>>>  #grid(
+>>>    columns: (1fr, 1fr),
+>>>    align(center)[
+>>>      Therese Tungsten \
+>>>      Artos Institute \
+>>>      #link("mailto:tung@artos.edu")
+>>>    ],
+>>>    align(center)[
+>>>      Dr. John Doe \
+>>>      Artos Institute \
+>>>      #link("mailto:doe@artos.edu")
+>>>    ]
+>>>  )
+>>>
+>>>   #align(center)[
+>>>     #set par(justify: false)
+>>>     *Abstract* \
+>>>     #lorem(80)
 >>>   ]
->>> )
->>>
->>> #align(center)[
->>>   #set par(justify: false)
->>>   *Abstract* \
->>>   #lorem(80)
 >>> ]
->>>
->>> #v(4mm)
->>> #show: rest => columns(2, rest)
 >>>
 >>> = Introduction
 >>> #lorem(35)
@@ -411,6 +440,7 @@ differentiate between section and subsection headings:
 >>>     title
 >>>   ),
 >>>   numbering: "1",
+>>>   columns: 2,
 >>> )
 >>>
 #show heading.where(
@@ -430,34 +460,38 @@ differentiate between section and subsection headings:
   it.body + [.],
 )
 >>>
->>> #align(center, text(
->>>   17pt,
->>>   weight: "bold",
->>>   title,
->>> ))
+>>> #place(
+>>>   top,
+>>>   float: true,
+>>>   scope: "parent",
+>>>   clearance: 4mm,
+>>> )[
+>>>   #align(center, text(
+>>>     17pt,
+>>>     weight: "bold",
+>>>     title,
+>>>   ))
 >>>
->>> #grid(
->>>   columns: (1fr, 1fr),
->>>   align(center)[
->>>     Therese Tungsten \
->>>     Artos Institute \
->>>     #link("mailto:tung@artos.edu")
->>>   ],
->>>   align(center)[
->>>     Dr. John Doe \
->>>     Artos Institute \
->>>     #link("mailto:doe@artos.edu")
+>>>  #grid(
+>>>    columns: (1fr, 1fr),
+>>>    align(center)[
+>>>      Therese Tungsten \
+>>>      Artos Institute \
+>>>      #link("mailto:tung@artos.edu")
+>>>    ],
+>>>    align(center)[
+>>>      Dr. John Doe \
+>>>      Artos Institute \
+>>>      #link("mailto:doe@artos.edu")
+>>>    ]
+>>>  )
+>>>
+>>>   #align(center)[
+>>>     #set par(justify: false)
+>>>     *Abstract* \
+>>>     #lorem(80)
 >>>   ]
->>> )
->>>
->>> #align(center)[
->>>   #set par(justify: false)
->>>   *Abstract* \
->>>   #lorem(80)
 >>> ]
->>>
->>> #v(4mm)
->>> #show: rest => columns(2, rest)
 >>>
 >>> = Introduction
 >>> #lorem(35)

--- a/docs/tutorial/3-advanced.md
+++ b/docs/tutorial/3-advanced.md
@@ -264,15 +264,18 @@ positions it over the other content without affecting the layout of other
 content in its container:
 
 ```example
-#place(top + center, square())
+#place(
+  top + center,
+  rect(fill: black),
+)
 #lorem(30)
 ```
 
-If we did not use the `{place}` function, the square would be on its own line,
-but here, it overlaps the few lines of text following it. Likewise, that text
-acts like as if there was no square. To change this behavior, we can pass the
-argument `{float: true}` to ensure that the space taken up by the placed item at
-the top or bottom of the page is not occupied by any other content.
+If we hadn't used `{place}` here, the square would be in its own line, but here
+it overlaps the few lines of text following it. Likewise, that text acts like as
+if there was no square. To change this behavior, we can pass the argument
+`{float: true}` to ensure that the space taken up by the placed item at the top
+or bottom of the page is not occupied by any other content.
 
 ```example:single
 >>> #let title = [
@@ -284,8 +287,8 @@ the top or bottom of the page is not occupied by any other content.
 >>> #set par(justify: true)
 >>>
 #set page(
-  "us-letter",
-  margin: auto,
+>>> margin: auto,
+  paper: "us-letter",
   header: align(
     right + horizon,
     title
@@ -295,25 +298,25 @@ the top or bottom of the page is not occupied by any other content.
 )
 
 #place(
-  top,
+  top + center,
   float: true,
   scope: "parent",
-  clearance: 4mm,
+  clearance: 2em,
 )[
->>>  #align(center, text(
+>>>  #text(
 >>>    17pt,
 >>>    weight: "bold",
 >>>    title,
->>>  ))
+>>>  )
 >>>
 >>>  #grid(
 >>>    columns: (1fr, 1fr),
->>>    align(center)[
+>>>    [
 >>>      Therese Tungsten \
 >>>      Artos Institute \
 >>>      #link("mailto:tung@artos.edu")
 >>>    ],
->>>    align(center)[
+>>>    [
 >>>      Dr. John Doe \
 >>>      Artos Institute \
 >>>      #link("mailto:doe@artos.edu")
@@ -321,8 +324,7 @@ the top or bottom of the page is not occupied by any other content.
 >>>  )
 <<<   ...
 
-  #align(center)[
-    #set par(justify: false)
+  #par(justify: false)[
     *Abstract* \
     #lorem(80)
   ]
@@ -335,9 +337,10 @@ the top or bottom of the page is not occupied by any other content.
 #lorem(200)
 ```
 
-In this example, we also used the `clearance` argument of the `{place}`
-function to provide the space between it and the body instead of using the
-[`{v}`]($v) function.
+In this example, we also used the `clearance` argument of the `{place}` function
+to provide the space between it and the body instead of using the [`{v}`]($v)
+function. We can also remove the explicit `{align(center, ..)}` calls around the
+various parts since they inherit the center alignment from the placement.
 
 Now there is only one thing left to do: Style our headings. We need to make them
 centered and use small capitals. Because the `heading` function does not offer
@@ -370,33 +373,32 @@ a way to set any of that, we need to write our own heading show rule.
 <<< ...
 >>>
 >>> #place(
->>>   top,
+>>>   top + center,
 >>>   float: true,
 >>>   scope: "parent",
->>>   clearance: 4mm,
+>>>   clearance: 2em,
 >>> )[
->>>   #align(center, text(
+>>>   #text(
 >>>     17pt,
 >>>     weight: "bold",
 >>>     title,
->>>   ))
+>>>   )
 >>>
->>>  #grid(
->>>    columns: (1fr, 1fr),
->>>    align(center)[
->>>      Therese Tungsten \
->>>      Artos Institute \
->>>      #link("mailto:tung@artos.edu")
->>>    ],
->>>    align(center)[
->>>      Dr. John Doe \
->>>      Artos Institute \
->>>      #link("mailto:doe@artos.edu")
->>>    ]
->>>  )
+>>>   #grid(
+>>>     columns: (1fr, 1fr),
+>>>     [
+>>>       Therese Tungsten \
+>>>       Artos Institute \
+>>>       #link("mailto:tung@artos.edu")
+>>>     ],
+>>>     [
+>>>       Dr. John Doe \
+>>>       Artos Institute \
+>>>       #link("mailto:doe@artos.edu")
+>>>     ]
+>>>   )
 >>>
->>>   #align(center)[
->>>     #set par(justify: false)
+>>>   #par(justify: false)[
 >>>     *Abstract* \
 >>>     #lorem(80)
 >>>   ]
@@ -461,33 +463,32 @@ differentiate between section and subsection headings:
 )
 >>>
 >>> #place(
->>>   top,
+>>>   top + center,
 >>>   float: true,
 >>>   scope: "parent",
->>>   clearance: 4mm,
+>>>   clearance: 2em,
 >>> )[
->>>   #align(center, text(
+>>>   #text(
 >>>     17pt,
 >>>     weight: "bold",
 >>>     title,
->>>   ))
+>>>   )
 >>>
 >>>  #grid(
 >>>    columns: (1fr, 1fr),
->>>    align(center)[
+>>>    [
 >>>      Therese Tungsten \
 >>>      Artos Institute \
 >>>      #link("mailto:tung@artos.edu")
 >>>    ],
->>>    align(center)[
+>>>    [
 >>>      Dr. John Doe \
 >>>      Artos Institute \
 >>>      #link("mailto:doe@artos.edu")
 >>>    ]
 >>>  )
 >>>
->>>   #align(center)[
->>>     #set par(justify: false)
+>>>   #par(justify: false)[
 >>>     *Abstract* \
 >>>     #lorem(80)
 >>>   ]

--- a/docs/tutorial/4-template.md
+++ b/docs/tutorial/4-template.md
@@ -161,10 +161,9 @@ are this:
    The function applies a few set and show rules and echoes the content it has
    been passed at the end.
 
-2. Moreover, we used a curly-braced code block
-   instead of a content block. This way, we don't need to prefix all set rules
-   and function calls with a `#`. In exchange, we cannot write markup directly
-   in the code block anymore.
+2. Moreover, we used a curly-braced code block instead of a content block. This
+   way, we don't need to prefix all set rules and function calls with a `#`. In
+   exchange, we cannot write markup directly in the code block anymore.
 
 Also note where the title comes from: We previously had it inside of a variable.
 Now, we are receiving it as the first parameter of the template function. To do
@@ -175,11 +174,11 @@ only pass the body. Therefore, we add a new function definition that allows us
 to set a paper title and use the single parameter from the show rule.
 
 ## Templates with named arguments { #named-arguments }
-Our paper in the previous chapter had a title and an author list. Let's add these
-things to our template. In addition to the title, we want our template to accept
-a list of authors with their affiliations and the paper's abstract. To keep
-things readable, we'll add those as named arguments. In the end, we want it to
-work like this:
+Our paper in the previous chapter had a title and an author list. Let's add
+these things to our template. In addition to the title, we want our template to
+accept a list of authors with their affiliations and the paper's abstract. To
+keep things readable, we'll add those as named arguments. In the end, we want it
+to work like this:
 
 ```typ
 #show: doc => conf(
@@ -278,12 +277,12 @@ definition inside of that new file. Now you can access it from your main file by
 adding an import before the show rule. Specify the path of the file between the
 `{import}` keyword and a colon, then name the function that you want to import.
 
-Another thing that you can do to make using template's just a bit more elegant
-is to use [`.with`]($function.with) to avoid spelling out a closure and
-appending the content argument at the bottom of your template list. Instead, you
-can just pass a function with all the named arguments pre-populated by using the
-with method of a function. Templates on [Typst Universe]($universe) are designed
-to work with this style of function call.
+Another thing that you can do to make applying templates just a bit more elegant
+is to use the [`.with`]($function.with) method on functions to pre-populate all
+the named arguments. This way, you can avoid spelling out a closure and
+appending the content argument at the bottom of your template list. Templates on
+[Typst Universe]($universe) are designed to work with this style of function
+call.
 
 ```example:single
 >>> #let conf(
@@ -331,7 +330,7 @@ to work with this style of function call.
 >>>    top,
 >>>    float: true,
 >>>    scope: "parent",
->>>    clearance: 4mm,
+>>>    clearance: 2em,
 >>>    {
 >>>      set align(center)
 >>>      text(17pt, title)


### PR DESCRIPTION
Replaces superseded uses of the columns function and introduces `place` as well as `fn.with`