### PR TITLE
Add a `rev` named argument to the `find` and `position` of `array` and `position` of `str`

### DIFF
--- a/crates/typst/src/foundations/array.rs
+++ b/crates/typst/src/foundations/array.rs
@@ -5,9 +5,9 @@ use std::ops::{Add, AddAssign};
 
 use comemo::Tracked;
 use ecow::{eco_format, EcoString, EcoVec};
-use rayon::iter::Either;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
+use typst_utils::MaybeReverseIter;
 
 use crate::diag::{bail, At, HintedStrResult, SourceDiagnostic, SourceResult, StrResult};
 use crate::engine::Engine;
@@ -314,13 +314,7 @@ impl Array {
         #[default(false)]
         rev: bool,
     ) -> SourceResult<Option<Value>> {
-        let iter = if rev {
-            Either::Right(self.iter().rev())
-        } else {
-            Either::Left(self.iter())
-        };
-
-        for item in iter {
+        for item in self.iter().rev_if(rev) {
             if searcher
                 .call(engine, context, [item.clone()])?
                 .cast::<bool>()
@@ -348,12 +342,7 @@ impl Array {
         #[default(false)]
         rev: bool,
     ) -> SourceResult<Option<i64>> {
-        let iter = if rev {
-            Either::Right(self.iter().enumerate().rev())
-        } else {
-            Either::Left(self.iter().enumerate())
-        };
-        for (i, item) in iter {
+        for (i, item) in self.iter().enumerate().rev_if(rev) {
             if searcher
                 .call(engine, context, [item.clone()])?
                 .cast::<bool>()

--- a/crates/typst/src/foundations/array.rs
+++ b/crates/typst/src/foundations/array.rs
@@ -5,6 +5,7 @@ use std::ops::{Add, AddAssign};
 
 use comemo::Tracked;
 use ecow::{eco_format, EcoString, EcoVec};
+use rayon::iter::Either;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
@@ -308,8 +309,18 @@ impl Array {
         context: Tracked<Context>,
         /// The function to apply to each item. Must return a boolean.
         searcher: Func,
+        /// Whether to look for a match in the reversed order.
+        #[named]
+        #[default(false)]
+        rev: bool,
     ) -> SourceResult<Option<Value>> {
-        for item in self.iter() {
+        let iter = if rev {
+            Either::Right(self.iter().rev())
+        } else {
+            Either::Left(self.iter())
+        };
+
+        for item in iter {
             if searcher
                 .call(engine, context, [item.clone()])?
                 .cast::<bool>()
@@ -332,8 +343,17 @@ impl Array {
         context: Tracked<Context>,
         /// The function to apply to each item. Must return a boolean.
         searcher: Func,
+        /// Whether to look for a match in the reversed order.
+        #[named]
+        #[default(false)]
+        rev: bool,
     ) -> SourceResult<Option<i64>> {
-        for (i, item) in self.iter().enumerate() {
+        let iter = if rev {
+            Either::Right(self.iter().enumerate().rev())
+        } else {
+            Either::Left(self.iter().enumerate())
+        };
+        for (i, item) in iter {
             if searcher
                 .call(engine, context, [item.clone()])?
                 .cast::<bool>()

--- a/crates/typst/src/foundations/str.rs
+++ b/crates/typst/src/foundations/str.rs
@@ -361,20 +361,26 @@ impl Str {
         &self,
         /// The pattern to search for.
         pattern: StrPattern,
-        /// Whether to look for a match in the reversed order.
+        /// Whether to look for a match in the reversed order. Currently not supported for regexes.
         #[named]
         #[default(false)]
         rev: bool,
-    ) -> Option<usize> {
+    ) -> StrResult<Option<usize>> {
         match pattern {
             StrPattern::Str(pat) => {
                 if rev {
-                    self.0.rfind(pat.as_str())
+                    Ok(self.0.rfind(pat.as_str()))
                 } else {
-                    self.0.find(pat.as_str())
+                    Ok(self.0.find(pat.as_str()))
                 }
             }
-            StrPattern::Regex(re) => re.find(self).map(|m| m.start()),
+            StrPattern::Regex(re) => {
+                if rev {
+                    Err(cant_reverse_regex_search())
+                } else {
+                    Ok(re.find(self).map(|m| m.start()))
+                }
+            }
         }
     }
 
@@ -843,6 +849,12 @@ fn not_a_char_boundary(index: i64) -> EcoString {
 #[cold]
 fn string_is_empty() -> EcoString {
     "string is empty".into()
+}
+
+/// The error message when a reverse regex search is needed.
+#[cold]
+fn cant_reverse_regex_search() -> EcoString {
+    "reverse regex search is not yet implemented".into()
 }
 
 /// A regular expression.

--- a/crates/typst/src/foundations/str.rs
+++ b/crates/typst/src/foundations/str.rs
@@ -361,9 +361,19 @@ impl Str {
         &self,
         /// The pattern to search for.
         pattern: StrPattern,
+        /// Whether to look for a match in the reversed order.
+        #[named]
+        #[default(false)]
+        rev: bool,
     ) -> Option<usize> {
         match pattern {
-            StrPattern::Str(pat) => self.0.find(pat.as_str()),
+            StrPattern::Str(pat) => {
+                if rev {
+                    self.0.rfind(pat.as_str())
+                } else {
+                    self.0.find(pat.as_str())
+                }
+            }
             StrPattern::Regex(re) => re.find(self).map(|m| m.start()),
         }
     }

--- a/tests/suite/foundations/array.typ
+++ b/tests/suite/foundations/array.typ
@@ -235,8 +235,18 @@
 --- array-position ---
 // Test the `position` method.
 #test(("Hi", "❤️", "Love").position(s => s == "❤️"), 1)
+#test(("Hi", "❤️", "Love").position(s => s == "❤️", rev: false), 1)
 #test(("Bye", "💘", "Apart").position(s => s == "❤️"), none)
 #test(("A", "B", "CDEF", "G").position(v => v.len() > 2), 2)
+
+--- array-position-rev ---
+// Test the `position` method with reversed.
+#test(("Hi", "❤️", "Love").position(s => s == "❤️", rev: true), 1)
+#test(("A", "B", "B", "A").position(s => s == "A", rev: true), 3)
+
+--- array-find-rev ---
+#test(("AB", "AC").find(s => s.at(0) == "A", rev: false), "AB")
+#test(("AB", "AC").find(s => s.at(0) == "A", rev: true), "AC")
 
 --- array-filter ---
 // Test the `filter` method.

--- a/tests/suite/foundations/str.typ
+++ b/tests/suite/foundations/str.typ
@@ -182,6 +182,10 @@
 #test("It's 12:13 now".find(date), "12:13")
 #test("It's 12:13 now".position(date), 5)
 
+--- string-find-and-position-rev ---
+#test("World World".position("World"), 0)
+#test("World World".position("World", rev: true), 6)
+
 --- string-match ---
 // Test the `match` method.
 #test("Is there a".match("for this?"), none)


### PR DESCRIPTION
Partially fixes #4981.

Currently lacks support for reverse regex search; Could be implemented with `regex_automata` supposedly.

I can try to implement reverse regex search using `regex_automata` if we want to go that route.