### PR TITLE
Improved docs for `par.line.numbering-scope`

### DIFF
--- a/crates/typst/src/model/par.rs
+++ b/crates/typst/src/model/par.rs
@@ -381,7 +381,7 @@ impl Construct for ParLine {
 /// Possible line numbering scope options, indicating how often the line number
 /// counter should be reset.
 ///
-/// Note that currently the manual reset of the line number counter is not
+/// Note that, currently, manually resetting the line number counter is not
 /// supported.
 #[derive(Debug, Cast, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum LineNumberingScope {

--- a/crates/typst/src/model/par.rs
+++ b/crates/typst/src/model/par.rs
@@ -380,13 +380,16 @@ impl Construct for ParLine {
 
 /// Possible line numbering scope options, indicating how often the line number
 /// counter should be reset.
+///
+/// Note that currently the manual reset of the line number counter is not
+/// supported.
 #[derive(Debug, Cast, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum LineNumberingScope {
-    /// Indicates the line number counter spans the whole document, that is,
-    /// is never automatically reset.
+    /// Indicates that the line number counter spans the whole document, i.e.,
+    /// it's never automatically reset.
     Document,
-    /// Indicates the line number counter should be reset at the start of every
-    /// new page.
+    /// Indicates that the line number counter should be reset at the start of
+    /// every new page.
     Page,
 }
 


### PR DESCRIPTION
If the numbering can't be reset at all, then the "automatically" part should be dropped to not confuse people into thinking that it can be reset manually.

I actually haven't tried it. Can you reset the numbering with `counter("par.line").update(0)` or something?

Also the "that is, is never" sounds strange to me. Another change could be replacing the "that is" with "i.e.".
