### PR TITLE
Disallow space between ident and paren in set rule

### DIFF
--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -1224,8 +1224,11 @@ fn array_or_dict_item(p: &mut Parser, state: &mut GroupState) {
 
 /// Parses a function call's argument list: `(12pt, y)`.
 fn args(p: &mut Parser) {
-    if !p.at(SyntaxKind::LeftParen) && !p.at(SyntaxKind::LeftBracket) {
+    if !p.directly_at(SyntaxKind::LeftParen) && !p.directly_at(SyntaxKind::LeftBracket) {
         p.expected("argument list");
+        if p.at(SyntaxKind::LeftParen) || p.at(SyntaxKind::LeftBracket) {
+            p.hint("there may not be any spaces before the argument list");
+        }
     }
 
     let m = p.marker();

--- a/tests/suite/styling/set.typ
+++ b/tests/suite/styling/set.typ
@@ -65,6 +65,21 @@ Hello *#x*
 // Error: 12-26 set is only allowed directly in code and content blocks
 #{ let x = set text(blue) }
 
+--- set-bad-trivia ---
+// Error cases parsing set rules with trivia between the function and args.
+// Error: 10 expected argument list
+#set page
+         (numbering: "1")
+// Error: 10 expected argument list
+// Hint: 10 there may not be any spaces before the argument list
+#set page (numbering: "2")
+// Error: 10 expected argument list
+// Hint: 10 there may not be any spaces before the argument list
+#set page/**/(numbering: "3")
+
+// This is fine though
+#set/**/page(numbering: "4")
+
 --- set-vs-construct-1 ---
 // Ensure that constructor styles aren't passed down the tree.
 // The inner list should have no extra indent.


### PR DESCRIPTION
Closes #5258

Let me know if the wording of the error should be changed.