### PR TITLE
Fix dockerfile not cross compiling correctly

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -36,18 +36,18 @@ jobs:
         run: echo "TYPST_BUILD_DATE=\"$(date -u +'%Y-%m-%dT%H:%M:%SZ')\" >> $GITHUB_ENV"
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v3.1.0
+        uses: docker/setup-buildx-action@v3.7.1
         with:
           platforms: ${{ matrix.platform }}
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5.0.0
+        uses: docker/metadata-action@v5.5.1
         with:
           images: ${{ env.IMAGE_NAME }}
 
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3.0.0
+        uses: docker/login-action@v3.3.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Build Docker image
         id: build
-        uses: docker/build-push-action@v5.1.0
+        uses: docker/build-push-action@v6.9.0
         with:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ matrix.platform }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
-ARG CREATED
-ARG REVISION
-ARG TARGETPLATFORM
-
 FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
 FROM --platform=$BUILDPLATFORM rust:alpine AS build
+
 COPY --from=xx / /
 
 RUN apk add --no-cache clang lld
@@ -14,6 +11,8 @@ RUN --mount=type=cache,target=/root/.cargo/git/db \
     --mount=type=cache,target=/root/.cargo/registry/index \
     CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse \
     cargo fetch
+
+ARG TARGETPLATFORM
 
 RUN xx-apk add --no-cache musl-dev openssl-dev openssl-libs-static
 RUN --mount=type=cache,target=/root/.cargo/git/db \
@@ -26,6 +25,8 @@ RUN --mount=type=cache,target=/root/.cargo/git/db \
     xx-verify target/release/typst
 
 FROM alpine:latest
+ARG CREATED
+ARG REVISION
 LABEL org.opencontainers.image.authors="The Typst Project Developers <hello@typst.app>"
 LABEL org.opencontainers.image.created=${CREATED}
 LABEL org.opencontainers.image.description="A markup-based typesetting system"


### PR DESCRIPTION
Fixes #5290.
ARG definitions are only valid for the current build stage in multistage
builds. We need to define them in the correct stage or they will go out of scope in later stages, causing `$TARGETPLATFORM` to be empty.
`xx`/`xx-cargo` will then silently fall back to targeting the build platform, which is x86_64.

I also bumped the action versions while experimenting and thought it would be a good idea to leave this in.