### PR TITLE
Make `math.bold` compatible with Greek digamma

### DIFF
--- a/crates/typst-layout/src/math/text.rs
+++ b/crates/typst-layout/src/math/text.rs
@@ -314,6 +314,13 @@ fn greek_exception(
     italic: bool,
 ) -> Option<char> {
     use MathVariant::*;
+    if c == 'Ϝ' && variant == Serif && bold {
+        return Some('𝟊');
+    }
+    if c == 'ϝ' && variant == Serif && bold {
+        return Some('𝟋');
+    }
+
     let list = match c {
         'ϴ' => ['𝚹', '𝛳', '𝜭', '𝝧', '𝞡', 'ϴ'],
         '∇' => ['𝛁', '𝛻', '𝜵', '𝝯', '𝞩', '∇'],


### PR DESCRIPTION
This small PR makes the `math.bold` function work with the archaic Greek letter [digamma](https://en.wikipedia.org/wiki/Digamma). I don't think Unicode defines anything other than bold serif variants of digamma, or variants of other archaic Greek letters.