### PR TITLE
Added Numero Sign № (U+2116)

### DIFF
--- a/crates/typst-library/src/symbols/sym.rs
+++ b/crates/typst-library/src/symbols/sym.rs
@@ -123,6 +123,7 @@ pub(crate) const SYM: &[(&str, Symbol)] = typst_macros::symbols! {
     interrobang: '‽',
     hash: '#',
     hyph: ['‐', minus: '\u{2D}', nobreak: '\u{2011}', point: '‧', soft: '\u{ad}'],
+    numero: '№',
     percent: '%',
     permille: '‰',
     pilcrow: ['¶', rev: '⁋'],


### PR DESCRIPTION
Closes https://github.com/typst/typst/issues/5325.

As a side note, I didn't get why not everything in each section/group is ordered alphabetically. I thought that was the whole point of sorting. I can fix that in a separate PR, if needed. I was confused as to where in the semi-ordered section to put the new symbol.