### PR TITLE
Bump rust in `release.yml`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@1.81.0
+    - uses: dtolnay/rust-toolchain@1.82.0
       with:
         target: ${{ matrix.target }}
 


### PR DESCRIPTION
`riscv64gc-unknown-linux-musl` is not supported since rust 1.82.0. ~So we can switch to it~.

See #5333 and https://github.com/typst/typst/pull/5333#issuecomment-2449677701 .

NOTE: I don't use flake, so I did not bump rust version in the flake. I left an issue for it, see #5341