### PR TITLE
Allow triggering the release workflow manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@
 
 name: Build Release Binaries
 on:
+  workflow_dispatch:
   release:
     types: [published]
 
@@ -71,7 +72,15 @@ jobs:
           tar cJf $directory.tar.xz $directory
         fi
 
+    - uses: actions/upload-artifact@v4
+      if: github.event_name == 'workflow_dispatch'
+      with:
+        name: typst-${{ matrix.target }}
+        path: "typst-${{ matrix.target }}.*"
+        retention-days: 3
+
     - uses: ncipollo/release-action@v1.14.0
+      if: github.event_name == 'release'
       with:
         artifacts: "typst-${{ matrix.target }}.*"
         allowUpdates: true


### PR DESCRIPTION
Before this PR, maintainers have to create a release to test the release workflow (e.g. https://github.com/laurmaedje/typst/actions/runs/11612330587). And with this PR, maintainers can test the release workflow by manually dispatching the workflow.

See https://github.com/Coekjan/typst/actions/runs/11628265117