### PR TITLE
Add funding-manifest-urls for FLOSS/fund

### DIFF
--- a/.github/.well-known/funding-manifest-urls
+++ b/.github/.well-known/funding-manifest-urls
@@ -1,0 +1,1 @@
+https://typst.app/funding.json


### PR DESCRIPTION
This file demonstrates the association between typst.app and this repo. It is required to conform with https://floss.fund/funding-manifest/