### PR TITLE
Add compare argument for array.sorted

### DIFF
--- a/crates/typst-library/src/foundations/array.rs
+++ b/crates/typst-library/src/foundations/array.rs
@@ -814,7 +814,7 @@ impl Array {
     /// function. The sorting algorithm used is stable.
     ///
     /// Returns an error if two values could not be compared or if the key
-    /// function (if given) yields an error.
+    /// or comparison function (if given) yields an error.
     ///
     /// To sort according to multiple criteria at once, e.g. in case of equality
     /// between some criteria, the key function can return an array. The results
@@ -841,8 +841,11 @@ impl Array {
         /// determine the keys to sort by.
         #[named]
         key: Option<Func>,
-        /// If given, uses this function to compare elements in the array to
-        /// determine their relative order.
+        /// If given, uses this function to compare elements in the array.
+        ///
+        /// This function should return an integer, whose sign is
+        /// used to determine the relative order of two given
+        /// elements.
         #[named]
         compare: Option<Func>,
     ) -> SourceResult<Array> {

--- a/tests/suite/foundations/array.typ
+++ b/tests/suite/foundations/array.typ
@@ -355,6 +355,8 @@
 #test((2, 1, 3, 10, 5, 8, 6, -7, 2).sorted(), (-7, 1, 2, 2, 3, 5, 6, 8, 10))
 #test((2, 1, 3, -10, -5, 8, 6, -7, 2).sorted(key: x => x), (-10, -7, -5, 1, 2, 2, 3, 6, 8))
 #test((2, 1, 3, -10, -5, 8, 6, -7, 2).sorted(key: x => x * x), (1, 2, 2, 3, -5, 6, -7, 8, -10))
+#test(("I", "the", "hi", "text").sorted(compare: (x, y) => x.len() - y.len()), ("I", "hi", "the", "text"))
+#test(("I", "the", "hi", "text").sorted(key: x => x.len(), compare: (x, y) => y - x), ("text", "the", "hi", "I"))
 
 --- array-sorted-key-function-positional-1 ---
 // Error: 12-18 unexpected argument


### PR DESCRIPTION
Fixes #5365.

I used `compare` for the argument name instead of `by` because `by` could plausibly refer to either the key or the comparison function.

According to the [Rust standard library documentation](https://doc.rust-lang.org/nightly/std/primitive.slice.html#method.sort_by), sorting might panic when a non-total ordering function is provided. I’ve been unable to produce a panic so far, but I think this is an important issue to resolve. We could `catch_unwind` such a panic, but this doesn’t solve the problem when `panic=abort` is turned on.