### PR TITLE
Add `sym.eq.triple.not`

### DIFF
--- a/crates/typst-library/src/symbols/sym.rs
+++ b/crates/typst-library/src/symbols/sym.rs
@@ -244,6 +244,7 @@ pub(crate) const SYM: &[(&str, Symbol)] = typst_macros::symbols! {
         small: '﹦',
         succ: '⋟',
         triple: '≡',
+        triple.not: '≢',
         quad: '≣',
     ],
     gt: [


### PR DESCRIPTION
Adds `sym.eq.triple.not` symbol. (`≢`)

(Before it was reachable only under `sym.equiv.not`.)