### PR TITLE
Removed deprecated `diff` symbol

### DIFF
--- a/crates/typst-library/src/symbols/sym.rs
+++ b/crates/typst-library/src/symbols/sym.rs
@@ -426,7 +426,6 @@ pub(crate) const SYM: &[(&str, Symbol)] = typst_macros::symbols! {
         tie: '⧝',
     ],
     oo: '∞',
-    diff: '∂', // Deprecation planned
     partial: '∂',
     gradient: '∇',
     nabla: '∇',

--- a/tests/suite/math/style.typ
+++ b/tests/suite/math/style.typ
@@ -2,13 +2,13 @@
 
 --- math-style-italic-default ---
 // Test italic defaults.
-$a, A, delta, ϵ, diff, Delta, ϴ$
+$a, A, delta, ϵ, partial, Delta, ϴ$
 
 --- math-style ---
 // Test forcing a specific style.
 $A, italic(A), upright(A), bold(A), bold(upright(A)), \
  serif(A), sans(A), cal(A), frak(A), mono(A), bb(A), \
- italic(diff), upright(diff), \
+ italic(partial), upright(partial), \
  bb("hello") + bold(cal("world")), \
  mono("SQRT")(x) wreath mono(123 + 456)$
 


### PR DESCRIPTION
Was deprecated in v0.11 and wasn't removed in v0.12. It's time.
