### PR TITLE
Add `asymp` and `asymp.not` symbols

### DIFF
--- a/crates/typst-library/src/symbols/sym.rs
+++ b/crates/typst-library/src/symbols/sym.rs
@@ -246,8 +246,6 @@ pub(crate) const SYM: &[(&str, Symbol)] = typst_macros::symbols! {
         triple: '≡',
         triple.not: '≢',
         quad: '≣',
-        equiv: '≍',
-        nequiv: '≭',
     ],
     gt: [
         '>',
@@ -340,6 +338,10 @@ pub(crate) const SYM: &[(&str, Symbol)] = typst_macros::symbols! {
     prop: '∝',
     original: '⊶',
     image: '⊷',
+    asymp: [
+        '≍',
+        not: '≭',
+    ],
 
     // Set theory.
     emptyset: [

--- a/crates/typst-library/src/symbols/sym.rs
+++ b/crates/typst-library/src/symbols/sym.rs
@@ -246,6 +246,8 @@ pub(crate) const SYM: &[(&str, Symbol)] = typst_macros::symbols! {
         triple: '≡',
         triple.not: '≢',
         quad: '≣',
+        equiv: '≍',
+        nequiv: '≭',
     ],
     gt: [
         '>',


### PR DESCRIPTION
See https://forum.typst.app/t/symbol-for-hardys-asymptotic-notation/1601/2.

The symbols ≍ and ≭ are in Unicode "Mathematical Operators 2200-22FF" as
EQUIVALENT TO and NOT EQUIVALENT TO respectively.

In practice, they are used in the literature for asymptotic behaviour,
providing a shorthand notation for the big-O notation, see https://en.wikipedia.org/wiki/Big_O_notation#:~:text=of%20his%20tract-,Hardy,-defined%20the%20symbol.
