### PR TITLE
Add support for evaluating Typst markup in SVG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "fontdb"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37be9fc20d966be438cd57a45767f73349477fb0f85ce86e000557f787298afb"
+checksum = "a3a6f9af55fb97ad673fb7a69533eb2f967648a06fa21f8c9bb2cd6d33975716"
 dependencies = [
  "fontconfig-parser",
  "log",
@@ -1994,9 +1994,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "resvg"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7314563c59c7ce31c18e23ad3dd092c37b928a0fa4e1c0a1a6504351ab411d1"
+checksum = "4a325d5e8d1cebddd070b13f44cec8071594ab67d1012797c121f27a669b7958"
 dependencies = [
  "gif",
  "image-webp",
@@ -2364,8 +2364,7 @@ checksum = "74f98178f34057d4d4de93d68104007c6dea4dfac930204a69ab4622daefa648"
 [[package]]
 name = "svg2pdf"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5014c9dadcf318fb7ef8c16438e95abcc9de1ae24d60d5bccc64c55100c50364"
+source = "git+https://github.com/typst/svg2pdf?rev=ed9b142#ed9b1429473368e0566da01c61e46abfec8795b7"
 dependencies = [
  "fontdb",
  "image",
@@ -2837,6 +2836,7 @@ dependencies = [
  "unicode-math-class",
  "unicode-script",
  "unicode-segmentation",
+ "usvg",
 ]
 
 [[package]]
@@ -3180,9 +3180,9 @@ dependencies = [
 
 [[package]]
 name = "usvg"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6803057b5cbb426e9fb8ce2216f3a9b4ca1dd2c705ba3cbebc13006e437735fd"
+checksum = "7447e703d7223b067607655e625e0dbca80822880248937da65966194c4864e6"
 dependencies = [
  "base64",
  "data-url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ dirs = "5"
 ecow = { version = "0.2", features = ["serde"] }
 env_proxy = "0.4"
 flate2 = "1"
-fontdb = { version = "0.21", default-features = false }
+fontdb = { version = "0.22", default-features = false }
 fs_extra = "1.3"
 hayagriva = "0.8"
 heck = "0.5"
@@ -92,7 +92,7 @@ qcms = "0.3.0"
 quote = "1"
 rayon = "1.7.0"
 regex = "1"
-resvg = { version = "0.43", default-features = false, features = ["raster-images"] }
+resvg = { version = "0.44", default-features = false, features = ["raster-images"] }
 roxmltree = "0.20"
 rust_decimal = { version = "1.36.0", default-features = false, features = ["maths"] }
 rustybuzz = "0.18"
@@ -107,7 +107,7 @@ siphasher = "1"
 smallvec = { version = "1.11.1", features = ["union", "const_generics", "const_new"] }
 stacker = "0.1.15"
 subsetter = "0.2"
-svg2pdf = "0.12"
+svg2pdf = { git = "https://github.com/typst/svg2pdf", rev = "ed9b142" }
 syn = { version = "2", features = ["full", "extra-traits"] }
 syntect = { version = "5", default-features = false, features = ["parsing", "regex-fancy", "plist-load", "yaml-load"] }
 tar = "0.4"
@@ -126,7 +126,7 @@ unicode-script = "0.5"
 unicode-segmentation = "1"
 unscanny = "0.1"
 ureq = { version = "2", default-features = false, features = ["native-tls", "gzip", "json"] }
-usvg = { version = "0.43", default-features = false, features = ["text"] }
+usvg = { version = "0.44", default-features = false, features = ["text"] }
 walkdir = "2"
 wasmi = "0.38.0"
 xmlparser = "0.13.5"

--- a/crates/typst-layout/Cargo.toml
+++ b/crates/typst-layout/Cargo.toml
@@ -33,6 +33,7 @@ kurbo = { workspace = true }
 rustybuzz = { workspace = true }
 smallvec = { workspace = true }
 ttf-parser = { workspace = true }
+usvg = { workspace = true }
 unicode-bidi = { workspace = true }
 unicode-math-class = { workspace = true }
 unicode-script = { workspace = true }

--- a/crates/typst-layout/src/image.rs
+++ b/crates/typst-layout/src/image.rs
@@ -176,7 +176,7 @@ pub fn layout_image(
                             let val = (engine.routines.eval_string)(
                                 engine.routines,
                                 engine.world,
-                                &chunk.text(),
+                                chunk.text(),
                                 span,
                                 EvalMode::Markup,
                                 Scope::new(),

--- a/crates/typst-layout/src/image.rs
+++ b/crates/typst-layout/src/image.rs
@@ -126,7 +126,10 @@ pub fn layout_image(
         /// The algorithm is as follows:
         /// - Any text node will be given visibility hidden (this already happened when generating
         ///   the usvg tree).
-        /// - We iterate over all text nodes
+        /// - We iterate over all text nodes, determine their position and calculate what
+        ///   their position would be after evaluating all transforms.
+        /// - We calculate the rotation of the text, and also resolve the `text-anchor` property
+        /// - We evaluate the SVG text and then place it accordingly.
         fn eval_text_nodes(
             svg: &SvgImage,
             group: &usvg::Group,

--- a/crates/typst-layout/src/image.rs
+++ b/crates/typst-layout/src/image.rs
@@ -1,11 +1,12 @@
 use std::ffi::OsStr;
 use std::ops::Neg;
+
 use typst_library::diag::{bail, warning, At, SourceResult, StrResult};
 use typst_library::engine::Engine;
 use typst_library::foundations::{Packed, Scope, Smart, StyleChain};
 use typst_library::introspection::Locator;
 use typst_library::layout::{
-    Abs, Axes, FixedAlignment, Frame, FrameItem, FrameKind, GroupItem, Point, Region,
+    Abs, Axes, FixedAlignment, Frame, FrameItem, GroupItem, Point, Region,
     Size,
 };
 use typst_library::loading::Readable;
@@ -16,6 +17,7 @@ use typst_library::visualize::{
     VectorFormat,
 };
 use typst_syntax::Span;
+
 use usvg::{tiny_skia_path, Node, TextAnchor, Transform};
 
 /// Layout the image.
@@ -183,7 +185,7 @@ pub fn layout_image(
                                 Size::new(Abs::inf(), Abs::inf()),
                                 Axes::splat(false),
                             );
-                            let mut inner_frame = crate::layout_frame(
+                            let inner_frame = crate::layout_frame(
                                 engine, &val, locator, styles, region,
                             )?;
 
@@ -229,9 +231,9 @@ pub fn layout_image(
             Ok(())
         }
 
-        clip = true;
-
         if elem.eval(styles) {
+            clip = true;
+
             eval_text_nodes(
                 svg,
                 svg.tree().root(),
@@ -249,6 +251,7 @@ pub fn layout_image(
     // or if the SVG is evaluated, in which overlaid text might exceed the
     // bounding box.
     clip |= fit == ImageFit::Cover && !target.fits(fitted);
+
     if clip {
         frame.clip(Path::rect(frame.size()));
     }

--- a/crates/typst-layout/src/image.rs
+++ b/crates/typst-layout/src/image.rs
@@ -1,16 +1,22 @@
 use std::ffi::OsStr;
 use std::ops::Neg;
-use usvg::{tiny_skia_path, Node, TextAnchor, Transform};
 use typst_library::diag::{bail, warning, At, SourceResult, StrResult};
 use typst_library::engine::Engine;
 use typst_library::foundations::{Packed, Scope, Smart, StyleChain};
 use typst_library::introspection::Locator;
-use typst_library::layout::{Abs, Axes, FixedAlignment, Frame, FrameItem, FrameKind, GroupItem, Point, Region, Size};
+use typst_library::layout::{
+    Abs, Axes, FixedAlignment, Frame, FrameItem, FrameKind, GroupItem, Point, Region,
+    Size,
+};
 use typst_library::loading::Readable;
 use typst_library::routines::EvalMode;
 use typst_library::text::families;
-use typst_library::visualize::{Image, ImageElem, ImageFit, ImageFormat, ImageKind, Path, RasterFormat, SvgImage, VectorFormat};
+use typst_library::visualize::{
+    Image, ImageElem, ImageFit, ImageFormat, ImageKind, Path, RasterFormat, SvgImage,
+    VectorFormat,
+};
 use typst_syntax::Span;
+use usvg::{tiny_skia_path, Node, TextAnchor, Transform};
 
 /// Layout the image.
 #[typst_macros::time(span = elem.span())]
@@ -108,52 +114,114 @@ pub fn layout_image(
     // process.
     let mut frame = Frame::soft(fitted);
     frame.push(Point::zero(), FrameItem::Image(image.clone(), fitted, span));
-    println!("{:?}", fitted);
-    println!("{:?}", target);
     let mut clip = false;
     if let ImageKind::Svg(svg) = image.kind() {
-        println!("{:?}", svg.tree().size());
-        fn traverse(svg: &SvgImage, group: &usvg::Group, image_size: Size, engine: &mut Engine, span: Span, styles: StyleChain, parent_frame: &mut Frame) -> SourceResult<()> {
+        /// The idea is as follows: By allowing to "evaluate" SVGs, users can insert arbitrary Typst
+        /// markup into their SVG and have it interpreted as such, instead of being interpreted as
+        /// normal text. This allows for example for the inclusion of math content in SVGs, or
+        /// ensure that SVG text looks consistent to other text in the document.
+        ///
+        /// The algorithm is as follows:
+        /// - Any text node will be given visibility hidden (this already happened when generating
+        ///   the usvg tree).
+        /// - We iterate over all text nodes
+        fn eval_text_nodes(
+            svg: &SvgImage,
+            group: &usvg::Group,
+            image_size: Size,
+            engine: &mut Engine,
+            span: Span,
+            styles: StyleChain,
+            parent_frame: &mut Frame,
+        ) -> SourceResult<()> {
             for child in group.children() {
                 match child {
                     Node::Group(g) => {
-                        traverse(svg, g, image_size, engine, span, styles, parent_frame)?;
-                    },
+                        eval_text_nodes(
+                            svg,
+                            g,
+                            image_size,
+                            engine,
+                            span,
+                            styles,
+                            parent_frame,
+                        )?;
+                    }
                     Node::Text(t) => {
                         for chunk in t.chunks() {
-                            let x_scale = image_size.x.to_raw() as f32 / svg.width() as f32;
-                            let y_scale = image_size.y.to_raw() as f32 / svg.height() as f32;
-                            let x = chunk.x().unwrap_or(0.0);
-                            let y = chunk.y().unwrap_or(0.0);
-                            let mut pos = tiny_skia_path::Point::from_xy(x, y);
-                            t.abs_transform().map_point(&mut pos);
-                            let (mut x, y) = (pos.x * x_scale, pos.y * y_scale);
-                            let val = (engine.routines.eval_string)(engine.routines, engine.world, &chunk.text(), span, EvalMode::Markup, Scope::new())?.display();
+                            // Calculate the x and y coordinates of the text node in Typst coordinates,
+                            // after all SVG transforms have been applied.
+                            let (x, y) = {
+                                let x_scale =
+                                    image_size.x.to_raw() as f32 / svg.width() as f32;
+                                let y_scale =
+                                    image_size.y.to_raw() as f32 / svg.height() as f32;
 
-                            let locator = Locator::root();
-                            let region = Region::new(Size::new(Abs::inf(), Abs::inf()), Axes::splat(false));
-                            let mut f = crate::layout_frame(engine, &val, locator, styles, region).unwrap();
-                            f.set_kind(FrameKind::Hard);
+                                let x = chunk.x().unwrap_or(0.0);
+                                let y = chunk.y().unwrap_or(0.0);
+                                // Determine the actual x/y coordinates of the text nodes after all
+                                // SVG transforms have been applied.
+                                let mut pos = tiny_skia_path::Point::from_xy(x, y);
+                                t.abs_transform().map_point(&mut pos);
 
-                            x = match chunk.anchor() {
-                                TextAnchor::Start => x,
-                                TextAnchor::Middle => x - (f.size().x.to_raw() / 2.0) as f32,
-                                TextAnchor::End => x - f.size().x.to_raw() as f32
+                                // Convert to Typst coordinates
+                                (pos.x * x_scale, pos.y * y_scale)
                             };
 
-                            let baseline = f.baseline();
-                            let mut text_frame = GroupItem::new(f);
-                            println!("abs transform: {:?}", t.abs_transform());
+                            let val = (engine.routines.eval_string)(
+                                engine.routines,
+                                engine.world,
+                                &chunk.text(),
+                                span,
+                                EvalMode::Markup,
+                                Scope::new(),
+                            )?
+                            .display();
 
-                            let rotation = -t.abs_transform().kx.atan2(t.abs_transform().sx).to_degrees();
-                            let transform = Transform::from_translate(x, y)
-                                .pre_concat(Transform::from_rotate(rotation))
-                                .pre_concat(Transform::from_translate(0.0, baseline.neg().to_raw() as f32));
+                            let locator = Locator::root();
+                            let region = Region::new(
+                                Size::new(Abs::inf(), Abs::inf()),
+                                Axes::splat(false),
+                            );
+                            let mut inner_frame = crate::layout_frame(
+                                engine, &val, locator, styles, region,
+                            )?;
+
+                            let anchor_shift = match chunk.anchor() {
+                                TextAnchor::Start => 0.0,
+                                TextAnchor::Middle => {
+                                    -(inner_frame.size().x.to_raw() / 2.0) as f32
+                                }
+                                TextAnchor::End => -inner_frame.size().x.to_raw() as f32,
+                            };
+
+                            let baseline = inner_frame.baseline();
+                            let mut text_frame = GroupItem::new(inner_frame);
+
+                            // Calculate how much the text is rotated.
+                            let rotation = -t
+                                .abs_transform()
+                                .kx
+                                .atan2(t.abs_transform().sx)
+                                .to_degrees();
+
+                            // Put everything together!
+                            let transform =
+                                // Shift text to actual position.
+                                Transform::from_translate(x, y)
+                                    // Apply rotation to the text.
+                                    .pre_concat(Transform::from_rotate(rotation))
+                                    // Account for the `text-anchor` property in SVG.
+                                    .pre_concat(Transform::from_translate(anchor_shift, 0.0))
+                                    // Shift baseline, since Typst text is placed on the top side,
+                                    // while SVG text is placed on the bottom side.
+                                    .pre_concat(Transform::from_translate(0.0, baseline.neg().to_raw() as f32));
 
                             text_frame.transform = transform.into();
-                            parent_frame.push(Point::zero(), FrameItem::Group(text_frame));
+                            parent_frame
+                                .push(Point::zero(), FrameItem::Group(text_frame));
                         }
-                    },
+                    }
                     _ => {}
                 }
             }
@@ -162,14 +230,26 @@ pub fn layout_image(
         }
 
         clip = true;
-        traverse(svg, svg.tree().root(), fitted, engine, span, styles, &mut frame)?;
+
+        if elem.eval(styles) {
+            eval_text_nodes(
+                svg,
+                svg.tree().root(),
+                fitted,
+                engine,
+                span,
+                styles,
+                &mut frame,
+            )?;
+        }
     }
     frame.resize(target, Axes::splat(FixedAlignment::Center));
 
+    // Create a clipping group if only part of the image should be visible,
+    // or if the SVG is evaluated, in which overlaid text might exceed the
+    // bounding box.
     clip |= fit == ImageFit::Cover && !target.fits(fitted);
-
-    // Create a clipping group if only part of the image should be visible.
-    if (clip)  {
+    if clip {
         frame.clip(Path::rect(frame.size()));
     }
 

--- a/crates/typst-library/src/layout/transform.rs
+++ b/crates/typst-library/src/layout/transform.rs
@@ -297,7 +297,6 @@ impl From<usvg::Transform> for Transform {
     }
 }
 
-
 impl Transform {
     /// The identity transformation.
     pub const fn identity() -> Self {

--- a/crates/typst-library/src/layout/transform.rs
+++ b/crates/typst-library/src/layout/transform.rs
@@ -284,6 +284,20 @@ pub struct Transform {
     pub ty: Abs,
 }
 
+impl From<usvg::Transform> for Transform {
+    fn from(value: usvg::Transform) -> Self {
+        Self {
+            sx: Ratio::new(value.sx as f64),
+            ky: Ratio::new(value.ky as f64),
+            kx: Ratio::new(value.kx as f64),
+            sy: Ratio::new(value.sy as f64),
+            tx: Abs::raw(value.tx as f64),
+            ty: Abs::raw(value.ty as f64),
+        }
+    }
+}
+
+
 impl Transform {
     /// The identity transformation.
     pub const fn identity() -> Self {

--- a/crates/typst-library/src/visualize/image/mod.rs
+++ b/crates/typst-library/src/visualize/image/mod.rs
@@ -97,7 +97,7 @@ pub struct ImageElem {
 
     /// TODO: Add docs
     #[default(false)]
-    pub eval: bool
+    pub eval: bool,
 }
 
 #[scope]

--- a/crates/typst-library/src/visualize/image/mod.rs
+++ b/crates/typst-library/src/visualize/image/mod.rs
@@ -94,6 +94,10 @@ pub struct ImageElem {
     /// ```
     #[default(ImageFit::Cover)]
     pub fit: ImageFit,
+
+    /// TODO: Add docs
+    #[default(false)]
+    pub eval: bool
 }
 
 #[scope]
@@ -245,6 +249,7 @@ impl Image {
         format: ImageFormat,
         alt: Option<EcoString>,
         world: Tracked<dyn World + '_>,
+        eval: bool,
         families: &[&str],
     ) -> StrResult<Image> {
         let kind = match format {
@@ -252,7 +257,7 @@ impl Image {
                 ImageKind::Raster(RasterImage::new(data, format)?)
             }
             ImageFormat::Vector(VectorFormat::Svg) => {
-                ImageKind::Svg(SvgImage::with_fonts(data, world, families)?)
+                ImageKind::Svg(SvgImage::with_fonts(data, world, eval, families)?)
             }
         };
 

--- a/crates/typst-library/src/visualize/image/svg.rs
+++ b/crates/typst-library/src/visualize/image/svg.rs
@@ -48,7 +48,7 @@ impl SvgImage {
         let resolver = Mutex::new(FontResolver::new(world, book, families));
         let stylesheet = if eval {
             Some("text { visibility: hidden !important }".to_string())
-        }   else {
+        } else {
             None
         };
 

--- a/crates/typst-library/src/visualize/image/svg.rs
+++ b/crates/typst-library/src/visualize/image/svg.rs
@@ -23,6 +23,7 @@ struct Repr {
     data: Bytes,
     size: Axes<f64>,
     font_hash: u128,
+
     tree: usvg::Tree,
 }
 
@@ -40,10 +41,17 @@ impl SvgImage {
     pub fn with_fonts(
         data: Bytes,
         world: Tracked<dyn World + '_>,
+        eval: bool,
         families: &[&str],
     ) -> StrResult<SvgImage> {
         let book = world.book();
         let resolver = Mutex::new(FontResolver::new(world, book, families));
+        let stylesheet = if eval {
+            Some("text { visibility: hidden !important }".to_string())
+        }   else {
+            None
+        };
+
         let tree = usvg::Tree::from_data(
             &data,
             &usvg::Options {
@@ -55,6 +63,7 @@ impl SvgImage {
                         resolver.lock().unwrap().select_fallback(c, exclude_fonts, db)
                     }),
                 },
+                style_sheet: stylesheet,
                 ..base_options()
             },
         )


### PR DESCRIPTION
Fixes https://github.com/typst/typst/issues/1417.

If we decide that we want this, I will add documentation to the `eval` property and also add a test case.

Here is an example:
```svg
#set page(width: auto, height: auto)
#set text(font: "Noto Sans", size: 17pt)

#image("im1.svg", width: 300pt, eval: true)

#set text(font: "Noto Sans", size: 11pt)
#image("im2.svg", eval: true)
#[
    #set text(size: 8pt, fill: gradient.linear(..color.map.rainbow))
    #image("im2.svg", width: 300pt, eval: true)
]
#image("im3.svg", eval: true)

#set text(fill: green)
#image("im4.svg", eval: true)

```

Output:
![typst](https://github.com/user-attachments/assets/87f03c88-5dd7-41e3-aa43-24ebd943ac98)

