### PR TITLE
Various IDE improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3303,9 +3303,9 @@ checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wasmi"
-version = "0.38.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07e84e3bcdab2f4301827623260ada2557596ca462f7470b60f5182a25270b1"
+checksum = "fc7a1acc721dd73e4fff2dc3796cc3efda6e008369e859a20fdbe058bddeebc3"
 dependencies = [
  "arrayvec",
  "multi-stash",
@@ -3319,32 +3319,28 @@ dependencies = [
 
 [[package]]
 name = "wasmi_collections"
-version = "0.38.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0fd5f4f2c4fe0c98554bb7293108ed2b1d0c124dce0974f999de7d517d37bc"
+checksum = "142fda775f9cda587681ff0ec63c7a7e5679dc95da75f3f9b7e3979ce3506a5b"
 dependencies = [
- "ahash",
- "hashbrown 0.14.5",
  "string-interner",
 ]
 
 [[package]]
 name = "wasmi_core"
-version = "0.38.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a5f7bbd933a0fb3bac6c541f8bd90c0c8adcd91bb3ac088a2088995325b3d9"
+checksum = "281a49ca3c12c8efa052cb67758454fc861d80ab5a03def352e04eb08c20beb2"
 dependencies = [
  "downcast-rs",
  "libm",
- "num-traits",
- "paste",
 ]
 
 [[package]]
 name = "wasmi_ir"
-version = "0.38.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3345445247388df2b5b35250a30c9209c27c8d2c6db1bf4c89b65636264bf9"
+checksum = "6bbadcf529808086a74bacd3ce8aedece444a847292198a56dcde920d1fb213c"
 dependencies = [
  "wasmi_core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2780,6 +2780,7 @@ dependencies = [
  "ecow",
  "if_chain",
  "once_cell",
+ "pathdiff",
  "serde",
  "typst",
  "typst-assets",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ unscanny = "0.1"
 ureq = { version = "2", default-features = false, features = ["native-tls", "gzip", "json"] }
 usvg = { version = "0.43", default-features = false, features = ["text"] }
 walkdir = "2"
-wasmi = "0.38.0"
+wasmi = "0.39.0"
 xmlparser = "0.13.5"
 xmlwriter = "0.1.0"
 xmp-writer = "0.3"

--- a/crates/typst-eval/src/import.rs
+++ b/crates/typst-eval/src/import.rs
@@ -3,6 +3,7 @@ use ecow::{eco_format, eco_vec, EcoString};
 use typst_library::diag::{
     bail, error, warning, At, FileError, SourceResult, Trace, Tracepoint,
 };
+use typst_library::engine::Engine;
 use typst_library::foundations::{Content, Module, Value};
 use typst_library::World;
 use typst_syntax::ast::{self, AstNode};
@@ -28,8 +29,16 @@ impl Eval for ast::ModuleImport<'_> {
                 }
             }
             Value::Type(_) => {}
-            other => {
-                source = Value::Module(import(vm, other.clone(), source_span, true)?);
+            Value::Module(_) => {}
+            Value::Str(path) => {
+                source = Value::Module(import(&mut vm.engine, path, source_span)?);
+            }
+            v => {
+                bail!(
+                    source_span,
+                    "expected path, module, function, or type, found {}",
+                    v.ty()
+                )
             }
         }
 
@@ -139,43 +148,34 @@ impl Eval for ast::ModuleInclude<'_> {
     fn eval(self, vm: &mut Vm) -> SourceResult<Self::Output> {
         let span = self.source().span();
         let source = self.source().eval(vm)?;
-        let module = import(vm, source, span, false)?;
+        let module = match source {
+            Value::Str(path) => import(&mut vm.engine, &path, span)?,
+            Value::Module(module) => module,
+            v => bail!(span, "expected path or module, found {}", v.ty()),
+        };
         Ok(module.content())
     }
 }
 
-/// Process an import of a module relative to the current location.
-pub fn import(
-    vm: &mut Vm,
-    source: Value,
-    span: Span,
-    allow_scopes: bool,
-) -> SourceResult<Module> {
-    let path = match source {
-        Value::Str(path) => path,
-        Value::Module(module) => return Ok(module),
-        v if allow_scopes => {
-            bail!(span, "expected path, module, function, or type, found {}", v.ty())
-        }
-        v => bail!(span, "expected path or module, found {}", v.ty()),
-    };
-
-    // Handle package and file imports.
-    let path = path.as_str();
-    if path.starts_with('@') {
-        let spec = path.parse::<PackageSpec>().at(span)?;
-        import_package(vm, spec, span)
+/// Process an import of a package or file relative to the current location.
+pub fn import(engine: &mut Engine, from: &str, span: Span) -> SourceResult<Module> {
+    if from.starts_with('@') {
+        let spec = from.parse::<PackageSpec>().at(span)?;
+        import_package(engine, spec, span)
     } else {
-        import_file(vm, path, span)
+        import_file(engine, from, span)
     }
 }
 
 /// Import an external package.
-fn import_package(vm: &mut Vm, spec: PackageSpec, span: Span) -> SourceResult<Module> {
+fn import_package(
+    engine: &mut Engine,
+    spec: PackageSpec,
+    span: Span,
+) -> SourceResult<Module> {
     // Evaluate the manifest.
-    let world = vm.world();
     let manifest_id = FileId::new(Some(spec.clone()), VirtualPath::new("typst.toml"));
-    let bytes = world.file(manifest_id).at(span)?;
+    let bytes = engine.world.file(manifest_id).at(span)?;
     let string = std::str::from_utf8(&bytes).map_err(FileError::from).at(span)?;
     let manifest: PackageManifest = toml::from_str(string)
         .map_err(|err| eco_format!("package manifest is malformed ({})", err.message()))
@@ -184,47 +184,47 @@ fn import_package(vm: &mut Vm, spec: PackageSpec, span: Span) -> SourceResult<Mo
 
     // Evaluate the entry point.
     let entrypoint_id = manifest_id.join(&manifest.package.entrypoint);
-    let source = world.source(entrypoint_id).at(span)?;
+    let source = engine.world.source(entrypoint_id).at(span)?;
 
     // Prevent cyclic importing.
-    if vm.engine.route.contains(source.id()) {
+    if engine.route.contains(source.id()) {
         bail!(span, "cyclic import");
     }
 
     let point = || Tracepoint::Import;
     Ok(eval(
-        vm.engine.routines,
-        vm.engine.world,
-        vm.engine.traced,
-        TrackedMut::reborrow_mut(&mut vm.engine.sink),
-        vm.engine.route.track(),
+        engine.routines,
+        engine.world,
+        engine.traced,
+        TrackedMut::reborrow_mut(&mut engine.sink),
+        engine.route.track(),
         &source,
     )
-    .trace(world, point, span)?
+    .trace(engine.world, point, span)?
     .with_name(manifest.package.name))
 }
 
-/// Import a file from a path.
-fn import_file(vm: &mut Vm, path: &str, span: Span) -> SourceResult<Module> {
+/// Import a file from a path. The path is resolved relative to the given
+/// `span`.
+fn import_file(engine: &mut Engine, path: &str, span: Span) -> SourceResult<Module> {
     // Load the source file.
-    let world = vm.world();
     let id = span.resolve_path(path).at(span)?;
-    let source = world.source(id).at(span)?;
+    let source = engine.world.source(id).at(span)?;
 
     // Prevent cyclic importing.
-    if vm.engine.route.contains(source.id()) {
+    if engine.route.contains(source.id()) {
         bail!(span, "cyclic import");
     }
 
     // Evaluate the file.
     let point = || Tracepoint::Import;
     eval(
-        vm.engine.routines,
-        vm.engine.world,
-        vm.engine.traced,
-        TrackedMut::reborrow_mut(&mut vm.engine.sink),
-        vm.engine.route.track(),
+        engine.routines,
+        engine.world,
+        engine.traced,
+        TrackedMut::reborrow_mut(&mut engine.sink),
+        engine.route.track(),
         &source,
     )
-    .trace(world, point, span)
+    .trace(engine.world, point, span)
 }

--- a/crates/typst-ide/Cargo.toml
+++ b/crates/typst-ide/Cargo.toml
@@ -18,6 +18,7 @@ typst-eval = { workspace = true }
 comemo = { workspace = true }
 ecow = { workspace = true }
 if_chain = { workspace = true }
+pathdiff = { workspace = true }
 serde = { workspace = true }
 unscanny = { workspace = true }
 

--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -15,12 +15,11 @@ use typst::syntax::{
 };
 use typst::text::RawElem;
 use typst::visualize::Color;
-use typst::World;
 use unscanny::Scanner;
 
 use crate::{
     analyze_expr, analyze_import, analyze_labels, named_items, plain_docs_sentence,
-    summarize_font_family,
+    summarize_font_family, IdeWorld,
 };
 
 /// Autocomplete a cursor position in a source file.
@@ -35,7 +34,7 @@ use crate::{
 /// the autocompletions. Label completions, for instance, are only generated
 /// when the document is available.
 pub fn autocomplete(
-    world: &dyn World,
+    world: &dyn IdeWorld,
     document: Option<&Document>,
     source: &Source,
     cursor: usize,
@@ -1023,7 +1022,7 @@ fn code_completions(ctx: &mut CompletionContext, hash: bool) {
 
 /// Context for autocompletion.
 struct CompletionContext<'a> {
-    world: &'a (dyn World + 'a),
+    world: &'a (dyn IdeWorld + 'a),
     document: Option<&'a Document>,
     global: &'a Scope,
     math: &'a Scope,
@@ -1042,6 +1041,7 @@ impl<'a> CompletionContext<'a> {
     /// Create a new autocompletion context.
     fn new(
         world: &'a (dyn World + 'a),
+        world: &'a (dyn IdeWorld + 'a),
         document: Option<&'a Document>,
         source: &'a Source,
         leaf: &'a LinkedNode<'a>,

--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -19,10 +19,8 @@ use typst::text::RawElem;
 use typst::visualize::Color;
 use unscanny::Scanner;
 
-use crate::{
-    analyze_expr, analyze_import, analyze_labels, named_items, plain_docs_sentence,
-    summarize_font_family, IdeWorld,
-};
+use crate::utils::{plain_docs_sentence, summarize_font_family};
+use crate::{analyze_expr, analyze_import, analyze_labels, named_items, IdeWorld};
 
 /// Autocomplete a cursor position in a source file.
 ///

--- a/crates/typst-ide/src/definition.rs
+++ b/crates/typst-ide/src/definition.rs
@@ -3,9 +3,10 @@ use typst::foundations::{Label, Module, Selector, Value};
 use typst::model::Document;
 use typst::syntax::ast::AstNode;
 use typst::syntax::{ast, LinkedNode, Side, Source, Span, SyntaxKind};
-use typst::World;
 
-use crate::{analyze_import, deref_target, named_items, DerefTarget, NamedItem};
+use crate::{
+    analyze_import, deref_target, named_items, DerefTarget, IdeWorld, NamedItem,
+};
 
 /// Find the definition of the item under the cursor.
 ///
@@ -13,7 +14,7 @@ use crate::{analyze_import, deref_target, named_items, DerefTarget, NamedItem};
 /// the definition search. Label definitions, for instance, are only generated
 /// when the document is available.
 pub fn definition(
-    world: &dyn World,
+    world: &dyn IdeWorld,
     document: Option<&Document>,
     source: &Source,
     cursor: usize,

--- a/crates/typst-ide/src/jump.rs
+++ b/crates/typst-ide/src/jump.rs
@@ -4,7 +4,8 @@ use typst::layout::{Frame, FrameItem, Point, Position, Size};
 use typst::model::{Destination, Document, Url};
 use typst::syntax::{FileId, LinkedNode, Side, Source, Span, SyntaxKind};
 use typst::visualize::Geometry;
-use typst::World;
+
+use crate::IdeWorld;
 
 /// Where to [jump](jump_from_click) to.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -18,7 +19,7 @@ pub enum Jump {
 }
 
 impl Jump {
-    fn from_span(world: &dyn World, span: Span) -> Option<Self> {
+    fn from_span(world: &dyn IdeWorld, span: Span) -> Option<Self> {
         let id = span.id()?;
         let source = world.source(id).ok()?;
         let node = source.find(span)?;
@@ -28,7 +29,7 @@ impl Jump {
 
 /// Determine where to jump to based on a click in a frame.
 pub fn jump_from_click(
-    world: &dyn World,
+    world: &dyn IdeWorld,
     document: &Document,
     frame: &Frame,
     click: Point,

--- a/crates/typst-ide/src/jump.rs
+++ b/crates/typst-ide/src/jump.rs
@@ -4,14 +4,15 @@ use typst::layout::{Frame, FrameItem, Point, Position, Size};
 use typst::model::{Destination, Document, Url};
 use typst::syntax::{FileId, LinkedNode, Side, Source, Span, SyntaxKind};
 use typst::visualize::Geometry;
+use typst::WorldExt;
 
 use crate::IdeWorld;
 
 /// Where to [jump](jump_from_click) to.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Jump {
-    /// Jump to a position in a source file.
-    Source(FileId, usize),
+    /// Jump to a position in a file.
+    File(FileId, usize),
     /// Jump to an external URL.
     Url(Url),
     /// Jump to a point on a page.
@@ -21,9 +22,8 @@ pub enum Jump {
 impl Jump {
     fn from_span(world: &dyn IdeWorld, span: Span) -> Option<Self> {
         let id = span.id()?;
-        let source = world.source(id).ok()?;
-        let node = source.find(span)?;
-        Some(Self::Source(id, node.offset()))
+        let offset = world.range(span)?.start;
+        Some(Self::File(id, offset))
     }
 }
 
@@ -83,7 +83,7 @@ pub fn jump_from_click(
                         } else {
                             node.offset()
                         };
-                        return Some(Jump::Source(source.id(), pos));
+                        return Some(Jump::File(source.id(), pos));
                     }
 
                     pos.x += width;
@@ -194,7 +194,7 @@ mod tests {
     }
 
     fn cursor(cursor: usize) -> Option<Jump> {
-        Some(Jump::Source(TestWorld::main_id(), cursor))
+        Some(Jump::File(TestWorld::main_id(), cursor))
     }
 
     fn pos(page: usize, x: f64, y: f64) -> Option<Position> {

--- a/crates/typst-ide/src/lib.rs
+++ b/crates/typst-ide/src/lib.rs
@@ -10,7 +10,7 @@ mod utils;
 
 pub use self::analyze::{analyze_expr, analyze_import, analyze_labels};
 pub use self::complete::{autocomplete, Completion, CompletionKind};
-pub use self::definition::{definition, Definition, DefinitionKind};
+pub use self::definition::{definition, Definition};
 pub use self::jump::{jump_from_click, jump_from_cursor, Jump};
 pub use self::matchers::{deref_target, named_items, DerefTarget, NamedItem};
 pub use self::tooltip::{tooltip, Tooltip};

--- a/crates/typst-ide/src/lib.rs
+++ b/crates/typst-ide/src/lib.rs
@@ -100,7 +100,7 @@ mod tests {
     use typst::diag::{FileError, FileResult};
     use typst::foundations::{Bytes, Datetime, Smart};
     use typst::layout::{Abs, Margin, PageElem};
-    use typst::syntax::{FileId, Source};
+    use typst::syntax::{FileId, Source, VirtualPath};
     use typst::text::{Font, FontBook, TextElem, TextSize};
     use typst::utils::{singleton, LazyHash};
     use typst::{Library, World};
@@ -117,7 +117,7 @@ mod tests {
         /// This is cheap because the shared base for all test runs is lazily
         /// initialized just once.
         pub fn new(text: &str) -> Self {
-            let main = Source::detached(text);
+            let main = Source::new(Self::main_id(), text.into());
             Self {
                 main,
                 base: singleton!(TestBase, TestBase::default()),
@@ -126,7 +126,7 @@ mod tests {
 
         /// The ID of the main file in a `TestWorld`.
         pub fn main_id() -> FileId {
-            *singleton!(FileId, Source::detached("").id())
+            *singleton!(FileId, FileId::new(None, VirtualPath::new("main.typ")))
         }
     }
 

--- a/crates/typst-ide/src/lib.rs
+++ b/crates/typst-ide/src/lib.rs
@@ -6,6 +6,7 @@ mod definition;
 mod jump;
 mod matchers;
 mod tooltip;
+mod utils;
 
 pub use self::analyze::{analyze_expr, analyze_import, analyze_labels};
 pub use self::complete::{autocomplete, Completion, CompletionKind};
@@ -14,20 +15,17 @@ pub use self::jump::{jump_from_click, jump_from_cursor, Jump};
 pub use self::matchers::{deref_target, named_items, DerefTarget, NamedItem};
 pub use self::tooltip::{tooltip, Tooltip};
 
-use std::fmt::Write;
-
-use ecow::{eco_format, EcoString};
+use ecow::EcoString;
 use typst::syntax::package::PackageSpec;
 use typst::syntax::FileId;
-use typst::text::{FontInfo, FontStyle};
 use typst::World;
 
 /// Extends the `World` for IDE functionality.
 pub trait IdeWorld: World {
-    /// Turn into a normal [`World`].
+    /// Turn this into a normal [`World`].
     ///
     /// This is necessary because trait upcasting is experimental in Rust.
-    /// See: https://github.com/rust-lang/rust/issues/65991
+    /// See <https://github.com/rust-lang/rust/issues/65991>.
     ///
     /// Implementors can simply return `self`.
     fn upcast(&self) -> &dyn World;
@@ -51,266 +49,5 @@ pub trait IdeWorld: World {
     }
 }
 
-/// Extract the first sentence of plain text of a piece of documentation.
-///
-/// Removes Markdown formatting.
-fn plain_docs_sentence(docs: &str) -> EcoString {
-    let mut s = unscanny::Scanner::new(docs);
-    let mut output = EcoString::new();
-    let mut link = false;
-    while let Some(c) = s.eat() {
-        match c {
-            '`' => {
-                let mut raw = s.eat_until('`');
-                if (raw.starts_with('{') && raw.ends_with('}'))
-                    || (raw.starts_with('[') && raw.ends_with(']'))
-                {
-                    raw = &raw[1..raw.len() - 1];
-                }
-
-                s.eat();
-                output.push('`');
-                output.push_str(raw);
-                output.push('`');
-            }
-            '[' => link = true,
-            ']' if link => {
-                if s.eat_if('(') {
-                    s.eat_until(')');
-                    s.eat();
-                } else if s.eat_if('[') {
-                    s.eat_until(']');
-                    s.eat();
-                }
-                link = false
-            }
-            '*' | '_' => {}
-            '.' => {
-                output.push('.');
-                break;
-            }
-            _ => output.push(c),
-        }
-    }
-
-    output
-}
-
-/// Create a short description of a font family.
-fn summarize_font_family<'a>(variants: impl Iterator<Item = &'a FontInfo>) -> EcoString {
-    let mut infos: Vec<_> = variants.collect();
-    infos.sort_by_key(|info| info.variant);
-
-    let mut has_italic = false;
-    let mut min_weight = u16::MAX;
-    let mut max_weight = 0;
-    for info in &infos {
-        let weight = info.variant.weight.to_number();
-        has_italic |= info.variant.style == FontStyle::Italic;
-        min_weight = min_weight.min(weight);
-        max_weight = min_weight.max(weight);
-    }
-
-    let count = infos.len();
-    let mut detail = eco_format!("{count} variant{}.", if count == 1 { "" } else { "s" });
-
-    if min_weight == max_weight {
-        write!(detail, " Weight {min_weight}.").unwrap();
-    } else {
-        write!(detail, " Weights {min_weight}–{max_weight}.").unwrap();
-    }
-
-    if has_italic {
-        detail.push_str(" Has italics.");
-    }
-
-    detail
-}
-
 #[cfg(test)]
-mod tests {
-    use std::collections::HashMap;
-
-    use ecow::EcoString;
-    use typst::diag::{FileError, FileResult};
-    use typst::foundations::{Bytes, Datetime, Smart};
-    use typst::layout::{Abs, Margin, PageElem};
-    use typst::syntax::package::{PackageSpec, PackageVersion};
-    use typst::syntax::{FileId, Source, VirtualPath};
-    use typst::text::{Font, FontBook, TextElem, TextSize};
-    use typst::utils::{singleton, LazyHash};
-    use typst::{Library, World};
-
-    use crate::IdeWorld;
-
-    /// A world for IDE testing.
-    pub struct TestWorld {
-        pub main: Source,
-        assets: HashMap<FileId, Bytes>,
-        sources: HashMap<FileId, Source>,
-        base: &'static TestBase,
-    }
-
-    impl TestWorld {
-        /// Create a new world for a single test.
-        ///
-        /// This is cheap because the shared base for all test runs is lazily
-        /// initialized just once.
-        pub fn new(text: &str) -> Self {
-            let main = Source::new(Self::main_id(), text.into());
-            Self {
-                main,
-                assets: HashMap::new(),
-                sources: HashMap::new(),
-                base: singleton!(TestBase, TestBase::default()),
-            }
-        }
-
-        /// Add an additional source file to the test world.
-        pub fn with_source(mut self, path: &str, text: &str) -> Self {
-            let id = FileId::new(None, VirtualPath::new(path));
-            let source = Source::new(id, text.into());
-            self.sources.insert(id, source);
-            self
-        }
-
-        /// Add an additional asset file to the test world.
-        #[track_caller]
-        pub fn with_asset(self, filename: &str) -> Self {
-            self.with_asset_at(filename, filename)
-        }
-
-        /// Add an additional asset file to the test world.
-        #[track_caller]
-        pub fn with_asset_at(mut self, path: &str, filename: &str) -> Self {
-            let id = FileId::new(None, VirtualPath::new(path));
-            let data = typst_dev_assets::get_by_name(filename).unwrap();
-            let bytes = Bytes::from_static(data);
-            self.assets.insert(id, bytes);
-            self
-        }
-
-        /// The ID of the main file in a `TestWorld`.
-        pub fn main_id() -> FileId {
-            *singleton!(FileId, FileId::new(None, VirtualPath::new("main.typ")))
-        }
-    }
-
-    impl World for TestWorld {
-        fn library(&self) -> &LazyHash<Library> {
-            &self.base.library
-        }
-
-        fn book(&self) -> &LazyHash<FontBook> {
-            &self.base.book
-        }
-
-        fn main(&self) -> FileId {
-            self.main.id()
-        }
-
-        fn source(&self, id: FileId) -> FileResult<Source> {
-            if id == self.main.id() {
-                Ok(self.main.clone())
-            } else if let Some(source) = self.sources.get(&id) {
-                Ok(source.clone())
-            } else {
-                Err(FileError::NotFound(id.vpath().as_rootless_path().into()))
-            }
-        }
-
-        fn file(&self, id: FileId) -> FileResult<Bytes> {
-            match self.assets.get(&id) {
-                Some(bytes) => Ok(bytes.clone()),
-                None => Err(FileError::NotFound(id.vpath().as_rootless_path().into())),
-            }
-        }
-
-        fn font(&self, index: usize) -> Option<Font> {
-            Some(self.base.fonts[index].clone())
-        }
-
-        fn today(&self, _: Option<i64>) -> Option<Datetime> {
-            None
-        }
-    }
-
-    impl IdeWorld for TestWorld {
-        fn upcast(&self) -> &dyn World {
-            self
-        }
-
-        fn files(&self) -> Vec<FileId> {
-            std::iter::once(self.main.id())
-                .chain(self.sources.keys().copied())
-                .chain(self.assets.keys().copied())
-                .collect()
-        }
-
-        fn packages(&self) -> &[(PackageSpec, Option<EcoString>)] {
-            const LIST: &[(PackageSpec, Option<EcoString>)] = &[(
-                PackageSpec {
-                    namespace: EcoString::inline("preview"),
-                    name: EcoString::inline("example"),
-                    version: PackageVersion { major: 0, minor: 1, patch: 0 },
-                },
-                None,
-            )];
-            LIST
-        }
-    }
-
-    /// Extra methods for [`Source`].
-    pub trait SourceExt {
-        /// Negative cursors index from the back.
-        fn cursor(&self, cursor: isize) -> usize;
-    }
-
-    impl SourceExt for Source {
-        fn cursor(&self, cursor: isize) -> usize {
-            if cursor < 0 {
-                self.len_bytes().checked_add_signed(cursor).unwrap()
-            } else {
-                cursor as usize
-            }
-        }
-    }
-
-    /// Shared foundation of all test worlds.
-    struct TestBase {
-        library: LazyHash<Library>,
-        book: LazyHash<FontBook>,
-        fonts: Vec<Font>,
-    }
-
-    impl Default for TestBase {
-        fn default() -> Self {
-            let fonts: Vec<_> = typst_assets::fonts()
-                .chain(typst_dev_assets::fonts())
-                .flat_map(|data| Font::iter(Bytes::from_static(data)))
-                .collect();
-
-            Self {
-                library: LazyHash::new(library()),
-                book: LazyHash::new(FontBook::from_fonts(&fonts)),
-                fonts,
-            }
-        }
-    }
-
-    /// The extended standard library for testing.
-    fn library() -> Library {
-        // Set page width to 120pt with 10pt margins, so that the inner page is
-        // exactly 100pt wide. Page height is unbounded and font size is 10pt so
-        // that it multiplies to nice round numbers.
-        let mut lib = typst::Library::default();
-        lib.styles
-            .set(PageElem::set_width(Smart::Custom(Abs::pt(120.0).into())));
-        lib.styles.set(PageElem::set_height(Smart::Auto));
-        lib.styles.set(PageElem::set_margin(Margin::splat(Some(Smart::Custom(
-            Abs::pt(10.0).into(),
-        )))));
-        lib.styles.set(TextElem::set_size(TextSize(Abs::pt(10.0).into())));
-        lib
-    }
-}
+mod tests;

--- a/crates/typst-ide/src/lib.rs
+++ b/crates/typst-ide/src/lib.rs
@@ -17,7 +17,30 @@ pub use self::tooltip::{tooltip, Tooltip};
 use std::fmt::Write;
 
 use ecow::{eco_format, EcoString};
+use typst::syntax::package::PackageSpec;
 use typst::text::{FontInfo, FontStyle};
+use typst::World;
+
+/// Extends the `World` for IDE functionality.
+pub trait IdeWorld: World {
+    /// Turn into a normal [`World`].
+    ///
+    /// This is necessary because trait upcasting is experimental in Rust.
+    /// See: https://github.com/rust-lang/rust/issues/65991
+    ///
+    /// Implementors can simply return `self`.
+    fn upcast(&self) -> &dyn World;
+
+    /// A list of all available packages and optionally descriptions for them.
+    ///
+    /// This function is **optional** to implement. It enhances the user
+    /// experience by enabling autocompletion for packages. Details about
+    /// packages from the `@preview` namespace are available from
+    /// `https://packages.typst.org/preview/index.json`.
+    fn packages(&self) -> &[(PackageSpec, Option<EcoString>)] {
+        &[]
+    }
+}
 
 /// Extract the first sentence of plain text of a piece of documentation.
 ///
@@ -107,6 +130,8 @@ mod tests {
     use typst::utils::{singleton, LazyHash};
     use typst::{Library, World};
 
+    use crate::IdeWorld;
+
     /// A world for IDE testing.
     pub struct TestWorld {
         pub main: Source,
@@ -190,6 +215,12 @@ mod tests {
 
         fn today(&self, _: Option<i64>) -> Option<Datetime> {
             None
+        }
+    }
+
+    impl IdeWorld for TestWorld {
+        fn upcast(&self) -> &dyn World {
+            self
         }
     }
 

--- a/crates/typst-ide/src/matchers.rs
+++ b/crates/typst-ide/src/matchers.rs
@@ -2,13 +2,12 @@ use ecow::EcoString;
 use typst::foundations::{Module, Value};
 use typst::syntax::ast::AstNode;
 use typst::syntax::{ast, LinkedNode, Span, SyntaxKind, SyntaxNode};
-use typst::World;
 
-use crate::analyze_import;
+use crate::{analyze_import, IdeWorld};
 
 /// Find the named items starting from the given position.
 pub fn named_items<T>(
-    world: &dyn World,
+    world: &dyn IdeWorld,
     position: LinkedNode,
     mut recv: impl FnMut(NamedItem) -> Option<T>,
 ) -> Option<T> {

--- a/crates/typst-ide/src/matchers.rs
+++ b/crates/typst-ide/src/matchers.rs
@@ -162,6 +162,14 @@ impl<'a> NamedItem<'a> {
             NamedItem::Import(_, _, value) => value.cloned(),
         }
     }
+
+    pub(crate) fn span(&self) -> Span {
+        match *self {
+            NamedItem::Var(name) | NamedItem::Fn(name) => name.span(),
+            NamedItem::Module(_, site) => site.span(),
+            NamedItem::Import(_, span, _) => span,
+        }
+    }
 }
 
 /// Categorize an expression into common classes IDE functionality can operate
@@ -177,29 +185,29 @@ pub fn deref_target(node: LinkedNode) -> Option<DerefTarget<'_>> {
     let expr_node = ancestor;
     let expr = expr_node.cast::<ast::Expr>()?;
     Some(match expr {
-        ast::Expr::Label(..) => DerefTarget::Label(expr_node),
-        ast::Expr::Ref(..) => DerefTarget::Ref(expr_node),
+        ast::Expr::Label(_) => DerefTarget::Label(expr_node),
+        ast::Expr::Ref(_) => DerefTarget::Ref(expr_node),
         ast::Expr::FuncCall(call) => {
             DerefTarget::Callee(expr_node.find(call.callee().span())?)
         }
         ast::Expr::Set(set) => DerefTarget::Callee(expr_node.find(set.target().span())?),
-        ast::Expr::Ident(..) | ast::Expr::MathIdent(..) | ast::Expr::FieldAccess(..) => {
+        ast::Expr::Ident(_) | ast::Expr::MathIdent(_) | ast::Expr::FieldAccess(_) => {
             DerefTarget::VarAccess(expr_node)
         }
-        ast::Expr::Str(..) => {
+        ast::Expr::Str(_) => {
             let parent = expr_node.parent()?;
             if parent.kind() == SyntaxKind::ModuleImport {
                 DerefTarget::ImportPath(expr_node)
             } else if parent.kind() == SyntaxKind::ModuleInclude {
                 DerefTarget::IncludePath(expr_node)
             } else {
-                DerefTarget::Code(expr_node.kind(), expr_node)
+                DerefTarget::Code(expr_node)
             }
         }
         _ if expr.hash()
             || matches!(expr_node.kind(), SyntaxKind::MathIdent | SyntaxKind::Error) =>
         {
-            DerefTarget::Code(expr_node.kind(), expr_node)
+            DerefTarget::Code(expr_node)
         }
         _ => return None,
     })
@@ -208,10 +216,6 @@ pub fn deref_target(node: LinkedNode) -> Option<DerefTarget<'_>> {
 /// Classes of expressions that can be operated on by IDE functionality.
 #[derive(Debug, Clone)]
 pub enum DerefTarget<'a> {
-    /// A label expression.
-    Label(LinkedNode<'a>),
-    /// A reference expression.
-    Ref(LinkedNode<'a>),
     /// A variable access expression.
     ///
     /// It can be either an identifier or a field access.
@@ -223,7 +227,11 @@ pub enum DerefTarget<'a> {
     /// An include path expression.
     IncludePath(LinkedNode<'a>),
     /// Any code expression.
-    Code(SyntaxKind, LinkedNode<'a>),
+    Code(LinkedNode<'a>),
+    /// A label expression.
+    Label(LinkedNode<'a>),
+    /// A reference expression.
+    Ref(LinkedNode<'a>),
 }
 
 #[cfg(test)]

--- a/crates/typst-ide/src/tests.rs
+++ b/crates/typst-ide/src/tests.rs
@@ -1,0 +1,184 @@
+use std::collections::HashMap;
+
+use ecow::EcoString;
+use typst::diag::{FileError, FileResult};
+use typst::foundations::{Bytes, Datetime, Smart};
+use typst::layout::{Abs, Margin, PageElem};
+use typst::syntax::package::{PackageSpec, PackageVersion};
+use typst::syntax::{FileId, Source, VirtualPath};
+use typst::text::{Font, FontBook, TextElem, TextSize};
+use typst::utils::{singleton, LazyHash};
+use typst::{Library, World};
+
+use crate::IdeWorld;
+
+/// A world for IDE testing.
+pub struct TestWorld {
+    pub main: Source,
+    assets: HashMap<FileId, Bytes>,
+    sources: HashMap<FileId, Source>,
+    base: &'static TestBase,
+}
+
+impl TestWorld {
+    /// Create a new world for a single test.
+    ///
+    /// This is cheap because the shared base for all test runs is lazily
+    /// initialized just once.
+    pub fn new(text: &str) -> Self {
+        let main = Source::new(Self::main_id(), text.into());
+        Self {
+            main,
+            assets: HashMap::new(),
+            sources: HashMap::new(),
+            base: singleton!(TestBase, TestBase::default()),
+        }
+    }
+
+    /// Add an additional source file to the test world.
+    pub fn with_source(mut self, path: &str, text: &str) -> Self {
+        let id = FileId::new(None, VirtualPath::new(path));
+        let source = Source::new(id, text.into());
+        self.sources.insert(id, source);
+        self
+    }
+
+    /// Add an additional asset file to the test world.
+    #[track_caller]
+    pub fn with_asset(self, filename: &str) -> Self {
+        self.with_asset_at(filename, filename)
+    }
+
+    /// Add an additional asset file to the test world.
+    #[track_caller]
+    pub fn with_asset_at(mut self, path: &str, filename: &str) -> Self {
+        let id = FileId::new(None, VirtualPath::new(path));
+        let data = typst_dev_assets::get_by_name(filename).unwrap();
+        let bytes = Bytes::from_static(data);
+        self.assets.insert(id, bytes);
+        self
+    }
+
+    /// The ID of the main file in a `TestWorld`.
+    pub fn main_id() -> FileId {
+        *singleton!(FileId, FileId::new(None, VirtualPath::new("main.typ")))
+    }
+}
+
+impl World for TestWorld {
+    fn library(&self) -> &LazyHash<Library> {
+        &self.base.library
+    }
+
+    fn book(&self) -> &LazyHash<FontBook> {
+        &self.base.book
+    }
+
+    fn main(&self) -> FileId {
+        self.main.id()
+    }
+
+    fn source(&self, id: FileId) -> FileResult<Source> {
+        if id == self.main.id() {
+            Ok(self.main.clone())
+        } else if let Some(source) = self.sources.get(&id) {
+            Ok(source.clone())
+        } else {
+            Err(FileError::NotFound(id.vpath().as_rootless_path().into()))
+        }
+    }
+
+    fn file(&self, id: FileId) -> FileResult<Bytes> {
+        match self.assets.get(&id) {
+            Some(bytes) => Ok(bytes.clone()),
+            None => Err(FileError::NotFound(id.vpath().as_rootless_path().into())),
+        }
+    }
+
+    fn font(&self, index: usize) -> Option<Font> {
+        Some(self.base.fonts[index].clone())
+    }
+
+    fn today(&self, _: Option<i64>) -> Option<Datetime> {
+        None
+    }
+}
+
+impl IdeWorld for TestWorld {
+    fn upcast(&self) -> &dyn World {
+        self
+    }
+
+    fn files(&self) -> Vec<FileId> {
+        std::iter::once(self.main.id())
+            .chain(self.sources.keys().copied())
+            .chain(self.assets.keys().copied())
+            .collect()
+    }
+
+    fn packages(&self) -> &[(PackageSpec, Option<EcoString>)] {
+        const LIST: &[(PackageSpec, Option<EcoString>)] = &[(
+            PackageSpec {
+                namespace: EcoString::inline("preview"),
+                name: EcoString::inline("example"),
+                version: PackageVersion { major: 0, minor: 1, patch: 0 },
+            },
+            None,
+        )];
+        LIST
+    }
+}
+
+/// Extra methods for [`Source`].
+pub trait SourceExt {
+    /// Negative cursors index from the back.
+    fn cursor(&self, cursor: isize) -> usize;
+}
+
+impl SourceExt for Source {
+    fn cursor(&self, cursor: isize) -> usize {
+        if cursor < 0 {
+            self.len_bytes().checked_add_signed(cursor).unwrap()
+        } else {
+            cursor as usize
+        }
+    }
+}
+
+/// Shared foundation of all test worlds.
+struct TestBase {
+    library: LazyHash<Library>,
+    book: LazyHash<FontBook>,
+    fonts: Vec<Font>,
+}
+
+impl Default for TestBase {
+    fn default() -> Self {
+        let fonts: Vec<_> = typst_assets::fonts()
+            .chain(typst_dev_assets::fonts())
+            .flat_map(|data| Font::iter(Bytes::from_static(data)))
+            .collect();
+
+        Self {
+            library: LazyHash::new(library()),
+            book: LazyHash::new(FontBook::from_fonts(&fonts)),
+            fonts,
+        }
+    }
+}
+
+/// The extended standard library for testing.
+fn library() -> Library {
+    // Set page width to 120pt with 10pt margins, so that the inner page is
+    // exactly 100pt wide. Page height is unbounded and font size is 10pt so
+    // that it multiplies to nice round numbers.
+    let mut lib = typst::Library::default();
+    lib.styles
+        .set(PageElem::set_width(Smart::Custom(Abs::pt(120.0).into())));
+    lib.styles.set(PageElem::set_height(Smart::Auto));
+    lib.styles.set(PageElem::set_margin(Margin::splat(Some(Smart::Custom(
+        Abs::pt(10.0).into(),
+    )))));
+    lib.styles.set(TextElem::set_size(TextSize(Abs::pt(10.0).into())));
+    lib
+}

--- a/crates/typst-ide/src/tooltip.rs
+++ b/crates/typst-ide/src/tooltip.rs
@@ -11,10 +11,8 @@ use typst::syntax::{ast, LinkedNode, Side, Source, SyntaxKind};
 use typst::utils::{round_with_precision, Numeric};
 use typst_eval::CapturesVisitor;
 
-use crate::{
-    analyze_expr, analyze_import, analyze_labels, plain_docs_sentence,
-    summarize_font_family, IdeWorld,
-};
+use crate::utils::{plain_docs_sentence, summarize_font_family};
+use crate::{analyze_expr, analyze_import, analyze_labels, IdeWorld};
 
 /// Describe the item under the cursor.
 ///

--- a/crates/typst-ide/src/utils.rs
+++ b/crates/typst-ide/src/utils.rs
@@ -3,7 +3,9 @@ use std::fmt::Write;
 use comemo::Track;
 use ecow::{eco_format, EcoString};
 use typst::engine::{Engine, Route, Sink, Traced};
+use typst::foundations::Scope;
 use typst::introspection::Introspector;
+use typst::syntax::{LinkedNode, SyntaxKind};
 use typst::text::{FontInfo, FontStyle};
 
 use crate::IdeWorld;
@@ -104,4 +106,22 @@ pub fn summarize_font_family<'a>(
     }
 
     detail
+}
+
+/// The global definitions at the given node.
+pub fn globals<'a>(world: &'a dyn IdeWorld, leaf: &LinkedNode) -> &'a Scope {
+    let in_math = matches!(
+        leaf.parent_kind(),
+        Some(SyntaxKind::Equation)
+            | Some(SyntaxKind::Math)
+            | Some(SyntaxKind::MathFrac)
+            | Some(SyntaxKind::MathAttach)
+    );
+
+    let library = world.library();
+    if in_math {
+        library.math.scope()
+    } else {
+        library.global.scope()
+    }
 }

--- a/crates/typst-ide/src/utils.rs
+++ b/crates/typst-ide/src/utils.rs
@@ -1,0 +1,82 @@
+use std::fmt::Write;
+
+use ecow::{eco_format, EcoString};
+use typst::text::{FontInfo, FontStyle};
+
+/// Extract the first sentence of plain text of a piece of documentation.
+///
+/// Removes Markdown formatting.
+pub fn plain_docs_sentence(docs: &str) -> EcoString {
+    let mut s = unscanny::Scanner::new(docs);
+    let mut output = EcoString::new();
+    let mut link = false;
+    while let Some(c) = s.eat() {
+        match c {
+            '`' => {
+                let mut raw = s.eat_until('`');
+                if (raw.starts_with('{') && raw.ends_with('}'))
+                    || (raw.starts_with('[') && raw.ends_with(']'))
+                {
+                    raw = &raw[1..raw.len() - 1];
+                }
+
+                s.eat();
+                output.push('`');
+                output.push_str(raw);
+                output.push('`');
+            }
+            '[' => link = true,
+            ']' if link => {
+                if s.eat_if('(') {
+                    s.eat_until(')');
+                    s.eat();
+                } else if s.eat_if('[') {
+                    s.eat_until(']');
+                    s.eat();
+                }
+                link = false
+            }
+            '*' | '_' => {}
+            '.' => {
+                output.push('.');
+                break;
+            }
+            _ => output.push(c),
+        }
+    }
+
+    output
+}
+
+/// Create a short description of a font family.
+pub fn summarize_font_family<'a>(
+    variants: impl Iterator<Item = &'a FontInfo>,
+) -> EcoString {
+    let mut infos: Vec<_> = variants.collect();
+    infos.sort_by_key(|info| info.variant);
+
+    let mut has_italic = false;
+    let mut min_weight = u16::MAX;
+    let mut max_weight = 0;
+    for info in &infos {
+        let weight = info.variant.weight.to_number();
+        has_italic |= info.variant.style == FontStyle::Italic;
+        min_weight = min_weight.min(weight);
+        max_weight = min_weight.max(weight);
+    }
+
+    let count = infos.len();
+    let mut detail = eco_format!("{count} variant{}.", if count == 1 { "" } else { "s" });
+
+    if min_weight == max_weight {
+        write!(detail, " Weight {min_weight}.").unwrap();
+    } else {
+        write!(detail, " Weights {min_weight}–{max_weight}.").unwrap();
+    }
+
+    if has_italic {
+        detail.push_str(" Has italics.");
+    }
+
+    detail
+}

--- a/crates/typst-ide/src/utils.rs
+++ b/crates/typst-ide/src/utils.rs
@@ -1,7 +1,32 @@
 use std::fmt::Write;
 
+use comemo::Track;
 use ecow::{eco_format, EcoString};
+use typst::engine::{Engine, Route, Sink, Traced};
+use typst::introspection::Introspector;
 use typst::text::{FontInfo, FontStyle};
+
+use crate::IdeWorld;
+
+/// Create a temporary engine and run a task on it.
+pub fn with_engine<F, T>(world: &dyn IdeWorld, f: F) -> T
+where
+    F: FnOnce(&mut Engine) -> T,
+{
+    let introspector = Introspector::default();
+    let traced = Traced::default();
+    let mut sink = Sink::new();
+    let mut engine = Engine {
+        routines: &typst::ROUTINES,
+        world: world.upcast().track(),
+        introspector: introspector.track(),
+        traced: traced.track(),
+        sink: sink.track_mut(),
+        route: Route::default(),
+    };
+
+    f(&mut engine)
+}
 
 /// Extract the first sentence of plain text of a piece of documentation.
 ///

--- a/crates/typst-ide/src/utils.rs
+++ b/crates/typst-ide/src/utils.rs
@@ -1,9 +1,10 @@
 use std::fmt::Write;
+use std::ops::ControlFlow;
 
 use comemo::Track;
 use ecow::{eco_format, EcoString};
 use typst::engine::{Engine, Route, Sink, Traced};
-use typst::foundations::Scope;
+use typst::foundations::{Scope, Value};
 use typst::introspection::Introspector;
 use typst::syntax::{LinkedNode, SyntaxKind};
 use typst::text::{FontInfo, FontStyle};
@@ -123,5 +124,68 @@ pub fn globals<'a>(world: &'a dyn IdeWorld, leaf: &LinkedNode) -> &'a Scope {
         library.math.scope()
     } else {
         library.global.scope()
+    }
+}
+
+/// Checks whether the given value or any of its constituent parts satisfy the
+/// predicate.
+pub fn check_value_recursively(
+    value: &Value,
+    predicate: impl Fn(&Value) -> bool,
+) -> bool {
+    let mut searcher = Searcher { steps: 0, predicate, max_steps: 1000 };
+    match searcher.find(value) {
+        ControlFlow::Break(matching) => matching,
+        ControlFlow::Continue(_) => false,
+    }
+}
+
+/// Recursively searches for a value that passes the filter, but without
+/// exceeding a maximum number of search steps.
+struct Searcher<F> {
+    max_steps: usize,
+    steps: usize,
+    predicate: F,
+}
+
+impl<F> Searcher<F>
+where
+    F: Fn(&Value) -> bool,
+{
+    fn find(&mut self, value: &Value) -> ControlFlow<bool> {
+        if (self.predicate)(value) {
+            return ControlFlow::Break(true);
+        }
+
+        if self.steps > self.max_steps {
+            return ControlFlow::Break(false);
+        }
+
+        self.steps += 1;
+
+        match value {
+            Value::Dict(dict) => {
+                self.find_iter(dict.iter().map(|(_, v)| v))?;
+            }
+            Value::Content(content) => {
+                self.find_iter(content.fields().iter().map(|(_, v)| v))?;
+            }
+            Value::Module(module) => {
+                self.find_iter(module.scope().iter().map(|(_, v, _)| v))?;
+            }
+            _ => {}
+        }
+
+        ControlFlow::Continue(())
+    }
+
+    fn find_iter<'a>(
+        &mut self,
+        iter: impl Iterator<Item = &'a Value>,
+    ) -> ControlFlow<bool> {
+        for item in iter {
+            self.find(item)?;
+        }
+        ControlFlow::Continue(())
     }
 }

--- a/crates/typst-library/src/lib.rs
+++ b/crates/typst-library/src/lib.rs
@@ -125,13 +125,13 @@ world_impl!(W for &W);
 pub trait WorldExt {
     /// Get the byte range for a span.
     ///
-    /// Returns `None` if the `Span` does not point into any source file.
+    /// Returns `None` if the `Span` does not point into any file.
     fn range(&self, span: Span) -> Option<Range<usize>>;
 }
 
-impl<T: World> WorldExt for T {
+impl<T: World + ?Sized> WorldExt for T {
     fn range(&self, span: Span) -> Option<Range<usize>> {
-        self.source(span.id()?).ok()?.range(span)
+        span.range().or_else(|| self.source(span.id()?).ok()?.range(span))
     }
 }
 

--- a/crates/typst-library/src/lib.rs
+++ b/crates/typst-library/src/lib.rs
@@ -27,8 +27,6 @@ pub mod visualize;
 
 use std::ops::{Deref, Range};
 
-use ecow::EcoString;
-use typst_syntax::package::PackageSpec;
 use typst_syntax::{FileId, Source, Span};
 use typst_utils::{LazyHash, SmallBitSet};
 
@@ -83,16 +81,6 @@ pub trait World: Send + Sync {
     /// If this function returns `None`, Typst's `datetime` function will
     /// return an error.
     fn today(&self, offset: Option<i64>) -> Option<Datetime>;
-
-    /// A list of all available packages and optionally descriptions for them.
-    ///
-    /// This function is optional to implement. It enhances the user experience
-    /// by enabling autocompletion for packages. Details about packages from the
-    /// `@preview` namespace are available from
-    /// `https://packages.typst.org/preview/index.json`.
-    fn packages(&self) -> &[(PackageSpec, Option<EcoString>)] {
-        &[]
-    }
 }
 
 macro_rules! world_impl {
@@ -124,10 +112,6 @@ macro_rules! world_impl {
 
             fn today(&self, offset: Option<i64>) -> Option<Datetime> {
                 self.deref().today(offset)
-            }
-
-            fn packages(&self) -> &[(PackageSpec, Option<EcoString>)] {
-                self.deref().packages()
             }
         }
     };

--- a/crates/typst-syntax/src/node.rs
+++ b/crates/typst-syntax/src/node.rs
@@ -241,7 +241,7 @@ impl SyntaxNode {
             return Err(Unnumberable);
         }
 
-        let mid = Span::new(id, (within.start + within.end) / 2).unwrap();
+        let mid = Span::from_number(id, (within.start + within.end) / 2).unwrap();
         match &mut self.0 {
             Repr::Leaf(leaf) => leaf.span = mid,
             Repr::Inner(inner) => Arc::make_mut(inner).numberize(id, None, within)?,
@@ -457,7 +457,7 @@ impl InnerNode {
         let mut start = within.start;
         if range.is_none() {
             let end = start + stride;
-            self.span = Span::new(id, (start + end) / 2).unwrap();
+            self.span = Span::from_number(id, (start + end) / 2).unwrap();
             self.upper = within.end;
             start = end;
         }

--- a/crates/typst-syntax/src/source.rs
+++ b/crates/typst-syntax/src/source.rs
@@ -166,6 +166,8 @@ impl Source {
     /// Get the byte range for the given span in this file.
     ///
     /// Returns `None` if the span does not point into this source file.
+    ///
+    /// Typically, it's easier to use `WorldExt::range` instead.
     pub fn range(&self, span: Span) -> Option<Range<usize>> {
         Some(self.find(span)?.range())
     }

--- a/crates/typst-syntax/src/span.rs
+++ b/crates/typst-syntax/src/span.rs
@@ -1,21 +1,37 @@
 use std::fmt::{self, Debug, Formatter};
-use std::num::NonZeroU64;
+use std::num::{NonZeroU16, NonZeroU64};
 use std::ops::Range;
 
 use ecow::EcoString;
 
 use crate::FileId;
 
-/// A unique identifier for a syntax node.
+/// Defines a range in a file.
 ///
-/// This is used throughout the compiler to track which source section an error
-/// or element stems from. Can be [mapped back](crate::Source::range) to a byte
-/// range for user facing display.
+/// This is used throughout the compiler to track which source section an
+/// element stems from or an error applies to.
 ///
-/// During editing, the span values stay mostly stable, even for nodes behind an
-/// insertion. This is not true for simple ranges as they would shift. Spans can
-/// be used as inputs to memoized functions without hurting cache performance
-/// when text is inserted somewhere in the document other than the end.
+/// - The [`.id()`](Self::id) function can be used to get the `FileId` for the
+///   span and, by extension, its file system path.
+/// - The `WorldExt::range` function can be used to map the span to a
+///   `Range<usize>`.
+///
+/// This type takes up 8 bytes and is copyable and null-optimized (i.e.
+/// `Option<Span>` also takes 8 bytes).
+///
+/// Spans come in two flavors: Numbered spans and raw range spans. The
+/// `WorldExt::range` function automatically handles both cases, yielding a
+/// `Range<usize>`.
+///
+/// # Numbered spans
+/// Typst source files use _numbered spans._ Rather than using byte ranges,
+/// which shift a lot as you type, each AST node gets a unique number.
+///
+/// During editing, the span numbers stay mostly stable, even for nodes behind
+/// an insertion. This is not true for simple ranges as they would shift. Spans
+/// can be used as inputs to memoized functions without hurting cache
+/// performance when text is inserted somewhere in the document other than the
+/// end.
 ///
 /// Span ids are ordered in the syntax tree to enable quickly finding the node
 /// with some id:
@@ -23,38 +39,37 @@ use crate::FileId;
 /// - The id of a node is always greater than any id in the subtrees of any left
 ///   sibling and smaller than any id in the subtrees of any right sibling.
 ///
-/// This type takes up 8 bytes and is null-optimized (i.e. `Option<Span>` also
-/// takes 8 bytes).
+/// # Raw range spans
+/// Non Typst-files use raw ranges instead of numbered spans. The maximum
+/// encodable value for start and end is 2^23. Larger values will be saturated.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Span(NonZeroU64);
 
 impl Span {
-    /// The full range of numbers available for span numbering.
-    pub(super) const FULL: Range<u64> = 2..(1 << Self::BITS);
+    /// The full range of numbers available for source file span numbering.
+    pub(crate) const FULL: Range<u64> = 2..(1 << 47);
 
     /// The value reserved for the detached span.
     const DETACHED: u64 = 1;
 
     /// Data layout:
-    /// | 16 bits source id | 48 bits number |
-    const BITS: usize = 48;
-
-    /// Create a new span from a source id and a unique number.
+    /// | 16 bits file id | 48 bits number |
     ///
-    /// Returns `None` if `number` is not contained in `FULL`.
-    pub(super) const fn new(id: FileId, number: u64) -> Option<Self> {
-        if number < Self::FULL.start || number >= Self::FULL.end {
-            return None;
-        }
+    /// Number =
+    /// - 1 means detached
+    /// - 2..2^47-1 is a numbered span
+    /// - 2^47..2^48-1 is a raw range span. To retrieve it, you must subtract
+    ///   `RANGE_BASE` and then use shifting/bitmasking to extract the
+    ///   components.
+    const NUMBER_BITS: usize = 48;
+    const FILE_ID_SHIFT: usize = Self::NUMBER_BITS;
+    const NUMBER_MASK: u64 = (1 << Self::NUMBER_BITS) - 1;
+    const RANGE_BASE: u64 = Self::FULL.end;
+    const RANGE_PART_BITS: usize = 23;
+    const RANGE_PART_SHIFT: usize = Self::RANGE_PART_BITS;
+    const RANGE_PART_MASK: u64 = (1 << Self::RANGE_PART_BITS) - 1;
 
-        let bits = ((id.into_raw() as u64) << Self::BITS) | number;
-        match NonZeroU64::new(bits) {
-            Some(v) => Some(Self(v)),
-            None => unreachable!(),
-        }
-    }
-
-    /// Create a span that does not point into any source file.
+    /// Create a span that does not point into any file.
     pub const fn detached() -> Self {
         match NonZeroU64::new(Self::DETACHED) {
             Some(v) => Self(v),
@@ -62,25 +77,26 @@ impl Span {
         }
     }
 
-    /// Whether the span is detached.
-    pub const fn is_detached(self) -> bool {
-        self.0.get() == Self::DETACHED
-    }
-
-    /// The id of the source file the span points into.
+    /// Create a new span from a file id and a number.
     ///
-    /// Returns `None` if the span is detached.
-    pub const fn id(self) -> Option<FileId> {
-        if self.is_detached() {
+    /// Returns `None` if `number` is not contained in `FULL`.
+    pub(crate) const fn from_number(id: FileId, number: u64) -> Option<Self> {
+        if number < Self::FULL.start || number >= Self::FULL.end {
             return None;
         }
-        let bits = (self.0.get() >> Self::BITS) as u16;
-        Some(FileId::from_raw(bits))
+        Some(Self::pack(id, number))
     }
 
-    /// The unique number of the span within its [`Source`](crate::Source).
-    pub const fn number(self) -> u64 {
-        self.0.get() & ((1 << Self::BITS) - 1)
+    /// Create a new span from a raw byte range instead of a span number.
+    ///
+    /// If one of the range's parts exceeds the maximum value (2^23), it is
+    /// saturated.
+    pub const fn from_range(id: FileId, range: Range<usize>) -> Self {
+        let max = 1 << Self::RANGE_PART_BITS;
+        let start = if range.start > max { max } else { range.start } as u64;
+        let end = if range.end > max { max } else { range.end } as u64;
+        let number = (start << Self::RANGE_PART_SHIFT) | end;
+        Self::pack(id, Self::RANGE_BASE + number)
     }
 
     /// Construct from a raw number.
@@ -90,6 +106,51 @@ impl Span {
     /// unsafety.
     pub const fn from_raw(v: NonZeroU64) -> Self {
         Self(v)
+    }
+
+    /// Pack a file ID and the low bits into a span.
+    const fn pack(id: FileId, low: u64) -> Self {
+        let bits = ((id.into_raw().get() as u64) << Self::FILE_ID_SHIFT) | low;
+        match NonZeroU64::new(bits) {
+            Some(v) => Self(v),
+            // The file ID is non-zero.
+            None => unreachable!(),
+        }
+    }
+
+    /// Whether the span is detached.
+    pub const fn is_detached(self) -> bool {
+        self.0.get() == Self::DETACHED
+    }
+
+    /// The id of the file the span points into.
+    ///
+    /// Returns `None` if the span is detached.
+    pub const fn id(self) -> Option<FileId> {
+        // Detached span has only zero high bits, so it will trigger the
+        // `None` case.
+        match NonZeroU16::new((self.0.get() >> Self::FILE_ID_SHIFT) as u16) {
+            Some(v) => Some(FileId::from_raw(v)),
+            None => None,
+        }
+    }
+
+    /// The unique number of the span within its [`Source`](crate::Source).
+    pub(crate) const fn number(self) -> u64 {
+        self.0.get() & Self::NUMBER_MASK
+    }
+
+    /// Extract a raw byte range from the span, if it is a raw range span.
+    ///
+    /// Typically, you should use `WorldExt::range` instead.
+    pub const fn range(self) -> Option<Range<usize>> {
+        let Some(number) = self.number().checked_sub(Self::RANGE_BASE) else {
+            return None;
+        };
+
+        let start = (number >> Self::RANGE_PART_SHIFT) as usize;
+        let end = (number & Self::RANGE_PART_MASK) as usize;
+        Some(start..end)
     }
 
     /// Extract the raw underlying number.
@@ -159,13 +220,40 @@ impl<T: Debug> Debug for Spanned<T> {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU16;
+    use std::ops::Range;
+
     use crate::{FileId, Span};
 
     #[test]
-    fn test_span_encoding() {
-        let id = FileId::from_raw(5);
-        let span = Span::new(id, 10).unwrap();
+    fn test_span_detached() {
+        let span = Span::detached();
+        assert!(span.is_detached());
+        assert_eq!(span.id(), None);
+        assert_eq!(span.range(), None);
+    }
+
+    #[test]
+    fn test_span_number_encoding() {
+        let id = FileId::from_raw(NonZeroU16::new(5).unwrap());
+        let span = Span::from_number(id, 10).unwrap();
         assert_eq!(span.id(), Some(id));
         assert_eq!(span.number(), 10);
+        assert_eq!(span.range(), None);
+    }
+
+    #[test]
+    fn test_span_range_encoding() {
+        let id = FileId::from_raw(NonZeroU16::new(u16::MAX).unwrap());
+        let roundtrip = |range: Range<usize>| {
+            let span = Span::from_range(id, range.clone());
+            assert_eq!(span.id(), Some(id));
+            assert_eq!(span.range(), Some(range));
+        };
+
+        roundtrip(0..0);
+        roundtrip(177..233);
+        roundtrip(0..8388607);
+        roundtrip(8388606..8388607);
     }
 }

--- a/crates/typst-timing/src/lib.rs
+++ b/crates/typst-timing/src/lib.rs
@@ -1,5 +1,7 @@
 //! Performance timing for Typst.
 
+#![cfg_attr(target_arch = "wasm32", allow(dead_code, unused_variables))]
+
 use std::hash::Hash;
 use std::io::Write;
 use std::num::NonZeroU64;


### PR DESCRIPTION
### User-facing
- Added autocompletion for file paths, including filtering depending on which function gets the path
- Autocompletions in typed positions (e.g. parameters) are filtered more smartly
- Different functions are now autocompleted with different bracket modes, e.g. `box` gets round parens, `footnote` will get square brackets, and `figure` will get round parens + newline
- Added image and table snippets for figure bodies
- Added tooltip for star import ("This star imports ...")
- Fixed autocompletion for `#cite`

### API
- Added `IdeWorld` trait to separate out additional functions for IDE tooling from core `World` functions. `World::packages` is moved there. `IdeWorld::files` is new.
- Added additional `CompletionKind`s
- Simplified go-to-definition API to make it easier to understand and removed unused things (also changed `deref_target` a bit)
- Added support for raw range `Spans`, which can encode ranges outside of Typst files. Will also be useful to report errors directly in bib files (though the biblatex crate's error ranges aren't the greatest)
- Cleaned up the typst-eval `import` API (which is used by typst-ide)

### Misc
- PicoStr and FileId are now null-optimized
- Fixed some wasm-related problems (wasmi bump & typst-timing warnings)
- Better IDE tests