### PR TITLE
Replace _magic_ "preview" literals with a constant

### DIFF
--- a/crates/typst-ide/src/tests.rs
+++ b/crates/typst-ide/src/tests.rs
@@ -119,7 +119,10 @@ impl IdeWorld for TestWorld {
     fn packages(&self) -> &[(PackageSpec, Option<EcoString>)] {
         const LIST: &[(PackageSpec, Option<EcoString>)] = &[(
             PackageSpec {
-                // NOTE: DEFAULT_NAMESPACE (i.e. "preview") in typst-kit/src/package.rs
+                // NOTE: This literal, `"preview"`, should match the const, `DEFAULT_NAMESPACE`,
+                // defined in `crates/typst-kit/src/package.rs`. However, we should always use the
+                // literal here, not `DEFAULT_NAMESPACE`, so that this test fails if its value
+                // changes in an unexpected way.
                 namespace: EcoString::inline("preview"),
                 name: EcoString::inline("example"),
                 version: PackageVersion { major: 0, minor: 1, patch: 0 },

--- a/crates/typst-ide/src/tests.rs
+++ b/crates/typst-ide/src/tests.rs
@@ -119,6 +119,7 @@ impl IdeWorld for TestWorld {
     fn packages(&self) -> &[(PackageSpec, Option<EcoString>)] {
         const LIST: &[(PackageSpec, Option<EcoString>)] = &[(
             PackageSpec {
+                // NOTE: DEFAULT_NAMESPACE (i.e. "preview") in typst-kit/src/package.rs
                 namespace: EcoString::inline("preview"),
                 name: EcoString::inline("example"),
                 version: PackageVersion { major: 0, minor: 1, patch: 0 },

--- a/crates/typst-kit/src/package.rs
+++ b/crates/typst-kit/src/package.rs
@@ -15,6 +15,9 @@ use crate::download::{Downloader, Progress};
 /// The default Typst registry.
 pub const DEFAULT_REGISTRY: &str = "https://packages.typst.org";
 
+/// The public namespace in the default Typst registry.
+pub const DEFAULT_NAMESPACE: &str = "preview";
+
 /// The default packages sub directory within the package and package cache paths.
 pub const DEFAULT_PACKAGES_SUBDIR: &str = "typst/packages";
 
@@ -85,7 +88,7 @@ impl PackageStorage {
             }
 
             // Download from network if it doesn't exist yet.
-            if spec.namespace == "preview" {
+            if spec.namespace == DEFAULT_NAMESPACE {
                 self.download_package(spec, &dir, progress)?;
                 if dir.exists() {
                     return Ok(dir);
@@ -101,7 +104,7 @@ impl PackageStorage {
         &self,
         spec: &VersionlessPackageSpec,
     ) -> StrResult<PackageVersion> {
-        if spec.namespace == "preview" {
+        if spec.namespace == DEFAULT_NAMESPACE {
             // For `@preview`, download the package index and find the latest
             // version.
             self.download_index()?
@@ -155,7 +158,7 @@ impl PackageStorage {
         package_dir: &Path,
         progress: &mut dyn Progress,
     ) -> PackageResult<()> {
-        assert_eq!(spec.namespace, "preview");
+        assert_eq!(spec.namespace, DEFAULT_NAMESPACE);
 
         let url =
             format!("{DEFAULT_REGISTRY}/preview/{}-{}.tar.gz", spec.name, spec.version);


### PR DESCRIPTION
Converts all instances of `"preview"` to `DEFAULT_NAMESPACE` which is defined in `typst-kit/src/package.rs`.