### PR TITLE
Add Bulgarian translation entries

### DIFF
--- a/crates/typst-library/src/text/lang.rs
+++ b/crates/typst-library/src/text/lang.rs
@@ -14,8 +14,9 @@ macro_rules! translation {
     };
 }
 
-const TRANSLATIONS: [(&str, &str); 37] = [
+const TRANSLATIONS: [(&str, &str); 38] = [
     translation!("ar"),
+    translation!("bg"),
     translation!("ca"),
     translation!("cs"),
     translation!("da"),
@@ -63,6 +64,7 @@ impl Lang {
     pub const ARABIC: Self = Self(*b"ar ", 2);
     pub const BASQUE: Self = Self(*b"eu ", 2);
     pub const BOKMÅL: Self = Self(*b"nb ", 2);
+    pub const BULGARIAN: Self = Self(*b"bg ", 2);
     pub const CATALAN: Self = Self(*b"ca ", 2);
     pub const CHINESE: Self = Self(*b"zh ", 2);
     pub const CROATIAN: Self = Self(*b"hr ", 2);

--- a/crates/typst-library/translations/bg.txt
+++ b/crates/typst-library/translations/bg.txt
@@ -1,0 +1,8 @@
+figure = Фиг.
+table = Таблица
+equation = Уравнение
+bibliography = Библиография
+heading = Раздел
+outline = Съдържание
+raw = Приложение
+page = стр.


### PR DESCRIPTION
Got inspired by looking at recent PRs (thanks to #5429).

Bulgarian is close to the [Russian language entries](https://github.com/typst/typst/blob/85d3a49a1a0bd50556b8b724a15aa29b074a2db7/crates/typst-library/translations/ru.txt), but is just different enough to contribute this PR.