### PR TITLE
Add missing full stop to documentation of `ImageElem` struct

### DIFF
--- a/crates/typst-library/src/visualize/image/mod.rs
+++ b/crates/typst-library/src/visualize/image/mod.rs
@@ -46,7 +46,7 @@ use crate::World;
 /// ```
 #[elem(scope, Show, LocalName, Figurable)]
 pub struct ImageElem {
-    /// Path to an image file
+    /// Path to an image file.
     ///
     /// For more details, see the [Paths section]($syntax/#paths).
     #[required]


### PR DESCRIPTION
I fixed the documentation of the `ImageElem` struct for consistency.