### PR TITLE
Make `math.italic` compatible with ħ

### DIFF
--- a/crates/typst-layout/src/math/text.rs
+++ b/crates/typst-layout/src/math/text.rs
@@ -150,8 +150,8 @@ fn styled_char(styles: StyleChain, c: char, auto_italic: bool) -> char {
         auto_italic
             && matches!(
                 c,
-                'a'..='z' | 'ı' | 'ȷ' | 'A'..='Z' | 'α'..='ω' |
-                '∂' | 'ϵ' | 'ϑ' | 'ϰ' | 'ϕ' | 'ϱ' | 'ϖ'
+                'a'..='z' | 'ħ' | 'ı' | 'ȷ' | 'A'..='Z' |
+                'α'..='ω' | '∂' | 'ϵ' | 'ϑ' | 'ϰ' | 'ϕ' | 'ϱ' | 'ϖ'
             )
             && matches!(variant, Sans | Serif),
     );
@@ -306,6 +306,7 @@ fn latin_exception(
         ('e', Cal, false, _) => 'ℯ',
         ('g', Cal, false, _) => 'ℊ',
         ('o', Cal, false, _) => 'ℴ',
+        ('ħ', Serif, .., true) => 'ℏ',
         ('ı', Serif, .., true) => '𝚤',
         ('ȷ', Serif, .., true) => '𝚥',
         _ => return None,


### PR DESCRIPTION
U+210F ℏ PLANCK CONSTANT OVER TWO PI (present in `sym` as `planck.reduce`) seems to be the mathematical italic counterpart of U+0127 ħ LATIN SMALL LETTER H WITH STROKE, as suggested in [the chart](https://unicode.org/charts/PDF/U2100.pdf):
![ℏ ≈ <font> 0127 ħ latin small letter h with stroke](https://github.com/user-attachments/assets/c522fab5-2617-4036-b2cc-978ea0c4c69d)
