### PR TITLE
HTML foundations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2674,6 +2674,7 @@ dependencies = [
  "comemo",
  "ecow",
  "typst-eval",
+ "typst-html",
  "typst-layout",
  "typst-library",
  "typst-macros",
@@ -2720,6 +2721,7 @@ dependencies = [
  "toml",
  "typst",
  "typst-eval",
+ "typst-html",
  "typst-kit",
  "typst-macros",
  "typst-pdf",
@@ -2785,6 +2787,20 @@ dependencies = [
  "typst-assets",
  "typst-render",
  "typst-syntax",
+]
+
+[[package]]
+name = "typst-html"
+version = "0.12.0"
+dependencies = [
+ "comemo",
+ "ecow",
+ "typst-library",
+ "typst-macros",
+ "typst-svg",
+ "typst-syntax",
+ "typst-timing",
+ "typst-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ readme = "README.md"
 typst = { path = "crates/typst", version = "0.12.0" }
 typst-cli = { path = "crates/typst-cli", version = "0.12.0" }
 typst-eval = { path = "crates/typst-eval", version = "0.12.0" }
+typst-html = { path = "crates/typst-html", version = "0.12.0" }
 typst-ide = { path = "crates/typst-ide", version = "0.12.0" }
 typst-kit = { path = "crates/typst-kit", version = "0.12.0" }
 typst-layout = { path = "crates/typst-layout", version = "0.12.0" }

--- a/crates/typst-cli/Cargo.toml
+++ b/crates/typst-cli/Cargo.toml
@@ -20,6 +20,7 @@ doc = false
 [dependencies]
 typst = { workspace = true }
 typst-eval = { workspace = true }
+typst-html = { workspace = true }
 typst-kit = { workspace = true }
 typst-macros = { workspace = true }
 typst-pdf = { workspace = true }

--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -283,7 +283,9 @@ pub struct SharedArgs {
 
 /// An in-development feature that may be changed or removed at any time.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, ValueEnum)]
-pub enum Feature {}
+pub enum Feature {
+    Html,
+}
 
 /// Arguments related to where packages are stored in the system.
 #[derive(Debug, Clone, Args)]

--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -512,6 +512,7 @@ pub enum OutputFormat {
     Pdf,
     Png,
     Svg,
+    Html,
 }
 
 impl Display for OutputFormat {

--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -12,8 +12,7 @@ use typst::diag::{
     bail, At, Severity, SourceDiagnostic, SourceResult, StrResult, Warned,
 };
 use typst::foundations::{Datetime, Smart};
-use typst::layout::{Frame, Page, PageRanges};
-use typst::model::Document;
+use typst::layout::{Frame, Page, PageRanges, PagedDocument};
 use typst::syntax::{FileId, Source, Span};
 use typst::WorldExt;
 use typst_pdf::{PdfOptions, PdfStandards};
@@ -171,7 +170,7 @@ pub fn compile_once(
 /// Export into the target format.
 fn export(
     world: &mut SystemWorld,
-    document: &Document,
+    document: &PagedDocument,
     command: &CompileCommand,
     watching: bool,
 ) -> SourceResult<()> {
@@ -189,7 +188,7 @@ fn export(
 }
 
 /// Export to a PDF.
-fn export_pdf(document: &Document, command: &CompileCommand) -> SourceResult<()> {
+fn export_pdf(document: &PagedDocument, command: &CompileCommand) -> SourceResult<()> {
     let options = PdfOptions {
         ident: Smart::Auto,
         timestamp: convert_datetime(
@@ -229,7 +228,7 @@ enum ImageExportFormat {
 /// Export to one or multiple images.
 fn export_image(
     world: &mut SystemWorld,
-    document: &Document,
+    document: &PagedDocument,
     command: &CompileCommand,
     watching: bool,
     fmt: ImageExportFormat,

--- a/crates/typst-cli/src/query.rs
+++ b/crates/typst-cli/src/query.rs
@@ -3,7 +3,7 @@ use ecow::{eco_format, EcoString};
 use serde::Serialize;
 use typst::diag::{bail, HintedStrResult, StrResult, Warned};
 use typst::foundations::{Content, IntoValue, LocatableSelector, Scope};
-use typst::model::Document;
+use typst::layout::PagedDocument;
 use typst::syntax::Span;
 use typst::World;
 use typst_eval::{eval_string, EvalMode};
@@ -53,7 +53,7 @@ pub fn query(command: &QueryCommand) -> HintedStrResult<()> {
 fn retrieve(
     world: &dyn World,
     command: &QueryCommand,
-    document: &Document,
+    document: &PagedDocument,
 ) -> HintedStrResult<Vec<Content>> {
     let selector = eval_string(
         &typst::ROUTINES,

--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -17,7 +17,7 @@ use typst_kit::fonts::{FontSlot, Fonts};
 use typst_kit::package::PackageStorage;
 use typst_timing::timed;
 
-use crate::args::{Input, SharedArgs};
+use crate::args::{Feature, Input, SharedArgs};
 use crate::compile::ExportCache;
 use crate::download::PrintDownload;
 use crate::package;
@@ -112,8 +112,13 @@ impl SystemWorld {
                 .map(|(k, v)| (k.as_str().into(), v.as_str().into_value()))
                 .collect();
 
-            let features =
-                command.feature.iter().map(|&feature| match feature {}).collect();
+            let features = command
+                .feature
+                .iter()
+                .map(|&feature| match feature {
+                    Feature::Html => typst::Feature::Html,
+                })
+                .collect();
 
             Library::builder().with_inputs(inputs).with_features(features).build()
         };

--- a/crates/typst-eval/src/call.rs
+++ b/crates/typst-eval/src/call.rs
@@ -391,7 +391,9 @@ fn wrap_args_in_math(
     }
     Ok(Value::Content(
         callee.display().spanned(callee_span)
-            + LrElem::new(TextElem::packed('(') + body + TextElem::packed(')')).pack(),
+            + LrElem::new(TextElem::packed('(') + body + TextElem::packed(')'))
+                .pack()
+                .spanned(args.span),
     ))
 }
 

--- a/crates/typst-eval/src/code.rs
+++ b/crates/typst-eval/src/code.rs
@@ -359,7 +359,7 @@ impl Eval for ast::Contextual<'_> {
         };
 
         let func = Func::from(closure).spanned(body.span());
-        Ok(ContextElem::new(func).pack())
+        Ok(ContextElem::new(func).pack().spanned(body.span()))
     }
 }
 

--- a/crates/typst-eval/src/lib.rs
+++ b/crates/typst-eval/src/lib.rs
@@ -148,7 +148,8 @@ pub fn eval_string(
         EvalMode::Math => Value::Content(
             EquationElem::new(root.cast::<ast::Math>().unwrap().eval(&mut vm)?)
                 .with_block(false)
-                .pack(),
+                .pack()
+                .spanned(span),
         ),
     };
 

--- a/crates/typst-html/Cargo.toml
+++ b/crates/typst-html/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
-name = "typst"
-description = "A new markup-based typesetting system that is powerful and easy to learn."
-categories = ["compilers", "science"]
-keywords = ["markup", "typesetting", "typst"]
+name = "typst-html"
+description = "Typst's HTML exporter."
 version = { workspace = true }
 rust-version = { workspace = true }
 authors = { workspace = true }
@@ -10,18 +8,17 @@ edition = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
+categories = { workspace = true }
+keywords = { workspace = true }
 readme = { workspace = true }
 
 [dependencies]
-typst-eval = { workspace = true }
-typst-html = { workspace = true }
-typst-layout = { workspace = true }
 typst-library = { workspace = true }
 typst-macros = { workspace = true }
-typst-realize = { workspace = true }
 typst-syntax = { workspace = true }
 typst-timing = { workspace = true }
 typst-utils = { workspace = true }
+typst-svg = { workspace = true }
 comemo = { workspace = true }
 ecow = { workspace = true }
 

--- a/crates/typst-html/src/encode.rs
+++ b/crates/typst-html/src/encode.rs
@@ -1,0 +1,104 @@
+use std::fmt::Write;
+
+use typst_library::diag::{bail, At, SourceResult, StrResult};
+use typst_library::foundations::Repr;
+use typst_library::html::{charsets, tag, HtmlDocument, HtmlElement, HtmlNode};
+use typst_library::layout::Frame;
+use typst_syntax::Span;
+
+/// Encodes an HTML document into a string.
+pub fn html(document: &HtmlDocument) -> SourceResult<String> {
+    let mut w = Writer { buf: String::new() };
+    w.buf.push_str("<!DOCTYPE html>");
+    write_element(&mut w, &document.root)?;
+    Ok(w.buf)
+}
+
+struct Writer {
+    buf: String,
+}
+
+/// Encode an HTML node into the writer.
+fn write_node(w: &mut Writer, node: &HtmlNode) -> SourceResult<()> {
+    match node {
+        HtmlNode::Tag(_) => {}
+        HtmlNode::Text(text, span) => write_text(w, text, *span)?,
+        HtmlNode::Element(element) => write_element(w, element)?,
+        HtmlNode::Frame(frame) => write_frame(w, frame),
+    }
+    Ok(())
+}
+
+/// Encode plain text into the writer.
+fn write_text(w: &mut Writer, text: &str, span: Span) -> SourceResult<()> {
+    for c in text.chars() {
+        if charsets::is_valid_in_normal_element_text(c) {
+            w.buf.push(c);
+        } else {
+            write_escape(w, c).at(span)?;
+        }
+    }
+    Ok(())
+}
+
+/// Encode one element into the write.
+fn write_element(w: &mut Writer, element: &HtmlElement) -> SourceResult<()> {
+    w.buf.push('<');
+    w.buf.push_str(&element.tag.resolve());
+
+    for (attr, value) in &element.attrs.0 {
+        w.buf.push(' ');
+        w.buf.push_str(&attr.resolve());
+        w.buf.push('=');
+        w.buf.push('"');
+        for c in value.chars() {
+            if charsets::is_valid_in_attribute_value(c) {
+                w.buf.push(c);
+            } else {
+                write_escape(w, c).at(element.span)?;
+            }
+        }
+        w.buf.push('"');
+    }
+
+    w.buf.push('>');
+
+    if tag::is_void(element.tag) {
+        return Ok(());
+    }
+
+    for node in &element.children {
+        write_node(w, node)?;
+    }
+
+    w.buf.push_str("</");
+    w.buf.push_str(&element.tag.resolve());
+    w.buf.push('>');
+
+    Ok(())
+}
+
+/// Escape a character.
+fn write_escape(w: &mut Writer, c: char) -> StrResult<()> {
+    // See <https://html.spec.whatwg.org/multipage/syntax.html#syntax-charref>
+    match c {
+        '&' => w.buf.push_str("&amp;"),
+        '<' => w.buf.push_str("&lt;"),
+        '>' => w.buf.push_str("&gt;"),
+        '"' => w.buf.push_str("&quot;"),
+        '\'' => w.buf.push_str("&apos;"),
+        c if charsets::is_w3c_text_char(c) && c != '\r' => {
+            write!(w.buf, "&#x{:x};", c as u32).unwrap()
+        }
+        _ => bail!("the character {} cannot be encoded in HTML", c.repr()),
+    }
+    Ok(())
+}
+
+/// Encode a laid out frame into the writer.
+fn write_frame(w: &mut Writer, frame: &Frame) {
+    // FIXME: This string replacement is obviously a hack.
+    let svg = typst_svg::svg_frame(frame)
+        .replace("<svg class", "<svg style=\"overflow: visible;\" class");
+    w.buf.push_str(&svg);
+}

--- a/crates/typst-html/src/lib.rs
+++ b/crates/typst-html/src/lib.rs
@@ -1,0 +1,315 @@
+//! Typst's HTML exporter.
+
+mod encode;
+
+pub use self::encode::html;
+
+use comemo::{Track, Tracked, TrackedMut};
+use typst_library::diag::{bail, warning, At, SourceResult};
+use typst_library::engine::{Engine, Route, Sink, Traced};
+use typst_library::foundations::{Content, StyleChain, Target, TargetElem};
+use typst_library::html::{
+    attr, tag, FrameElem, HtmlDocument, HtmlElem, HtmlElement, HtmlNode,
+};
+use typst_library::introspection::{
+    Introspector, Locator, LocatorLink, SplitLocator, TagElem,
+};
+use typst_library::layout::{Abs, Axes, BoxElem, Region, Size};
+use typst_library::model::{DocumentInfo, ParElem};
+use typst_library::routines::{Arenas, Pair, RealizationKind, Routines};
+use typst_library::text::{LinebreakElem, SmartQuoteElem, SpaceElem, TextElem};
+use typst_library::World;
+use typst_syntax::Span;
+
+/// Produce an HTML document from content.
+///
+/// This first performs root-level realization and then turns the resulting
+/// elements into HTML.
+#[typst_macros::time(name = "html document")]
+pub fn html_document(
+    engine: &mut Engine,
+    content: &Content,
+    styles: StyleChain,
+) -> SourceResult<HtmlDocument> {
+    html_document_impl(
+        engine.routines,
+        engine.world,
+        engine.introspector,
+        engine.traced,
+        TrackedMut::reborrow_mut(&mut engine.sink),
+        engine.route.track(),
+        content,
+        styles,
+    )
+}
+
+/// The internal implementation of `html_document`.
+#[comemo::memoize]
+#[allow(clippy::too_many_arguments)]
+fn html_document_impl(
+    routines: &Routines,
+    world: Tracked<dyn World + '_>,
+    introspector: Tracked<Introspector>,
+    traced: Tracked<Traced>,
+    sink: TrackedMut<Sink>,
+    route: Tracked<Route>,
+    content: &Content,
+    styles: StyleChain,
+) -> SourceResult<HtmlDocument> {
+    let mut locator = Locator::root().split();
+    let mut engine = Engine {
+        routines,
+        world,
+        introspector,
+        traced,
+        sink,
+        route: Route::extend(route).unnested(),
+    };
+
+    // Mark the external styles as "outside" so that they are valid at the page
+    // level.
+    let styles = styles.to_map().outside();
+    let styles = StyleChain::new(&styles);
+
+    let arenas = Arenas::default();
+    let mut info = DocumentInfo::default();
+    let children = (engine.routines.realize)(
+        RealizationKind::HtmlDocument(&mut info),
+        &mut engine,
+        &mut locator,
+        &arenas,
+        content,
+        styles,
+    )?;
+
+    let output = handle_list(&mut engine, &mut locator, children.iter().copied())?;
+    let root = root_element(output, &info)?;
+    let introspector = Introspector::html(&root);
+
+    Ok(HtmlDocument { info, root, introspector })
+}
+
+/// Produce HTML nodes from content.
+#[typst_macros::time(name = "html fragment")]
+pub fn html_fragment(
+    engine: &mut Engine,
+    content: &Content,
+    locator: Locator,
+    styles: StyleChain,
+) -> SourceResult<Vec<HtmlNode>> {
+    html_fragment_impl(
+        engine.routines,
+        engine.world,
+        engine.introspector,
+        engine.traced,
+        TrackedMut::reborrow_mut(&mut engine.sink),
+        engine.route.track(),
+        content,
+        locator.track(),
+        styles,
+    )
+}
+
+/// The cached, internal implementation of [`html_fragment`].
+#[comemo::memoize]
+#[allow(clippy::too_many_arguments)]
+fn html_fragment_impl(
+    routines: &Routines,
+    world: Tracked<dyn World + '_>,
+    introspector: Tracked<Introspector>,
+    traced: Tracked<Traced>,
+    sink: TrackedMut<Sink>,
+    route: Tracked<Route>,
+    content: &Content,
+    locator: Tracked<Locator>,
+    styles: StyleChain,
+) -> SourceResult<Vec<HtmlNode>> {
+    let link = LocatorLink::new(locator);
+    let mut locator = Locator::link(&link).split();
+    let mut engine = Engine {
+        routines,
+        world,
+        introspector,
+        traced,
+        sink,
+        route: Route::extend(route),
+    };
+
+    engine.route.check_html_depth().at(content.span())?;
+
+    let arenas = Arenas::default();
+    let children = (engine.routines.realize)(
+        RealizationKind::HtmlFragment,
+        &mut engine,
+        &mut locator,
+        &arenas,
+        content,
+        styles,
+    )?;
+
+    handle_list(&mut engine, &mut locator, children.iter().copied())
+}
+
+/// Convert children into HTML nodes.
+fn handle_list<'a>(
+    engine: &mut Engine,
+    locator: &mut SplitLocator,
+    children: impl IntoIterator<Item = Pair<'a>>,
+) -> SourceResult<Vec<HtmlNode>> {
+    let mut output = Vec::new();
+    for (child, styles) in children {
+        handle(engine, child, locator, styles, &mut output)?;
+    }
+    Ok(output)
+}
+
+/// Convert a child into HTML node(s).
+fn handle(
+    engine: &mut Engine,
+    child: &Content,
+    locator: &mut SplitLocator,
+    styles: StyleChain,
+    output: &mut Vec<HtmlNode>,
+) -> SourceResult<()> {
+    if let Some(elem) = child.to_packed::<TagElem>() {
+        output.push(HtmlNode::Tag(elem.tag.clone()));
+    } else if let Some(elem) = child.to_packed::<HtmlElem>() {
+        let mut children = vec![];
+        if let Some(body) = elem.body(styles) {
+            children = html_fragment(engine, body, locator.next(&elem.span()), styles)?;
+        }
+        if tag::is_void(elem.tag) && !children.is_empty() {
+            bail!(elem.span(), "HTML void elements may not have children");
+        }
+        let element = HtmlElement {
+            tag: elem.tag,
+            attrs: elem.attrs(styles).clone(),
+            children,
+            span: elem.span(),
+        };
+        output.push(element.into());
+    } else if let Some(elem) = child.to_packed::<ParElem>() {
+        let children = handle_list(engine, locator, elem.children.iter(&styles))?;
+        output.push(
+            HtmlElement::new(tag::p)
+                .with_children(children)
+                .spanned(elem.span())
+                .into(),
+        );
+    } else if let Some(elem) = child.to_packed::<BoxElem>() {
+        // FIXME: Very incomplete and hacky, but makes boxes kind fulfill their
+        // purpose for now.
+        if let Some(body) = elem.body(styles) {
+            let children =
+                html_fragment(engine, body, locator.next(&elem.span()), styles)?;
+            output.extend(children);
+        }
+    } else if child.is::<SpaceElem>() {
+        output.push(HtmlNode::text(' ', child.span()));
+    } else if let Some(elem) = child.to_packed::<TextElem>() {
+        output.push(HtmlNode::text(elem.text.clone(), elem.span()));
+    } else if let Some(elem) = child.to_packed::<LinebreakElem>() {
+        output.push(HtmlElement::new(tag::br).spanned(elem.span()).into());
+    } else if let Some(elem) = child.to_packed::<SmartQuoteElem>() {
+        output.push(HtmlNode::text(
+            if elem.double(styles) { '"' } else { '\'' },
+            child.span(),
+        ));
+    } else if let Some(elem) = child.to_packed::<FrameElem>() {
+        let locator = locator.next(&elem.span());
+        let style = TargetElem::set_target(Target::Paged).wrap();
+        let frame = (engine.routines.layout_frame)(
+            engine,
+            &elem.body,
+            locator,
+            styles.chain(&style),
+            Region::new(Size::splat(Abs::inf()), Axes::splat(false)),
+        )?;
+        output.push(HtmlNode::Frame(frame));
+    } else {
+        engine.sink.warn(warning!(
+            child.span(),
+            "{} was ignored during HTML export",
+            child.elem().name()
+        ));
+    }
+    Ok(())
+}
+
+/// Wrap the nodes in `<html>` and `<body>` if they are not yet rooted,
+/// supplying a suitable `<head>`.
+fn root_element(output: Vec<HtmlNode>, info: &DocumentInfo) -> SourceResult<HtmlElement> {
+    let body = match classify_output(output)? {
+        OutputKind::Html(element) => return Ok(element),
+        OutputKind::Body(body) => body,
+        OutputKind::Leafs(leafs) => HtmlElement::new(tag::body).with_children(leafs),
+    };
+    Ok(HtmlElement::new(tag::html)
+        .with_children(vec![head_element(info).into(), body.into()]))
+}
+
+/// Generate a `<head>` element.
+fn head_element(info: &DocumentInfo) -> HtmlElement {
+    let mut children = vec![];
+
+    children.push(HtmlElement::new(tag::meta).with_attr(attr::charset, "utf-8").into());
+
+    children.push(
+        HtmlElement::new(tag::meta)
+            .with_attr(attr::name, "viewport")
+            .with_attr(attr::content, "width=device-width, initial-scale=1")
+            .into(),
+    );
+
+    if let Some(title) = &info.title {
+        children.push(
+            HtmlElement::new(tag::title)
+                .with_children(vec![HtmlNode::Text(title.clone(), Span::detached())])
+                .into(),
+        );
+    }
+
+    if let Some(description) = &info.description {
+        children.push(
+            HtmlElement::new(tag::meta)
+                .with_attr(attr::name, "description")
+                .with_attr(attr::content, description.clone())
+                .into(),
+        );
+    }
+
+    HtmlElement::new(tag::head).with_children(children)
+}
+
+/// Determine which kind of output the user generated.
+fn classify_output(mut output: Vec<HtmlNode>) -> SourceResult<OutputKind> {
+    let len = output.len();
+    for node in &mut output {
+        let HtmlNode::Element(elem) = node else { continue };
+        let tag = elem.tag;
+        let mut take = || std::mem::replace(elem, HtmlElement::new(tag::html));
+        match (tag, len) {
+            (tag::html, 1) => return Ok(OutputKind::Html(take())),
+            (tag::body, 1) => return Ok(OutputKind::Body(take())),
+            (tag::html | tag::body, _) => bail!(
+                elem.span,
+                "`{}` element must be the only element in the document",
+                elem.tag
+            ),
+            _ => {}
+        }
+    }
+    Ok(OutputKind::Leafs(output))
+}
+
+/// What kinds of output the user generated.
+enum OutputKind {
+    /// The user generated their own `<html>` element. We do not need to supply
+    /// one.
+    Html(HtmlElement),
+    /// The user generate their own `<body>` element. We do not need to supply
+    /// one, but need supply the `<html>` element.
+    Body(HtmlElement),
+    /// The user generated leafs which we wrap in a `<body>` and `<html>`.
+    Leafs(Vec<HtmlNode>),
+}

--- a/crates/typst-ide/src/analyze.rs
+++ b/crates/typst-ide/src/analyze.rs
@@ -37,7 +37,7 @@ pub fn analyze_expr(
                 }
             }
 
-            return typst::trace(world.upcast(), node.span());
+            return typst::trace::<PagedDocument>(world.upcast(), node.span());
         }
     };
 

--- a/crates/typst-ide/src/analyze.rs
+++ b/crates/typst-ide/src/analyze.rs
@@ -1,7 +1,8 @@
 use comemo::Track;
 use ecow::{eco_vec, EcoString, EcoVec};
 use typst::foundations::{Label, Styles, Value};
-use typst::model::{BibliographyElem, Document};
+use typst::layout::PagedDocument;
+use typst::model::BibliographyElem;
 use typst::syntax::{ast, LinkedNode, SyntaxKind};
 
 use crate::IdeWorld;
@@ -65,7 +66,9 @@ pub fn analyze_import(world: &dyn IdeWorld, source: &LinkedNode) -> Option<Value
 /// - All labels and descriptions for them, if available
 /// - A split offset: All labels before this offset belong to nodes, all after
 ///   belong to a bibliography.
-pub fn analyze_labels(document: &Document) -> (Vec<(Label, Option<EcoString>)>, usize) {
+pub fn analyze_labels(
+    document: &PagedDocument,
+) -> (Vec<(Label, Option<EcoString>)>, usize) {
     let mut output = vec![];
 
     // Labels in the document.

--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -9,8 +9,7 @@ use typst::foundations::{
     fields_on, repr, AutoValue, CastInfo, Func, Label, NoneValue, ParamInfo, Repr,
     StyleChain, Styles, Type, Value,
 };
-use typst::layout::{Alignment, Dir};
-use typst::model::Document;
+use typst::layout::{Alignment, Dir, PagedDocument};
 use typst::syntax::ast::AstNode;
 use typst::syntax::{
     ast, is_id_continue, is_id_start, is_ident, FileId, LinkedNode, Side, Source,
@@ -38,7 +37,7 @@ use crate::{analyze_expr, analyze_import, analyze_labels, named_items, IdeWorld}
 /// when the document is available.
 pub fn autocomplete(
     world: &dyn IdeWorld,
-    document: Option<&Document>,
+    document: Option<&PagedDocument>,
     source: &Source,
     cursor: usize,
     explicit: bool,
@@ -1063,7 +1062,7 @@ fn code_completions(ctx: &mut CompletionContext, hash: bool) {
 /// Context for autocompletion.
 struct CompletionContext<'a> {
     world: &'a (dyn IdeWorld + 'a),
-    document: Option<&'a Document>,
+    document: Option<&'a PagedDocument>,
     text: &'a str,
     before: &'a str,
     after: &'a str,
@@ -1079,7 +1078,7 @@ impl<'a> CompletionContext<'a> {
     /// Create a new autocompletion context.
     fn new(
         world: &'a (dyn IdeWorld + 'a),
-        document: Option<&'a Document>,
+        document: Option<&'a PagedDocument>,
         source: &'a Source,
         leaf: &'a LinkedNode<'a>,
         cursor: usize,
@@ -1507,7 +1506,7 @@ impl BracketMode {
 mod tests {
     use std::collections::BTreeSet;
 
-    use typst::model::Document;
+    use typst::layout::PagedDocument;
     use typst::syntax::{FileId, Source, VirtualPath};
     use typst::World;
 
@@ -1607,7 +1606,7 @@ mod tests {
     fn test_full(
         world: &TestWorld,
         source: &Source,
-        doc: Option<&Document>,
+        doc: Option<&PagedDocument>,
         cursor: isize,
     ) -> Response {
         autocomplete(world, doc, source, source.cursor(cursor), true)

--- a/crates/typst-ide/src/definition.rs
+++ b/crates/typst-ide/src/definition.rs
@@ -1,5 +1,5 @@
 use typst::foundations::{Label, Selector, Value};
-use typst::model::Document;
+use typst::layout::PagedDocument;
 use typst::syntax::{ast, LinkedNode, Side, Source, Span};
 use typst::utils::PicoStr;
 
@@ -25,7 +25,7 @@ pub enum Definition {
 /// when the document is available.
 pub fn definition(
     world: &dyn IdeWorld,
-    document: Option<&Document>,
+    document: Option<&PagedDocument>,
     source: &Source,
     cursor: usize,
     side: Side,

--- a/crates/typst-ide/src/jump.rs
+++ b/crates/typst-ide/src/jump.rs
@@ -1,7 +1,7 @@
 use std::num::NonZeroUsize;
 
-use typst::layout::{Frame, FrameItem, Point, Position, Size};
-use typst::model::{Destination, Document, Url};
+use typst::layout::{Frame, FrameItem, PagedDocument, Point, Position, Size};
+use typst::model::{Destination, Url};
 use typst::syntax::{FileId, LinkedNode, Side, Source, Span, SyntaxKind};
 use typst::visualize::Geometry;
 use typst::WorldExt;
@@ -30,7 +30,7 @@ impl Jump {
 /// Determine where to jump to based on a click in a frame.
 pub fn jump_from_click(
     world: &dyn IdeWorld,
-    document: &Document,
+    document: &PagedDocument,
     frame: &Frame,
     click: Point,
 ) -> Option<Jump> {
@@ -110,7 +110,7 @@ pub fn jump_from_click(
 
 /// Find the output location in the document for a cursor position.
 pub fn jump_from_cursor(
-    document: &Document,
+    document: &PagedDocument,
     source: &Source,
     cursor: usize,
 ) -> Vec<Position> {

--- a/crates/typst-ide/src/tooltip.rs
+++ b/crates/typst-ide/src/tooltip.rs
@@ -4,8 +4,7 @@ use ecow::{eco_format, EcoString};
 use if_chain::if_chain;
 use typst::engine::Sink;
 use typst::foundations::{repr, Capturer, CastInfo, Repr, Value};
-use typst::layout::Length;
-use typst::model::Document;
+use typst::layout::{Length, PagedDocument};
 use typst::syntax::ast::AstNode;
 use typst::syntax::{ast, LinkedNode, Side, Source, SyntaxKind};
 use typst::utils::{round_with_precision, Numeric};
@@ -21,7 +20,7 @@ use crate::{analyze_expr, analyze_import, analyze_labels, IdeWorld};
 /// document is available.
 pub fn tooltip(
     world: &dyn IdeWorld,
-    document: Option<&Document>,
+    document: Option<&PagedDocument>,
     source: &Source,
     cursor: usize,
     side: Side,
@@ -173,7 +172,7 @@ fn length_tooltip(length: Length) -> Option<Tooltip> {
 }
 
 /// Tooltip for a hovered reference or label.
-fn label_tooltip(document: &Document, leaf: &LinkedNode) -> Option<Tooltip> {
+fn label_tooltip(document: &PagedDocument, leaf: &LinkedNode) -> Option<Tooltip> {
     let target = match leaf.kind() {
         SyntaxKind::RefMarker => leaf.text().trim_start_matches('@'),
         SyntaxKind::Label => leaf.text().trim_start_matches('<').trim_end_matches('>'),

--- a/crates/typst-layout/src/flow/collect.rs
+++ b/crates/typst-layout/src/flow/collect.rs
@@ -5,7 +5,7 @@ use std::hash::Hash;
 use bumpalo::boxed::Box as BumpBox;
 use bumpalo::Bump;
 use comemo::{Track, Tracked, TrackedMut};
-use typst_library::diag::{bail, SourceResult};
+use typst_library::diag::{bail, warning, SourceResult};
 use typst_library::engine::{Engine, Route, Sink, Traced};
 use typst_library::foundations::{Packed, Resolve, Smart, StyleChain};
 use typst_library::introspection::{
@@ -83,7 +83,11 @@ impl<'a> Collector<'a, '_, '_> {
                     hint: "try using a `#colbreak()` instead",
                 );
             } else {
-                bail!(child.span(), "{} is not allowed here", child.func().name());
+                self.engine.sink.warn(warning!(
+                    child.span(),
+                    "{} was ignored during paged export",
+                    child.func().name()
+                ));
             }
         }
 

--- a/crates/typst-layout/src/flow/mod.rs
+++ b/crates/typst-layout/src/flow/mod.rs
@@ -142,7 +142,7 @@ fn layout_fragment_impl(
 
     let arenas = Arenas::default();
     let children = (engine.routines.realize)(
-        RealizationKind::Container,
+        RealizationKind::LayoutFragment,
         &mut engine,
         &mut locator,
         &arenas,

--- a/crates/typst-layout/src/pages/mod.rs
+++ b/crates/typst-layout/src/pages/mod.rs
@@ -75,7 +75,7 @@ fn layout_document_impl(
     let arenas = Arenas::default();
     let mut info = DocumentInfo::default();
     let mut children = (engine.routines.realize)(
-        RealizationKind::Root(&mut info),
+        RealizationKind::LayoutDocument(&mut info),
         &mut engine,
         &mut locator,
         &arenas,
@@ -84,7 +84,7 @@ fn layout_document_impl(
     )?;
 
     let pages = layout_pages(&mut engine, &mut children, locator, styles)?;
-    let introspector = Introspector::new(&pages);
+    let introspector = Introspector::paged(&pages);
 
     Ok(PagedDocument { pages, info, introspector })
 }

--- a/crates/typst-layout/src/pages/mod.rs
+++ b/crates/typst-layout/src/pages/mod.rs
@@ -11,8 +11,8 @@ use typst_library::foundations::{Content, StyleChain};
 use typst_library::introspection::{
     Introspector, Locator, ManualPageCounter, SplitLocator, TagElem,
 };
-use typst_library::layout::{FrameItem, Page, Point};
-use typst_library::model::{Document, DocumentInfo};
+use typst_library::layout::{FrameItem, Page, PagedDocument, Point};
+use typst_library::model::DocumentInfo;
 use typst_library::routines::{Arenas, Pair, RealizationKind, Routines};
 use typst_library::World;
 
@@ -26,12 +26,12 @@ use self::run::{layout_blank_page, layout_page_run, LayoutedPage};
 /// elements. In contrast to [`layout_fragment`](crate::layout_fragment),
 /// this does not take regions since the regions are defined by the page
 /// configuration in the content and style chain.
-#[typst_macros::time(name = "document")]
+#[typst_macros::time(name = "layout document")]
 pub fn layout_document(
     engine: &mut Engine,
     content: &Content,
     styles: StyleChain,
-) -> SourceResult<Document> {
+) -> SourceResult<PagedDocument> {
     layout_document_impl(
         engine.routines,
         engine.world,
@@ -56,7 +56,7 @@ fn layout_document_impl(
     route: Tracked<Route>,
     content: &Content,
     styles: StyleChain,
-) -> SourceResult<Document> {
+) -> SourceResult<PagedDocument> {
     let mut locator = Locator::root().split();
     let mut engine = Engine {
         routines,
@@ -86,7 +86,7 @@ fn layout_document_impl(
     let pages = layout_pages(&mut engine, &mut children, locator, styles)?;
     let introspector = Introspector::new(&pages);
 
-    Ok(Document { pages, info, introspector })
+    Ok(PagedDocument { pages, info, introspector })
 }
 
 /// Layouts the document's pages.

--- a/crates/typst-library/src/engine.rs
+++ b/crates/typst-library/src/engine.rs
@@ -301,6 +301,9 @@ impl Route<'_> {
     /// The maximum layout nesting depth.
     const MAX_LAYOUT_DEPTH: usize = 72;
 
+    /// The maximum HTML nesting depth.
+    const MAX_HTML_DEPTH: usize = 72;
+
     /// The maximum function call nesting depth.
     const MAX_CALL_DEPTH: usize = 80;
 
@@ -321,6 +324,17 @@ impl Route<'_> {
             bail!(
                 "maximum layout depth exceeded";
                 hint: "try to reduce the amount of nesting in your layout",
+            );
+        }
+        Ok(())
+    }
+
+    /// Ensures that we are within the maximum HTML depth.
+    pub fn check_html_depth(&self) -> HintedStrResult<()> {
+        if !self.within(Route::MAX_HTML_DEPTH) {
+            bail!(
+                "maximum HTML depth exceeded";
+                hint: "try to reduce the amount of nesting of your HTML",
             );
         }
         Ok(())

--- a/crates/typst-library/src/foundations/args.rs
+++ b/crates/typst-library/src/foundations/args.rs
@@ -187,7 +187,7 @@ impl Args {
         self.items.retain(|item| {
             if item.name.is_some() {
                 return true;
-            };
+            }
             let span = item.value.span;
             let spanned = Spanned::new(std::mem::take(&mut item.value.v), span);
             match T::from_value(spanned).at(span) {

--- a/crates/typst-library/src/foundations/content.rs
+++ b/crates/typst-library/src/foundations/content.rs
@@ -481,17 +481,20 @@ impl Content {
 impl Content {
     /// Strongly emphasize this content.
     pub fn strong(self) -> Self {
-        StrongElem::new(self).pack()
+        let span = self.span();
+        StrongElem::new(self).pack().spanned(span)
     }
 
     /// Emphasize this content.
     pub fn emph(self) -> Self {
-        EmphElem::new(self).pack()
+        let span = self.span();
+        EmphElem::new(self).pack().spanned(span)
     }
 
     /// Underline this content.
     pub fn underlined(self) -> Self {
-        UnderlineElem::new(self).pack()
+        let span = self.span();
+        UnderlineElem::new(self).pack().spanned(span)
     }
 
     /// Link the content somewhere.
@@ -506,17 +509,24 @@ impl Content {
 
     /// Pad this content at the sides.
     pub fn padded(self, padding: Sides<Rel<Length>>) -> Self {
+        let span = self.span();
         PadElem::new(self)
             .with_left(padding.left)
             .with_top(padding.top)
             .with_right(padding.right)
             .with_bottom(padding.bottom)
             .pack()
+            .spanned(span)
     }
 
     /// Transform this content's contents without affecting layout.
     pub fn moved(self, delta: Axes<Rel<Length>>) -> Self {
-        MoveElem::new(self).with_dx(delta.x).with_dy(delta.y).pack()
+        let span = self.span();
+        MoveElem::new(self)
+            .with_dx(delta.x)
+            .with_dy(delta.y)
+            .pack()
+            .spanned(span)
     }
 }
 

--- a/crates/typst-library/src/foundations/func.rs
+++ b/crates/typst-library/src/foundations/func.rs
@@ -443,7 +443,7 @@ pub trait NativeFunc {
         Func::from(Self::data())
     }
 
-    /// Get the function data for the native Rust type.
+    /// Get the function data for the native Rust function.
     fn data() -> &'static NativeFuncData;
 }
 
@@ -462,6 +462,7 @@ pub struct NativeFuncData {
     pub keywords: &'static [&'static str],
     /// Whether this function makes use of context.
     pub contextual: bool,
+    /// Definitions in the scope of the function.
     pub scope: LazyLock<Scope>,
     /// A list of parameter information for each parameter.
     pub params: LazyLock<Vec<ParamInfo>>,

--- a/crates/typst-library/src/foundations/mod.rs
+++ b/crates/typst-library/src/foundations/mod.rs
@@ -31,6 +31,8 @@ mod selector;
 mod str;
 mod styles;
 mod symbol;
+#[path = "target.rs"]
+mod target_;
 mod ty;
 mod value;
 mod version;
@@ -61,6 +63,7 @@ pub use self::selector::*;
 pub use self::str::*;
 pub use self::styles::*;
 pub use self::symbol::*;
+pub use self::target_::*;
 pub use self::ty::*;
 pub use self::value::*;
 pub use self::version::*;
@@ -79,6 +82,7 @@ use typst_syntax::Spanned;
 use crate::diag::{bail, SourceResult, StrResult};
 use crate::engine::Engine;
 use crate::routines::EvalMode;
+use crate::{Feature, Features};
 
 /// Foundational types and functions.
 ///
@@ -88,7 +92,7 @@ use crate::routines::EvalMode;
 pub static FOUNDATIONS: Category;
 
 /// Hook up all `foundations` definitions.
-pub(super) fn define(global: &mut Scope, inputs: Dict) {
+pub(super) fn define(global: &mut Scope, inputs: Dict, features: &Features) {
     global.category(FOUNDATIONS);
     global.define_type::<bool>();
     global.define_type::<i64>();
@@ -116,6 +120,9 @@ pub(super) fn define(global: &mut Scope, inputs: Dict) {
     global.define_func::<assert>();
     global.define_func::<eval>();
     global.define_func::<style>();
+    if features.is_enabled(Feature::Html) {
+        global.define_func::<target>();
+    }
     global.define_module(calc::module());
     global.define_module(sys::module(inputs));
 }

--- a/crates/typst-library/src/foundations/str.rs
+++ b/crates/typst-library/src/foundations/str.rs
@@ -646,11 +646,17 @@ impl Repr for str {
                 '\0' => r.push_str(r"\u{0}"),
                 '\'' => r.push('\''),
                 '"' => r.push_str(r#"\""#),
-                _ => c.escape_debug().for_each(|c| r.push(c)),
+                _ => r.extend(c.escape_debug()),
             }
         }
         r.push('"');
         r
+    }
+}
+
+impl Repr for char {
+    fn repr(&self) -> EcoString {
+        EcoString::from(*self).repr()
     }
 }
 

--- a/crates/typst-library/src/foundations/target.rs
+++ b/crates/typst-library/src/foundations/target.rs
@@ -1,0 +1,38 @@
+use comemo::Tracked;
+
+use crate::diag::HintedStrResult;
+use crate::foundations::{elem, func, Cast, Context};
+
+/// The compilation target.
+#[derive(Debug, Default, Copy, Clone, PartialEq, Hash, Cast)]
+pub enum Target {
+    /// The target that is used for paged, fully laid-out content.
+    #[default]
+    Paged,
+    /// The target that is used for HTML export.
+    Html,
+}
+
+impl Target {
+    /// Whether this is the HTML target.
+    pub fn is_html(self) -> bool {
+        self == Self::Html
+    }
+}
+
+/// This element exists solely to host the `target` style chain field.
+/// It is never constructed and not visible to users.
+#[elem]
+pub struct TargetElem {
+    /// The compilation target.
+    pub target: Target,
+}
+
+/// Returns the current compilation target.
+#[func(contextual)]
+pub fn target(
+    /// The callsite context.
+    context: Tracked<Context>,
+) -> HintedStrResult<Target> {
+    Ok(TargetElem::target_in(context.styles()?))
+}

--- a/crates/typst-library/src/foundations/ty.rs
+++ b/crates/typst-library/src/foundations/ty.rs
@@ -199,6 +199,7 @@ pub trait NativeType {
 pub struct NativeTypeData {
     /// The type's normal name (e.g. `str`), as exposed to Typst.
     pub name: &'static str,
+    /// The type's long name (e.g. `string`), for error messages.
     pub long_name: &'static str,
     /// The function's title case name (e.g. `String`).
     pub title: &'static str,
@@ -208,6 +209,7 @@ pub struct NativeTypeData {
     pub keywords: &'static [&'static str],
     /// The constructor for this type.
     pub constructor: LazyLock<Option<&'static NativeFuncData>>,
+    /// Definitions in the scope of the type.
     pub scope: LazyLock<Scope>,
 }
 

--- a/crates/typst-library/src/html/dom.rs
+++ b/crates/typst-library/src/html/dom.rs
@@ -1,0 +1,572 @@
+use std::fmt::{self, Debug, Display, Formatter};
+
+use ecow::{EcoString, EcoVec};
+use typst_syntax::Span;
+use typst_utils::{PicoStr, ResolvedPicoStr};
+
+use crate::diag::{bail, HintedStrResult, StrResult};
+use crate::foundations::{cast, Dict, Repr, Str};
+use crate::introspection::{Introspector, Tag};
+use crate::layout::Frame;
+use crate::model::DocumentInfo;
+
+/// An HTML document.
+#[derive(Debug, Clone)]
+pub struct HtmlDocument {
+    /// The document's root HTML element.
+    pub root: HtmlElement,
+    /// Details about the document.
+    pub info: DocumentInfo,
+    /// Provides the ability to execute queries on the document.
+    pub introspector: Introspector,
+}
+
+/// A child of an HTML element.
+#[derive(Debug, Clone, Hash)]
+pub enum HtmlNode {
+    /// An introspectable element that produced something within this node.
+    Tag(Tag),
+    /// Plain text.
+    Text(EcoString, Span),
+    /// Another element.
+    Element(HtmlElement),
+    /// A frame that will be displayed as an embedded SVG.
+    Frame(Frame),
+}
+
+impl HtmlNode {
+    /// Create a plain text node.
+    pub fn text(text: impl Into<EcoString>, span: Span) -> Self {
+        Self::Text(text.into(), span)
+    }
+}
+
+impl From<HtmlElement> for HtmlNode {
+    fn from(element: HtmlElement) -> Self {
+        Self::Element(element)
+    }
+}
+
+/// An HTML element.
+#[derive(Debug, Clone, Hash)]
+pub struct HtmlElement {
+    /// The HTML tag.
+    pub tag: HtmlTag,
+    /// The element's attributes.
+    pub attrs: HtmlAttrs,
+    /// The element's children.
+    pub children: Vec<HtmlNode>,
+    /// The span from which the element originated, if any.
+    pub span: Span,
+}
+
+impl HtmlElement {
+    /// Create a new, blank element without attributes or children.
+    pub fn new(tag: HtmlTag) -> Self {
+        Self {
+            tag,
+            attrs: HtmlAttrs::default(),
+            children: vec![],
+            span: Span::detached(),
+        }
+    }
+
+    /// Attach children to the element.
+    ///
+    /// Note: This overwrites potential previous children.
+    pub fn with_children(mut self, children: Vec<HtmlNode>) -> Self {
+        self.children = children;
+        self
+    }
+
+    /// Add an atribute to the element.
+    pub fn with_attr(mut self, key: HtmlAttr, value: impl Into<EcoString>) -> Self {
+        self.attrs.push(key, value);
+        self
+    }
+
+    /// Attach a span to the element.
+    pub fn spanned(mut self, span: Span) -> Self {
+        self.span = span;
+        self
+    }
+}
+
+/// The tag of an HTML element.
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
+pub struct HtmlTag(PicoStr);
+
+impl HtmlTag {
+    /// Intern an HTML tag string at runtime.
+    pub fn intern(string: &str) -> StrResult<Self> {
+        if string.is_empty() {
+            bail!("tag name must not be empty");
+        }
+
+        if let Some(c) = string.chars().find(|&c| !charsets::is_valid_in_tag_name(c)) {
+            bail!("the character {} is not valid in a tag name", c.repr());
+        }
+
+        Ok(Self(PicoStr::intern(string)))
+    }
+
+    /// Creates a compile-time constant `HtmlTag`.
+    ///
+    /// Should only be used in const contexts because it can panic.
+    #[track_caller]
+    pub const fn constant(string: &'static str) -> Self {
+        if string.is_empty() {
+            panic!("tag name must not be empty");
+        }
+
+        let bytes = string.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() {
+            if !bytes[i].is_ascii_alphanumeric() {
+                panic!("constant tag name must be ASCII alphanumeric");
+            }
+            i += 1;
+        }
+
+        Self(PicoStr::constant(string))
+    }
+
+    /// Resolves the tag to a string.
+    pub fn resolve(self) -> ResolvedPicoStr {
+        self.0.resolve()
+    }
+
+    /// Turns the tag into its inner interned string.
+    pub const fn into_inner(self) -> PicoStr {
+        self.0
+    }
+}
+
+impl Debug for HtmlTag {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl Display for HtmlTag {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "<{}>", self.resolve())
+    }
+}
+
+cast! {
+    HtmlTag,
+    self => self.0.resolve().as_str().into_value(),
+    v: Str => Self::intern(&v)?,
+}
+
+/// Attributes of an HTML element.
+#[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
+pub struct HtmlAttrs(pub EcoVec<(HtmlAttr, EcoString)>);
+
+impl HtmlAttrs {
+    /// Add an attribute.
+    pub fn push(&mut self, attr: HtmlAttr, value: impl Into<EcoString>) {
+        self.0.push((attr, value.into()));
+    }
+}
+
+cast! {
+    HtmlAttrs,
+    self => self.0
+        .into_iter()
+        .map(|(key, value)| (key.resolve().as_str().into(), value.into_value()))
+        .collect::<Dict>()
+        .into_value(),
+    values: Dict => Self(values
+        .into_iter()
+        .map(|(k, v)| {
+            let attr = HtmlAttr::intern(&k)?;
+            let value = v.cast::<EcoString>()?;
+            Ok((attr, value))
+        })
+        .collect::<HintedStrResult<_>>()?),
+}
+
+/// An attribute of an HTML.
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
+pub struct HtmlAttr(PicoStr);
+
+impl HtmlAttr {
+    /// Intern an HTML attribute string at runtime.
+    pub fn intern(string: &str) -> StrResult<Self> {
+        if string.is_empty() {
+            bail!("attribute name must not be empty");
+        }
+
+        if let Some(c) =
+            string.chars().find(|&c| !charsets::is_valid_in_attribute_name(c))
+        {
+            bail!("the character {} is not valid in an attribute name", c.repr());
+        }
+
+        Ok(Self(PicoStr::intern(string)))
+    }
+
+    /// Creates a compile-time constant `HtmlAttr`.
+    ///
+    /// Should only be used in const contexts because it can panic.
+    #[track_caller]
+    pub const fn constant(string: &'static str) -> Self {
+        if string.is_empty() {
+            panic!("attribute name must not be empty");
+        }
+
+        let bytes = string.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() {
+            if !bytes[i].is_ascii_alphanumeric() {
+                panic!("constant attribute name must be ASCII alphanumeric");
+            }
+            i += 1;
+        }
+
+        Self(PicoStr::constant(string))
+    }
+
+    /// Resolves the attribute to a string.
+    pub fn resolve(self) -> ResolvedPicoStr {
+        self.0.resolve()
+    }
+
+    /// Turns the attribute into its inner interned string.
+    pub const fn into_inner(self) -> PicoStr {
+        self.0
+    }
+}
+
+impl Debug for HtmlAttr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl Display for HtmlAttr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.resolve())
+    }
+}
+
+cast! {
+    HtmlAttr,
+    self => self.0.resolve().as_str().into_value(),
+    v: Str => Self::intern(&v)?,
+}
+
+/// Defines syntactical properties of HTML tags, attributes, and text.
+pub mod charsets {
+    /// Check whether a character is in a tag name.
+    pub const fn is_valid_in_tag_name(c: char) -> bool {
+        c.is_ascii_alphanumeric()
+    }
+
+    /// Check whether a character is valid in an attribute name.
+    pub const fn is_valid_in_attribute_name(c: char) -> bool {
+        match c {
+            // These are forbidden.
+            '\0' | ' ' | '"' | '\'' | '>' | '/' | '=' => false,
+            c if is_whatwg_control_char(c) => false,
+            c if is_whatwg_non_char(c) => false,
+            // _Everything_ else is allowed, including U+2029 paragraph
+            // separator. Go wild.
+            _ => true,
+        }
+    }
+
+    /// Check whether a character can be an used in an attribute value without
+    /// escaping.
+    ///
+    /// See <https://html.spec.whatwg.org/multipage/syntax.html#attributes-2>
+    pub const fn is_valid_in_attribute_value(c: char) -> bool {
+        match c {
+            // Ampersands are sometimes legal (i.e. when they are not _ambiguous
+            // ampersands_) but it is not worth the trouble to check for that.
+            '&' => false,
+            // Quotation marks are not allowed in double-quote-delimited attribute
+            // values.
+            '"' => false,
+            // All other text characters are allowed.
+            c => is_w3c_text_char(c),
+        }
+    }
+
+    /// Check whether a character can be an used in normal text without
+    /// escaping.
+    pub const fn is_valid_in_normal_element_text(c: char) -> bool {
+        match c {
+            // Ampersands are sometimes legal (i.e. when they are not _ambiguous
+            // ampersands_) but it is not worth the trouble to check for that.
+            '&' => false,
+            // Less-than signs are not allowed in text.
+            '<' => false,
+            // All other text characters are allowed.
+            c => is_w3c_text_char(c),
+        }
+    }
+
+    /// Check if something is valid text in HTML.
+    pub const fn is_w3c_text_char(c: char) -> bool {
+        match c {
+            // Non-characters are obviously not text characters.
+            c if is_whatwg_non_char(c) => false,
+            // Control characters are disallowed, except for whitespace.
+            c if is_whatwg_control_char(c) => c.is_ascii_whitespace(),
+            // Everything else is allowed.
+            _ => true,
+        }
+    }
+
+    const fn is_whatwg_non_char(c: char) -> bool {
+        match c {
+            '\u{fdd0}'..='\u{fdef}' => true,
+            // Non-characters matching xxFFFE or xxFFFF up to x10FFFF (inclusive).
+            c if c as u32 & 0xfffe == 0xfffe && c as u32 <= 0x10ffff => true,
+            _ => false,
+        }
+    }
+
+    const fn is_whatwg_control_char(c: char) -> bool {
+        match c {
+            // C0 control characters.
+            '\u{00}'..='\u{1f}' => true,
+            // Other control characters.
+            '\u{7f}'..='\u{9f}' => true,
+            _ => false,
+        }
+    }
+}
+
+/// Predefined constants for HTML tags.
+pub mod tag {
+    use super::HtmlTag;
+
+    macro_rules! tags {
+        ($($tag:ident)*) => {
+            $(#[allow(non_upper_case_globals)]
+            pub const $tag: HtmlTag = HtmlTag::constant(
+                stringify!($tag)
+            );)*
+        }
+    }
+
+    tags! {
+        a
+        abbr
+        address
+        area
+        article
+        aside
+        audio
+        b
+        base
+        bdi
+        bdo
+        blockquote
+        body
+        br
+        button
+        canvas
+        caption
+        cite
+        code
+        col
+        colgroup
+        data
+        datalist
+        dd
+        del
+        details
+        dfn
+        dialog
+        div
+        dl
+        dt
+        em
+        embed
+        fieldset
+        figcaption
+        figure
+        footer
+        form
+        h1
+        h2
+        h3
+        h4
+        h5
+        h6
+        head
+        header
+        hgroup
+        hr
+        html
+        i
+        iframe
+        img
+        input
+        ins
+        kbd
+        label
+        legend
+        li
+        link
+        main
+        map
+        mark
+        menu
+        meta
+        meter
+        nav
+        noscript
+        object
+        ol
+        optgroup
+        option
+        output
+        p
+        param
+        picture
+        pre
+        progress
+        q
+        rp
+        rt
+        ruby
+        s
+        samp
+        script
+        search
+        section
+        select
+        slot
+        small
+        source
+        span
+        strong
+        style
+        sub
+        summary
+        sup
+        table
+        tbody
+        td
+        template
+        textarea
+        tfoot
+        th
+        thead
+        time
+        title
+        tr
+        track
+        u
+        ul
+        var
+        video
+        wbr
+    }
+
+    /// Whether the element is inline-level as opposed to being block-level.
+    ///
+    /// Not sure whether this distinction really makes sense. But we somehow
+    /// need to decide what to put into automatic paragraphs. A `<strong>`
+    /// should merged into a paragraph created by realization, but a `<div>`
+    /// shouldn't.
+    ///
+    /// <https://www.w3.org/TR/html401/struct/global.html#block-inline>
+    /// <https://developer.mozilla.org/en-US/docs/Glossary/Inline-level_content>
+    /// <https://github.com/orgs/mdn/discussions/353>
+    pub fn is_inline(tag: HtmlTag) -> bool {
+        matches!(
+            tag,
+            self::abbr
+                | self::a
+                | self::bdi
+                | self::b
+                | self::br
+                | self::bdo
+                | self::code
+                | self::cite
+                | self::dfn
+                | self::data
+                | self::i
+                | self::em
+                | self::mark
+                | self::kbd
+                | self::rp
+                | self::q
+                | self::ruby
+                | self::rt
+                | self::samp
+                | self::s
+                | self::span
+                | self::small
+                | self::sub
+                | self::strong
+                | self::time
+                | self::sup
+                | self::var
+                | self::u
+        )
+    }
+
+    /// Whether this is a void tag whose associated element may not have a
+    /// children.
+    pub fn is_void(tag: HtmlTag) -> bool {
+        matches!(
+            tag,
+            self::area
+                | self::base
+                | self::br
+                | self::col
+                | self::embed
+                | self::hr
+                | self::img
+                | self::input
+                | self::link
+                | self::meta
+                | self::param
+                | self::source
+                | self::track
+                | self::wbr
+        )
+    }
+
+    /// Whether this is a tag containing raw text.
+    pub fn is_raw(tag: HtmlTag) -> bool {
+        matches!(tag, self::script | self::style)
+    }
+
+    /// Whether this is a tag containing escapable raw text.
+    pub fn is_escapable_raw(tag: HtmlTag) -> bool {
+        matches!(tag, self::textarea | self::title)
+    }
+}
+
+/// Predefined constants for HTML attributes.
+///
+/// Note: These are very incomplete.
+pub mod attr {
+    use super::HtmlAttr;
+
+    macro_rules! attrs {
+        ($($attr:ident)*) => {
+            $(#[allow(non_upper_case_globals)]
+            pub const $attr: HtmlAttr = HtmlAttr::constant(
+                stringify!($attr)
+            );)*
+        }
+    }
+
+    attrs! {
+        charset
+        content
+        href
+        name
+        value
+    }
+}

--- a/crates/typst-library/src/html/mod.rs
+++ b/crates/typst-library/src/html/mod.rs
@@ -1,0 +1,59 @@
+//! HTML output.
+
+mod dom;
+
+pub use self::dom::*;
+
+use ecow::EcoString;
+
+use crate::foundations::{category, elem, Category, Content, Module, Scope};
+
+/// HTML output.
+#[category]
+pub static HTML: Category;
+
+/// Create a module with all HTML definitions.
+pub fn module() -> Module {
+    let mut html = Scope::deduplicating();
+    html.category(HTML);
+    html.define_elem::<HtmlElem>();
+    html.define_elem::<FrameElem>();
+    Module::new("html", html)
+}
+
+/// A HTML element that can contain Typst content.
+#[elem(name = "elem")]
+pub struct HtmlElem {
+    /// The element's tag.
+    #[required]
+    pub tag: HtmlTag,
+
+    /// The element's attributes.
+    #[borrowed]
+    pub attrs: HtmlAttrs,
+
+    /// The contents of the HTML element.
+    #[positional]
+    #[borrowed]
+    pub body: Option<Content>,
+}
+
+impl HtmlElem {
+    /// Add an atribute to the element.
+    pub fn with_attr(mut self, attr: HtmlAttr, value: impl Into<EcoString>) -> Self {
+        self.attrs.get_or_insert_with(Default::default).push(attr, value);
+        self
+    }
+}
+
+/// An element that forces its contents to be laid out.
+///
+/// Integrates content that requires layout (e.g. a plot) into HTML output
+/// by turning it into an inline SVG.
+#[elem]
+pub struct FrameElem {
+    /// The contents that shall be laid out.
+    #[positional]
+    #[required]
+    pub body: Content,
+}

--- a/crates/typst-library/src/layout/frame.rs
+++ b/crates/typst-library/src/layout/frame.rs
@@ -520,8 +520,7 @@ pub enum FrameItem {
     Image(Image, Size, Span),
     /// An internal or external link to a destination.
     Link(Destination, Size),
-    /// An introspectable element that produced something within this frame
-    /// alongside its key.
+    /// An introspectable element that produced something within this frame.
     Tag(Tag),
 }
 

--- a/crates/typst-library/src/layout/page.rs
+++ b/crates/typst-library/src/layout/page.rs
@@ -12,11 +12,12 @@ use crate::foundations::{
     cast, elem, Args, AutoValue, Cast, Construct, Content, Context, Dict, Fold, Func,
     NativeElement, Set, Smart, StyleChain, Value,
 };
+use crate::introspection::Introspector;
 use crate::layout::{
     Abs, Alignment, FlushElem, Frame, HAlignment, Length, OuterVAlignment, Ratio, Rel,
     Sides, SpecificAlignment,
 };
-use crate::model::Numbering;
+use crate::model::{DocumentInfo, Numbering};
 use crate::text::LocalName;
 use crate::visualize::{Color, Paint};
 
@@ -449,6 +450,17 @@ impl PagebreakElem {
             PagebreakElem::new().with_weak(true).with_boundary(true).pack()
         )
     }
+}
+
+/// A finished document with metadata and page frames.
+#[derive(Debug, Default, Clone)]
+pub struct PagedDocument {
+    /// The document's finished pages.
+    pub pages: Vec<Page>,
+    /// Details about the document.
+    pub info: DocumentInfo,
+    /// Provides the ability to execute queries on the document.
+    pub introspector: Introspector,
 }
 
 /// A finished page.
@@ -941,4 +953,15 @@ papers! {
     (NEWSPAPER_BROADSHEET: 381.0,    578.0, "newspaper-broadsheet")
     (PRESENTATION_16_9:    297.0, 167.0625, "presentation-16-9")
     (PRESENTATION_4_3:     280.0,    210.0, "presentation-4-3")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_paged_document_is_send_and_sync() {
+        fn ensure_send_and_sync<T: Send + Sync>() {}
+        ensure_send_and_sync::<PagedDocument>();
+    }
 }

--- a/crates/typst-library/src/lib.rs
+++ b/crates/typst-library/src/lib.rs
@@ -15,6 +15,7 @@ extern crate self as typst_library;
 pub mod diag;
 pub mod engine;
 pub mod foundations;
+pub mod html;
 pub mod introspection;
 pub mod layout;
 pub mod loading;
@@ -248,6 +249,10 @@ fn global(math: Module, inputs: Dict, features: &Features) -> Module {
     self::introspection::define(&mut global);
     self::loading::define(&mut global);
     self::symbols::define(&mut global);
+    global.reset_category();
+    if features.is_enabled(Feature::Html) {
+        global.define_module(self::html::module());
+    }
     prelude(&mut global);
     Module::new("global", global)
 }

--- a/crates/typst-library/src/lib.rs
+++ b/crates/typst-library/src/lib.rs
@@ -193,7 +193,7 @@ impl LibraryBuilder {
     pub fn build(self) -> Library {
         let math = math::module();
         let inputs = self.inputs.unwrap_or_default();
-        let global = global(math.clone(), inputs);
+        let global = global(math.clone(), inputs, &self.features);
         let std = Value::Module(global.clone());
         Library {
             global,
@@ -236,9 +236,9 @@ pub enum Feature {
 }
 
 /// Construct the module with global definitions.
-fn global(math: Module, inputs: Dict) -> Module {
+fn global(math: Module, inputs: Dict, features: &Features) -> Module {
     let mut global = Scope::deduplicating();
-    self::foundations::define(&mut global, inputs);
+    self::foundations::define(&mut global, inputs, features);
     self::model::define(&mut global);
     self::text::define(&mut global);
     global.reset_category();

--- a/crates/typst-library/src/lib.rs
+++ b/crates/typst-library/src/lib.rs
@@ -231,7 +231,9 @@ impl FromIterator<Feature> for Features {
 /// An in-development feature that should be enabled.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[non_exhaustive]
-pub enum Feature {}
+pub enum Feature {
+    Html,
+}
 
 /// Construct the module with global definitions.
 fn global(math: Module, inputs: Dict) -> Module {

--- a/crates/typst-library/src/model/document.rs
+++ b/crates/typst-library/src/model/document.rs
@@ -6,8 +6,6 @@ use crate::foundations::{
     cast, elem, Args, Array, Construct, Content, Datetime, Fields, Smart, StyleChain,
     Styles, Value,
 };
-use crate::introspection::Introspector;
-use crate::layout::Page;
 
 /// The root element of a document and its metadata.
 ///
@@ -86,17 +84,6 @@ cast! {
     v: Array => Self(v.into_iter().map(Value::cast).collect::<HintedStrResult<_>>()?),
 }
 
-/// A finished document with metadata and page frames.
-#[derive(Debug, Default, Clone)]
-pub struct Document {
-    /// The document's finished pages.
-    pub pages: Vec<Page>,
-    /// Details about the document.
-    pub info: DocumentInfo,
-    /// Provides the ability to execute queries on the document.
-    pub introspector: Introspector,
-}
-
 /// Details about the document.
 #[derive(Debug, Default, Clone, PartialEq, Hash)]
 pub struct DocumentInfo {
@@ -130,16 +117,5 @@ impl DocumentInfo {
         if has(<DocumentElem as Fields>::Enum::Date) {
             self.date = DocumentElem::date_in(chain);
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_document_is_send_and_sync() {
-        fn ensure_send_and_sync<T: Send + Sync>() {}
-        ensure_send_and_sync::<Document>();
     }
 }

--- a/crates/typst-library/src/model/document.rs
+++ b/crates/typst-library/src/model/document.rs
@@ -37,6 +37,10 @@ pub struct DocumentElem {
     #[ghost]
     pub author: Author,
 
+    /// The document's description.
+    #[ghost]
+    pub description: Option<Content>,
+
     /// The document's keywords.
     #[ghost]
     pub keywords: Keywords,
@@ -91,6 +95,8 @@ pub struct DocumentInfo {
     pub title: Option<EcoString>,
     /// The document's author.
     pub author: Vec<EcoString>,
+    /// The document's description.
+    pub description: Option<EcoString>,
     /// The document's keywords.
     pub keywords: Vec<EcoString>,
     /// The document's creation date.
@@ -110,6 +116,10 @@ impl DocumentInfo {
         }
         if has(<DocumentElem as Fields>::Enum::Author) {
             self.author = DocumentElem::author_in(chain).0;
+        }
+        if has(<DocumentElem as Fields>::Enum::Description) {
+            self.description =
+                DocumentElem::description_in(chain).map(|content| content.plain_text());
         }
         if has(<DocumentElem as Fields>::Enum::Keywords) {
             self.keywords = DocumentElem::keywords_in(chain).0;

--- a/crates/typst-library/src/model/emph.rs
+++ b/crates/typst-library/src/model/emph.rs
@@ -1,6 +1,9 @@
 use crate::diag::SourceResult;
 use crate::engine::Engine;
-use crate::foundations::{elem, Content, Packed, Show, StyleChain};
+use crate::foundations::{
+    elem, Content, NativeElement, Packed, Show, StyleChain, TargetElem,
+};
+use crate::html::{tag, HtmlElem};
 use crate::text::{ItalicToggle, TextElem};
 
 /// Emphasizes content by toggling italics.
@@ -35,7 +38,15 @@ pub struct EmphElem {
 
 impl Show for Packed<EmphElem> {
     #[typst_macros::time(name = "emph", span = self.span())]
-    fn show(&self, _: &mut Engine, _: StyleChain) -> SourceResult<Content> {
-        Ok(self.body().clone().styled(TextElem::set_emph(ItalicToggle(true))))
+    fn show(&self, _: &mut Engine, styles: StyleChain) -> SourceResult<Content> {
+        let body = self.body.clone();
+        Ok(if TargetElem::target_in(styles).is_html() {
+            HtmlElem::new(tag::em)
+                .with_body(Some(body))
+                .pack()
+                .spanned(self.span())
+        } else {
+            body.styled(TextElem::set_emph(ItalicToggle(true)))
+        })
     }
 }

--- a/crates/typst-library/src/model/figure.rs
+++ b/crates/typst-library/src/model/figure.rs
@@ -9,8 +9,9 @@ use crate::diag::{bail, SourceResult};
 use crate::engine::Engine;
 use crate::foundations::{
     cast, elem, scope, select_where, Content, Element, NativeElement, Packed, Selector,
-    Show, ShowSet, Smart, StyleChain, Styles, Synthesize,
+    Show, ShowSet, Smart, StyleChain, Styles, Synthesize, TargetElem,
 };
+use crate::html::{tag, HtmlElem};
 use crate::introspection::{
     Count, Counter, CounterKey, CounterUpdate, Locatable, Location,
 };
@@ -326,15 +327,30 @@ impl Synthesize for Packed<FigureElem> {
 impl Show for Packed<FigureElem> {
     #[typst_macros::time(name = "figure", span = self.span())]
     fn show(&self, _: &mut Engine, styles: StyleChain) -> SourceResult<Content> {
-        let mut realized = self.body().clone();
+        let target = TargetElem::target_in(styles);
+        let mut realized = self.body.clone();
 
         // Build the caption, if any.
         if let Some(caption) = self.caption(styles) {
-            let v = VElem::new(self.gap(styles).into()).with_weak(true).pack();
-            realized = match caption.position(styles) {
-                OuterVAlignment::Top => caption.pack() + v + realized,
-                OuterVAlignment::Bottom => realized + v + caption.pack(),
+            let (first, second) = match caption.position(styles) {
+                OuterVAlignment::Top => (caption.pack(), realized),
+                OuterVAlignment::Bottom => (realized, caption.pack()),
             };
+            let mut seq = Vec::with_capacity(3);
+            seq.push(first);
+            if !target.is_html() {
+                let v = VElem::new(self.gap(styles).into()).with_weak(true);
+                seq.push(v.pack().spanned(self.span()))
+            }
+            seq.push(second);
+            realized = Content::sequence(seq)
+        }
+
+        if target.is_html() {
+            return Ok(HtmlElem::new(tag::figure)
+                .with_body(Some(realized))
+                .pack()
+                .spanned(self.span()));
         }
 
         // Wrap the contents in a block.
@@ -605,6 +621,13 @@ impl Show for Packed<FigureCaption> {
                 supplement += TextElem::packed('\u{a0}');
             }
             realized = supplement + numbers + self.get_separator(styles) + realized;
+        }
+
+        if TargetElem::target_in(styles).is_html() {
+            return Ok(HtmlElem::new(tag::figcaption)
+                .with_body(Some(realized))
+                .pack()
+                .spanned(self.span()));
         }
 
         Ok(realized)

--- a/crates/typst-library/src/model/link.rs
+++ b/crates/typst-library/src/model/link.rs
@@ -3,11 +3,13 @@ use std::ops::Deref;
 use ecow::{eco_format, EcoString};
 use smallvec::SmallVec;
 
-use crate::diag::{bail, At, SourceResult, StrResult};
+use crate::diag::{bail, warning, At, SourceResult, StrResult};
 use crate::engine::Engine;
 use crate::foundations::{
-    cast, elem, Content, Label, Packed, Repr, Show, Smart, StyleChain,
+    cast, elem, Content, Label, NativeElement, Packed, Repr, Show, Smart, StyleChain,
+    TargetElem,
 };
+use crate::html::{attr, tag, HtmlElem};
 use crate::introspection::Location;
 use crate::layout::Position;
 use crate::text::{Hyphenate, TextElem};
@@ -99,18 +101,36 @@ impl LinkElem {
 
 impl Show for Packed<LinkElem> {
     #[typst_macros::time(name = "link", span = self.span())]
-    fn show(&self, engine: &mut Engine, _: StyleChain) -> SourceResult<Content> {
+    fn show(&self, engine: &mut Engine, styles: StyleChain) -> SourceResult<Content> {
         let body = self.body().clone();
-        let linked = match self.dest() {
-            LinkTarget::Dest(dest) => body.linked(dest.clone()),
-            LinkTarget::Label(label) => {
-                let elem = engine.introspector.query_label(*label).at(self.span())?;
-                let dest = Destination::Location(elem.location().unwrap());
-                body.clone().linked(dest)
-            }
-        };
+        let dest = self.dest();
 
-        Ok(linked.styled(TextElem::set_hyphenate(Hyphenate(Smart::Custom(false)))))
+        Ok(if TargetElem::target_in(styles).is_html() {
+            if let LinkTarget::Dest(Destination::Url(url)) = dest {
+                HtmlElem::new(tag::a)
+                    .with_attr(attr::href, url.clone().into_inner())
+                    .with_body(Some(body))
+                    .pack()
+                    .spanned(self.span())
+            } else {
+                engine.sink.warn(warning!(
+                    self.span(),
+                    "non-URL links are not yet supported by HTML export"
+                ));
+                body
+            }
+        } else {
+            let linked = match self.dest() {
+                LinkTarget::Dest(dest) => body.linked(dest.clone()),
+                LinkTarget::Label(label) => {
+                    let elem = engine.introspector.query_label(*label).at(self.span())?;
+                    let dest = Destination::Location(elem.location().unwrap());
+                    body.clone().linked(dest)
+                }
+            };
+
+            linked.styled(TextElem::set_hyphenate(Hyphenate(Smart::Custom(false))))
+        })
     }
 }
 

--- a/crates/typst-library/src/model/list.rs
+++ b/crates/typst-library/src/model/list.rs
@@ -4,8 +4,9 @@ use crate::diag::{bail, SourceResult};
 use crate::engine::Engine;
 use crate::foundations::{
     cast, elem, scope, Array, Content, Context, Depth, Func, NativeElement, Packed, Show,
-    Smart, StyleChain, Styles, Value,
+    Smart, StyleChain, Styles, TargetElem, Value,
 };
+use crate::html::{tag, HtmlElem};
 use crate::layout::{BlockElem, Em, Length, VElem};
 use crate::model::ParElem;
 use crate::text::TextElem;
@@ -140,6 +141,18 @@ impl ListElem {
 
 impl Show for Packed<ListElem> {
     fn show(&self, engine: &mut Engine, styles: StyleChain) -> SourceResult<Content> {
+        if TargetElem::target_in(styles).is_html() {
+            return Ok(HtmlElem::new(tag::ul)
+                .with_body(Some(Content::sequence(self.children.iter().map(|item| {
+                    HtmlElem::new(tag::li)
+                        .with_body(Some(item.body.clone()))
+                        .pack()
+                        .spanned(item.span())
+                }))))
+                .pack()
+                .spanned(self.span()));
+        }
+
         let mut realized =
             BlockElem::multi_layouter(self.clone(), engine.routines.layout_list)
                 .pack()

--- a/crates/typst-library/src/model/outline.rs
+++ b/crates/typst-library/src/model/outline.rs
@@ -248,7 +248,7 @@ impl Show for Packed<OutlineElem> {
             )?;
 
             // Add the overridable outline entry, followed by a line break.
-            seq.push(entry.pack());
+            seq.push(entry.pack().spanned(self.span()));
             seq.push(LinebreakElem::shared().clone());
 
             ancestors.push(elem);
@@ -332,15 +332,18 @@ impl OutlineIndent {
                 }
 
                 if !ancestors.is_empty() {
-                    seq.push(HideElem::new(hidden).pack());
-                    seq.push(SpaceElem::shared().clone());
+                    seq.push(HideElem::new(hidden).pack().spanned(span));
+                    seq.push(SpaceElem::shared().clone().spanned(span));
                 }
             }
 
             // Length => indent with some fixed spacing per level
             Some(Smart::Custom(OutlineIndent::Rel(length))) => {
                 seq.push(
-                    HElem::new(Spacing::Rel(*length)).pack().repeat(ancestors.len()),
+                    HElem::new(Spacing::Rel(*length))
+                        .pack()
+                        .spanned(span)
+                        .repeat(ancestors.len()),
                 );
             }
 
@@ -535,7 +538,7 @@ impl Show for Packed<OutlineEntry> {
             );
             seq.push(SpaceElem::shared().clone());
         } else {
-            seq.push(HElem::new(Fr::one().into()).pack());
+            seq.push(HElem::new(Fr::one().into()).pack().spanned(self.span()));
         }
 
         // Add the page number.

--- a/crates/typst-library/src/model/strong.rs
+++ b/crates/typst-library/src/model/strong.rs
@@ -1,6 +1,9 @@
 use crate::diag::SourceResult;
 use crate::engine::Engine;
-use crate::foundations::{elem, Content, Packed, Show, StyleChain};
+use crate::foundations::{
+    elem, Content, NativeElement, Packed, Show, StyleChain, TargetElem,
+};
+use crate::html::{tag, HtmlElem};
 use crate::text::{TextElem, WeightDelta};
 
 /// Strongly emphasizes content by increasing the font weight.
@@ -40,9 +43,14 @@ pub struct StrongElem {
 impl Show for Packed<StrongElem> {
     #[typst_macros::time(name = "strong", span = self.span())]
     fn show(&self, _: &mut Engine, styles: StyleChain) -> SourceResult<Content> {
-        Ok(self
-            .body()
-            .clone()
-            .styled(TextElem::set_delta(WeightDelta(self.delta(styles)))))
+        let body = self.body.clone();
+        Ok(if TargetElem::target_in(styles).is_html() {
+            HtmlElem::new(tag::strong)
+                .with_body(Some(body))
+                .pack()
+                .spanned(self.span())
+        } else {
+            body.styled(TextElem::set_delta(WeightDelta(self.delta(styles))))
+        })
     }
 }

--- a/crates/typst-library/src/model/terms.rs
+++ b/crates/typst-library/src/model/terms.rs
@@ -127,7 +127,7 @@ impl Show for Packed<TermsElem> {
 
         let pad = hanging_indent + indent;
         let unpad = (!hanging_indent.is_zero())
-            .then(|| HElem::new((-hanging_indent).into()).pack());
+            .then(|| HElem::new((-hanging_indent).into()).pack().spanned(self.span()));
 
         let mut children = vec![];
         for child in self.children().iter() {
@@ -149,12 +149,16 @@ impl Show for Packed<TermsElem> {
         let mut realized = StackElem::new(children)
             .with_spacing(Some(gutter.into()))
             .pack()
+            .spanned(self.span())
             .padded(padding);
 
         if self.tight(styles) {
             let leading = ParElem::leading_in(styles);
-            let spacing =
-                VElem::new(leading.into()).with_weak(true).with_attach(true).pack();
+            let spacing = VElem::new(leading.into())
+                .with_weak(true)
+                .with_attach(true)
+                .pack()
+                .spanned(self.span());
             realized = spacing + realized;
         }
 

--- a/crates/typst-library/src/routines.rs
+++ b/crates/typst-library/src/routines.rs
@@ -16,10 +16,11 @@ use crate::foundations::{
 use crate::introspection::{Introspector, Locator, SplitLocator};
 use crate::layout::{
     Abs, BoxElem, ColumnsElem, Fragment, Frame, GridElem, InlineItem, MoveElem, PadElem,
-    Region, Regions, Rel, RepeatElem, RotateElem, ScaleElem, Size, SkewElem, StackElem,
+    PagedDocument, Region, Regions, Rel, RepeatElem, RotateElem, ScaleElem, Size,
+    SkewElem, StackElem,
 };
 use crate::math::EquationElem;
-use crate::model::{Document, DocumentInfo, EnumElem, ListElem, TableElem};
+use crate::model::{DocumentInfo, EnumElem, ListElem, TableElem};
 use crate::visualize::{
     CircleElem, EllipseElem, ImageElem, LineElem, PathElem, PolygonElem, RectElem,
     SquareElem,
@@ -90,7 +91,7 @@ routines! {
         engine: &mut Engine,
         content: &Content,
         styles: StyleChain,
-    ) -> SourceResult<Document>
+    ) -> SourceResult<PagedDocument>
 
     /// Lays out content into multiple regions.
     fn layout_fragment(

--- a/crates/typst-library/src/routines.rs
+++ b/crates/typst-library/src/routines.rs
@@ -86,13 +86,6 @@ routines! {
         styles: StyleChain<'a>,
     ) -> SourceResult<Vec<Pair<'a>>>
 
-    /// Layout content into a document.
-    fn layout_document(
-        engine: &mut Engine,
-        content: &Content,
-        styles: StyleChain,
-    ) -> SourceResult<PagedDocument>
-
     /// Lays out content into multiple regions.
     fn layout_fragment(
         engine: &mut Engine,
@@ -343,11 +336,16 @@ pub enum EvalMode {
 
 /// Defines what kind of realization we are performing.
 pub enum RealizationKind<'a> {
-    /// This the root realization for the document. Requires a mutable reference
+    /// This the root realization for layout. Requires a mutable reference
     /// to document metadata that will be filled from `set document` rules.
-    Root(&'a mut DocumentInfo),
+    LayoutDocument(&'a mut DocumentInfo),
     /// A nested realization in a container (e.g. a `block`).
-    Container,
+    LayoutFragment,
+    /// This the root realization for HTML. Requires a mutable reference
+    /// to document metadata that will be filled from `set document` rules.
+    HtmlDocument(&'a mut DocumentInfo),
+    /// A nested realization in a container (e.g. a `block`).
+    HtmlFragment,
     /// A realization within math.
     Math,
 }

--- a/crates/typst-library/src/text/raw.rs
+++ b/crates/typst-library/src/text/raw.rs
@@ -14,8 +14,9 @@ use crate::diag::{At, FileError, HintedStrResult, SourceResult, StrResult};
 use crate::engine::Engine;
 use crate::foundations::{
     cast, elem, scope, Args, Array, Bytes, Content, Fold, NativeElement, Packed,
-    PlainText, Show, ShowSet, Smart, StyleChain, Styles, Synthesize, Value,
+    PlainText, Show, ShowSet, Smart, StyleChain, Styles, Synthesize, TargetElem, Value,
 };
+use crate::html::{tag, HtmlElem};
 use crate::layout::{BlockBody, BlockElem, Em, HAlignment};
 use crate::model::{Figurable, ParElem};
 use crate::text::{
@@ -451,6 +452,14 @@ impl Show for Packed<RawElem> {
         }
 
         let mut realized = Content::sequence(seq);
+
+        if TargetElem::target_in(styles).is_html() {
+            return Ok(HtmlElem::new(tag::pre)
+                .with_body(Some(realized))
+                .pack()
+                .spanned(self.span()));
+        }
+
         if self.block(styles) {
             // Align the text before inserting it into the block.
             realized = realized.aligned(self.align(styles).into());

--- a/crates/typst-macros/src/cast.rs
+++ b/crates/typst-macros/src/cast.rs
@@ -273,7 +273,7 @@ fn create_output_body(input: &CastInput) -> TokenStream {
     if input.dynamic {
         quote! { #foundations::CastInfo::Type(#foundations::Type::of::<Self>()) }
     } else {
-        quote! { Self::input() }
+        quote! { <Self as #foundations::Reflect>::input() }
     }
 }
 

--- a/crates/typst-pdf/src/catalog.rs
+++ b/crates/typst-pdf/src/catalog.rs
@@ -48,6 +48,11 @@ pub fn write_catalog(
         xmp.title([(None, title.as_str())]);
     }
 
+    if let Some(description) = &ctx.document.info.description {
+        info.subject(TextStr::trimmed(description));
+        xmp.description([(None, description.as_str())]);
+    }
+
     let authors = &ctx.document.info.author;
     if !authors.is_empty() {
         // Turns out that if the authors are given in both the document

--- a/crates/typst-realize/src/lib.rs
+++ b/crates/typst-realize/src/lib.rs
@@ -18,6 +18,7 @@ use typst_library::foundations::{
     SequenceElem, Show, ShowSet, Style, StyleChain, StyleVec, StyledElem, Styles,
     Synthesize, Transformation,
 };
+use typst_library::html::{tag, HtmlElem};
 use typst_library::introspection::{Locatable, SplitLocator, Tag, TagElem};
 use typst_library::layout::{
     AlignElem, BoxElem, HElem, InlineElem, PageElem, PagebreakElem, VElem,
@@ -47,12 +48,16 @@ pub fn realize<'a>(
         locator,
         arenas,
         rules: match kind {
-            RealizationKind::Root(_) | RealizationKind::Container => NORMAL_RULES,
+            RealizationKind::LayoutDocument(_) | RealizationKind::LayoutFragment => {
+                LAYOUT_RULES
+            }
+            RealizationKind::HtmlDocument(_) => HTML_DOCUMENT_RULES,
+            RealizationKind::HtmlFragment => HTML_FRAGMENT_RULES,
             RealizationKind::Math => MATH_RULES,
         },
         sink: vec![],
         groupings: ArrayVec::new(),
-        outside: matches!(kind, RealizationKind::Root(_)),
+        outside: matches!(kind, RealizationKind::LayoutDocument(_)),
         may_attach: false,
         kind,
     };
@@ -105,10 +110,10 @@ struct GroupingRule {
     /// be visible to `finish`.
     tags: bool,
     /// Defines which kinds of elements start and make up this kind of grouping.
-    trigger: fn(Element) -> bool,
+    trigger: fn(&Content, &RealizationKind) -> bool,
     /// Defines elements that may appear in the interior of the grouping, but
     /// not at the edges.
-    inner: fn(Element) -> bool,
+    inner: fn(&Content) -> bool,
     /// Defines whether styles for this kind of element interrupt the grouping.
     interrupt: fn(Element) -> bool,
     /// Should convert the accumulated elements in `s.sink[start..]` into
@@ -555,14 +560,16 @@ fn visit_styled<'a>(
     for style in local.iter() {
         let Some(elem) = style.element() else { continue };
         if elem == DocumentElem::elem() {
-            let RealizationKind::Root(info) = &mut s.kind else {
-                let span = style.span();
-                bail!(span, "document set rules are not allowed inside of containers");
-            };
-
-            info.populate(&local);
+            match &mut s.kind {
+                RealizationKind::LayoutDocument(info)
+                | RealizationKind::HtmlDocument(info) => info.populate(&local),
+                _ => bail!(
+                    style.span(),
+                    "document set rules are not allowed inside of containers"
+                ),
+            }
         } else if elem == PageElem::elem() {
-            let RealizationKind::Root(_) = s.kind else {
+            let RealizationKind::LayoutDocument(_) = s.kind else {
                 let span = style.span();
                 bail!(span, "page configuration is not allowed inside of containers");
             };
@@ -618,8 +625,7 @@ fn visit_grouping_rules<'a>(
     content: &'a Content,
     styles: StyleChain<'a>,
 ) -> SourceResult<bool> {
-    let elem = content.elem();
-    let matching = s.rules.iter().find(|&rule| (rule.trigger)(elem));
+    let matching = s.rules.iter().find(|&rule| (rule.trigger)(content, &s.kind));
 
     // Try to continue or finish an existing grouping.
     while let Some(active) = s.groupings.last() {
@@ -629,7 +635,7 @@ fn visit_grouping_rules<'a>(
         }
 
         // If the element can be added to the active grouping, do it.
-        if (active.rule.trigger)(elem) || (active.rule.inner)(elem) {
+        if (active.rule.trigger)(content, &s.kind) || (active.rule.inner)(content) {
             s.sink.push((content, styles));
             return Ok(true);
         }
@@ -655,7 +661,9 @@ fn visit_filter_rules<'a>(
     content: &'a Content,
     styles: StyleChain<'a>,
 ) -> SourceResult<bool> {
-    if content.is::<SpaceElem>() && !matches!(s.kind, RealizationKind::Math) {
+    if content.is::<SpaceElem>()
+        && !matches!(s.kind, RealizationKind::Math | RealizationKind::HtmlFragment)
+    {
         // Outside of maths, spaces that were not collected by the paragraph
         // grouper don't interest us.
         return Ok(true);
@@ -730,7 +738,7 @@ fn finish_innermost_grouping(s: &mut State) -> SourceResult<()> {
     let Grouping { start, rule } = s.groupings.pop().unwrap();
 
     // Trim trailing non-trigger elements.
-    let trimmed = s.sink[start..].trim_end_matches(|(c, _)| !(rule.trigger)(c.elem()));
+    let trimmed = s.sink[start..].trim_end_matches(|(c, _)| !(rule.trigger)(c, &s.kind));
     let end = start + trimmed.len();
     let tail = s.store_slice(&s.sink[end..]);
     s.sink.truncate(end);
@@ -768,22 +776,30 @@ fn finish_innermost_grouping(s: &mut State) -> SourceResult<()> {
 /// number of unique priority levels.
 const MAX_GROUP_NESTING: usize = 3;
 
-/// Grouping rules used in normal realizations.
-static NORMAL_RULES: &[&GroupingRule] = &[&TEXTUAL, &PAR, &CITES, &LIST, &ENUM, &TERMS];
+/// Grouping rules used in layout realization.
+static LAYOUT_RULES: &[&GroupingRule] = &[&TEXTUAL, &PAR, &CITES, &LIST, &ENUM, &TERMS];
 
-/// Grouping rules used in math realization.
+/// Grouping rules used in HTML root realization.
+static HTML_DOCUMENT_RULES: &[&GroupingRule] =
+    &[&TEXTUAL, &PAR, &CITES, &LIST, &ENUM, &TERMS];
+
+/// Grouping rules used in HTML fragment realization.
+static HTML_FRAGMENT_RULES: &[&GroupingRule] = &[&TEXTUAL, &CITES, &LIST, &ENUM, &TERMS];
+
+/// Grouping rules used in math realizatio.
 static MATH_RULES: &[&GroupingRule] = &[&CITES, &LIST, &ENUM, &TERMS];
 
 /// Groups adjacent textual elements for text show rule application.
 static TEXTUAL: GroupingRule = GroupingRule {
     priority: 3,
     tags: true,
-    trigger: |elem| {
+    trigger: |content, _| {
+        let elem = content.elem();
         elem == TextElem::elem()
             || elem == LinebreakElem::elem()
             || elem == SmartQuoteElem::elem()
     },
-    inner: |elem| elem == SpaceElem::elem(),
+    inner: |content| content.elem() == SpaceElem::elem(),
     // Any kind of style interrupts this kind of grouping since regex show
     // rules cannot match over style changes anyway.
     interrupt: |_| true,
@@ -794,15 +810,22 @@ static TEXTUAL: GroupingRule = GroupingRule {
 static PAR: GroupingRule = GroupingRule {
     priority: 1,
     tags: true,
-    trigger: |elem| {
+    trigger: |content, kind| {
+        let elem = content.elem();
         elem == TextElem::elem()
             || elem == HElem::elem()
             || elem == LinebreakElem::elem()
             || elem == SmartQuoteElem::elem()
             || elem == InlineElem::elem()
             || elem == BoxElem::elem()
+            || (matches!(
+                kind,
+                RealizationKind::HtmlDocument(_) | RealizationKind::HtmlFragment
+            ) && content
+                .to_packed::<HtmlElem>()
+                .is_some_and(|elem| tag::is_inline(elem.tag)))
     },
-    inner: |elem| elem == SpaceElem::elem(),
+    inner: |content| content.elem() == SpaceElem::elem(),
     interrupt: |elem| elem == ParElem::elem() || elem == AlignElem::elem(),
     finish: finish_par,
 };
@@ -811,8 +834,8 @@ static PAR: GroupingRule = GroupingRule {
 static CITES: GroupingRule = GroupingRule {
     priority: 2,
     tags: false,
-    trigger: |elem| elem == CiteElem::elem(),
-    inner: |elem| elem == SpaceElem::elem(),
+    trigger: |content, _| content.elem() == CiteElem::elem(),
+    inner: |content| content.elem() == SpaceElem::elem(),
     interrupt: |elem| elem == CiteGroup::elem(),
     finish: finish_cites,
 };
@@ -831,8 +854,11 @@ const fn list_like_grouping<T: ListLike>() -> GroupingRule {
     GroupingRule {
         priority: 2,
         tags: false,
-        trigger: |elem| elem == T::Item::elem(),
-        inner: |elem| elem == SpaceElem::elem() || elem == ParbreakElem::elem(),
+        trigger: |content, _| content.elem() == T::Item::elem(),
+        inner: |content| {
+            let elem = content.elem();
+            elem == SpaceElem::elem() || elem == ParbreakElem::elem()
+        },
         interrupt: |elem| elem == T::elem(),
         finish: finish_list_like::<T>,
     }
@@ -867,7 +893,7 @@ fn finish_textual(Grouped { s, mut start }: Grouped) -> SourceResult<()> {
     // 1. We are already in a paragraph group. In this case, the elements just
     //    transparently become part of it.
     // 2. There is no group at all. In this case, we create one.
-    if s.groupings.is_empty() {
+    if s.groupings.is_empty() && s.rules.iter().any(|&rule| std::ptr::eq(rule, &PAR)) {
         s.groupings.push(Grouping { start, rule: &PAR });
     }
 

--- a/crates/typst-render/src/lib.rs
+++ b/crates/typst-render/src/lib.rs
@@ -7,9 +7,9 @@ mod text;
 
 use tiny_skia as sk;
 use typst_library::layout::{
-    Abs, Axes, Frame, FrameItem, FrameKind, GroupItem, Page, Point, Size, Transform,
+    Abs, Axes, Frame, FrameItem, FrameKind, GroupItem, Page, PagedDocument, Point, Size,
+    Transform,
 };
-use typst_library::model::Document;
 use typst_library::visualize::{Color, Geometry, Paint};
 
 /// Export a page into a raster image.
@@ -43,7 +43,7 @@ pub fn render(page: &Page, pixel_per_pt: f32) -> sk::Pixmap {
 
 /// Export a document with potentially multiple pages into a single raster image.
 pub fn render_merged(
-    document: &Document,
+    document: &PagedDocument,
     pixel_per_pt: f32,
     gap: Abs,
     fill: Option<Color>,

--- a/crates/typst-svg/src/lib.rs
+++ b/crates/typst-svg/src/lib.rs
@@ -32,6 +32,17 @@ pub fn svg(page: &Page) -> String {
     renderer.finalize()
 }
 
+/// Export a frame into a SVG file.
+#[typst_macros::time(name = "svg frame")]
+pub fn svg_frame(frame: &Frame) -> String {
+    let mut renderer = SVGRenderer::new();
+    renderer.write_header(frame.size());
+
+    let state = State::new(frame.size(), Transform::identity());
+    renderer.render_frame(state, Transform::identity(), frame);
+    renderer.finalize()
+}
+
 /// Export a document with potentially multiple pages into a single SVG file.
 ///
 /// The padding will be added around and between the individual frames.

--- a/crates/typst-svg/src/lib.rs
+++ b/crates/typst-svg/src/lib.rs
@@ -11,9 +11,9 @@ use std::fmt::{self, Display, Formatter, Write};
 use ecow::EcoString;
 use ttf_parser::OutlineBuilder;
 use typst_library::layout::{
-    Abs, Frame, FrameItem, FrameKind, GroupItem, Page, Point, Ratio, Size, Transform,
+    Abs, Frame, FrameItem, FrameKind, GroupItem, Page, PagedDocument, Point, Ratio, Size,
+    Transform,
 };
-use typst_library::model::Document;
 use typst_library::visualize::{Geometry, Gradient, Pattern};
 use typst_utils::hash128;
 use xmlwriter::XmlWriter;
@@ -35,7 +35,7 @@ pub fn svg(page: &Page) -> String {
 /// Export a document with potentially multiple pages into a single SVG file.
 ///
 /// The padding will be added around and between the individual frames.
-pub fn svg_merged(document: &Document, padding: Abs) -> String {
+pub fn svg_merged(document: &PagedDocument, padding: Abs) -> String {
     let width = 2.0 * padding
         + document
             .pages

--- a/crates/typst-utils/src/pico.rs
+++ b/crates/typst-utils/src/pico.rs
@@ -216,6 +216,8 @@ mod exceptions {
     pub const LIST: &[&str] = &[
         "cjk-latin-spacing",
         "discretionary-ligatures",
+        "h5",
+        "h6",
         "historical-ligatures",
         "number-clearance",
         "number-margin",

--- a/crates/typst/src/lib.rs
+++ b/crates/typst/src/lib.rs
@@ -47,7 +47,7 @@ use typst_library::diag::{warning, FileError, SourceDiagnostic, SourceResult, Wa
 use typst_library::engine::{Engine, Route, Sink, Traced};
 use typst_library::foundations::{StyleChain, Styles, Value};
 use typst_library::introspection::Introspector;
-use typst_library::model::Document;
+use typst_library::layout::PagedDocument;
 use typst_library::routines::Routines;
 use typst_syntax::{FileId, Span};
 use typst_timing::{timed, TimingScope};
@@ -57,7 +57,7 @@ use typst_timing::{timed, TimingScope};
 /// - Returns `Ok(document)` if there were no fatal errors.
 /// - Returns `Err(errors)` if there were fatal errors.
 #[typst_macros::time]
-pub fn compile(world: &dyn World) -> Warned<SourceResult<Document>> {
+pub fn compile(world: &dyn World) -> Warned<SourceResult<PagedDocument>> {
     let mut sink = Sink::new();
     let output = compile_impl(world.track(), Traced::default().track(), &mut sink)
         .map_err(deduplicate);
@@ -80,7 +80,7 @@ fn compile_impl(
     world: Tracked<dyn World + '_>,
     traced: Tracked<Traced>,
     sink: &mut Sink,
-) -> SourceResult<Document> {
+) -> SourceResult<PagedDocument> {
     let library = world.library();
     let styles = StyleChain::new(&library.styles);
 
@@ -103,7 +103,7 @@ fn compile_impl(
 
     let mut iter = 0;
     let mut subsink;
-    let mut document = Document::default();
+    let mut document = PagedDocument::default();
 
     // Relayout until all introspections stabilize.
     // If that doesn't happen within five attempts, we give up.

--- a/crates/typst/src/lib.rs
+++ b/crates/typst/src/lib.rs
@@ -234,18 +234,21 @@ fn warn_or_error_for_html(
     world: Tracked<dyn World + '_>,
     sink: &mut Sink,
 ) -> SourceResult<()> {
+    const ISSUE: &str = "https://github.com/typst/typst/issues/5512";
     if world.library().features.is_enabled(Feature::Html) {
         sink.warn(warning!(
             Span::detached(),
             "html export is under active development and incomplete";
             hint: "its behaviour may change at any time";
-            hint: "do not rely on this feature for production use cases"
+            hint: "do not rely on this feature for production use cases";
+            hint: "see {ISSUE} for more information"
         ));
     } else {
         bail!(
             Span::detached(),
             "html export is only available when `--feature html` is passed";
-            hint: "html export is under active development and incomplete"
+            hint: "html export is under active development and incomplete";
+            hint: "see {ISSUE} for more information"
         );
     }
     Ok(())

--- a/crates/typst/src/lib.rs
+++ b/crates/typst/src/lib.rs
@@ -13,11 +13,11 @@
 //!   order-independent and thus much better suited for further processing than
 //!   the raw markup.
 //! - **Layouting:**
-//!   Next, the content is [laid out] into a [document] containing one [frame]
-//!   per page with items at fixed positions.
+//!   Next, the content is [laid out] into a [`PagedDocument`] containing one
+//!   [frame] per page with items at fixed positions.
 //! - **Exporting:**
 //!   These frames can finally be exported into an output format (currently PDF,
-//!   PNG, or SVG).
+//!   PNG, SVG, and HTML).
 //!
 //! [tokens]: typst_syntax::SyntaxKind
 //! [parsed]: typst_syntax::parse
@@ -43,23 +43,32 @@ use std::collections::HashSet;
 
 use comemo::{Track, Tracked, Validate};
 use ecow::{eco_format, eco_vec, EcoString, EcoVec};
-use typst_library::diag::{warning, FileError, SourceDiagnostic, SourceResult, Warned};
+use typst_library::diag::{
+    bail, warning, FileError, SourceDiagnostic, SourceResult, Warned,
+};
 use typst_library::engine::{Engine, Route, Sink, Traced};
 use typst_library::foundations::{StyleChain, Styles, Value};
+use typst_library::html::HtmlDocument;
 use typst_library::introspection::Introspector;
 use typst_library::layout::PagedDocument;
 use typst_library::routines::Routines;
 use typst_syntax::{FileId, Span};
 use typst_timing::{timed, TimingScope};
 
+use crate::foundations::{Target, TargetElem};
+use crate::model::DocumentInfo;
+
 /// Compile sources into a fully layouted document.
 ///
 /// - Returns `Ok(document)` if there were no fatal errors.
 /// - Returns `Err(errors)` if there were fatal errors.
 #[typst_macros::time]
-pub fn compile(world: &dyn World) -> Warned<SourceResult<PagedDocument>> {
+pub fn compile<D>(world: &dyn World) -> Warned<SourceResult<D>>
+where
+    D: Document,
+{
     let mut sink = Sink::new();
-    let output = compile_impl(world.track(), Traced::default().track(), &mut sink)
+    let output = compile_impl::<D>(world.track(), Traced::default().track(), &mut sink)
         .map_err(deduplicate);
     Warned { output, warnings: sink.warnings() }
 }
@@ -67,22 +76,32 @@ pub fn compile(world: &dyn World) -> Warned<SourceResult<PagedDocument>> {
 /// Compiles sources and returns all values and styles observed at the given
 /// `span` during compilation.
 #[typst_macros::time]
-pub fn trace(world: &dyn World, span: Span) -> EcoVec<(Value, Option<Styles>)> {
+pub fn trace<D>(world: &dyn World, span: Span) -> EcoVec<(Value, Option<Styles>)>
+where
+    D: Document,
+{
     let mut sink = Sink::new();
     let traced = Traced::new(span);
-    compile_impl(world.track(), traced.track(), &mut sink).ok();
+    compile_impl::<D>(world.track(), traced.track(), &mut sink).ok();
     sink.values()
 }
 
 /// The internal implementation of `compile` with a bit lower-level interface
 /// that is also used by `trace`.
-fn compile_impl(
+fn compile_impl<D: Document>(
     world: Tracked<dyn World + '_>,
     traced: Tracked<Traced>,
     sink: &mut Sink,
-) -> SourceResult<PagedDocument> {
+) -> SourceResult<D> {
+    if D::TARGET == Target::Html {
+        warn_or_error_for_html(world, sink)?;
+    }
+
     let library = world.library();
-    let styles = StyleChain::new(&library.styles);
+    let base = StyleChain::new(&library.styles);
+    let target = TargetElem::set_target(D::TARGET).wrap();
+    let styles = base.chain(&target);
+    let empty_introspector = Introspector::default();
 
     // Fetch the main source file once.
     let main = world.main();
@@ -103,7 +122,8 @@ fn compile_impl(
 
     let mut iter = 0;
     let mut subsink;
-    let mut document = PagedDocument::default();
+    let mut introspector = &empty_introspector;
+    let mut document: D;
 
     // Relayout until all introspections stabilize.
     // If that doesn't happen within five attempts, we give up.
@@ -118,7 +138,7 @@ fn compile_impl(
         let constraint = <Introspector as Validate>::Constraint::new();
         let mut engine = Engine {
             world,
-            introspector: document.introspector.track_with(&constraint),
+            introspector: introspector.track_with(&constraint),
             traced,
             sink: subsink.track_mut(),
             route: Route::default(),
@@ -126,10 +146,11 @@ fn compile_impl(
         };
 
         // Layout!
-        document = (engine.routines.layout_document)(&mut engine, &content, styles)?;
+        document = D::create(&mut engine, &content, styles)?;
+        introspector = document.introspector();
         iter += 1;
 
-        if timed!("check stabilized", document.introspector.validate(&constraint)) {
+        if timed!("check stabilized", introspector.validate(&constraint)) {
             break;
         }
 
@@ -208,6 +229,97 @@ fn hint_invalid_main_file(
     eco_vec![diagnostic]
 }
 
+/// HTML export will warn or error depending on whether the feature flag is enabled.
+fn warn_or_error_for_html(
+    world: Tracked<dyn World + '_>,
+    sink: &mut Sink,
+) -> SourceResult<()> {
+    if world.library().features.is_enabled(Feature::Html) {
+        sink.warn(warning!(
+            Span::detached(),
+            "html export is under active development and incomplete";
+            hint: "its behaviour may change at any time";
+            hint: "do not rely on this feature for production use cases"
+        ));
+    } else {
+        bail!(
+            Span::detached(),
+            "html export is only available when `--feature html` is passed";
+            hint: "html export is under active development and incomplete"
+        );
+    }
+    Ok(())
+}
+
+/// A document is what results from compilation.
+pub trait Document: sealed::Sealed {
+    /// Get the document's metadata.
+    fn info(&self) -> &DocumentInfo;
+
+    /// Get the document's introspector.
+    fn introspector(&self) -> &Introspector;
+}
+
+impl Document for PagedDocument {
+    fn info(&self) -> &DocumentInfo {
+        &self.info
+    }
+
+    fn introspector(&self) -> &Introspector {
+        &self.introspector
+    }
+}
+
+impl Document for HtmlDocument {
+    fn info(&self) -> &DocumentInfo {
+        &self.info
+    }
+
+    fn introspector(&self) -> &Introspector {
+        &self.introspector
+    }
+}
+
+mod sealed {
+    use typst_library::foundations::{Content, Target};
+
+    use super::*;
+
+    pub trait Sealed: Sized {
+        const TARGET: Target;
+
+        fn create(
+            engine: &mut Engine,
+            content: &Content,
+            styles: StyleChain,
+        ) -> SourceResult<Self>;
+    }
+
+    impl Sealed for PagedDocument {
+        const TARGET: Target = Target::Paged;
+
+        fn create(
+            engine: &mut Engine,
+            content: &Content,
+            styles: StyleChain,
+        ) -> SourceResult<Self> {
+            typst_layout::layout_document(engine, content, styles)
+        }
+    }
+
+    impl Sealed for HtmlDocument {
+        const TARGET: Target = Target::Html;
+
+        fn create(
+            engine: &mut Engine,
+            content: &Content,
+            styles: StyleChain,
+        ) -> SourceResult<Self> {
+            typst_html::html_document(engine, content, styles)
+        }
+    }
+}
+
 /// Defines implementation of various Typst compiler routines as a table of
 /// function pointers.
 ///
@@ -216,7 +328,6 @@ pub static ROUTINES: Routines = Routines {
     eval_string: typst_eval::eval_string,
     eval_closure: typst_eval::eval_closure,
     realize: typst_realize::realize,
-    layout_document: typst_layout::layout_document,
     layout_fragment: typst_layout::layout_fragment,
     layout_frame: typst_layout::layout_frame,
     layout_inline: typst_layout::layout_inline,

--- a/docs/src/html.rs
+++ b/docs/src/html.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use typed_arena::Arena;
 use typst::diag::{FileError, FileResult, StrResult};
 use typst::foundations::{Bytes, Datetime};
-use typst::layout::{Abs, Point, Size};
+use typst::layout::{Abs, PagedDocument, Point, Size};
 use typst::syntax::{FileId, Source, VirtualPath};
 use typst::text::{Font, FontBook};
 use typst::utils::LazyHash;
@@ -419,7 +419,7 @@ fn code_block(resolver: &dyn Resolver, lang: &str, text: &str) -> Html {
     let source = Source::new(id, compile);
     let world = DocWorld(source);
 
-    let mut document = match typst::compile(&world).output {
+    let mut document = match typst::compile::<PagedDocument>(&world).output {
         Ok(doc) => doc,
         Err(err) => {
             let msg = &err[0].message;

--- a/docs/src/lib.rs
+++ b/docs/src/lib.rs
@@ -21,10 +21,10 @@ use typst::foundations::{
     Scope, Smart, Type, Value, FOUNDATIONS,
 };
 use typst::introspection::INTROSPECTION;
-use typst::layout::{Abs, Margin, PageElem, LAYOUT};
+use typst::layout::{Abs, Margin, PageElem, PagedDocument, LAYOUT};
 use typst::loading::DATA_LOADING;
 use typst::math::MATH;
-use typst::model::{Document, MODEL};
+use typst::model::MODEL;
 use typst::symbols::SYMBOLS;
 use typst::text::{Font, FontBook, TEXT};
 use typst::utils::LazyHash;
@@ -105,7 +105,8 @@ pub trait Resolver {
     fn image(&self, filename: &str, data: &[u8]) -> String;
 
     /// Produce HTML for an example.
-    fn example(&self, hash: u128, source: Option<Html>, document: &Document) -> Html;
+    fn example(&self, hash: u128, source: Option<Html>, document: &PagedDocument)
+        -> Html;
 
     /// Determine the commits between two tags.
     fn commits(&self, from: &str, to: &str) -> Vec<Commit>;
@@ -800,7 +801,7 @@ mod tests {
             None
         }
 
-        fn example(&self, _: u128, _: Option<Html>, _: &Document) -> Html {
+        fn example(&self, _: u128, _: Option<Html>, _: &PagedDocument) -> Html {
             Html::new(String::new())
         }
 

--- a/docs/src/main.rs
+++ b/docs/src/main.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use clap::Parser;
-use typst::model::Document;
+use typst::layout::PagedDocument;
 use typst_docs::{provide, Html, Resolver};
 use typst_render::render;
 
@@ -25,7 +25,7 @@ impl<'a> Resolver for CliResolver<'a> {
         &self,
         hash: u128,
         source: Option<Html>,
-        document: &Document,
+        document: &PagedDocument,
     ) -> typst_docs::Html {
         if self.verbose {
             eprintln!(

--- a/tests/fuzz/src/compile.rs
+++ b/tests/fuzz/src/compile.rs
@@ -3,6 +3,7 @@
 use libfuzzer_sys::fuzz_target;
 use typst::diag::{FileError, FileResult};
 use typst::foundations::{Bytes, Datetime};
+use typst::layout::PagedDocument;
 use typst::syntax::{FileId, Source};
 use typst::text::{Font, FontBook};
 use typst::utils::LazyHash;
@@ -65,7 +66,7 @@ impl World for FuzzWorld {
 
 fuzz_target!(|text: &str| {
     let world = FuzzWorld::new(text);
-    if let Ok(document) = typst::compile(&world).output {
+    if let Ok(document) = typst::compile::<PagedDocument>(&world).output {
         if let Some(page) = document.pages.first() {
             std::hint::black_box(typst_render::render(page, 1.0));
         }

--- a/tests/src/custom.rs
+++ b/tests/src/custom.rs
@@ -1,7 +1,8 @@
 use std::fmt::Write;
 
 use typst::foundations::Smart;
-use typst::model::{Document, DocumentInfo};
+use typst::layout::PagedDocument;
+use typst::model::DocumentInfo;
 use typst::World;
 
 use crate::collect::Test;
@@ -18,7 +19,7 @@ macro_rules! test_eq {
 
 /// Run special checks for specific tests for which it is not worth it to create
 /// custom annotations.
-pub fn check(test: &Test, world: &TestWorld, doc: Option<&Document>) -> String {
+pub fn check(test: &Test, world: &TestWorld, doc: Option<&PagedDocument>) -> String {
     let mut sink = String::new();
     match test.name.as_str() {
         "document-set-author-date" => {
@@ -41,6 +42,6 @@ pub fn check(test: &Test, world: &TestWorld, doc: Option<&Document>) -> String {
 }
 
 /// Extract the document information.
-fn info(doc: Option<&Document>) -> DocumentInfo {
+fn info(doc: Option<&PagedDocument>) -> DocumentInfo {
     doc.map(|doc| doc.info.clone()).unwrap_or_default()
 }

--- a/tests/src/run.rs
+++ b/tests/src/run.rs
@@ -5,8 +5,7 @@ use std::path::Path;
 use ecow::eco_vec;
 use tiny_skia as sk;
 use typst::diag::{SourceDiagnostic, Warned};
-use typst::layout::{Abs, Frame, FrameItem, Page, Transform};
-use typst::model::Document;
+use typst::layout::{Abs, Frame, FrameItem, Page, PagedDocument, Transform};
 use typst::visualize::Color;
 use typst::WorldExt;
 use typst_pdf::PdfOptions;
@@ -116,7 +115,7 @@ impl<'a> Runner<'a> {
 
     /// Run custom checks for which it is not worth to create special
     /// annotations.
-    fn check_custom(&mut self, doc: Option<&Document>) {
+    fn check_custom(&mut self, doc: Option<&PagedDocument>) {
         let errors = crate::custom::check(self.test, &self.world, doc);
         if !errors.is_empty() {
             log!(self, "custom check failed");
@@ -127,7 +126,7 @@ impl<'a> Runner<'a> {
     }
 
     /// Check that the document output is correct.
-    fn check_document(&mut self, document: Option<&Document>) {
+    fn check_document(&mut self, document: Option<&PagedDocument>) {
         let live_path = format!("{}/render/{}.png", crate::STORE_PATH, self.test.name);
         let ref_path = format!("{}/{}.png", crate::REF_PATH, self.test.name);
         let has_ref = Path::new(&ref_path).exists();
@@ -351,7 +350,7 @@ impl<'a> Runner<'a> {
 }
 
 /// Draw all frames into one image with padding in between.
-fn render(document: &Document, pixel_per_pt: f32) -> sk::Pixmap {
+fn render(document: &PagedDocument, pixel_per_pt: f32) -> sk::Pixmap {
     for page in &document.pages {
         let limit = Abs::cm(100.0);
         if page.frame.width() > limit || page.frame.height() > limit {


### PR DESCRIPTION
Please read the [Tracking issue for HTML export](https://github.com/typst/typst/issues/5512) first.


---

This PR implements foundations for HTML export, just enough to turn a Typst file into a single `.html` file. Many things are not implemented or implemented with shortcuts and will not work properly.

This PR consists of the following major changes (best reviewed commit by commit):
- The existing `Document` type is renamed to `PagedDocument`, with the name `Document` being used for a new trait. This trait is implemented by `PagedDocument` and the new `HtmlDocument` type. The `typst::compile` function is now generic over the returned document type.
- Adds a new `html` feature flag, which must be enabled to use HTML export
- Adds an initial `target` function, which returns the current export target as `"paged" | "html"`. This function is contextual, it may change throughout the document if we layout parts of an HTML export and embed as SVG via `html.frame`. The target API is still in flux (we may change it into a proper type instead of a string enum and the granularity is also not yet fully decided). For this reason, it is also guarded behind the `html` feature.
- Adds a new `html.elem` element function, which produces an arbitrary HTML element. We'll add convenient typed APIs like `html.div` etc. in the future. These raw HTML elements are primarily intended to be used in show rules and templates, guarded by `target` checks.
- Adds a new `html.frame` element function, which lays out arbitrary content with the normal procedures and embeds the result as an SVG in the output document. Just a very rough initial draft, which will be expanded later.
- Added `document.description` (also for non-HTML targets)
- For elements to properly work in HTML export, their show rules must either be target-aware or produced only elements, that in turn already have target-aware show rules. This PR ships with a few basic show rules: For `strong`, `emph`, `heading`, `figure`, `link`, `list`, `enum`, `terms`, and `raw`. These are very incomplete and mostly for demonstration purposes. They will be improved in the future.
- Implements routines for turning content into HTML. It hooks in at the same time as layout would typically (after evaluation of the main module) and just like layout it depends on realization internally, tough with a slightly different realization rule configuration. These routines automatically wrap the resulting content into `<html>` and `<body>`, generating a suitable `<head>` element, unless the user provided these themselves.
- Implements writing of an HTML tree to a string with escaping, but without further validity checks and without pretty-printing.
