### PR TITLE
Consider parameters when iterating items in scope

### DIFF
--- a/crates/typst-ide/src/matchers.rs
+++ b/crates/typst-ide/src/matchers.rs
@@ -123,6 +123,32 @@ pub fn named_items<T>(
                 }
             }
 
+            if let Some(v) = parent.cast::<ast::Closure>() {
+                for param in v.params().children() {
+                    match param {
+                        ast::Param::Pos(pattern) => {
+                            for ident in pattern.bindings() {
+                                if let Some(t) = recv(NamedItem::Var(ident)) {
+                                    return Some(t);
+                                }
+                            }
+                        }
+                        ast::Param::Named(n) => {
+                            if let Some(t) = recv(NamedItem::Var(n.name())) {
+                                return Some(t);
+                            }
+                        }
+                        ast::Param::Spread(s) => {
+                            if let Some(sink_ident) = s.sink_ident() {
+                                if let Some(t) = recv(NamedItem::Var(sink_ident)) {
+                                    return Some(t);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
             ancestor = Some(parent.clone());
             continue;
         }

--- a/crates/typst-ide/src/matchers.rs
+++ b/crates/typst-ide/src/matchers.rs
@@ -123,7 +123,11 @@ pub fn named_items<T>(
                 }
             }
 
-            if let Some(v) = parent.cast::<ast::Closure>() {
+            if let Some(v) = parent.cast::<ast::Closure>().filter(|v| {
+                // Check if the node is in the body of the closure.
+                let body = parent.find(v.body().span());
+                body.is_some_and(|n| n.find(node.span()).is_some())
+            }) {
                 for param in v.params().children() {
                     match param {
                         ast::Param::Pos(pattern) => {

--- a/crates/typst-ide/src/matchers.rs
+++ b/crates/typst-ide/src/matchers.rs
@@ -300,6 +300,17 @@ mod tests {
     }
 
     #[test]
+    fn test_param_named_items() {
+        // Has named items
+        assert!(has_named_items(r#"#let f(a) = 1;#let b = 2;"#, 12, "a"));
+        assert!(has_named_items(r#"#let f(a: b) = 1;#let b = 2;"#, 15, "a"));
+
+        // Doesn't have named items
+        assert!(!has_named_items(r#"#let f(a) = 1;#let b = 2;"#, 19, "a"));
+        assert!(!has_named_items(r#"#let f(a: b) = 1;#let b = 2;"#, 15, "b"));
+    }
+
+    #[test]
     fn test_import_named_items() {
         // Cannot test much.
         assert!(has_named_items(r#"#import "foo.typ": a; #(a);"#, 24, "a"));


### PR DESCRIPTION
The iterator didn't consider parameters. This PR checks them when the node comes from the body of a closure.