### PR TITLE
Live reloading HTTP server for `typst watch` and HTML export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +287,12 @@ dependencies = [
  "num-traits",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "ciborium"
@@ -910,6 +922,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hypher"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1296,13 +1314,12 @@ dependencies = [
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96cfd5557eb82f2b83fed4955246c988d331975a002961b07c81584d107e7f7"
+checksum = "9b9569d2f74e257076d8c6bfa73fb505b46b851e51ddaecc825944aa3bed17fa"
 dependencies = [
  "arbitrary",
  "cc",
- "once_cell",
 ]
 
 [[package]]
@@ -2582,6 +2599,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2718,6 +2747,7 @@ dependencies = [
  "sigpipe",
  "tar",
  "tempfile",
+ "tiny_http",
  "toml",
  "typst",
  "typst-eval",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ tar = "0.4"
 tempfile = "3.7.0"
 thin-vec = "0.2.13"
 time = { version = "0.3.20", features = ["formatting", "macros", "parsing"] }
+tiny_http = "0.12"
 tiny-skia = "0.11"
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }
 ttf-parser = "0.24.1"

--- a/crates/typst-cli/Cargo.toml
+++ b/crates/typst-cli/Cargo.toml
@@ -50,6 +50,7 @@ shell-escape = { workspace = true }
 sigpipe = { workspace = true }
 tar = { workspace = true }
 tempfile = { workspace = true }
+tiny_http = { workspace = true }
 toml = { workspace = true }
 ureq = { workspace = true }
 xz2 = { workspace = true, optional = true }

--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -97,6 +97,21 @@ pub struct WatchCommand {
     /// Arguments for compilation.
     #[clap(flatten)]
     pub args: CompileArgs,
+
+    /// Disables the built-in HTTP server for HTML export.
+    #[clap(long)]
+    pub no_serve: bool,
+
+    /// Disables the injected live reload script for HTML export. The HTML that
+    /// is written to disk isn't affected either way.
+    #[clap(long)]
+    pub no_reload: bool,
+
+    /// The port where HTML is served.
+    ///
+    /// Defaults to the first free port in the range 3000-3005.
+    #[clap(long)]
+    pub port: Option<u16>,
 }
 
 /// Initializes a new project from a template.

--- a/crates/typst-cli/src/main.rs
+++ b/crates/typst-cli/src/main.rs
@@ -6,6 +6,7 @@ mod greet;
 mod init;
 mod package;
 mod query;
+mod server;
 mod terminal;
 mod timings;
 #[cfg(feature = "self-update")]

--- a/crates/typst-cli/src/server.rs
+++ b/crates/typst-cli/src/server.rs
@@ -1,0 +1,217 @@
+use std::io::{self, Write};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener};
+use std::sync::Arc;
+
+use ecow::eco_format;
+use parking_lot::{Condvar, Mutex, MutexGuard};
+use tiny_http::{Header, Request, Response, StatusCode};
+use typst::diag::{bail, StrResult};
+
+use crate::args::Input;
+
+/// Serves HTML with live reload.
+pub struct HtmlServer {
+    addr: SocketAddr,
+    bucket: Arc<Bucket<String>>,
+}
+
+impl HtmlServer {
+    /// Create a new HTTP server that serves live HTML.
+    pub fn new(input: &Input, port: Option<u16>, reload: bool) -> StrResult<Self> {
+        let (addr, server) = start_server(port)?;
+
+        let placeholder = PLACEHOLDER_HTML.replace("{INPUT}", &input.to_string());
+        let bucket = Arc::new(Bucket::new(placeholder));
+        let bucket2 = bucket.clone();
+
+        std::thread::spawn(move || {
+            for req in server.incoming_requests() {
+                let _ = handle(req, reload, &bucket2);
+            }
+        });
+
+        Ok(Self { addr, bucket })
+    }
+
+    /// The address that we serve the HTML on.
+    pub fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    /// Updates the HTML, triggering a reload all connected browsers.
+    pub fn update(&self, html: String) {
+        self.bucket.put(html);
+    }
+}
+
+/// Starts a local HTTP server.
+///
+/// Uses the specified port or tries to find a free port in the range
+/// `3000..=3005`.
+fn start_server(port: Option<u16>) -> StrResult<(SocketAddr, tiny_http::Server)> {
+    const BASE_PORT: u16 = 3000;
+
+    let mut addr;
+    let mut retries = 0;
+
+    let listener = loop {
+        addr = SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            port.unwrap_or(BASE_PORT + retries),
+        );
+
+        match TcpListener::bind(addr) {
+            Ok(listener) => break listener,
+            Err(err) if err.kind() == io::ErrorKind::AddrInUse => {
+                if let Some(port) = port {
+                    bail!("port {port} is already in use")
+                } else if retries < 5 {
+                    // If the port is in use, try the next one.
+                    retries += 1;
+                } else {
+                    bail!("could not find free port for HTTP server");
+                }
+            }
+            Err(err) => bail!("failed to start TCP server: {err}"),
+        }
+    };
+
+    let server = tiny_http::Server::from_listener(listener, None)
+        .map_err(|err| eco_format!("failed to start HTTP server: {err}"))?;
+
+    Ok((addr, server))
+}
+
+/// Handles a request.
+fn handle(req: Request, reload: bool, bucket: &Arc<Bucket<String>>) -> io::Result<()> {
+    let path = req.url();
+    match path {
+        "/" => handle_root(req, reload, bucket),
+        "/events" => handle_events(req, bucket.clone()),
+        _ => req.respond(Response::new_empty(StatusCode(404))),
+    }
+}
+
+/// Handles for the `/` route. Serves the compiled HTML.
+fn handle_root(req: Request, reload: bool, bucket: &Bucket<String>) -> io::Result<()> {
+    let mut html = bucket.get().clone();
+    if reload {
+        inject_live_reload_script(&mut html);
+    }
+    req.respond(Response::new(
+        StatusCode(200),
+        vec![Header::from_bytes("Content-Type", "text/html").unwrap()],
+        html.as_bytes(),
+        Some(html.len()),
+        None,
+    ))
+}
+
+/// Handler for the `/events` route.
+fn handle_events(req: Request, bucket: Arc<Bucket<String>>) -> io::Result<()> {
+    std::thread::spawn(move || {
+        // When this returns an error, the client is disconnected and we can
+        // terminate the thread.
+        let _ = handle_events_blocking(req, &bucket);
+    });
+    Ok(())
+}
+
+/// Event stream for the `/events` route.
+fn handle_events_blocking(req: Request, bucket: &Bucket<String>) -> io::Result<()> {
+    let mut writer = req.into_writer();
+    let writer: &mut dyn Write = &mut *writer;
+
+    // We need to write the header manually because `tiny-http` defaults to
+    // `Transfer-Encoding: chunked` when no `Content-Length` is provided, which
+    // Chrome & Safari dislike for `Content-Type: text/event-stream`.
+    write!(writer, "HTTP/1.1 200 OK\r\n")?;
+    write!(writer, "Content-Type: text/event-stream\r\n")?;
+    write!(writer, "Cache-Control: no-cache\r\n")?;
+    write!(writer, "\r\n")?;
+    writer.flush()?;
+
+    // If the user closes the browser tab, this loop will terminate once it
+    // tries to write to the dead socket for the first time.
+    loop {
+        bucket.wait();
+        // Trigger a server-sent event. The browser is listening to it via
+        // an `EventSource` listener` (see `inject_script`).
+        write!(writer, "event: reload\ndata:\n\n")?;
+        writer.flush()?;
+    }
+}
+
+/// Injects the live reload script into a string of HTML.
+fn inject_live_reload_script(html: &mut String) {
+    let pos = html.rfind("</html>").unwrap_or(html.len());
+    html.insert_str(pos, LIVE_RELOAD_SCRIPT);
+}
+
+/// Holds data and notifies consumers when it's updated.
+struct Bucket<T> {
+    mutex: Mutex<T>,
+    condvar: Condvar,
+}
+
+impl<T> Bucket<T> {
+    /// Creates a new bucket with initial data.
+    fn new(init: T) -> Self {
+        Self { mutex: Mutex::new(init), condvar: Condvar::new() }
+    }
+
+    /// Retrieves the current data in the bucket.
+    fn get(&self) -> MutexGuard<T> {
+        self.mutex.lock()
+    }
+
+    /// Puts new data into the bucket and notifies everyone who's currently
+    /// [waiting](Self::wait).
+    fn put(&self, data: T) {
+        *self.mutex.lock() = data;
+        self.condvar.notify_all();
+    }
+
+    /// Waits for new data in the bucket.
+    fn wait(&self) {
+        self.condvar.wait(&mut self.mutex.lock());
+    }
+}
+
+/// The initial HTML before compilation is finished.
+const PLACEHOLDER_HTML: &str = "\
+<html>
+  <head>
+    <title>Waiting for {INPUT}</title>
+    <style>
+      body {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        color: #565565;
+        background: #eff0f3;
+      }
+
+      body > main > div {
+        margin-block: 16px;
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div>Waiting for output ...</div>
+      <div><code>typst watch {INPUT}</code></div>
+    </main>
+  </body>
+</html>
+";
+
+/// Reloads the page whenever it receives a "reload" server-sent event
+/// on the `/events` route.
+const LIVE_RELOAD_SCRIPT: &str = "\
+<script>\
+  new EventSource(\"/events\")\
+    .addEventListener(\"reload\", () => location.reload())\
+</script>\
+";

--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -18,7 +18,6 @@ use typst_kit::package::PackageStorage;
 use typst_timing::timed;
 
 use crate::args::{Feature, Input, ProcessArgs, WorldArgs};
-use crate::compile::ExportCache;
 use crate::download::PrintDownload;
 use crate::package;
 
@@ -49,9 +48,6 @@ pub struct SystemWorld {
     /// always the same within one compilation.
     /// Reset between compilations if not [`Now::Fixed`].
     now: Now,
-    /// The export cache, used for caching output files in `typst watch`
-    /// sessions.
-    export_cache: ExportCache,
 }
 
 impl SystemWorld {
@@ -146,7 +142,6 @@ impl SystemWorld {
             slots: Mutex::new(HashMap::new()),
             package_storage: package::storage(&world_args.package),
             now,
-            export_cache: ExportCache::new(),
         })
     }
 
@@ -190,11 +185,6 @@ impl SystemWorld {
     #[track_caller]
     pub fn lookup(&self, id: FileId) -> Source {
         self.source(id).expect("file id does not point to any source file")
-    }
-
-    /// Gets access to the export cache.
-    pub fn export_cache(&self) -> &ExportCache {
-        &self.export_cache
     }
 }
 


### PR DESCRIPTION
Adds a built-in HTTP server that serves HTML output with live reload when using `typst watch`. The output file is still written as usual; the server is purely additional.

Adds three new CLI arguments to `typst watch`:
- `--no-serve` disables the server, only writing the file
- `--no-reload` keeps the server enabled, but disables live reload
- `--port` lets you override the port, by default it picks a free port in the range 3000-3005

The server injects a live reload script into both the placeholder and the real exported HTML. This script uses [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events) to notify the browser whenever there is an update, which then refreshes the page. The file written to disk is not affected by this script, meaning that `typst watch` and `typst compile` continue to produce the same output (which I consider somewhat important). 

Further remarks:
- When the file isn't yet available, a placeholder page with the text "Waiting for output ..." is rendered. 
- The `--open` flag will default to the server, but still open the file if the server is disabled.
- The server is implemented with `tiny-http`, which is very lightweight (just 4 new dependencies).
- The server will need to be extended once we support multi-file output.