### PR TITLE
Transform high level headings to HTML

### DIFF
--- a/crates/typst-library/src/html/dom.rs
+++ b/crates/typst-library/src/html/dom.rs
@@ -122,8 +122,8 @@ impl HtmlTag {
         let bytes = string.as_bytes();
         let mut i = 0;
         while i < bytes.len() {
-            if !bytes[i].is_ascii_alphanumeric() {
-                panic!("constant tag name must be ASCII alphanumeric");
+            if !bytes[i].is_ascii() || !charsets::is_valid_in_tag_name(bytes[i] as char) {
+                panic!("not all characters are valid in a tag name");
             }
             i += 1;
         }
@@ -220,8 +220,10 @@ impl HtmlAttr {
         let bytes = string.as_bytes();
         let mut i = 0;
         while i < bytes.len() {
-            if !bytes[i].is_ascii_alphanumeric() {
-                panic!("constant attribute name must be ASCII alphanumeric");
+            if !bytes[i].is_ascii()
+                || !charsets::is_valid_in_attribute_name(bytes[i] as char)
+            {
+                panic!("not all characters are valid in an attribute name");
             }
             i += 1;
         }
@@ -568,5 +570,9 @@ pub mod attr {
         href
         name
         value
+        role
     }
+
+    #[allow(non_upper_case_globals)]
+    pub const aria_level: HtmlAttr = HtmlAttr::constant("aria-level");
 }

--- a/crates/typst-library/src/model/heading.rs
+++ b/crates/typst-library/src/model/heading.rs
@@ -1,5 +1,6 @@
 use std::num::NonZeroUsize;
 
+use ecow::eco_format;
 use typst_utils::NonZeroExt;
 
 use crate::diag::{warning, SourceResult};
@@ -277,7 +278,7 @@ impl Show for Packed<HeadingElem> {
                 engine.sink.warn(warning!(span,
                     "heading of level {} was transformed to \
                     <div role=\"heading\" aria-level=\"{}\">, which is not \
-                    supported by all screen readers",
+                    supported by all assistive technology",
                     level, level + 1;
                     hint: "HTML only supports <h1> to <h6>, not <h{}>", level + 1;
                     hint: "you may want to restructure your document so that \
@@ -285,7 +286,7 @@ impl Show for Packed<HeadingElem> {
                 HtmlElem::new(tag::div)
                     .with_body(Some(realized))
                     .with_attr(attr::role, "heading")
-                    .with_attr(attr::aria_level, (level + 1).to_string())
+                    .with_attr(attr::aria_level, eco_format!("{}", level + 1))
                     .pack()
                     .spanned(span)
             } else {


### PR DESCRIPTION
Currently, high level headings get silently transformed to `h6`. I suggest that Typst throws an error instead.