### PR TITLE
Add missing functions to the gradient object.

### DIFF
--- a/crates/typst-library/src/visualize/gradient.rs
+++ b/crates/typst-library/src/visualize/gradient.rs
@@ -706,6 +706,46 @@ impl Gradient {
         }
     }
 
+    /// Returns the radius of this gradient.
+    #[func]
+    pub fn center(&self) -> Option<Axes<Ratio>> {
+        match self {
+            Self::Linear(_) => None,
+            Self::Radial(radial) => Some(radial.center), 
+            Self::Conic(conic) => Some(conic.center),
+        }
+    }
+
+    /// Returns the radius of this gradient.
+    #[func]
+    pub fn radius(&self) -> Option<Ratio> {
+        match self {
+            Self::Linear(_) => None,
+            Self::Radial(radial) => Some(radial.radius), 
+            Self::Conic(_) => None,
+        }
+    }
+
+    /// Returns the focal-center of this gradient.
+    #[func]
+    pub fn focal_center(&self) -> Option<Axes<Ratio>> {
+        match self {
+            Self::Linear(_) => None,
+            Self::Radial(radial) => Some(radial.focal_center), 
+            Self::Conic(_) => None,
+        }
+    }
+
+    /// Returns the focal-center of this gradient.
+    #[func]
+    pub fn focal_radius(&self) -> Option<Ratio> {
+        match self {
+            Self::Linear(_) => None,
+            Self::Radial(radial) => Some(radial.focal_radius), 
+            Self::Conic(_) => None,
+        }
+    }
+
     /// Sample the gradient at a given position.
     ///
     /// The position is either a position along the gradient (a [ratio] between


### PR DESCRIPTION
Needed to fully access the values of radial and conic gradients.

All of the functions needed to read gradient.linear existed, but not radial or conic gradients.  This PR adds them.
The use would be a function to modify a gradient, such as lightening the colors.
```typ
#let lighten-grad(clr) = {
  let new-stops = clr.stops().map(it => (it.at(0).lighten(50%), it.at(1)))
  gradient.radial(
    ..new-stops,
    space: clr.space(),
    relative: clr.relative(),
    focal-center:clr.focal-center(),
    focal-radius:clr.focal-radius()
  )
}
#let g = gradient.radial(..color.map.rainbow)
#box(width:5in, height:3in, fill:g)
#box(width:5in, height:3in, fill:lighten-grad(g))
```
Currently fails with
```
Error: type gradient has no method `focal-center`
    ╭─[/main.typ:14:22]
    │
 14 │     focal-center:clr.focal-center(),
────╯
```

And this is obviously undesirable.