### PR TITLE
Fix autocompletion of half-completed import item

### DIFF
--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -521,6 +521,8 @@ fn complete_imports(ctx: &mut CompletionContext) -> bool {
     if_chain! {
         if ctx.leaf.kind() == SyntaxKind::Ident;
         if let Some(parent) = ctx.leaf.parent();
+        if parent.kind() == SyntaxKind::ImportItemPath;
+        if let Some(parent) = ctx.leaf.parent();
         if parent.kind() == SyntaxKind::ImportItems;
         if let Some(grand) = parent.parent();
         if let Some(ast::Expr::Import(import)) = grand.get().cast();


### PR DESCRIPTION
When completing behind a half-started identifier in an import list:
`#import "path.typ": thi|",`, the parent should be and ImportItemPath, which parent is ImportItems.

This bug make completion behind a half-started identifier in an import list NEVER possible.