### PR TITLE
Add test for issue #4573

### DIFF
--- a/tests/suite/scripting/destructuring.typ
+++ b/tests/suite/scripting/destructuring.typ
@@ -373,3 +373,19 @@
 // Error: 6-12 too many elements to destructure
 // Hint: 6-12 the provided array has a length of 3, but the pattern expects 2 elements
 #for (x, y) in ((1,2,3), (4,5,6)) {}
+
+--- issue-4573-destructuring-unclosed-delimiter ---
+// See comment in issue for explanation. This one's complex.
+#{
+  (
+    // Error: 5-7 expected pattern, found keyword `if`
+    // Hint: 5-7 keyword `if` is not allowed as an identifier; try `if_` instead
+    // Error: 9 expected comma
+    // Error: 13-17 unexpected keyword `else`
+    // Error: 20 expected comma
+    if x {} else {}
+    // Error: 5-6 unclosed delimiter
+    { () = 2
+  ) = 3
+}
+

--- a/tests/suite/scripting/destructuring.typ
+++ b/tests/suite/scripting/destructuring.typ
@@ -375,7 +375,11 @@
 #for (x, y) in ((1,2,3), (4,5,6)) {}
 
 --- issue-4573-destructuring-unclosed-delimiter ---
-// See comment in issue for explanation. This one's complex.
+// Tests a case where parsing within an incorrectly predicted paren expression
+// (the "outer" assignment) would put the parser in an invalid state when
+// reloading a stored prediction (the "inner" assignment) and cause a panic when
+// generating the unclosed delimiter error. See the comment in the issue for
+// more details.
 #{
   (
     // Error: 5-7 expected pattern, found keyword `if`
@@ -385,7 +389,7 @@
     // Error: 20 expected comma
     if x {} else {}
     // Error: 5-6 unclosed delimiter
-    { () = 2
-  ) = 3
+    { () = "inner"
+  ) = "outer"
 }
 


### PR DESCRIPTION
#4573 is already fixed, but this PR adds the minimal example I commented as a test case. Running it on a commit before commit 5 of the parser refactor (16cc7eb) should cause a crash in the parser.
