### PR TITLE
Bump hashbrown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,9 +890,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "hayagriva"
@@ -1169,7 +1169,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.2",
  "rayon",
  "serde",
 ]


### PR DESCRIPTION
A CVE was filed against hashbrown 0.15.0 We didn't use the borsh feature of hashbrown, so we aren't really affected, but updating doesn't hurt, in particular, as to not trigger vulnerability scanners.