### PR TITLE
Add release target `loongarch64-unknown-linux-musl`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
         - target: riscv64gc-unknown-linux-gnu
           os: ubuntu-latest
           cross: true
+        - target: loongarch64-unknown-linux-musl
+          os: ubuntu-latest
+          cross: true
         - target: x86_64-apple-darwin
           os: macos-latest
           cross: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Run Cross
       if: ${{ matrix.cross }}
       run: |
-        cargo install cross --git https://github.com/cross-rs/cross.git --locked --rev 085092ca
+        cargo install cross --git https://github.com/cross-rs/cross.git --locked --rev 4090beca
         cross build -p typst-cli --release --target ${{ matrix.target }} --features self-update,vendor-openssl
 
     - name: Run Cargo

--- a/crates/typst-cli/src/update.rs
+++ b/crates/typst-cli/src/update.rs
@@ -28,6 +28,7 @@ macro_rules! determine_asset {
             "aarch64-unknown-linux-gnu" => "aarch64-unknown-linux-musl",
             "armv7-unknown-linux-gnueabi" => "armv7-unknown-linux-musleabi",
             "riscv64gc-unknown-linux-musl" => "riscv64gc-unknown-linux-gnu",
+            "loongarch64-unknown-linux-gnu" => "loongarch64-unknown-linux-musl",
         })
     };
 


### PR DESCRIPTION
LoongArch is an emerging RISC ISA developed by Loongson Technology, which has been mainlined in the Linux kernel. As LoongArch-based systems gain wider adoption, particularly in various computing environments, adding support for this architecture would benefit Typst users on these platforms.

### Details

- Adding loongarch64-unknown-linux-musl as a new release target
- Using musl variant for better portability
- Target is now supported in upstream cross-rs

### References

- [LoongArch Documentation](https://loongson.github.io/LoongArch-Documentation/README-EN.html)
- [Wikipedia: LoongArch](https://en.wikipedia.org/wiki/Loongson)