### PR TITLE
Change error when accessing non-existant label

### DIFF
--- a/crates/typst-library/src/foundations/content.rs
+++ b/crates/typst-library/src/foundations/content.rs
@@ -211,9 +211,10 @@ impl Content {
     /// instead.
     pub fn get_by_name(&self, name: &str) -> Result<Value, FieldAccessError> {
         if name == "label" {
-            if let Some(label) = self.label() {
-                return Ok(label.into_value());
-            }
+            return self
+                .label()
+                .map(|label| label.into_value())
+                .ok_or(FieldAccessError::Unknown);
         }
         let id = self.elem().field_id(name).ok_or(FieldAccessError::Unknown)?;
         self.get(id, None)

--- a/tests/suite/foundations/label.typ
+++ b/tests/suite/foundations/label.typ
@@ -88,3 +88,7 @@ _Visible_
 #set heading(numbering: "1.")
 // Warning: 1-4 label `<a>` is not attached to anything
 <a>
+
+--- label-non-existent-error ---
+// Error: 5-10 sequence does not have field "label"
+#[].label


### PR DESCRIPTION
Fixes #5569 by returning a `FieldAccessError::Unknown` instead of a `FieldAccessError::Internal` if we try to access the label of an element that does not have a label (and thus outputting the message `[x] does not have field "label"`).

_Prima facie_, this behavior seems more helpful than the existing behavior but if there is a reason for the existing behavior then do let me know.