### PR TITLE
Document result of splitting string with empty string as separator

### DIFF
--- a/crates/typst-library/src/foundations/str.rs
+++ b/crates/typst-library/src/foundations/str.rs
@@ -575,6 +575,10 @@ impl Str {
 
     /// Splits a string at matches of a specified pattern and returns an array
     /// of the resulting parts.
+    ///
+    /// When the empty string is used as a separator, it separates every
+    /// character in the string, along with the beginning and end of the
+    /// string.
     #[func]
     pub fn split(
         &self,

--- a/crates/typst-library/src/foundations/str.rs
+++ b/crates/typst-library/src/foundations/str.rs
@@ -578,7 +578,8 @@ impl Str {
     ///
     /// When the empty string is used as a separator, it separates every
     /// character in the string, along with the beginning and end of the
-    /// string.
+    /// string. In practice, this means that the resulting list of parts
+    /// will contain the empty string at the start and end of the list.
     #[func]
     pub fn split(
         &self,


### PR DESCRIPTION
Provisionally fixes #5443.

I can add an example of Typst code to clarify if requested.