### PR TITLE
Derivation comment for calculation in `repeat`

### DIFF
--- a/crates/typst-layout/src/repeat.rs
+++ b/crates/typst-layout/src/repeat.rs
@@ -33,8 +33,17 @@ pub fn layout_repeat(
     let fill = region.size.x;
     let width = piece.width();
 
-    // count * width + (count - 1) * gap = fill, but count is an integer so
-    // we need to round down and get the remainder.
+    // We need to fit the body N times, but the number of gaps is (N - 1):
+    // N * w + (N - 1) * g ≤ F
+    // where N - body count (count)
+    //       w - body width (width)
+    //       g - gap width (gap)
+    //       F - available space to fill (fill)
+    //
+    // N * w + N * g - g ≤ F
+    // N * (w + g) ≤ F + g
+    // N ≤ (F + g) / (w + g)
+    // N = ⌊(F + g) / (w + g)⌋
     let count = ((fill + gap) / (width + gap)).floor();
     let remaining = (fill + gap) % (width + gap);
 
@@ -52,7 +61,7 @@ pub fn layout_repeat(
     if width > Abs::zero() {
         for _ in 0..(count as usize).min(1000) {
             frame.push_frame(Point::with_x(offset), piece.clone());
-            offset += piece.width() + gap;
+            offset += width + gap;
         }
     }
 


### PR DESCRIPTION
While I was writing the code for https://github.com/typst/typst/issues/5095#issuecomment-2541953110, I found a few things in the source code that can be improved. I was very confused by the `frame.push_frame(Point::with_x(offset), piece.clone());` part, but I guess it's just how you have to work with `Frame`s, which I'm not familiar with and which is very different from how you would do this in Typst.

By the way, can `move(dx: offset)` + `text(tracking: gap, range(count).map(_ => body).join())` be done in Rust? If so, then https://github.com/typst/typst/issues/758 can easily be fixed.
