### PR TITLE
Error on duplicate symbol variant with modifiers in different orders

### DIFF
--- a/crates/typst-library/src/foundations/symbol.rs
+++ b/crates/typst-library/src/foundations/symbol.rs
@@ -231,7 +231,7 @@ impl Symbol {
             if let Some(ms) = modifiers.windows(2).find(|ms| ms[0] == ms[1]) {
                 bail!(
                     span, "duplicate modifier within variant: {}", ms[0].repr();
-                    hint: "the modifiers of a variant constitute a set, repetition does not matter"
+                    hint: "modifiers are not ordered, so each one may appear only once"
                 )
             }
 
@@ -245,7 +245,7 @@ impl Symbol {
                 } else {
                     bail!(
                         span, "duplicate variant: {}", v.0.repr();
-                        hint: "the modifiers of a variant constitute a set, order does not matter"
+                        hint: "variants with the same modifiers are identical, regardless of their order"
                     )
                 }
             }

--- a/crates/typst-library/src/foundations/symbol.rs
+++ b/crates/typst-library/src/foundations/symbol.rs
@@ -203,8 +203,17 @@ impl Symbol {
             bail!(span, "expected at least one variant");
         }
         for Spanned { v, span } in variants {
-            if list.iter().any(|(prev, _)| same_modifiers(&v.0, prev)) {
-                bail!(span, "duplicate variant");
+            if let Some((prev, _)) =
+                list.iter().find(|(prev, _)| same_modifiers(&v.0, prev))
+            {
+                if &v.0 == prev {
+                    bail!(span, "duplicate variant: {:?}", v.0);
+                } else {
+                    bail!(
+                        span, "duplicate variant: {:?}", v.0;
+                        hint: "modifiers are a set, meaning order and repetition do not matter"
+                    )
+                }
             }
             if !v.0.is_empty() {
                 for modifier in v.0.split('.') {

--- a/crates/typst-library/src/foundations/symbol.rs
+++ b/crates/typst-library/src/foundations/symbol.rs
@@ -1,13 +1,15 @@
-use crate::diag::{bail, SourceResult, StrResult};
-use crate::foundations::{cast, func, scope, ty, Array, Func, NativeFunc, Repr as _};
-use ecow::{eco_format, EcoString};
-use serde::{Serialize, Serializer};
 use std::cmp::Reverse;
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use std::fmt::{self, Debug, Display, Formatter, Write};
 use std::sync::Arc;
+
+use ecow::{eco_format, EcoString};
+use serde::{Serialize, Serializer};
 use typst_syntax::{is_ident, Span, Spanned};
 use typst_utils::hash128;
+
+use crate::diag::{bail, SourceResult, StrResult};
+use crate::foundations::{cast, func, scope, ty, Array, Func, NativeFunc, Repr as _};
 
 /// A Unicode symbol.
 ///
@@ -197,50 +199,62 @@ impl Symbol {
         #[variadic]
         variants: Vec<Spanned<SymbolVariant>>,
     ) -> SourceResult<Symbol> {
-        let mut list = Vec::<(EcoString, _)>::new();
-        // A list of all previous variants. Each variant is represented by a
-        // sorted list of unique modifiers.
-        let mut previous = Vec::<u128>::new();
         if variants.is_empty() {
             bail!(span, "expected at least one variant");
         }
-        for Spanned { v, span } in variants {
+
+        // Maps from canonicalized 128-bit hashes to indices of variants we've
+        // seen before.
+        let mut seen = HashMap::<u128, usize>::new();
+
+        // A list of modifiers, cleared & reused in each iteration.
+        let mut modifiers = Vec::new();
+
+        // Validate the variants.
+        for (i, &Spanned { ref v, span }) in variants.iter().enumerate() {
+            modifiers.clear();
+
             if !v.0.is_empty() {
+                // Collect all modifiers.
                 for modifier in v.0.split('.') {
                     if !is_ident(modifier) {
                         bail!(span, "invalid symbol modifier: {}", modifier.repr());
                     }
+                    modifiers.push(modifier);
                 }
             }
-            let mut unique_modifiers = parts(&v.0).collect::<Vec<_>>();
-            unique_modifiers.sort();
-            if let Some(ms) = unique_modifiers.windows(2).find(|ms| ms[0] == ms[1]) {
+
+            // Canonicalize the modifier order.
+            modifiers.sort();
+
+            // Ensure that there are no duplicate modifiers.
+            if let Some(ms) = modifiers.windows(2).find(|ms| ms[0] == ms[1]) {
                 bail!(
                     span, "duplicate modifier within variant: {}", ms[0].repr();
-                    hint: "the modifiers of a variant constitute a set, meaning repetition does not matter"
+                    hint: "the modifiers of a variant constitute a set, repetition does not matter"
                 )
             }
-            unique_modifiers.dedup();
-            let h = hash128(&unique_modifiers);
-            if let Some(i) = previous.iter().position(|prev| prev == &h) {
-                let (prev, _) = &list[i];
-                if same_modifiers(prev, &v.0) {
-                    if v.0.is_empty() {
-                        bail!(span, "duplicate default variant");
-                    } else if &v.0 == prev {
-                        bail!(span, "duplicate variant: {}", v.0.repr());
-                    } else {
-                        bail!(
-                            span, "duplicate variant: {}", v.0.repr();
-                            hint: "the modifiers of a variant constitute a set, meaning order does not matter"
-                        )
-                    }
+
+            // Check whether we had this set of modifiers before.
+            let hash = hash128(&modifiers);
+            if let Some(&i) = seen.get(&hash) {
+                if v.0.is_empty() {
+                    bail!(span, "duplicate default variant");
+                } else if v.0 == variants[i].v.0 {
+                    bail!(span, "duplicate variant: {}", v.0.repr());
+                } else {
+                    bail!(
+                        span, "duplicate variant: {}", v.0.repr();
+                        hint: "the modifiers of a variant constitute a set, order does not matter"
+                    )
                 }
             }
-            list.push((v.0, v.1));
-            previous.push(h);
+
+            seen.insert(hash, i);
         }
-        Ok(Symbol::runtime(list.into_boxed_slice()))
+
+        let list = variants.into_iter().map(|s| (s.v.0, s.v.1)).collect();
+        Ok(Symbol::runtime(list))
     }
 }
 
@@ -411,12 +425,4 @@ fn parts(modifiers: &str) -> impl Iterator<Item = &str> {
 /// Whether the modifier string contains the modifier `m`.
 fn contained(modifiers: &str, m: &str) -> bool {
     parts(modifiers).any(|part| part == m)
-}
-
-/// Tests whether two variants contain the same modifiers.
-///
-/// This function has a quadratic complexity, and should therefore be used as a
-/// last resort.
-fn same_modifiers(left: &str, right: &str) -> bool {
-    parts(left).all(|m| contained(right, m)) && parts(right).all(|m| contained(left, m))
 }

--- a/crates/typst-library/src/foundations/symbol.rs
+++ b/crates/typst-library/src/foundations/symbol.rs
@@ -198,12 +198,12 @@ impl Symbol {
         #[variadic]
         variants: Vec<Spanned<SymbolVariant>>,
     ) -> SourceResult<Symbol> {
-        let mut list = Vec::new();
+        let mut list = Vec::<(EcoString, _)>::new();
         if variants.is_empty() {
             bail!(span, "expected at least one variant");
         }
         for Spanned { v, span } in variants {
-            if list.iter().any(|(prev, _)| &v.0 == prev) {
+            if list.iter().any(|(prev, _)| same_modifiers(&v.0, prev)) {
                 bail!(span, "duplicate variant");
             }
             if !v.0.is_empty() {
@@ -386,4 +386,10 @@ fn parts(modifiers: &str) -> impl Iterator<Item = &str> {
 /// Whether the modifier string contains the modifier `m`.
 fn contained(modifiers: &str, m: &str) -> bool {
     parts(modifiers).any(|part| part == m)
+}
+
+/// Tests whether two variants contain the same modifiers.
+fn same_modifiers(left: &str, right: &str) -> bool {
+    // Variants typically contain few modifiers, so the quadratic complexity is fine.
+    parts(left).all(|m| contained(right, m)) && parts(right).all(|m| contained(left, m))
 }

--- a/tests/suite/symbols/symbol.typ
+++ b/tests/suite/symbols/symbol.typ
@@ -41,7 +41,7 @@
 
 --- symbol-constructor-duplicate-modifier ---
 // Error: 2:3-2:31 duplicate modifier within variant: "duplicate"
-// Hint: 2:3-2:31 the modifiers of a variant constitute a set, meaning repetition does not matter
+// Hint: 2:3-2:31 the modifiers of a variant constitute a set, repetition does not matter
 #symbol(
   ("duplicate.duplicate", "x"),
 )
@@ -76,7 +76,7 @@
 
 --- symbol-constructor-duplicate-variant-different-order ---
 // Error: 3:3-3:29 duplicate variant: "variant.duplicate"
-// Hint: 3:3-3:29 the modifiers of a variant constitute a set, meaning order does not matter
+// Hint: 3:3-3:29 the modifiers of a variant constitute a set, order does not matter
 #symbol(
   ("duplicate.variant", "x"),
   ("variant.duplicate", "y"),

--- a/tests/suite/symbols/symbol.typ
+++ b/tests/suite/symbols/symbol.typ
@@ -46,6 +46,13 @@
   ("duplicate.variant", "y"),
 )
 
+--- symbol-constructor-duplicate-variant-different-order ---
+// Error: 3:3-3:29 duplicate variant
+#symbol(
+  ("duplicate.variant", "x"),
+  ("variant.duplicate", "y"),
+)
+
 --- symbol-unknown-modifier ---
 // Error: 13-20 unknown symbol modifier
 #emoji.face.garbage

--- a/tests/suite/symbols/symbol.typ
+++ b/tests/suite/symbols/symbol.typ
@@ -41,7 +41,7 @@
 
 --- symbol-constructor-duplicate-modifier ---
 // Error: 2:3-2:31 duplicate modifier within variant: "duplicate"
-// Hint: 2:3-2:31 the modifiers of a variant constitute a set, repetition does not matter
+// Hint: 2:3-2:31 modifiers are not ordered, so each one may appear only once
 #symbol(
   ("duplicate.duplicate", "x"),
 )
@@ -76,7 +76,7 @@
 
 --- symbol-constructor-duplicate-variant-different-order ---
 // Error: 3:3-3:29 duplicate variant: "variant.duplicate"
-// Hint: 3:3-3:29 the modifiers of a variant constitute a set, order does not matter
+// Hint: 3:3-3:29 variants with the same modifiers are identical, regardless of their order
 #symbol(
   ("duplicate.variant", "x"),
   ("variant.duplicate", "y"),

--- a/tests/suite/symbols/symbol.typ
+++ b/tests/suite/symbols/symbol.typ
@@ -39,6 +39,34 @@
   ("invalid. id!", "x")
 )
 
+--- symbol-constructor-duplicate-modifier ---
+// Error: 2:3-2:31 duplicate modifier within variant: "duplicate"
+// Hint: 2:3-2:31 the modifiers of a variant constitute a set, meaning repetition does not matter
+#symbol(
+  ("duplicate.duplicate", "x"),
+)
+
+--- symbol-constructor-duplicate-default-variant ---
+// Error: 3:3-3:6 duplicate default variant
+#symbol(
+  "x",
+  "y",
+)
+
+--- symbol-constructor-duplicate-empty-variant ---
+// Error: 3:3-3:12 duplicate default variant
+#symbol(
+  ("", "x"),
+  ("", "y"),
+)
+
+--- symbol-constructor-default-and-empty-variants ---
+// Error: 3:3-3:12 duplicate default variant
+#symbol(
+  "x",
+  ("", "y"),
+)
+
 --- symbol-constructor-duplicate-variant ---
 // Error: 3:3-3:29 duplicate variant: "duplicate.variant"
 #symbol(
@@ -48,18 +76,10 @@
 
 --- symbol-constructor-duplicate-variant-different-order ---
 // Error: 3:3-3:29 duplicate variant: "variant.duplicate"
-// Hint: 3:3-3:29 modifiers are a set, meaning order and repetition do not matter
+// Hint: 3:3-3:29 the modifiers of a variant constitute a set, meaning order does not matter
 #symbol(
   ("duplicate.variant", "x"),
   ("variant.duplicate", "y"),
-)
-
---- symbol-constructor-duplicate-variant-duplicate-modifier ---
-// Error: 3:3-3:31 duplicate variant: "duplicate.duplicate"
-// Hint: 3:3-3:31 modifiers are a set, meaning order and repetition do not matter
-#symbol(
-  ("duplicate", "x"),
-  ("duplicate.duplicate", "y"),
 )
 
 --- symbol-unknown-modifier ---

--- a/tests/suite/symbols/symbol.typ
+++ b/tests/suite/symbols/symbol.typ
@@ -40,17 +40,26 @@
 )
 
 --- symbol-constructor-duplicate-variant ---
-// Error: 3:3-3:29 duplicate variant
+// Error: 3:3-3:29 duplicate variant: "duplicate.variant"
 #symbol(
   ("duplicate.variant", "x"),
   ("duplicate.variant", "y"),
 )
 
 --- symbol-constructor-duplicate-variant-different-order ---
-// Error: 3:3-3:29 duplicate variant
+// Error: 3:3-3:29 duplicate variant: "variant.duplicate"
+// Hint: 3:3-3:29 modifiers are a set, meaning order and repetition do not matter
 #symbol(
   ("duplicate.variant", "x"),
   ("variant.duplicate", "y"),
+)
+
+--- symbol-constructor-duplicate-variant-duplicate-modifier ---
+// Error: 3:3-3:31 duplicate variant: "duplicate.duplicate"
+// Hint: 3:3-3:31 modifiers are a set, meaning order and repetition do not matter
+#symbol(
+  ("duplicate", "x"),
+  ("duplicate.duplicate", "y"),
 )
 
 --- symbol-unknown-modifier ---


### PR DESCRIPTION
As suggested in https://github.com/typst/typst/pull/5505#discussion_r1877486255, this should be an error. Previously, an error would happen only if the duplicate variants had the modifiers in the same order.