### PR TITLE
Mention the `calc` module in the operator list

### DIFF
--- a/crates/typst-library/src/foundations/calc.rs
+++ b/crates/typst-library/src/foundations/calc.rs
@@ -909,7 +909,7 @@ pub fn odd(
 /// #calc.rem(-7, -3) \
 /// #calc.rem(1.75, 0.5)
 /// ```
-#[func(title = "Remainder")]
+#[func(title = "Remainder", keywords = ["modulo", "modulus"])]
 pub fn rem(
     /// The span of the function call.
     span: Span,

--- a/crates/typst-library/src/foundations/calc.rs
+++ b/crates/typst-library/src/foundations/calc.rs
@@ -909,7 +909,7 @@ pub fn odd(
 /// #calc.rem(-7, -3) \
 /// #calc.rem(1.75, 0.5)
 /// ```
-#[func(title = "Remainder", keywords = ["modulo", "modulus"])]
+#[func(title = "Remainder")]
 pub fn rem(
     /// The span of the function call.
     span: Span,
@@ -992,7 +992,7 @@ pub fn div_euclid(
 /// #calc.rem-euclid(1.75, 0.5) \
 /// #calc.rem-euclid(decimal("1.75"), decimal("0.5"))
 /// ```
-#[func(title = "Euclidean Remainder")]
+#[func(title = "Euclidean Remainder", keywords = ["modulo", "modulus"])]
 pub fn rem_euclid(
     /// The callsite span.
     span: Span,

--- a/docs/reference/scripting.md
+++ b/docs/reference/scripting.md
@@ -341,9 +341,9 @@ packages. For more details on this, see the
 ## Operators
 The following table lists all available unary and binary operators with effect,
 arity (unary, binary) and precedence level (higher binds stronger). Some
-operations, such as [modulus]($calc.rem), do not have a special syntax and can
-be achieved using functions from the [`calc`]($category/foundations/calc)
-module.
+operations, such as [modulus]($calc.rem-euclid), do not have a special syntax
+and can be achieved using functions from the
+[`calc`]($category/foundations/calc) module.
 
 | Operator   | Effect                          | Arity  | Precedence |
 |:----------:|---------------------------------|:------:|:----------:|

--- a/docs/reference/scripting.md
+++ b/docs/reference/scripting.md
@@ -340,7 +340,9 @@ packages. For more details on this, see the
 
 ## Operators
 The following table lists all available unary and binary operators with effect,
-arity (unary, binary) and precedence level (higher binds stronger).
+arity (unary, binary) and precedence level (higher binds stronger). Some
+operations, such as [modulus]($calc.rem), do not have a special syntax and can 
+be achieved using functions from the [`calc`] module.
 
 | Operator   | Effect                          | Arity  | Precedence |
 |:----------:|---------------------------------|:------:|:----------:|

--- a/docs/reference/scripting.md
+++ b/docs/reference/scripting.md
@@ -341,8 +341,9 @@ packages. For more details on this, see the
 ## Operators
 The following table lists all available unary and binary operators with effect,
 arity (unary, binary) and precedence level (higher binds stronger). Some
-operations, such as [modulus]($calc.rem), do not have a special syntax and can 
-be achieved using functions from the [`calc`] module.
+operations, such as [modulus]($calc.rem), do not have a special syntax and can
+be achieved using functions from the [`calc`]($category/foundations/calc)
+module.
 
 | Operator   | Effect                          | Arity  | Precedence |
 |:----------:|---------------------------------|:------:|:----------:|


### PR DESCRIPTION
As illustrated by #5593, the absence of special syntax for a modulus operator can be confusing.

I added a sentence to the operator list in the documentation to mention that other common operations are available under the `calc` module. I also specifically linked to the `calc.rem` function, as it cannot be found by searching for "modulus" or "mod" on the `calc` page.

Additionally, I added "modulo" and "modulus" as keywords for `calc.rem` to improve the search feature. I am debating whether to add the same keywords for `calc.rem-euclid`.