### PR TITLE
Cyrillic numbering

### DIFF
--- a/crates/typst-library/src/model/numbering.rs
+++ b/crates/typst-library/src/model/numbering.rs
@@ -316,6 +316,10 @@ pub enum NumberingKind {
     CircledNumber,
     /// Double-circled numbers (⓵, ⓶, ⓷, etc.), up to 10.
     DoubleCircledNumber,
+    /// Lowercase Russian letters (а, б, в, etc.)
+    LowerRussian,
+    /// Uppercase Russian letters (А, Б, В, etc.)
+    UpperRussian,
 }
 
 impl NumberingKind {
@@ -346,6 +350,8 @@ impl NumberingKind {
             '\u{0995}' => NumberingKind::BengaliLetter,
             '①' => NumberingKind::CircledNumber,
             '⓵' => NumberingKind::DoubleCircledNumber,
+            'а' => NumberingKind::LowerRussian,
+            'А' => NumberingKind::UpperRussian,
             _ => return None,
         })
     }
@@ -377,6 +383,8 @@ impl NumberingKind {
             Self::BengaliLetter => '\u{0995}',
             Self::CircledNumber => '①',
             Self::DoubleCircledNumber => '⓵',
+            Self::LowerRussian => 'а',
+            Self::UpperRussian => 'А',
         }
     }
 
@@ -489,6 +497,20 @@ impl NumberingKind {
             Self::DoubleCircledNumber => {
                 zeroless(['⓵', '⓶', '⓷', '⓸', '⓹', '⓺', '⓻', '⓼', '⓽', '⓾'], n)
             }
+            Self::LowerRussian => zeroless(
+                [
+                    'а', 'б', 'в', 'г', 'д', 'е', 'ж', 'з', 'и', 'к', 'л', 'м', 'н', 'о',
+                    'п', 'р', 'с', 'т', 'у', 'ф', 'х', 'ц', 'ч', 'ш', 'щ', 'э', 'ю', 'я',
+                ],
+                n,
+            ),
+            Self::UpperRussian => zeroless(
+                [
+                    'А', 'Б', 'В', 'Г', 'Д', 'Е', 'Ж', 'З', 'И', 'К', 'Л', 'М', 'Н', 'О',
+                    'П', 'Р', 'С', 'Т', 'У', 'Ф', 'Х', 'Ц', 'Ч', 'Ш', 'Щ', 'Э', 'Ю', 'Я',
+                ],
+                n,
+            ),
 
             Self::LowerSimplifiedChinese => {
                 usize_to_chinese(ChineseVariant::Simple, ChineseCase::Lower, n).into()


### PR DESCRIPTION
Test cases still needed, and I feel all numbering could be tied up here in line with https://www.w3.org/TR/predefined-counter-styles/#cyrillic-styles as mentioned in https://github.com/typst/typst/issues/1595.

Since all the languages which use the cyrillic alphabet use the same first character (U430) for their numbering system, there needs to be some way to distinguish between the language. I'm not sure the best way to proceed with this - there was a suggestion to use the language which was set in the file; I guess this would be pretty neat.