### PR TITLE
Further improve IDE tests

### DIFF
--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -1614,29 +1614,29 @@ mod tests {
 
     #[test]
     fn test_autocomplete_hash_expr() {
-        test("#i", 2).must_include(["int", "if conditional"]);
+        test("#i", -1).must_include(["int", "if conditional"]);
     }
 
     #[test]
     fn test_autocomplete_array_method() {
-        test("#().", 4).must_include(["insert", "remove", "len", "all"]);
-        test("#{ let x = (1, 2, 3); x. }", -2).must_include(["at", "push", "pop"]);
+        test("#().", -1).must_include(["insert", "remove", "len", "all"]);
+        test("#{ let x = (1, 2, 3); x. }", -3).must_include(["at", "push", "pop"]);
     }
 
     /// Test that extra space before '.' is handled correctly.
     #[test]
     fn test_autocomplete_whitespace() {
-        test("#() .", 5).must_exclude(["insert", "remove", "len", "all"]);
-        test("#{() .}", 6).must_include(["insert", "remove", "len", "all"]);
-        test("#() .a", 6).must_exclude(["insert", "remove", "len", "all"]);
-        test("#{() .a}", 7).must_include(["at", "any", "all"]);
+        test("#() .", -1).must_exclude(["insert", "remove", "len", "all"]);
+        test("#{() .}", -2).must_include(["insert", "remove", "len", "all"]);
+        test("#() .a", -1).must_exclude(["insert", "remove", "len", "all"]);
+        test("#{() .a}", -2).must_include(["at", "any", "all"]);
     }
 
     /// Test that the `before_window` doesn't slice into invalid byte
     /// boundaries.
     #[test]
     fn test_autocomplete_before_window_char_boundary() {
-        test("😀😀     #text(font: \"\")", -2);
+        test("😀😀     #text(font: \"\")", -3);
     }
 
     /// Ensure that autocompletion for `#cite(|)` completes bibligraphy labels,
@@ -1653,7 +1653,7 @@ mod tests {
         let end = world.main.len_bytes();
         world.main.edit(end..end, " #cite()");
 
-        test_full(&world, &world.main, doc.as_ref(), -1)
+        test_full(&world, &world.main, doc.as_ref(), -2)
             .must_include(["netwok", "glacier-melt", "supplement"])
             .must_exclude(["bib"]);
     }
@@ -1677,13 +1677,13 @@ mod tests {
     #[test]
     fn test_autocomplete_positional_param() {
         // No string given yet.
-        test("#numbering()", -1).must_include(["string", "integer"]);
+        test("#numbering()", -2).must_include(["string", "integer"]);
         // String is already given.
-        test("#numbering(\"foo\", )", -1)
+        test("#numbering(\"foo\", )", -2)
             .must_include(["integer"])
             .must_exclude(["string"]);
         // Integer is already given, but numbering is variadic.
-        test("#numbering(\"foo\", 1, )", -1)
+        test("#numbering(\"foo\", 1, )", -2)
             .must_include(["integer"])
             .must_exclude(["string"]);
     }
@@ -1698,14 +1698,14 @@ mod tests {
                 "#let clrs = (a: red, b: blue); #let nums = (a: 1, b: 2)",
             );
 
-        test_with_world(&world, -1)
+        test_with_world(&world, -2)
             .must_include(["clrs", "aqua"])
             .must_exclude(["nums", "a", "b"]);
     }
 
     #[test]
     fn test_autocomplete_packages() {
-        test("#import \"@\"", -1).must_include([q!("@preview/example:0.1.0")]);
+        test("#import \"@\"", -2).must_include([q!("@preview/example:0.1.0")]);
     }
 
     #[test]
@@ -1719,28 +1719,28 @@ mod tests {
             .with_asset_at("assets/rhino.png", "rhino.png")
             .with_asset_at("data/example.csv", "example.csv");
 
-        test_with_path(&world, "main.typ", -1)
+        test_with_path(&world, "main.typ", -2)
             .must_include([q!("content/a.typ"), q!("content/b.typ"), q!("utils.typ")])
             .must_exclude([q!("assets/tiger.jpg")]);
 
-        test_with_path(&world, "content/c.typ", -1)
+        test_with_path(&world, "content/c.typ", -2)
             .must_include([q!("../main.typ"), q!("a.typ"), q!("b.typ")])
             .must_exclude([q!("c.typ")]);
 
-        test_with_path(&world, "content/a.typ", -1)
+        test_with_path(&world, "content/a.typ", -2)
             .must_include([q!("../assets/tiger.jpg"), q!("../assets/rhino.png")])
             .must_exclude([q!("../data/example.csv"), q!("b.typ")]);
 
-        test_with_path(&world, "content/b.typ", -2)
+        test_with_path(&world, "content/b.typ", -3)
             .must_include([q!("../data/example.csv")]);
     }
 
     #[test]
     fn test_autocomplete_figure_snippets() {
-        test("#figure()", -1)
+        test("#figure()", -2)
             .must_apply("image", "image(\"${}\"),")
             .must_apply("table", "table(\n  ${}\n),");
 
-        test("#figure(cap)", -1).must_apply("caption", "caption: [${}]");
+        test("#figure(cap)", -2).must_apply("caption", "caption: [${}]");
     }
 }

--- a/crates/typst-ide/src/definition.rs
+++ b/crates/typst-ide/src/definition.rs
@@ -94,7 +94,7 @@ mod tests {
     use typst::WorldExt;
 
     use super::{definition, Definition};
-    use crate::tests::{SourceExt, TestWorld, WorldLike};
+    use crate::tests::{FilePos, TestWorld, WorldLike};
 
     type Response = (TestWorld, Option<Definition>);
 
@@ -133,12 +133,12 @@ mod tests {
     }
 
     #[track_caller]
-    fn test(world: impl WorldLike, cursor: isize, side: Side) -> Response {
+    fn test(world: impl WorldLike, pos: impl FilePos, side: Side) -> Response {
         let world = world.acquire();
         let world = world.borrow();
         let doc = typst::compile(world).output.ok();
-        let source = &world.main;
-        let def = definition(world, doc.as_ref(), source, source.cursor(cursor), side);
+        let (source, cursor) = pos.resolve(world);
+        let def = definition(world, doc.as_ref(), &source, cursor, side);
         (world.clone(), def)
     }
 

--- a/crates/typst-ide/src/definition.rs
+++ b/crates/typst-ide/src/definition.rs
@@ -147,8 +147,8 @@ mod tests {
 
     #[test]
     fn test_definition_let() {
-        test("#let x; #x", 9, Side::After).must_be_at("main.typ", 5..6);
-        test("#let x() = {}; #x", 16, Side::After).must_be_at("main.typ", 5..6);
+        test("#let x; #x", -2, Side::After).must_be_at("main.typ", 5..6);
+        test("#let x() = {}; #x", -2, Side::After).must_be_at("main.typ", 5..6);
     }
 
     #[test]
@@ -158,14 +158,14 @@ mod tests {
 
         // The span is at the args here because that's what the function value's
         // span is. Not ideal, but also not too big of a big deal.
-        test_with_world(world, -1, Side::Before).must_be_at("other.typ", 8..11);
+        test_with_world(world, -2, Side::Before).must_be_at("other.typ", 8..11);
     }
 
     #[test]
     fn test_definition_cross_file() {
         let world = TestWorld::new("#import \"other.typ\": x; #x")
             .with_source("other.typ", "#let x = 1");
-        test_with_world(world, -1, Side::After).must_be_at("other.typ", 5..6);
+        test_with_world(world, -2, Side::After).must_be_at("other.typ", 5..6);
     }
 
     #[test]
@@ -184,7 +184,7 @@ mod tests {
 
     #[test]
     fn test_definition_ref() {
-        test("#figure[] <hi> See @hi", 21, Side::After).must_be_at("main.typ", 1..9);
+        test("#figure[] <hi> See @hi", -2, Side::After).must_be_at("main.typ", 1..9);
     }
 
     #[test]

--- a/crates/typst-ide/src/jump.rs
+++ b/crates/typst-ide/src/jump.rs
@@ -188,7 +188,7 @@ mod tests {
     use typst::layout::{Abs, Point, Position};
 
     use super::{jump_from_click, jump_from_cursor, Jump};
-    use crate::tests::{TestWorld, WorldLike};
+    use crate::tests::{FilePos, TestWorld, WorldLike};
 
     fn point(x: f64, y: f64) -> Point {
         Point::new(Abs::pt(x), Abs::pt(y))
@@ -229,11 +229,12 @@ mod tests {
     }
 
     #[track_caller]
-    fn test_cursor(world: impl WorldLike, cursor: usize, expected: Option<Position>) {
+    fn test_cursor(world: impl WorldLike, pos: impl FilePos, expected: Option<Position>) {
         let world = world.acquire();
         let world = world.borrow();
         let doc = typst::compile(world).output.unwrap();
-        let pos = jump_from_cursor(&doc, &world.main, cursor);
+        let (source, cursor) = pos.resolve(world);
+        let pos = jump_from_cursor(&doc, &source, cursor);
         assert_eq!(!pos.is_empty(), expected.is_some());
         if let (Some(pos), Some(expected)) = (pos.first(), expected) {
             assert_eq!(pos.page, expected.page);

--- a/crates/typst-ide/src/jump.rs
+++ b/crates/typst-ide/src/jump.rs
@@ -182,12 +182,13 @@ mod tests {
     //! ))
     //! ```
 
+    use std::borrow::Borrow;
     use std::num::NonZeroUsize;
 
     use typst::layout::{Abs, Point, Position};
 
     use super::{jump_from_click, jump_from_cursor, Jump};
-    use crate::tests::TestWorld;
+    use crate::tests::{TestWorld, WorldLike};
 
     fn point(x: f64, y: f64) -> Point {
         Point::new(Abs::pt(x), Abs::pt(y))
@@ -211,10 +212,11 @@ mod tests {
     }
 
     #[track_caller]
-    fn test_click(text: &str, click: Point, expected: Option<Jump>) {
-        let world = TestWorld::new(text);
-        let doc = typst::compile(&world).output.unwrap();
-        let jump = jump_from_click(&world, &doc, &doc.pages[0].frame, click);
+    fn test_click(world: impl WorldLike, click: Point, expected: Option<Jump>) {
+        let world = world.acquire();
+        let world = world.borrow();
+        let doc = typst::compile(world).output.unwrap();
+        let jump = jump_from_click(world, &doc, &doc.pages[0].frame, click);
         if let (Some(Jump::Position(pos)), Some(Jump::Position(expected))) =
             (&jump, &expected)
         {
@@ -227,9 +229,10 @@ mod tests {
     }
 
     #[track_caller]
-    fn test_cursor(text: &str, cursor: usize, expected: Option<Position>) {
-        let world = TestWorld::new(text);
-        let doc = typst::compile(&world).output.unwrap();
+    fn test_cursor(world: impl WorldLike, cursor: usize, expected: Option<Position>) {
+        let world = world.acquire();
+        let world = world.borrow();
+        let doc = typst::compile(world).output.unwrap();
         let pos = jump_from_cursor(&doc, &world.main, cursor);
         assert_eq!(!pos.is_empty(), expected.is_some());
         if let (Some(pos), Some(expected)) = (pos.first(), expected) {

--- a/crates/typst-ide/src/matchers.rs
+++ b/crates/typst-ide/src/matchers.rs
@@ -266,53 +266,76 @@ pub enum DerefTarget<'a> {
 
 #[cfg(test)]
 mod tests {
+    use ecow::EcoString;
     use typst::syntax::{LinkedNode, Side};
 
-    use crate::{named_items, tests::TestWorld};
+    use super::named_items;
+    use crate::tests::{SourceExt, TestWorld};
+
+    type Response = Vec<EcoString>;
+
+    trait ResponseExt {
+        fn must_include<'a>(&self, includes: impl IntoIterator<Item = &'a str>) -> &Self;
+        fn must_exclude<'a>(&self, excludes: impl IntoIterator<Item = &'a str>) -> &Self;
+    }
+
+    impl ResponseExt for Response {
+        #[track_caller]
+        fn must_include<'a>(&self, includes: impl IntoIterator<Item = &'a str>) -> &Self {
+            for item in includes {
+                assert!(
+                    self.iter().any(|v| v == item),
+                    "{item:?} was not contained in {self:?}",
+                );
+            }
+            self
+        }
+
+        #[track_caller]
+        fn must_exclude<'a>(&self, excludes: impl IntoIterator<Item = &'a str>) -> &Self {
+            for item in excludes {
+                assert!(
+                    !self.iter().any(|v| v == item),
+                    "{item:?} was wrongly contained in {self:?}",
+                );
+            }
+            self
+        }
+    }
 
     #[track_caller]
-    fn has_named_items(text: &str, cursor: usize, containing: &str) -> bool {
+    fn test(text: &str, cursor: isize) -> Response {
         let world = TestWorld::new(text);
-
-        let src = world.main.clone();
-        let node = LinkedNode::new(src.root());
-        let leaf = node.leaf_at(cursor, Side::After).unwrap();
-
-        let res = named_items(&world, leaf, |s| {
-            if containing == s.name() {
-                return Some(true);
-            }
-
-            None
+        let source = world.main.clone();
+        let node = LinkedNode::new(source.root());
+        let leaf = node.leaf_at(source.cursor(cursor), Side::After).unwrap();
+        let mut items = vec![];
+        named_items(&world, leaf, |s| {
+            items.push(s.name().clone());
+            None::<()>
         });
-
-        res.unwrap_or_default()
+        items
     }
 
     #[test]
-    fn test_simple_named_items() {
-        // Has named items
-        assert!(has_named_items(r#"#let a = 1;#let b = 2;"#, 8, "a"));
-        assert!(has_named_items(r#"#let a = 1;#let b = 2;"#, 15, "a"));
-
-        // Doesn't have named items
-        assert!(!has_named_items(r#"#let a = 1;#let b = 2;"#, 8, "b"));
+    fn test_named_items_simple() {
+        let s = "#let a = 1;#let b = 2;";
+        test(s, 8).must_include(["a"]).must_exclude(["b"]);
+        test(s, 15).must_include(["b"]);
     }
 
     #[test]
-    fn test_param_named_items() {
-        // Has named items
-        assert!(has_named_items(r#"#let f(a) = 1;#let b = 2;"#, 12, "a"));
-        assert!(has_named_items(r#"#let f(a: b) = 1;#let b = 2;"#, 15, "a"));
+    fn test_named_items_param() {
+        let pos = "#let f(a) = 1;#let b = 2;";
+        test(pos, 12).must_include(["a"]);
+        test(pos, 19).must_include(["b", "f"]).must_exclude(["a"]);
 
-        // Doesn't have named items
-        assert!(!has_named_items(r#"#let f(a) = 1;#let b = 2;"#, 19, "a"));
-        assert!(!has_named_items(r#"#let f(a: b) = 1;#let b = 2;"#, 15, "b"));
+        let named = "#let f(a: b) = 1;#let b = 2;";
+        test(named, 15).must_include(["a", "f"]).must_exclude(["b"]);
     }
 
     #[test]
-    fn test_import_named_items() {
-        // Cannot test much.
-        assert!(has_named_items(r#"#import "foo.typ": a; #(a);"#, 24, "a"));
+    fn test_named_items_import() {
+        test("#import \"foo.typ\": a; #(a);", 2).must_include(["a"]);
     }
 }

--- a/crates/typst-ide/src/matchers.rs
+++ b/crates/typst-ide/src/matchers.rs
@@ -266,11 +266,13 @@ pub enum DerefTarget<'a> {
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Borrow;
+
     use ecow::EcoString;
     use typst::syntax::{LinkedNode, Side};
 
     use super::named_items;
-    use crate::tests::{SourceExt, TestWorld};
+    use crate::tests::{SourceExt, WorldLike};
 
     type Response = Vec<EcoString>;
 
@@ -304,13 +306,14 @@ mod tests {
     }
 
     #[track_caller]
-    fn test(text: &str, cursor: isize) -> Response {
-        let world = TestWorld::new(text);
+    fn test(world: impl WorldLike, cursor: isize) -> Response {
+        let world = world.acquire();
+        let world = world.borrow();
         let source = world.main.clone();
         let node = LinkedNode::new(source.root());
         let leaf = node.leaf_at(source.cursor(cursor), Side::After).unwrap();
         let mut items = vec![];
-        named_items(&world, leaf, |s| {
+        named_items(world, leaf, |s| {
             items.push(s.name().clone());
             None::<()>
         });

--- a/crates/typst-ide/src/matchers.rs
+++ b/crates/typst-ide/src/matchers.rs
@@ -272,7 +272,7 @@ mod tests {
     use typst::syntax::{LinkedNode, Side};
 
     use super::named_items;
-    use crate::tests::{SourceExt, WorldLike};
+    use crate::tests::{FilePos, WorldLike};
 
     type Response = Vec<EcoString>;
 
@@ -306,12 +306,12 @@ mod tests {
     }
 
     #[track_caller]
-    fn test(world: impl WorldLike, cursor: isize) -> Response {
+    fn test(world: impl WorldLike, pos: impl FilePos) -> Response {
         let world = world.acquire();
         let world = world.borrow();
-        let source = world.main.clone();
+        let (source, cursor) = pos.resolve(world);
         let node = LinkedNode::new(source.root());
-        let leaf = node.leaf_at(source.cursor(cursor), Side::After).unwrap();
+        let leaf = node.leaf_at(cursor, Side::After).unwrap();
         let mut items = vec![];
         named_items(world, leaf, |s| {
             items.push(s.name().clone());

--- a/crates/typst-ide/src/tests.rs
+++ b/crates/typst-ide/src/tests.rs
@@ -142,7 +142,7 @@ pub trait SourceExt {
 impl SourceExt for Source {
     fn cursor(&self, cursor: isize) -> usize {
         if cursor < 0 {
-            self.len_bytes().checked_add_signed(cursor).unwrap()
+            self.len_bytes().checked_add_signed(cursor + 1).unwrap()
         } else {
             cursor as usize
         }

--- a/crates/typst-ide/src/tooltip.rs
+++ b/crates/typst-ide/src/tooltip.rs
@@ -322,7 +322,7 @@ mod tests {
 
     #[test]
     fn test_tooltip() {
-        test("#let x = 1 + 2", 14, Side::After).must_be_none();
+        test("#let x = 1 + 2", -1, Side::After).must_be_none();
         test("#let x = 1 + 2", 5, Side::After).must_be_code("3");
         test("#let x = 1 + 2", 6, Side::Before).must_be_code("3");
         test("#let x = 1 + 2", 6, Side::Before).must_be_code("3");
@@ -330,7 +330,7 @@ mod tests {
 
     #[test]
     fn test_tooltip_empty_contextual() {
-        test("#{context}", 10, Side::Before).must_be_code("context()");
+        test("#{context}", -1, Side::Before).must_be_code("context()");
     }
 
     #[test]
@@ -358,8 +358,8 @@ mod tests {
     fn test_tooltip_star_import() {
         let world = TestWorld::new("#import \"other.typ\": *")
             .with_source("other.typ", "#let (a, b, c) = (1, 2, 3)");
-        test_with_world(&world, 21, Side::Before).must_be_none();
-        test_with_world(&world, 21, Side::After)
+        test_with_world(&world, -2, Side::Before).must_be_none();
+        test_with_world(&world, -2, Side::After)
             .must_be_text("This star imports `a`, `b`, and `c`");
     }
 }

--- a/crates/typst-ide/src/tooltip.rs
+++ b/crates/typst-ide/src/tooltip.rs
@@ -279,7 +279,7 @@ mod tests {
     use typst::syntax::Side;
 
     use super::{tooltip, Tooltip};
-    use crate::tests::{SourceExt, TestWorld, WorldLike};
+    use crate::tests::{FilePos, TestWorld, WorldLike};
 
     type Response = Option<Tooltip>;
 
@@ -310,12 +310,12 @@ mod tests {
     }
 
     #[track_caller]
-    fn test(world: impl WorldLike, cursor: isize, side: Side) -> Response {
+    fn test(world: impl WorldLike, pos: impl FilePos, side: Side) -> Response {
         let world = world.acquire();
         let world = world.borrow();
-        let source = &world.main;
+        let (source, cursor) = pos.resolve(world);
         let doc = typst::compile(world).output.ok();
-        tooltip(world, doc.as_ref(), source, source.cursor(cursor), side)
+        tooltip(world, doc.as_ref(), &source, cursor, side)
     }
 
     #[test]


### PR DESCRIPTION
Makes the IDE testing framework more flexible and convenient to use via `WorldLike` and `FilePos` traits that allow flexible combinations of string / full TestWorld  and cursor in main / cursor in specific file via tuple as inputs. Also fixes negative indexing being off-by-one from the usual convention.