### PR TITLE
Remove unused single quote shorthand

### DIFF
--- a/crates/typst-syntax/src/ast.rs
+++ b/crates/typst-syntax/src/ast.rs
@@ -743,7 +743,6 @@ impl MathShorthand<'_> {
     pub const LIST: &'static [(&'static str, char)] = &[
         ("...", '…'),
         ("-", '−'),
-        ("'", '′'),
         ("*", '∗'),
         ("~", '∼'),
         ("!=", '≠'),


### PR DESCRIPTION
This was left over from #1614 when we moved primes to be their own element, they weren't removed from the shorthand table in the ast.