### PR TITLE
Add `#str.normalize(form)`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2953,6 +2953,7 @@ dependencies = [
  "typst-timing",
  "typst-utils",
  "unicode-math-class",
+ "unicode-normalization",
  "unicode-segmentation",
  "unscanny",
  "usvg",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,7 @@ unicode-bidi = "0.3.18"
 unicode-ident = "1.0"
 unicode-math-class = "0.1"
 unicode-script = "0.5"
+unicode-normalization = "0.1.24"
 unicode-segmentation = "1"
 unscanny = "0.1"
 ureq = { version = "2", default-features = false, features = ["native-tls", "gzip", "json"] }

--- a/crates/typst-library/Cargo.toml
+++ b/crates/typst-library/Cargo.toml
@@ -60,6 +60,7 @@ ttf-parser = { workspace = true }
 two-face = { workspace = true }
 typed-arena = { workspace = true }
 unicode-math-class = { workspace = true }
+unicode-normalization = { workspace = true }
 unicode-segmentation = { workspace = true }
 unscanny = { workspace = true }
 usvg = { workspace = true }

--- a/tests/suite/foundations/str.typ
+++ b/tests/suite/foundations/str.typ
@@ -86,6 +86,13 @@
 // Error: 2-28 0x110000 is not a valid codepoint
 #str.from-unicode(0x110000) // 0x10ffff is the highest valid code point
 
+--- str-normalize ---
+// Test the `normalize` method.
+#test("e\u{0301}".normalize("NFC"), "é")
+#test("é".normalize("NFD"), "e\u{0301}")
+#test("ſ\u{0301}".normalize("NFKC"), "ś")
+#test("ſ\u{0301}".normalize("NFKD"), "s\u{0301}")
+
 --- string-len ---
 // Test the `len` method.
 #test("Hello World!".len(), 12)


### PR DESCRIPTION
Closes #5617. I added tests in `str.typ` but `cargo test --workspace`'s output made no mention of `foundations::str` etc. Hopefully that is fine. (first time contributing to this so idk)

