### PR TITLE
Allow adding and joining `arguments`

### DIFF
--- a/crates/typst-library/src/foundations/args.rs
+++ b/crates/typst-library/src/foundations/args.rs
@@ -1,4 +1,5 @@
 use std::fmt::{self, Debug, Formatter};
+use std::ops::Add;
 
 use ecow::{eco_format, eco_vec, EcoString, EcoVec};
 use typst_syntax::{Span, Spanned};
@@ -373,6 +374,21 @@ impl Repr for Args {
 impl PartialEq for Args {
     fn eq(&self, other: &Self) -> bool {
         self.to_pos() == other.to_pos() && self.to_named() == other.to_named()
+    }
+}
+
+impl Add for Args {
+    type Output = Self;
+
+    fn add(mut self, rhs: Self) -> Self::Output {
+        self.items.retain(|item| {
+            !item.name.as_ref().is_some_and(|name| {
+                rhs.items.iter().any(|a| a.name.as_ref() == Some(name))
+            })
+        });
+        self.items.extend(rhs.items);
+        self.span = Span::detached();
+        self
     }
 }
 

--- a/crates/typst-library/src/foundations/ops.rs
+++ b/crates/typst-library/src/foundations/ops.rs
@@ -36,6 +36,7 @@ pub fn join(lhs: Value, rhs: Value) -> StrResult<Value> {
         (Symbol(a), Content(b)) => Content(TextElem::packed(a.get()) + b),
         (Array(a), Array(b)) => Array(a + b),
         (Dict(a), Dict(b)) => Dict(a + b),
+        (Args(a), Args(b)) => Args(a + b),
         (a, b) => mismatch!("cannot join {} with {}", a, b),
     })
 }
@@ -136,6 +137,7 @@ pub fn add(lhs: Value, rhs: Value) -> HintedStrResult<Value> {
 
         (Array(a), Array(b)) => Array(a + b),
         (Dict(a), Dict(b)) => Dict(a + b),
+        (Args(a), Args(b)) => Args(a + b),
 
         (Color(color), Length(thickness)) | (Length(thickness), Color(color)) => {
             Stroke::from_pair(color, thickness).into_value()

--- a/tests/suite/foundations/arguments.typ
+++ b/tests/suite/foundations/arguments.typ
@@ -16,3 +16,12 @@
 #let args = arguments(0, 1, a: 2, 3)
 // Error: 2-14 arguments do not contain key "b" and no default value was specified
 #args.at("b")
+
+--- arguments-plus-sum-join ---
+#let lhs = arguments(0, "1", key: "value", 3)
+#let rhs = arguments(other-key: 4, key: "other value", 3)
+#let result = arguments(0, "1", 3, other-key: 4, key: "other value", 3)
+#test(lhs + rhs, result)
+#test({lhs; rhs}, result)
+#test((lhs, rhs).sum(), result)
+#test((lhs, rhs).join(), result)


### PR DESCRIPTION
Closes #5640.

This PR enables addition and joining for `arguments`. This is also compatible with `array.sum` and `array.join`. In case of a duplicate named argument key, the last one will be kept.
