### PR TITLE
Improve `repr` for `arguments`

### DIFF
--- a/crates/typst-library/src/foundations/args.rs
+++ b/crates/typst-library/src/foundations/args.rs
@@ -366,7 +366,7 @@ impl Debug for Args {
 impl Repr for Args {
     fn repr(&self) -> EcoString {
         let pieces = self.items.iter().map(Arg::repr).collect::<Vec<_>>();
-        repr::pretty_array_like(&pieces, false).into()
+        eco_format!("arguments{}", repr::pretty_array_like(&pieces, false))
     }
 }
 

--- a/tests/suite/math/call.typ
+++ b/tests/suite/math/call.typ
@@ -11,11 +11,11 @@ $ pi(a,b,) $
 --- math-call-repr ---
 #let args(..body) = body
 #let check(it, r) = test-repr(it.body.text, r)
-#check($args(a)$, "([a])")
-#check($args(a,)$, "([a])")
-#check($args(a,b)$, "([a], [b])")
-#check($args(a,b,)$, "([a], [b])")
-#check($args(,a,b,,,)$, "([], [a], [b], [], [])")
+#check($args(a)$, "arguments([a])")
+#check($args(a,)$, "arguments([a])")
+#check($args(a,b)$, "arguments([a], [b])")
+#check($args(a,b,)$, "arguments([a], [b])")
+#check($args(,a,b,,,)$, "arguments([], [a], [b], [], [])")
 
 --- math-call-2d-non-func ---
 // Error: 6-7 expected content, found array
@@ -31,21 +31,21 @@ $ mat(#"code"; "wins") $
 --- math-call-2d-repr ---
 #let args(..body) = body
 #let check(it, r) = test-repr(it.body.text, r)
-#check($args(a;b)$, "(([a],), ([b],))")
-#check($args(a,b;c)$, "(([a], [b]), ([c],))")
-#check($args(a,b;c,d;e,f)$, "(([a], [b]), ([c], [d]), ([e], [f]))")
+#check($args(a;b)$, "arguments(([a],), ([b],))")
+#check($args(a,b;c)$, "arguments(([a], [b]), ([c],))")
+#check($args(a,b;c,d;e,f)$, "arguments(([a], [b]), ([c], [d]), ([e], [f]))")
 
 --- math-call-2d-repr-structure ---
 #let args(..body) = body
 #let check(it, r) = test-repr(it.body.text, r)
-#check($args( a; b; )$, "(([a],), ([b],))")
-#check($args(a;  ; c)$, "(([a],), ([],), ([c],))")
-#check($args(a b,/**/; b)$, "((sequence([a], [ ], [b]), []), ([b],))")
-#check($args(a/**/b, ; b)$, "((sequence([a], [b]), []), ([b],))")
-#check($args( ;/**/a/**/b/**/; )$, "(([],), (sequence([a], [b]),))")
-#check($args( ; , ; )$, "(([],), ([], []))")
+#check($args( a; b; )$, "arguments(([a],), ([b],))")
+#check($args(a;  ; c)$, "arguments(([a],), ([],), ([c],))")
+#check($args(a b,/**/; b)$, "arguments((sequence([a], [ ], [b]), []), ([b],))")
+#check($args(a/**/b, ; b)$, "arguments((sequence([a], [b]), []), ([b],))")
+#check($args( ;/**/a/**/b/**/; )$, "arguments(([],), (sequence([a], [b]),))")
+#check($args( ; , ; )$, "arguments(([],), ([], []))")
 #check($args(/**/; // funky whitespace/trivia
-    ,   /**/  ;/**/)$, "(([],), ([], []))")
+    ,   /**/  ;/**/)$, "arguments(([],), ([], []))")
 
 --- math-call-empty-args-non-func ---
 // Trailing commas and empty args introduce blank content in math
@@ -56,9 +56,9 @@ $ sin( ,/**/x/**/, , /**/y, ,/**/, ) $
 --- math-call-empty-args-repr ---
 #let args(..body) = body
 #let check(it, r) = test-repr(it.body.text, r)
-#check($args(,x,,y,,)$, "([], [x], [], [y], [])")
+#check($args(,x,,y,,)$, "arguments([], [x], [], [y], [])")
 // with whitespace/trivia:
-#check($args( ,/**/x/**/, , /**/y, ,/**/, )$, "([], [x], [], [y], [], [])")
+#check($args( ,/**/x/**/, , /**/y, ,/**/, )$, "arguments([], [x], [], [y], [], [])")
 
 --- math-call-value-non-func ---
 $ sin(1) $

--- a/tests/suite/scripting/call.typ
+++ b/tests/suite/scripting/call.typ
@@ -141,7 +141,7 @@
 #{
   let save(..args) = {
     test(type(args), arguments)
-    test(repr(args), "(three: true, 1, 2)")
+    test(repr(args), "arguments(three: true, 1, 2)")
   }
 
   save(1, 2, three: true)
@@ -159,7 +159,7 @@
 #{
   let more = (c: 3, d: 4)
   let tostr(..args) = repr(args)
-  test(tostr(a: 1, ..more, b: 2), "(a: 1, c: 3, d: 4, b: 2)")
+  test(tostr(a: 1, ..more, b: 2), "arguments(a: 1, c: 3, d: 4, b: 2)")
 }
 
 --- call-args-spread-none ---

--- a/tests/suite/scripting/params.typ
+++ b/tests/suite/scripting/params.typ
@@ -29,17 +29,17 @@
 // Spread at beginning.
 #{
   let f(..a, b) = (a, b)
-  test(repr(f(1)), "((), 1)")
-  test(repr(f(1, 2, 3)), "((1, 2), 3)")
-  test(repr(f(1, 2, 3, 4, 5)), "((1, 2, 3, 4), 5)")
+  test(repr(f(1)), "(arguments(), 1)")
+  test(repr(f(1, 2, 3)), "(arguments(1, 2), 3)")
+  test(repr(f(1, 2, 3, 4, 5)), "(arguments(1, 2, 3, 4), 5)")
 }
 
 --- params-sink-in-middle ---
 // Spread in the middle.
 #{
   let f(a, ..b, c) = (a, b, c)
-  test(repr(f(1, 2)), "(1, (), 2)")
-  test(repr(f(1, 2, 3, 4, 5)), "(1, (2, 3, 4), 5)")
+  test(repr(f(1, 2)), "(1, arguments(), 2)")
+  test(repr(f(1, 2, 3, 4, 5)), "(1, arguments(2, 3, 4), 5)")
 }
 
 --- params-sink-unnamed-empty ---


### PR DESCRIPTION
This PR improves the `repr` for `arguments` by making it valid Typst syntax, using a call to the `arguments` constructor.