### PR TITLE
Avoid stripping url prefixes multiple times or multiple prefixes

### DIFF
--- a/crates/typst-library/src/model/link.rs
+++ b/crates/typst-library/src/model/link.rs
@@ -135,10 +135,10 @@ impl Show for Packed<LinkElem> {
 }
 
 fn body_from_url(url: &Url) -> Content {
-    let mut text = url.as_str();
-    for prefix in ["mailto:", "tel:"] {
-        text = text.trim_start_matches(prefix);
-    }
+    let text = ["mailto:", "tel:"]
+        .into_iter()
+        .find_map(|prefix| url.strip_prefix(prefix))
+        .unwrap_or(url);
     let shorter = text.len() < url.len();
     TextElem::packed(if shorter { text.into() } else { (**url).clone() })
 }


### PR DESCRIPTION
```typ
#let l(url) = {
  link(url)
  sym.arrow.r
  url
}

#l("foo")

#l("mailto:foo")

#l("mailto:tel:foo")

#l("mailto:mailto:foo")
```

Before:
![image](https://github.com/user-attachments/assets/78eb7088-6f3a-400e-9f55-952d28c21586)
After:
![image](https://github.com/user-attachments/assets/925b2bca-9316-4195-9bdb-9b84da0eb253)

There's no valid `mailto:` or `tel:` that start with `mailto:` or `tel:`, so such links are always invalid as in "the url isn't valid", but typst isn't concerned (currently?) about link validation and there might be more prefixes in the future (e.g. `sms`, `geo`), so this seems more sensible.