### PR TITLE
Remove now-unnecessary `is_nan` function

### DIFF
--- a/crates/typst-utils/src/scalar.rs
+++ b/crates/typst-utils/src/scalar.rs
@@ -28,24 +28,13 @@ impl Scalar {
     ///
     /// If the value is NaN, then it is set to `0.0` in the result.
     pub const fn new(x: f64) -> Self {
-        Self(if is_nan(x) { 0.0 } else { x })
+        Self(if x.is_nan() { 0.0 } else { x })
     }
 
     /// Gets the value of this [`Scalar`].
     pub const fn get(self) -> f64 {
         self.0
     }
-}
-
-// We have to detect NaNs this way since `f64::is_nan` isn’t const
-// on stable yet:
-// ([tracking issue](https://github.com/rust-lang/rust/issues/57241))
-#[allow(clippy::unusual_byte_groupings)]
-const fn is_nan(x: f64) -> bool {
-    // Safety: all bit patterns are valid for u64, and f64 has no padding bits.
-    // We cannot use `f64::to_bits` because it is not const.
-    let x_bits = unsafe { std::mem::transmute::<f64, u64>(x) };
-    (x_bits << 1 >> (64 - 12 + 1)) == 0b0_111_1111_1111 && (x_bits << 12) != 0
 }
 
 impl Numeric for Scalar {


### PR DESCRIPTION
This additionally removes an `unsafe` block.

Only merge it once the minimum Rust version has been bumped to 1.83 though. `f64::is_nan` is only const from 1.83.0 and onwards.