### PR TITLE
Remove closing slashes from img tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,19 @@
 <p align="center">
   <a href="https://typst.app/docs/">
     <img alt="Documentation" src="https://img.shields.io/website?down_message=offline&label=docs&up_color=007aff&up_message=online&url=https%3A%2F%2Ftypst.app%2Fdocs"
-  /></a>
+  ></a>
   <a href="https://typst.app/">
     <img alt="Typst App" src="https://img.shields.io/website?down_message=offline&label=typst.app&up_color=239dad&up_message=online&url=https%3A%2F%2Ftypst.app"
-  /></a>
+  ></a>
   <a href="https://discord.gg/2uDybryKPe">
     <img alt="Discord Server" src="https://img.shields.io/discord/1054443721975922748?color=5865F2&label=discord&labelColor=555"
-  /></a>
+  ></a>
   <a href="https://github.com/typst/typst/blob/main/LICENSE">
     <img alt="Apache-2 License" src="https://img.shields.io/badge/license-Apache%202-brightgreen"
-  /></a>
+  ></a>
   <a href="https://typst.app/jobs/">
     <img alt="Jobs at Typst" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Ftypst.app%2Fassets%2Fdata%2Fshields.json&query=%24.jobs.text&label=jobs&color=%23A561FF&cacheSeconds=1800"
-  /></a>
+  ></a>
 </p>
 
 Typst is a new markup-based typesetting system that is designed to be as powerful
@@ -39,7 +39,7 @@ A [gentle introduction][tutorial] to Typst is available in our documentation.
 However, if you want to see the power of Typst encapsulated in one image, here
 it is:
 <p align="center">
- <img alt="Example" width="900" src="https://user-images.githubusercontent.com/17899797/228031796-ced0e452-fcee-4ae9-92da-b9287764ff25.png"/>
+ <img alt="Example" width="900" src="https://user-images.githubusercontent.com/17899797/228031796-ced0e452-fcee-4ae9-92da-b9287764ff25.png">
 </p>
 
 

--- a/docs/src/main.rs
+++ b/docs/src/main.rs
@@ -46,11 +46,11 @@ impl Resolver for CliResolver<'_> {
         if let Some(code) = source {
             let code_safe = code.as_str();
             Html::new(format!(
-                r#"<div class="previewed-code"><pre>{code_safe}</pre><div class="preview"><img src="{src}" alt="Preview" /></div></div>"#
+                r#"<div class="previewed-code"><pre>{code_safe}</pre><div class="preview"><img src="{src}" alt="Preview"></div></div>"#
             ))
         } else {
             Html::new(format!(
-                r#"<div class="preview"><img src="{src}" alt="Preview" /></div>"#
+                r#"<div class="preview"><img src="{src}" alt="Preview"></div>"#
             ))
         }
     }

--- a/tools/test-helper/src/extension.ts
+++ b/tools/test-helper/src/extension.ts
@@ -474,7 +474,7 @@ function getWebviewContent(
             data-vscode-context='{"webviewSection":"png"}'
             src="${webViewSrcs.png}"
             alt="Placeholder"
-          />
+          >
         </div>
 
         <div>
@@ -484,7 +484,7 @@ function getWebviewContent(
             data-vscode-context='{"webviewSection":"ref"}'
             src="${webViewSrcs.ref}"
             alt="Placeholder"
-          />
+          >
         </div>
       </div>
       ${stdoutHtml}


### PR DESCRIPTION
HTML5 does not use slashes for void elements, that's XHTML syntax.