### PR TITLE
More flexible and efficient `Bytes` representation

### DIFF
--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -305,7 +305,7 @@ impl FileSlot {
     ) -> FileResult<Bytes> {
         self.file.get_or_init(
             || read(self.id, project_root, package_storage),
-            |data, _| Ok(data.into()),
+            |data, _| Ok(Bytes::new(data)),
         )
     }
 }

--- a/crates/typst-ide/src/tests.rs
+++ b/crates/typst-ide/src/tests.rs
@@ -55,7 +55,7 @@ impl TestWorld {
     pub fn with_asset_at(mut self, path: &str, filename: &str) -> Self {
         let id = FileId::new(None, VirtualPath::new(path));
         let data = typst_dev_assets::get_by_name(filename).unwrap();
-        let bytes = Bytes::from_static(data);
+        let bytes = Bytes::new(data);
         Arc::make_mut(&mut self.files).assets.insert(id, bytes);
         self
     }
@@ -152,7 +152,7 @@ impl Default for TestBase {
     fn default() -> Self {
         let fonts: Vec<_> = typst_assets::fonts()
             .chain(typst_dev_assets::fonts())
-            .flat_map(|data| Font::iter(Bytes::from_static(data)))
+            .flat_map(|data| Font::iter(Bytes::new(data)))
             .collect();
 
         Self {

--- a/crates/typst-kit/src/fonts.rs
+++ b/crates/typst-kit/src/fonts.rs
@@ -13,6 +13,7 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use fontdb::{Database, Source};
+use typst_library::foundations::Bytes;
 use typst_library::text::{Font, FontBook, FontInfo};
 use typst_timing::TimingScope;
 
@@ -52,9 +53,8 @@ impl FontSlot {
                         .as_ref()
                         .expect("`path` is not `None` if `font` is uninitialized"),
                 )
-                .ok()?
-                .into();
-                Font::new(data, self.index)
+                .ok()?;
+                Font::new(Bytes::new(data), self.index)
             })
             .clone()
     }
@@ -196,7 +196,7 @@ impl FontSearcher {
     #[cfg(feature = "embed-fonts")]
     fn add_embedded(&mut self) {
         for data in typst_assets::fonts() {
-            let buffer = typst_library::foundations::Bytes::from_static(data);
+            let buffer = Bytes::new(data);
             for (i, font) in Font::iter(buffer).enumerate() {
                 self.book.push(font.info().clone());
                 self.fonts.push(FontSlot {

--- a/crates/typst-layout/src/image.rs
+++ b/crates/typst-layout/src/image.rs
@@ -50,7 +50,7 @@ pub fn layout_image(
 
     // Construct the image itself.
     let image = Image::with_fonts(
-        data.clone().into(),
+        data.clone().into_bytes(),
         format,
         elem.alt(styles),
         engine.world,

--- a/crates/typst-library/src/foundations/float.rs
+++ b/crates/typst-library/src/foundations/float.rs
@@ -163,18 +163,14 @@ impl f64 {
         size: u32,
     ) -> StrResult<Bytes> {
         Ok(match size {
-            8 => match endian {
+            8 => Bytes::new(match endian {
                 Endianness::Little => self.to_le_bytes(),
                 Endianness::Big => self.to_be_bytes(),
-            }
-            .as_slice()
-            .into(),
-            4 => match endian {
+            }),
+            4 => Bytes::new(match endian {
                 Endianness::Little => (self as f32).to_le_bytes(),
                 Endianness::Big => (self as f32).to_be_bytes(),
-            }
-            .as_slice()
-            .into(),
+            }),
             _ => bail!("size must be either 4 or 8"),
         })
     }

--- a/crates/typst-library/src/foundations/int.rs
+++ b/crates/typst-library/src/foundations/int.rs
@@ -1,6 +1,7 @@
 use std::num::{NonZeroI64, NonZeroIsize, NonZeroU64, NonZeroUsize, ParseIntError};
 
 use ecow::{eco_format, EcoString};
+use smallvec::SmallVec;
 
 use crate::diag::{bail, StrResult};
 use crate::foundations::{
@@ -322,7 +323,7 @@ impl i64 {
             Endianness::Little => self.to_le_bytes(),
         };
 
-        let mut buf = vec![0u8; size];
+        let mut buf = SmallVec::<[u8; 8]>::from_elem(0, size);
         match endian {
             Endianness::Big => {
                 // Copy the bytes from the array to the buffer, starting from
@@ -339,7 +340,7 @@ impl i64 {
             }
         }
 
-        Bytes::from(buf)
+        Bytes::new(buf)
     }
 }
 

--- a/crates/typst-library/src/foundations/plugin.rs
+++ b/crates/typst-library/src/foundations/plugin.rs
@@ -293,7 +293,7 @@ impl Plugin {
             _ => bail!("plugin did not respect the protocol"),
         };
 
-        Ok(output.into())
+        Ok(Bytes::new(output))
     }
 
     /// An iterator over all the function names defined by the plugin.

--- a/crates/typst-library/src/foundations/value.rs
+++ b/crates/typst-library/src/foundations/value.rs
@@ -459,15 +459,15 @@ impl<'de> Visitor<'de> for ValueVisitor {
     }
 
     fn visit_bytes<E: Error>(self, v: &[u8]) -> Result<Self::Value, E> {
-        Ok(Bytes::from(v).into_value())
+        Ok(Bytes::new(v.to_vec()).into_value())
     }
 
     fn visit_borrowed_bytes<E: Error>(self, v: &'de [u8]) -> Result<Self::Value, E> {
-        Ok(Bytes::from(v).into_value())
+        Ok(Bytes::new(v.to_vec()).into_value())
     }
 
     fn visit_byte_buf<E: Error>(self, v: Vec<u8>) -> Result<Self::Value, E> {
-        Ok(Bytes::from(v).into_value())
+        Ok(Bytes::new(v).into_value())
     }
 
     fn visit_none<E: Error>(self) -> Result<Self::Value, E> {

--- a/crates/typst-library/src/loading/cbor.rs
+++ b/crates/typst-library/src/loading/cbor.rs
@@ -55,7 +55,7 @@ impl cbor {
         let Spanned { v: value, span } = value;
         let mut res = Vec::new();
         ciborium::into_writer(&value, &mut res)
-            .map(|_| res.into())
+            .map(|_| Bytes::new(res))
             .map_err(|err| eco_format!("failed to encode value as CBOR ({err})"))
             .at(span)
     }

--- a/crates/typst-library/src/loading/mod.rs
+++ b/crates/typst-library/src/loading/mod.rs
@@ -56,15 +56,22 @@ pub enum Readable {
 impl Readable {
     pub fn as_slice(&self) -> &[u8] {
         match self {
-            Readable::Bytes(v) => v,
-            Readable::Str(v) => v.as_bytes(),
+            Self::Bytes(v) => v,
+            Self::Str(v) => v.as_bytes(),
         }
     }
 
     pub fn as_str(&self) -> Option<&str> {
         match self {
-            Readable::Str(v) => Some(v.as_str()),
-            Readable::Bytes(v) => std::str::from_utf8(v).ok(),
+            Self::Str(v) => Some(v.as_str()),
+            Self::Bytes(v) => std::str::from_utf8(v).ok(),
+        }
+    }
+
+    pub fn into_bytes(self) -> Bytes {
+        match self {
+            Self::Bytes(v) => v,
+            Self::Str(v) => Bytes::from_string(v),
         }
     }
 }
@@ -77,13 +84,4 @@ cast! {
     },
     v: Str => Self::Str(v),
     v: Bytes => Self::Bytes(v),
-}
-
-impl From<Readable> for Bytes {
-    fn from(value: Readable) -> Self {
-        match value {
-            Readable::Bytes(v) => v,
-            Readable::Str(v) => v.as_bytes().into(),
-        }
-    }
 }

--- a/crates/typst-library/src/text/font/color.rs
+++ b/crates/typst-library/src/text/font/color.rs
@@ -7,6 +7,7 @@ use typst_syntax::Span;
 use usvg::tiny_skia_path;
 use xmlwriter::XmlWriter;
 
+use crate::foundations::Bytes;
 use crate::layout::{Abs, Frame, FrameItem, Point, Size};
 use crate::text::{Font, Glyph};
 use crate::visualize::{FixedStroke, Geometry, Image, RasterFormat, VectorFormat};
@@ -101,8 +102,12 @@ fn draw_raster_glyph(
     upem: Abs,
     raster_image: ttf_parser::RasterGlyphImage,
 ) -> Option<()> {
-    let image =
-        Image::new(raster_image.data.into(), RasterFormat::Png.into(), None).ok()?;
+    let image = Image::new(
+        Bytes::new(raster_image.data.to_vec()),
+        RasterFormat::Png.into(),
+        None,
+    )
+    .ok()?;
 
     // Apple Color emoji doesn't provide offset information (or at least
     // not in a way ttf-parser understands), so we artificially shift their
@@ -175,7 +180,7 @@ fn draw_colr_glyph(
 
     let data = svg.end_document().into_bytes();
 
-    let image = Image::new(data.into(), VectorFormat::Svg.into(), None).ok()?;
+    let image = Image::new(Bytes::new(data), VectorFormat::Svg.into(), None).ok()?;
 
     let y_shift = Abs::pt(upem.to_pt() - y_max);
     let position = Point::new(Abs::pt(x_min), y_shift);
@@ -251,7 +256,7 @@ fn draw_svg_glyph(
     );
 
     let image =
-        Image::new(wrapper_svg.into_bytes().into(), VectorFormat::Svg.into(), None)
+        Image::new(Bytes::new(wrapper_svg.into_bytes()), VectorFormat::Svg.into(), None)
             .ok()?;
 
     let position = Point::new(Abs::pt(left), Abs::pt(top) + upem);

--- a/crates/typst-library/src/visualize/image/raster.rs
+++ b/crates/typst-library/src/visualize/image/raster.rs
@@ -274,7 +274,7 @@ mod tests {
         #[track_caller]
         fn test(path: &str, format: RasterFormat, dpi: f64) {
             let data = typst_dev_assets::get(path).unwrap();
-            let bytes = Bytes::from_static(data);
+            let bytes = Bytes::new(data);
             let image = RasterImage::new(bytes, format).unwrap();
             assert_eq!(image.dpi().map(f64::round), Some(dpi));
         }

--- a/crates/typst-svg/src/text.rs
+++ b/crates/typst-svg/src/text.rs
@@ -3,6 +3,7 @@ use std::io::Read;
 use base64::Engine;
 use ecow::EcoString;
 use ttf_parser::GlyphId;
+use typst_library::foundations::Bytes;
 use typst_library::layout::{Abs, Point, Ratio, Size, Transform};
 use typst_library::text::{Font, TextItem};
 use typst_library::visualize::{FillRule, Image, Paint, RasterFormat, RelativeTo};
@@ -243,7 +244,9 @@ fn convert_bitmap_glyph_to_image(font: &Font, id: GlyphId) -> Option<(Image, f64
     if raster.format != ttf_parser::RasterImageFormat::PNG {
         return None;
     }
-    let image = Image::new(raster.data.into(), RasterFormat::Png.into(), None).ok()?;
+    let image =
+        Image::new(Bytes::new(raster.data.to_vec()), RasterFormat::Png.into(), None)
+            .ok()?;
     Some((image, raster.x as f64, raster.y as f64))
 }
 

--- a/docs/src/html.rs
+++ b/docs/src/html.rs
@@ -486,7 +486,7 @@ impl World for DocWorld {
 
     fn file(&self, id: FileId) -> FileResult<Bytes> {
         assert!(id.package().is_none());
-        Ok(Bytes::from_static(
+        Ok(Bytes::new(
             typst_dev_assets::get_by_name(
                 &id.vpath().as_rootless_path().to_string_lossy(),
             )

--- a/docs/src/lib.rs
+++ b/docs/src/lib.rs
@@ -77,7 +77,7 @@ static LIBRARY: LazyLock<LazyHash<Library>> = LazyLock::new(|| {
 static FONTS: LazyLock<(LazyHash<FontBook>, Vec<Font>)> = LazyLock::new(|| {
     let fonts: Vec<_> = typst_assets::fonts()
         .chain(typst_dev_assets::fonts())
-        .flat_map(|data| Font::iter(Bytes::from_static(data)))
+        .flat_map(|data| Font::iter(Bytes::new(data)))
         .collect();
     let book = FontBook::from_fonts(&fonts);
     (LazyHash::new(book), fonts)

--- a/tests/fuzz/src/compile.rs
+++ b/tests/fuzz/src/compile.rs
@@ -19,7 +19,7 @@ struct FuzzWorld {
 impl FuzzWorld {
     fn new(text: &str) -> Self {
         let data = typst_assets::fonts().next().unwrap();
-        let font = Font::new(Bytes::from_static(data), 0).unwrap();
+        let font = Font::new(Bytes::new(data), 0).unwrap();
         let book = FontBook::from_fonts([&font]);
         Self {
             library: LazyHash::new(Library::default()),

--- a/tests/src/world.rs
+++ b/tests/src/world.rs
@@ -98,7 +98,7 @@ impl Default for TestBase {
     fn default() -> Self {
         let fonts: Vec<_> = typst_assets::fonts()
             .chain(typst_dev_assets::fonts())
-            .flat_map(|data| Font::iter(Bytes::from_static(data)))
+            .flat_map(|data| Font::iter(Bytes::new(data)))
             .collect();
 
         Self {
@@ -140,8 +140,8 @@ impl FileSlot {
         self.file
             .get_or_init(|| {
                 read(&system_path(self.id)?).map(|cow| match cow {
-                    Cow::Owned(buf) => buf.into(),
-                    Cow::Borrowed(buf) => Bytes::from_static(buf),
+                    Cow::Owned(buf) => Bytes::new(buf),
+                    Cow::Borrowed(buf) => Bytes::new(buf),
                 })
             })
             .clone()


### PR DESCRIPTION
Any `AsRef<[u8]>` or `AsRef<str>` can now back the `Bytes`, so we can use types like the following without copying into a new vector: `[u8; 8]`, `EcoString`, `String`. Of course, `&'static [u8]` is also possible, but this was the case before as well.

This also removes the `From<&[u8]>` and `From<Vec<u8>>` impls from `Bytes` because they may hide unnecessary copies and `Bytes::new` forces the caller to think more about what they want to pass in.