### PR TITLE
Make `typst-timing` WASM-compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3093,6 +3093,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
+ "web-sys",
 ]
 
 [[package]]
@@ -3416,6 +3417,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5a015fe95f3504a94bb1462c717aae75253e39b9dd6c3fb1062c934535c64aa"
 dependencies = [
  "indexmap-nostd",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,7 @@ ureq = { version = "2", default-features = false, features = ["native-tls", "gzi
 usvg = { version = "0.43", default-features = false, features = ["text"] }
 walkdir = "2"
 wasmi = "0.39.0"
+web-sys = "0.3"
 xmlparser = "0.13.5"
 xmlwriter = "0.1.0"
 xmp-writer = "0.3"

--- a/crates/typst-timing/Cargo.toml
+++ b/crates/typst-timing/Cargo.toml
@@ -18,7 +18,10 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-web-sys = { workspace = true, features = ["Window", "WorkerGlobalScope", "Performance"] }
+web-sys = { workspace = true, features = ["Window", "WorkerGlobalScope", "Performance"], optional = true }
+
+[features]
+wasm = ["dep:web-sys"]
 
 [lints]
 workspace = true

--- a/crates/typst-timing/Cargo.toml
+++ b/crates/typst-timing/Cargo.toml
@@ -17,5 +17,8 @@ parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+web-sys = { workspace = true, features = ["Window", "WorkerGlobalScope", "Performance"] }
+
 [lints]
 workspace = true

--- a/crates/typst-timing/src/lib.rs
+++ b/crates/typst-timing/src/lib.rs
@@ -8,6 +8,41 @@ use parking_lot::Mutex;
 use serde::ser::SerializeSeq;
 use serde::{Serialize, Serializer};
 
+/// Creates a timing scope around an expression.
+///
+/// The output of the expression is returned.
+///
+/// The scope will be named `name` and will have the span `span`. The span is
+/// optional.
+///
+/// ## Example
+///
+/// ```rs
+/// // With a scope name and span.
+/// timed!(
+///     "my scope",
+///     span = Span::detached(),
+///     std::thread::sleep(std::time::Duration::from_secs(1)),
+/// );
+///
+/// // With a scope name and no span.
+/// timed!(
+///     "my scope",
+///     std::thread::sleep(std::time::Duration::from_secs(1)),
+/// );
+/// ```
+#[macro_export]
+macro_rules! timed {
+    ($name:expr, span = $span:expr, $body:expr $(,)?) => {{
+        let __scope = $crate::TimingScope::with_span($name, Some($span));
+        $body
+    }};
+    ($name:expr, $body:expr $(,)?) => {{
+        let __scope = $crate::TimingScope::new($name);
+        $body
+    }};
+}
+
 thread_local! {
     /// Data that is initialized once per thread.
     static THREAD_DATA: ThreadData = ThreadData {
@@ -28,40 +63,6 @@ static ENABLED: AtomicBool = AtomicBool::new(false);
 /// The list of collected events.
 static EVENTS: Mutex<Vec<Event>> = Mutex::new(Vec::new());
 
-/// Per-thread data.
-struct ThreadData {
-    /// The thread's ID.
-    ///
-    /// In contrast to `std::thread::current().id()`, this is wasm-compatible
-    /// and also a bit cheaper to access because the std version does a bit more
-    /// stuff (including cloning an `Arc`).
-    id: u64,
-    /// A way to get the time from WebAssembly.
-    #[cfg(all(target_arch = "wasm32", feature = "wasm"))]
-    timer: WasmTimer,
-}
-
-/// An event that has been recorded.
-struct Event {
-    /// Whether this is a start or end event.
-    kind: EventKind,
-    /// The time at which this event occurred.
-    timestamp: Timestamp,
-    /// The name of this event.
-    name: &'static str,
-    /// The raw value of the span of code that this event was recorded in.
-    span: Option<NonZeroU64>,
-    /// The thread ID of this event.
-    thread_id: u64,
-}
-
-/// Whether an event marks the start or end of a scope.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-enum EventKind {
-    Start,
-    End,
-}
-
 /// Enable the timer.
 #[inline]
 pub fn enable() {
@@ -80,6 +81,61 @@ pub fn is_enabled() -> bool {
 #[inline]
 pub fn clear() {
     EVENTS.lock().clear();
+}
+
+/// Export data as JSON for Chrome's tracing tool.
+///
+/// The `source` function is called for each span to get the source code
+/// location of the span. The first element of the tuple is the file path and
+/// the second element is the line number.
+pub fn export_json<W: Write>(
+    writer: W,
+    mut source: impl FnMut(NonZeroU64) -> (String, u32),
+) -> Result<(), String> {
+    #[derive(Serialize)]
+    struct Entry {
+        name: &'static str,
+        cat: &'static str,
+        ph: &'static str,
+        ts: f64,
+        pid: u64,
+        tid: u64,
+        args: Option<Args>,
+    }
+
+    #[derive(Serialize)]
+    struct Args {
+        file: String,
+        line: u32,
+    }
+
+    let lock = EVENTS.lock();
+    let events = lock.as_slice();
+
+    let mut serializer = serde_json::Serializer::new(writer);
+    let mut seq = serializer
+        .serialize_seq(Some(events.len()))
+        .map_err(|e| format!("failed to serialize events: {e}"))?;
+
+    for event in events.iter() {
+        seq.serialize_element(&Entry {
+            name: event.name,
+            cat: "typst",
+            ph: match event.kind {
+                EventKind::Start => "B",
+                EventKind::End => "E",
+            },
+            ts: event.timestamp.micros_since(events[0].timestamp),
+            pid: 1,
+            tid: event.thread_id,
+            args: event.span.map(&mut source).map(|(file, line)| Args { file, line }),
+        })
+        .map_err(|e| format!("failed to serialize event: {e}"))?;
+    }
+
+    seq.end().map_err(|e| format!("failed to serialize events: {e}"))?;
+
+    Ok(())
 }
 
 /// A scope that records an event when it is dropped.
@@ -137,6 +193,27 @@ impl Drop for TimingScope {
     }
 }
 
+/// An event that has been recorded.
+struct Event {
+    /// Whether this is a start or end event.
+    kind: EventKind,
+    /// The time at which this event occurred.
+    timestamp: Timestamp,
+    /// The name of this event.
+    name: &'static str,
+    /// The raw value of the span of code that this event was recorded in.
+    span: Option<NonZeroU64>,
+    /// The thread ID of this event.
+    thread_id: u64,
+}
+
+/// Whether an event marks the start or end of a scope.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum EventKind {
+    Start,
+    End,
+}
+
 /// A cross-platform way to get the current time.
 #[derive(Copy, Clone)]
 struct Timestamp {
@@ -181,94 +258,17 @@ impl Timestamp {
     }
 }
 
-/// Creates a timing scope around an expression.
-///
-/// The output of the expression is returned.
-///
-/// The scope will be named `name` and will have the span `span`. The span is
-/// optional.
-///
-/// ## Example
-///
-/// ```rs
-/// // With a scope name and span.
-/// timed!(
-///     "my scope",
-///     span = Span::detached(),
-///     std::thread::sleep(std::time::Duration::from_secs(1)),
-/// );
-///
-/// // With a scope name and no span.
-/// timed!(
-///     "my scope",
-///     std::thread::sleep(std::time::Duration::from_secs(1)),
-/// );
-/// ```
-#[macro_export]
-macro_rules! timed {
-    ($name:expr, span = $span:expr, $body:expr $(,)?) => {{
-        let __scope = $crate::TimingScope::with_span($name, Some($span));
-        $body
-    }};
-    ($name:expr, $body:expr $(,)?) => {{
-        let __scope = $crate::TimingScope::new($name);
-        $body
-    }};
-}
-
-/// Export data as JSON for Chrome's tracing tool.
-///
-/// The `source` function is called for each span to get the source code
-/// location of the span. The first element of the tuple is the file path and
-/// the second element is the line number.
-pub fn export_json<W: Write>(
-    writer: W,
-    mut source: impl FnMut(NonZeroU64) -> (String, u32),
-) -> Result<(), String> {
-    #[derive(Serialize)]
-    struct Entry {
-        name: &'static str,
-        cat: &'static str,
-        ph: &'static str,
-        ts: f64,
-        pid: u64,
-        tid: u64,
-        args: Option<Args>,
-    }
-
-    #[derive(Serialize)]
-    struct Args {
-        file: String,
-        line: u32,
-    }
-
-    let lock = EVENTS.lock();
-    let events = lock.as_slice();
-
-    let mut serializer = serde_json::Serializer::new(writer);
-    let mut seq = serializer
-        .serialize_seq(Some(events.len()))
-        .map_err(|e| format!("failed to serialize events: {e}"))?;
-
-    for event in events.iter() {
-        seq.serialize_element(&Entry {
-            name: event.name,
-            cat: "typst",
-            ph: match event.kind {
-                EventKind::Start => "B",
-                EventKind::End => "E",
-            },
-            ts: event.timestamp.micros_since(events[0].timestamp),
-            pid: 1,
-            tid: event.thread_id,
-            args: event.span.map(&mut source).map(|(file, line)| Args { file, line }),
-        })
-        .map_err(|e| format!("failed to serialize event: {e}"))?;
-    }
-
-    seq.end().map_err(|e| format!("failed to serialize events: {e}"))?;
-
-    Ok(())
+/// Per-thread data.
+struct ThreadData {
+    /// The thread's ID.
+    ///
+    /// In contrast to `std::thread::current().id()`, this is wasm-compatible
+    /// and also a bit cheaper to access because the std version does a bit more
+    /// stuff (including cloning an `Arc`).
+    id: u64,
+    /// A way to get the time from WebAssembly.
+    #[cfg(all(target_arch = "wasm32", feature = "wasm"))]
+    timer: WasmTimer,
 }
 
 /// A way to get the time from WebAssembly.

--- a/crates/typst-timing/src/lib.rs
+++ b/crates/typst-timing/src/lib.rs
@@ -190,9 +190,9 @@ impl Timestamp {
         Self::now()
     }
 
-    fn millis_since(self, start: Self) -> f64 {
+    fn micros_since(self, start: Self) -> f64 {
         #[cfg(target_arch = "wasm32")]
-        return self.inner - start.inner;
+        return (self.inner - start.inner) * 1000.0;
 
         #[cfg(not(target_arch = "wasm32"))]
         (self
@@ -281,7 +281,7 @@ pub fn export_json<W: Write>(
                 EventKind::Start => "B",
                 EventKind::End => "E",
             },
-            ts: event.timestamp.millis_since(events[0].timestamp),
+            ts: event.timestamp.micros_since(events[0].timestamp),
             pid: 1,
             tid: event.thread_id,
             args: event.span.map(&mut source).map(|(file, line)| Args { file, line }),

--- a/crates/typst-timing/src/lib.rs
+++ b/crates/typst-timing/src/lib.rs
@@ -36,7 +36,7 @@ struct ThreadData {
     /// and also a bit cheaper to access because the std version does a bit more
     /// stuff (including cloning an `Arc`).
     id: u64,
-    /// A way to get the time in Wasm.
+    /// A way to get the time from WebAssembly.
     #[cfg(all(target_arch = "wasm32", feature = "wasm"))]
     timer: WasmTimer,
 }
@@ -271,6 +271,7 @@ pub fn export_json<W: Write>(
     Ok(())
 }
 
+/// A way to get the time from WebAssembly.
 #[cfg(all(target_arch = "wasm32", feature = "wasm"))]
 struct WasmTimer {
     /// The cached JS performance handle for the thread.
@@ -282,7 +283,7 @@ struct WasmTimer {
 #[cfg(all(target_arch = "wasm32", feature = "wasm"))]
 impl WasmTimer {
     fn new() -> Self {
-        // Retrieve `performance` from global object, either the window
+        // Retrieve `performance` from global object, either the window or
         // globalThis.
         let perf = web_sys::window()
             .and_then(|window| window.performance())


### PR DESCRIPTION
- `std::thread::current().id()` is replaced with a manual thread ID solution based on one atomic counter and one thread local. We now also use this for non-wasm because it looks like the std solution has more overhead. We can also get rid of a `transmute` that way.
- `SystemTime::now()` is replaced with `performance.now()` for WebAssembly, which makes `typst-timing` depend on `web-sys` for that platform. That couples it to the wasm-bindgen ecosystem, but that's anyway a general assumption across the current Rust WebAssembly ecosystem.