### PR TITLE
Ignore shebang at start of file

### DIFF
--- a/crates/typst-syntax/src/highlight.rs
+++ b/crates/typst-syntax/src/highlight.rs
@@ -287,6 +287,7 @@ pub fn highlight(node: &LinkedNode) -> Option<Tag> {
         SyntaxKind::Destructuring => None,
         SyntaxKind::DestructAssignment => None,
 
+        SyntaxKind::Shebang => Some(Tag::Comment),
         SyntaxKind::LineComment => Some(Tag::Comment),
         SyntaxKind::BlockComment => Some(Tag::Comment),
         SyntaxKind::Error => Some(Tag::Error),

--- a/crates/typst-syntax/src/kind.rs
+++ b/crates/typst-syntax/src/kind.rs
@@ -359,7 +359,11 @@ impl SyntaxKind {
     pub fn is_trivia(self) -> bool {
         matches!(
             self,
-            Self::LineComment | Self::BlockComment | Self::Space | Self::Parbreak
+            Self::Shebang
+                | Self::LineComment
+                | Self::BlockComment
+                | Self::Space
+                | Self::Parbreak
         )
     }
 

--- a/crates/typst-syntax/src/kind.rs
+++ b/crates/typst-syntax/src/kind.rs
@@ -9,6 +9,8 @@ pub enum SyntaxKind {
     /// An invalid sequence of characters.
     Error,
 
+    /// A shebang: `#! ...`
+    Shebang,
     /// A line comment: `// ...`.
     LineComment,
     /// A block comment: `/* ... */`.
@@ -371,6 +373,7 @@ impl SyntaxKind {
         match self {
             Self::End => "end of tokens",
             Self::Error => "syntax error",
+            Self::Shebang => "shebang",
             Self::LineComment => "line comment",
             Self::BlockComment => "block comment",
             Self::Markup => "markup",

--- a/crates/typst-syntax/src/lexer.rs
+++ b/crates/typst-syntax/src/lexer.rs
@@ -103,6 +103,7 @@ impl Lexer<'_> {
         self.newline = false;
         let kind = match self.s.eat() {
             Some(c) if is_space(c, self.mode) => self.whitespace(start, c),
+            Some('#') if start == 0 && self.s.eat_if('!') => self.shebang(),
             Some('/') if self.s.eat_if('/') => self.line_comment(),
             Some('/') if self.s.eat_if('*') => self.block_comment(),
             Some('*') if self.s.eat_if('/') => {
@@ -149,6 +150,11 @@ impl Lexer<'_> {
         } else {
             SyntaxKind::Space
         }
+    }
+
+    fn shebang(&mut self) -> SyntaxKind {
+        self.s.eat_until(is_newline);
+        SyntaxKind::Shebang
     }
 
     fn line_comment(&mut self) -> SyntaxKind {

--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -93,6 +93,8 @@ fn markup_expr(p: &mut Parser, at_start: bool, nesting: &mut usize) {
             p.hint("try using a backslash escape: \\]");
         }
 
+        SyntaxKind::Shebang => p.eat(),
+
         SyntaxKind::Text
         | SyntaxKind::Linebreak
         | SyntaxKind::Escape

--- a/tests/suite/syntax/shebang.typ
+++ b/tests/suite/syntax/shebang.typ
@@ -1,0 +1,7 @@
+// Test shebang support.
+
+--- shebang ---
+#!typst compile
+
+// Error: 2-3 the character `!` is not valid in code
+#!not-a-shebang


### PR DESCRIPTION
Closes #4899.

There haven't been any new objections after https://github.com/typst/typst/issues/4899#issuecomment-2329484793, which also has 9 thumbs up (including one from me).
I think it's fair to call this change uncontroversial.

Note that a shebang can only be at the very beginning of a file,
so everywhere else `#!` parses just like it did before (as an error).