### PR TITLE
New `count()` function (Counter Rework)

### DIFF
--- a/crates/typst-library/src/introspection/count.rs
+++ b/crates/typst-library/src/introspection/count.rs
@@ -1,0 +1,92 @@
+use comemo::Tracked;
+
+use crate::diag::HintedStrResult;
+use crate::engine::Engine;
+use crate::foundations::{func, Array, Context, IntoValue, LocatableSelector, Selector};
+
+/// Counts element in the document.
+///
+/// The `count` function lets you count elements in your document of a
+/// particular type or with a particular label. It also allows to count them
+/// in a hierachical way. To use it, you first need to ensure that [context]
+/// is available.
+///
+/// Always returns an array of integers, even if called with just a single
+/// target.
+
+/// # Counting elements - simple
+///
+/// To just count elements of a single type/label up to the current location,
+/// pass the selector you want to count:
+/// ```example
+/// = Heading
+///
+/// = Another Heading
+///
+/// #context count(heading)
+///
+/// = Third Heading
+/// ```
+///
+/// Note that it will not return an integer, but an array with a single integer
+/// entry.
+
+/// # Counting elements - hierarchical
+///
+/// If you pass multiple targets, then it starts by counting the first target.
+/// Then the second target is counted _starting only from the last counted
+/// element of the first target_.
+///
+/// ```example
+/// = Some Heading
+///
+/// == Some Subheading
+///
+/// = Another Heading
+///
+/// == Some Subheading
+///
+/// #context count(heading.where(level: 1), heading.where(level: 2))
+///
+/// == Another Subheading
+/// ```
+#[func(contextual)]
+pub fn count(
+    /// The engine.
+    engine: &mut Engine,
+    /// The callsite context.
+    context: Tracked<Context>,
+    /// Each target can be
+    /// - an element function like a `heading` or `figure`,
+    /// - a `{<label>}`,
+    /// - a more complex selector like `{heading.where(level: 1)}`,
+    /// - or `{selector(heading).before(here())}`.
+    ///
+    /// Only [locatable]($location/#locatable) element functions are supported.
+    #[variadic]
+    targets: Vec<LocatableSelector>,
+    /// When passing this argument, it will count everything only from a
+    /// certain location on.
+    /// The selector must match exactly one element in the document. The most
+    /// useful kinds of selectors for this are [labels]($label) and
+    /// [locations]($location).
+    // TODO remove Option as soon as there is a special `start` location
+    #[named]
+    after: Option<LocatableSelector>,
+) -> HintedStrResult<Array> {
+    // NOTE this could be made more efficient
+    // one could directly get a slice &[Selector] from Vec<LocatableSelector>
+    // by using #[repr(transparent)] on LocatableSelector
+    let selectors: Vec<Selector> = targets.into_iter().map(|sel| sel.0).collect();
+    // TODO add argument "at" with default value "here"
+    // and compute `before` accordingly
+    let before = Some(context.location()?);
+    let after = match after {
+        Some(selector) => Some(selector.resolve_unique(engine.introspector, context)?),
+        None => None,
+    };
+
+    let nums = engine.introspector.count(&selectors, after, before);
+
+    Ok(nums.into_iter().map(IntoValue::into_value).collect())
+}

--- a/crates/typst-library/src/introspection/mod.rs
+++ b/crates/typst-library/src/introspection/mod.rs
@@ -1,5 +1,7 @@
 //! Interaction between document parts.
 
+#[path = "count.rs"]
+mod count_;
 mod counter;
 #[path = "here.rs"]
 mod here_;
@@ -14,6 +16,7 @@ mod query_;
 mod state;
 mod tag;
 
+pub use self::count_::*;
 pub use self::counter::*;
 pub use self::here_::*;
 pub use self::introspector::*;
@@ -49,5 +52,6 @@ pub fn define(global: &mut Scope) {
     global.define_elem::<MetadataElem>();
     global.define_func::<here>();
     global.define_func::<query>();
+    global.define_func::<count>();
     global.define_func::<locate>();
 }


### PR DESCRIPTION
This adds a new _hierarchical_ `count()` function which will both enable dependent counters and simplify the Rust code for counters at the same time.

I propose that this mechanism will replace the `counter` element/type, with the reasons and mechanism explained below.
This would be a breaking change and proceed in ~3 phases:
1. Add the `count` function. (this PR)
2. Replace the default show rules of `heading`, `figure`, etc. with `count` and deprecate `counter`. (future big PR)
3. Fully remove `counter`.

<details><summary>OPEN ME: Motivation and thoughts behind it.</summary>

The main issue with current counters is that one cannot define e.g. a theorem counter that inherits the first level of the heading counter.

I thought a lot about how a good counter design should look like, while also being idiomatic/nice/efficient to implement.

I came to the conclusion that the `counter` type has the following flaw which hinders it from easily supporting dependent counters: _Stepping and getting a counter happen through the same object._

A typical math document consists of multiple levels of headings and a counted theorem environment, which however only inherits the first level of the heading counter. So counting-wise it's like a tree: The basis are the headings of level 1, and based on that count both headings of level two (and higher) and theorems. Now if you would want to model this with something like `counter`, you would have something like `counter(heading.where(level: 1), heading.where(level: 2)` and `counter(heading: where(level: 1), "mytheorem")`. This models the "get" side very well, this (rough) syntax describes exactly what the user wants. But the problem is that _stepping is tied to a counter_, i.e., tied to the "getting". In this case, each `heading` would need to step both of the counters.

**The resolution.**
Instead, it is naturally the case that _stepping and getting happen on different objects_.
What you step are the little units, like headings of level 1, or "Theorem", or "Lemma". When you step this, you don't even care in what context it will be counted at some point, you only want to make clear that you insert a new element of something.
Conversely, when you "get"/count, then you are combining a few different of those little units and want to have them counted in a hierarchical way.
So to reflect this in Typst, we should get rid of one combining `counter` object, and split it into one "marking" and "counting". Luckily, we don't even need a special element for "marking", because we already have elements/labels/metadata, which are pretty much exactly that.
Then we only need a way to count hierarchically, which is what this PR provides with the `count()` function.
</details>

<details><summary>OPEN ME: The `count` function.</summary>

The API of `count()` is very simple. You just pass a list of targets (selectors), and it counts them hierarchically.
That is, it will first count all the elements of the first selector. Then it will count all the elements of the second selector, _but only those which appear after the last element of the first selector_. And so on.
So what is currently `counter(heading).get()` would then be something like:
```
count(heading.where(level: 1), heading.where(level: 2), heading.where(level: 3))
```

Now if you want to count your theorems as explained before, just tag them with some label (or in the future they will be elements themselves), and do:
```
count(heading.where(level: 1), <my_theorem_label>)
```

The function returns an array of integers, which can then be displayed using `numbering(...)`.
</details>

<details><summary>OPEN ME: But how do I do X and Y then?!</summary>

Now this also throws away the `update` function. But this is not a problem! I have seen `update` used in only two ways:
1. To reset the counter to zero, e.g. for the headings in the appendix.
   With `count()` you can achieve the same thing, in a semantically much better way. Just put a metadata/label somewhere to indicate that the appendix begins (e.g. `metadata(()) <appendix_start>`), and then use `count(after: <appendix_start>, ...)`.
2. To do some actually complicated update stuff. But well, I think then you cannot call it simply "counting" anymore, and you can simply use `state`.

Another question is maybe what the default show rule of `heading` will be, because it somehow has infinitely many levels but `count()` can only take finitely many arguments. The answer is, the show rule for a heading of level `k` will roughly incorporate `count(heading.where(level: 1), ..., heading.where(level: k))`. There is still the issue with ignoring headings that don't want to be numbered, that's discussed below.
</details>

Now to the issues / points of discussion / todos.

1. One problem is, how do you get a selector for all `heading`s/`figure`s/etc. which have `numbering != none`? You would want a selector `count(figure.where(numbering !: none)`. I guess one could introduce this syntax, but that would be pain on adapting parsing (I think right now it's just parsed as a dict). Or use a syntax like `figure.wherenot(numbering: none)`.
   Another solution would be to introduce a new boolean field `counted` which is automatically computed from whether `numbering` is something or `none`.
2. Another problem is, how to easily adapt the default show rule of headings, given that it's so complicated then.
   For example, if you want to make an appendix as explained above, you don't want to manually change the show rule of heading with code that lists the selectors up until the level of the heading. One option would be to introduce a new field on heading called `count-after` which is passed as `count(after: this.count-after, ...)` in the default show rule. But there are also other solutions, I hope we can find a better one.
3. I guess the pages selector needs to be handled separately, but should be doable?!
4. What should the syntax be for counting up until the _current_ location vs some specified location? (like `get()` vs `at()` for `counter`) By default until the current location, and have an optional parameter for `at`/`before`?
5. Should there be syntax to make the `before`/`after` inclusive/exclusive?
6. Must-do before merging:
   - add tests
   - add some way of counting at a different location (e.g. through `at`/`before` argument)

Let me know what you think! I know the issues seem annoying, and indeed they are, but thinking about this for so long made it clear to me that there definitely needs to be a separation of objects between stepping and counting!