### PR TITLE
Add lcm as an operator in math mode

### DIFF
--- a/crates/typst-library/src/math/op.rs
+++ b/crates/typst-library/src/math/op.rs
@@ -75,6 +75,7 @@ ops! {
     dim,
     exp,
     gcd (limits),
+    lcm (limits),
     hom,
     id,
     im,

--- a/crates/typst-library/src/math/op.rs
+++ b/crates/typst-library/src/math/op.rs
@@ -17,9 +17,9 @@ use crate::text::TextElem;
 /// # Predefined Operators { #predefined }
 /// Typst predefines the operators `arccos`, `arcsin`, `arctan`, `arg`, `cos`,
 /// `cosh`, `cot`, `coth`, `csc`, `csch`, `ctg`, `deg`, `det`, `dim`, `exp`,
-/// `gcd`, `hom`, `id`, `im`, `inf`, `ker`, `lg`, `lim`, `liminf`, `limsup`,
-/// `ln`, `log`, `max`, `min`, `mod`, `Pr`, `sec`, `sech`, `sin`, `sinc`,
-/// `sinh`, `sup`, `tan`, `tanh`, `tg` and `tr`.
+/// `gcd`, `lcm`, `hom`, `id`, `im`, `inf`, `ker`, `lg`, `lim`, `liminf`,
+/// `limsup`, `ln`, `log`, `max`, `min`, `mod`, `Pr`, `sec`, `sech`, `sin`,
+/// `sinc`, `sinh`, `sup`, `tan`, `tanh`, `tg` and `tr`.
 #[elem(title = "Text Operator", Mathy)]
 pub struct OpElem {
     /// The operator's text.


### PR DESCRIPTION
As discussed starting https://discord.com/channels/1054443721975922748/1088371867913572452/1330227286586163221, although new operators will generally not added, a good case can be made for `lcm` specifically as a counterpart to the already-existing `gcd`. This PR simply adds this operation.