### PR TITLE
Methods on elements

### DIFF
--- a/tests/suite/scripting/methods.typ
+++ b/tests/suite/scripting/methods.typ
@@ -31,7 +31,7 @@
 #numbers.fun()
 
 --- method-unknown-but-field-exists ---
-// Error: 2:4-2:10 type content has no method `stroke`
+// Error: 2:4-2:10 element line has no method `stroke`
 // Hint: 2:4-2:10 did you mean to access the field `stroke`?
 #let l = line(stroke: red)
 #l.stroke()


### PR DESCRIPTION
This PR adds support for calling functions in an element function's scope with method syntax.

```typ
#show example: it => it.method()
```

With the planned unification of types and elements, elements will naturally gain the ability to have methods. A good application of such methods is exposing individually useful parts of a default show rule. This way, one can build on what's already there when writing a show rule instead of starting from scratch.

Why add this now? The unification of types and elements is still a bit away. Exposing methods on elements today is a straight-forward and future-compatible addition that allows us to start experimenting with this pattern today. The first element that will make use of the feature is `outline.entry`, for which a PR will be up soon.