### PR TITLE
Fetch output format in Typst

### DIFF
--- a/crates/typst-cli/src/query.rs
+++ b/crates/typst-cli/src/query.rs
@@ -15,7 +15,8 @@ use crate::world::SystemWorld;
 
 /// Execute a query command.
 pub fn query(command: &QueryCommand) -> HintedStrResult<()> {
-    let mut world = SystemWorld::new(&command.input, &command.world, &command.process)?;
+    let mut world =
+        SystemWorld::new(&command.input, &command.world, &command.process, None)?;
 
     // Reset everything and ensure that the main file is present.
     world.reset();

--- a/crates/typst-cli/src/watch.rs
+++ b/crates/typst-cli/src/watch.rs
@@ -37,6 +37,7 @@ pub fn watch(timer: &mut Timer, command: &WatchCommand) -> StrResult<()> {
             &command.args.input,
             &command.args.world,
             &command.args.process,
+            Some(&command.args),
         ) {
             Ok(world) => break world,
             Err(

--- a/crates/typst-library/src/foundations/mod.rs
+++ b/crates/typst-library/src/foundations/mod.rs
@@ -82,6 +82,7 @@ use typst_syntax::Spanned;
 use crate::diag::{bail, SourceResult, StrResult};
 use crate::engine::Engine;
 use crate::routines::EvalMode;
+use crate::OutputFormat;
 use crate::{Feature, Features};
 
 /// Foundational types and functions.
@@ -92,7 +93,12 @@ use crate::{Feature, Features};
 pub static FOUNDATIONS: Category;
 
 /// Hook up all `foundations` definitions.
-pub(super) fn define(global: &mut Scope, inputs: Dict, features: &Features) {
+pub(super) fn define(
+    global: &mut Scope,
+    inputs: Dict,
+    features: &Features,
+    output_format: OutputFormat,
+) {
     global.category(FOUNDATIONS);
     global.define_type::<bool>();
     global.define_type::<i64>();
@@ -123,7 +129,7 @@ pub(super) fn define(global: &mut Scope, inputs: Dict, features: &Features) {
         global.define_func::<target>();
     }
     global.define_module(calc::module());
-    global.define_module(sys::module(inputs));
+    global.define_module(sys::module(inputs, output_format));
 }
 
 /// Fails with an error.

--- a/crates/typst-library/src/foundations/sys.rs
+++ b/crates/typst-library/src/foundations/sys.rs
@@ -1,9 +1,10 @@
 //! System-related things.
 
 use crate::foundations::{Dict, Module, Scope, Version};
+use crate::OutputFormat;
 
 /// A module with system-related things.
-pub fn module(inputs: Dict) -> Module {
+pub fn module(inputs: Dict, output_format: OutputFormat) -> Module {
     let mut scope = Scope::deduplicating();
     scope.define(
         "version",
@@ -14,5 +15,6 @@ pub fn module(inputs: Dict) -> Module {
         ]),
     );
     scope.define("inputs", inputs);
+    scope.define("output-format", output_format.to_string());
     Module::new("sys", scope)
 }


### PR DESCRIPTION
Since currently it's not possible to conditionally use paged output (e.g., PDF) and HTML output (e.g., when overriding body tag), I whipped up this workaround.

It adds `sys.output-format` that can be `"pdf"`, `"png"`, `"svg"`, or `"html"`. For `typst query` it will use `"pdf"` since we can't resolve the output format for that command (could potentially change it to none or `"query"`).

I thought that instead of just providing the same `target()` output but non-contextual, I would just add all inputs. This can make the document more customizable. Which is actually kind of a separate proposal, though it is not really how Typst should work.


```typ
#if sys.output-format != "html" {
  set page(...)
  [document-body]
} else {
  html.elem("body", attrs: ..., html.frame([document-body]))
}
```
