### PR TITLE
Fixed typo in the new outline docs

### DIFF
--- a/crates/typst-library/src/model/outline.rs
+++ b/crates/typst-library/src/model/outline.rs
@@ -461,13 +461,13 @@ impl OutlineEntry {
         /// The `prefix` is aligned with the `inner` content of entries that
         /// have level one less.
         ///
-        /// In the default show rule, this is just to `it.prefix()`, but it can
-        /// be freely customized.
+        /// In the default show rule, this is just `it.prefix()`, but it can be
+        /// freely customized.
         prefix: Option<Content>,
         /// The formatted inner content of the entry.
         ///
-        /// In the default show rule, this is just to `it.inner()`, but it can
-        /// be freely customized.
+        /// In the default show rule, this is just `it.inner()`, but it can be
+        /// freely customized.
         inner: Content,
         /// The gap between the prefix and the inner content.
         #[named]

--- a/crates/typst-library/src/model/outline.rs
+++ b/crates/typst-library/src/model/outline.rs
@@ -445,9 +445,9 @@ impl OutlineEntry {
     ///
     /// If the parent outline's [`indent`]($outline.indent) is `{auto}`, the
     /// inner content of all entries at level `N` is aligned with the prefix of
-    /// all entries at with level `N + 1`, leaving at least `gap` space between
-    /// the prefix and inner parts. Furthermore, the `inner` contents of all
-    /// entries at the same level are aligned.
+    /// all entries at level `N + 1`, leaving at least `gap` space between the
+    /// prefix and inner parts. Furthermore, the `inner` contents of all entries
+    /// at the same level are aligned.
     ///
     /// If the outline's indent is a fixed value or a function, the prefixes are
     /// indented, but the inner contents are simply inset from the prefix by the


### PR DESCRIPTION
I don't know if this is a typo, but it does look like one. Perhaps the whole sentence should be rephrased.
