### PR TITLE
Change type repr to short name

### DIFF
--- a/crates/typst-library/src/foundations/ty.rs
+++ b/crates/typst-library/src/foundations/ty.rs
@@ -136,7 +136,7 @@ impl Repr for Type {
         } else if *self == Type::of::<NoneValue>() {
             "type(none)"
         } else {
-            self.long_name()
+            self.short_name()
         }
         .into()
     }

--- a/tests/suite/foundations/repr.typ
+++ b/tests/suite/foundations/repr.typ
@@ -37,8 +37,8 @@
 #t(() => none, `(..) => ..`)
 
 // Types.
-#t(int, `integer`)
-#t(type("hi"), `string`)
+#t(int, `int`)
+#t(type("hi"), `str`)
 #t(type((a: 1)), `dictionary`)
 
 // Constants.


### PR DESCRIPTION
Some types have a long name (for diagnostics) and a short name (for the identifier itself). For example, the type is spelled `int`, but in error messages it says "expected integer".

Currently, the `repr` uses the long name, but that's rather confusing since the repr output is typically (not always) close to the code that produces the value. Thus, this PR changes the type repr to the short name.

Converting a type to a string (`str(ty)`) will continue to output the long name. Changing that would be a breaking change. Also, it's mostly used for error messages and that's what the long name is for.

Closes #4891.