### PR TITLE
Revert adding `flatten-text` to `image`

### DIFF
--- a/crates/typst-layout/src/image.rs
+++ b/crates/typst-layout/src/image.rs
@@ -63,7 +63,6 @@ pub fn layout_image(
             SvgImage::with_fonts(
                 data.clone(),
                 engine.world,
-                elem.flatten_text(styles),
                 &families(styles).map(|f| f.as_str()).collect::<Vec<_>>(),
             )
             .at(span)?,

--- a/crates/typst-library/src/visualize/image/mod.rs
+++ b/crates/typst-library/src/visualize/image/mod.rs
@@ -150,12 +150,6 @@ pub struct ImageElem {
     })]
     #[borrowed]
     pub icc: Smart<Derived<DataSource, Bytes>>,
-
-    /// Whether text in SVG images should be converted into curves before
-    /// embedding. This will result in the text becoming unselectable in the
-    /// output.
-    #[default(false)]
-    pub flatten_text: bool,
 }
 
 #[scope]
@@ -199,10 +193,6 @@ impl ImageElem {
         /// A hint to viewers how they should scale the image.
         #[named]
         scaling: Option<Smart<ImageScaling>>,
-        /// Whether text in SVG images should be converted into curves before
-        /// embedding.
-        #[named]
-        flatten_text: Option<bool>,
     ) -> StrResult<Content> {
         let bytes = data.into_bytes();
         let source = Derived::new(DataSource::Bytes(bytes.clone()), bytes);
@@ -224,9 +214,6 @@ impl ImageElem {
         }
         if let Some(scaling) = scaling {
             elem.push_scaling(scaling);
-        }
-        if let Some(flatten_text) = flatten_text {
-            elem.push_flatten_text(flatten_text);
         }
         Ok(elem.pack().spanned(span))
     }

--- a/crates/typst-library/src/visualize/image/svg.rs
+++ b/crates/typst-library/src/visualize/image/svg.rs
@@ -22,7 +22,6 @@ pub struct SvgImage(Arc<Repr>);
 struct Repr {
     data: Bytes,
     size: Axes<f64>,
-    flatten_text: bool,
     font_hash: u128,
     tree: usvg::Tree,
 }
@@ -38,7 +37,6 @@ impl SvgImage {
             data,
             size: tree_size(&tree),
             font_hash: 0,
-            flatten_text: false,
             tree,
         })))
     }
@@ -49,7 +47,6 @@ impl SvgImage {
     pub fn with_fonts(
         data: Bytes,
         world: Tracked<dyn World + '_>,
-        flatten_text: bool,
         families: &[&str],
     ) -> StrResult<SvgImage> {
         let book = world.book();
@@ -74,7 +71,6 @@ impl SvgImage {
             data,
             size: tree_size(&tree),
             font_hash,
-            flatten_text,
             tree,
         })))
     }
@@ -87,11 +83,6 @@ impl SvgImage {
     /// The SVG's width in pixels.
     pub fn width(&self) -> f64 {
         self.0.size.x
-    }
-
-    /// Whether the SVG's text should be flattened.
-    pub fn flatten_text(&self) -> bool {
-        self.0.flatten_text
     }
 
     /// The SVG's height in pixels.
@@ -112,7 +103,6 @@ impl Hash for Repr {
         // all used fonts gives us something similar.
         self.data.hash(state);
         self.font_hash.hash(state);
-        self.flatten_text.hash(state);
     }
 }
 

--- a/crates/typst-library/src/visualize/image/svg.rs
+++ b/crates/typst-library/src/visualize/image/svg.rs
@@ -33,12 +33,7 @@ impl SvgImage {
     pub fn new(data: Bytes) -> StrResult<SvgImage> {
         let tree =
             usvg::Tree::from_data(&data, &base_options()).map_err(format_usvg_error)?;
-        Ok(Self(Arc::new(Repr {
-            data,
-            size: tree_size(&tree),
-            font_hash: 0,
-            tree,
-        })))
+        Ok(Self(Arc::new(Repr { data, size: tree_size(&tree), font_hash: 0, tree })))
     }
 
     /// Decode an SVG image with access to fonts.
@@ -67,12 +62,7 @@ impl SvgImage {
         )
         .map_err(format_usvg_error)?;
         let font_hash = resolver.into_inner().unwrap().finish();
-        Ok(Self(Arc::new(Repr {
-            data,
-            size: tree_size(&tree),
-            font_hash,
-            tree,
-        })))
+        Ok(Self(Arc::new(Repr { data, size: tree_size(&tree), font_hash, tree })))
     }
 
     /// The raw image data.

--- a/crates/typst-pdf/src/image.rs
+++ b/crates/typst-pdf/src/image.rs
@@ -205,11 +205,7 @@ fn encode_svg(
 ) -> Result<(Chunk, Ref), svg2pdf::ConversionError> {
     svg2pdf::to_chunk(
         svg.tree(),
-        svg2pdf::ConversionOptions {
-            pdfa,
-            embed_text: !svg.flatten_text(),
-            ..Default::default()
-        },
+        svg2pdf::ConversionOptions { pdfa, ..Default::default() },
     )
 }
 


### PR DESCRIPTION
This reverts https://github.com/typst/typst/pull/5390

Adding a configuration for making text unselectable in Typst more generally (e.g. `set text(selectable: false)`) is realistic in the near future and this will naturally allow for `show image: set text(selectable: false)`. For this reason, I'd rather not release a parameter that we already know will be obsolete soon.