### PR TITLE
Scope deprecations

### DIFF
--- a/crates/typst-eval/src/math.rs
+++ b/crates/typst-eval/src/math.rs
@@ -35,7 +35,13 @@ impl Eval for ast::MathIdent<'_> {
     type Output = Value;
 
     fn eval(self, vm: &mut Vm) -> SourceResult<Self::Output> {
-        Ok(vm.scopes.get_in_math(&self).at(self.span())?.read().clone())
+        let span = self.span();
+        Ok(vm
+            .scopes
+            .get_in_math(&self)
+            .at(span)?
+            .read_checked((&mut vm.engine, span))
+            .clone())
     }
 }
 

--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -414,7 +414,7 @@ fn field_access_completions(
         // with method syntax;
         // 2. We can unwrap the field's value since it's a field belonging to
         // this value's type, so accessing it should not fail.
-        ctx.value_completion(field, &value.field(field).unwrap());
+        ctx.value_completion(field, &value.field(field, ()).unwrap());
     }
 
     match value {

--- a/crates/typst-library/src/foundations/module.rs
+++ b/crates/typst-library/src/foundations/module.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use ecow::{eco_format, EcoString};
 use typst_syntax::FileId;
 
-use crate::diag::{bail, StrResult};
+use crate::diag::{bail, DeprecationSink, StrResult};
 use crate::foundations::{repr, ty, Content, Scope, Value};
 
 /// An module of definitions.
@@ -118,9 +118,9 @@ impl Module {
     }
 
     /// Try to access a definition in the module.
-    pub fn field(&self, field: &str) -> StrResult<&Value> {
+    pub fn field(&self, field: &str, sink: impl DeprecationSink) -> StrResult<&Value> {
         match self.scope().get(field) {
-            Some(binding) => Ok(binding.read()),
+            Some(binding) => Ok(binding.read_checked(sink)),
             None => match &self.name {
                 Some(name) => bail!("module `{name}` does not contain `{field}`"),
                 None => bail!("module does not contain `{field}`"),

--- a/crates/typst-library/src/foundations/ty.rs
+++ b/crates/typst-library/src/foundations/ty.rs
@@ -8,7 +8,7 @@ use std::sync::LazyLock;
 use ecow::{eco_format, EcoString};
 use typst_utils::Static;
 
-use crate::diag::{bail, StrResult};
+use crate::diag::{bail, DeprecationSink, StrResult};
 use crate::foundations::{
     cast, func, AutoValue, Func, NativeFuncData, NoneValue, Repr, Scope, Value,
 };
@@ -94,9 +94,13 @@ impl Type {
     }
 
     /// Get a field from this type's scope, if possible.
-    pub fn field(&self, field: &str) -> StrResult<&'static Value> {
+    pub fn field(
+        &self,
+        field: &str,
+        sink: impl DeprecationSink,
+    ) -> StrResult<&'static Value> {
         match self.scope().get(field) {
-            Some(binding) => Ok(binding.read()),
+            Some(binding) => Ok(binding.read_checked(sink)),
             None => bail!("type {self} does not contain field `{field}`"),
         }
     }

--- a/crates/typst-library/src/foundations/value.rs
+++ b/crates/typst-library/src/foundations/value.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use typst_syntax::{ast, Span};
 use typst_utils::ArcExt;
 
-use crate::diag::{HintedStrResult, HintedString, StrResult};
+use crate::diag::{DeprecationSink, HintedStrResult, HintedString, StrResult};
 use crate::foundations::{
     fields, ops, repr, Args, Array, AutoValue, Bytes, CastInfo, Content, Datetime,
     Decimal, Dict, Duration, Fold, FromValue, Func, IntoValue, Label, Module,
@@ -155,15 +155,15 @@ impl Value {
     }
 
     /// Try to access a field on the value.
-    pub fn field(&self, field: &str) -> StrResult<Value> {
+    pub fn field(&self, field: &str, sink: impl DeprecationSink) -> StrResult<Value> {
         match self {
             Self::Symbol(symbol) => symbol.clone().modified(field).map(Self::Symbol),
             Self::Version(version) => version.component(field).map(Self::Int),
             Self::Dict(dict) => dict.get(field).cloned(),
             Self::Content(content) => content.field_by_name(field),
-            Self::Type(ty) => ty.field(field).cloned(),
-            Self::Func(func) => func.field(field).cloned(),
-            Self::Module(module) => module.field(field).cloned(),
+            Self::Type(ty) => ty.field(field, sink).cloned(),
+            Self::Func(func) => func.field(field, sink).cloned(),
+            Self::Module(module) => module.field(field, sink).cloned(),
             _ => fields::field(self, field),
         }
     }

--- a/crates/typst-library/src/loading/cbor.rs
+++ b/crates/typst-library/src/loading/cbor.rs
@@ -38,6 +38,7 @@ impl cbor {
     /// This function is deprecated. The [`cbor`] function now accepts bytes
     /// directly.
     #[func(title = "Decode CBOR")]
+    #[deprecated = "`cbor.decode` is deprecated, directly pass bytes to `cbor` instead"]
     pub fn decode(
         engine: &mut Engine,
         /// CBOR data.

--- a/crates/typst-library/src/loading/csv.rs
+++ b/crates/typst-library/src/loading/csv.rs
@@ -100,6 +100,7 @@ impl csv {
     /// This function is deprecated. The [`csv`] function now accepts bytes
     /// directly.
     #[func(title = "Decode CSV")]
+    #[deprecated = "`csv.decode` is deprecated, directly pass bytes to `csv` instead"]
     pub fn decode(
         engine: &mut Engine,
         /// CSV data.

--- a/crates/typst-library/src/loading/json.rs
+++ b/crates/typst-library/src/loading/json.rs
@@ -69,6 +69,7 @@ impl json {
     /// This function is deprecated. The [`json`] function now accepts bytes
     /// directly.
     #[func(title = "Decode JSON")]
+    #[deprecated = "`json.decode` is deprecated, directly pass bytes to `json` instead"]
     pub fn decode(
         engine: &mut Engine,
         /// JSON data.

--- a/crates/typst-library/src/loading/toml.rs
+++ b/crates/typst-library/src/loading/toml.rs
@@ -48,6 +48,7 @@ impl toml {
     /// This function is deprecated. The [`toml`] function now accepts bytes
     /// directly.
     #[func(title = "Decode TOML")]
+    #[deprecated = "`toml.decode` is deprecated, directly pass bytes to `toml` instead"]
     pub fn decode(
         engine: &mut Engine,
         /// TOML data.

--- a/crates/typst-library/src/loading/xml.rs
+++ b/crates/typst-library/src/loading/xml.rs
@@ -81,6 +81,7 @@ impl xml {
     /// This function is deprecated. The [`xml`] function now accepts bytes
     /// directly.
     #[func(title = "Decode XML")]
+    #[deprecated = "`xml.decode` is deprecated, directly pass bytes to `xml` instead"]
     pub fn decode(
         engine: &mut Engine,
         /// XML data.

--- a/crates/typst-library/src/loading/yaml.rs
+++ b/crates/typst-library/src/loading/yaml.rs
@@ -59,6 +59,7 @@ impl yaml {
     /// This function is deprecated. The [`yaml`] function now accepts bytes
     /// directly.
     #[func(title = "Decode YAML")]
+    #[deprecated = "`yaml.decode` is deprecated, directly pass bytes to `yaml` instead"]
     pub fn decode(
         engine: &mut Engine,
         /// YAML data.

--- a/crates/typst-library/src/visualize/image/mod.rs
+++ b/crates/typst-library/src/visualize/image/mod.rs
@@ -171,6 +171,7 @@ impl ImageElem {
     /// #image.decode(changed)
     /// ```
     #[func(title = "Decode Image")]
+    #[deprecated = "`image.decode` is deprecated, directly pass bytes to `image` instead"]
     pub fn decode(
         span: Span,
         /// The data to decode as an image. Can be a string for SVGs.

--- a/crates/typst-library/src/visualize/mod.rs
+++ b/crates/typst-library/src/visualize/mod.rs
@@ -24,7 +24,7 @@ pub use self::shape::*;
 pub use self::stroke::*;
 pub use self::tiling::*;
 
-use crate::foundations::{category, Category, Scope, Type};
+use crate::foundations::{category, Category, Element, Scope, Type};
 
 /// Drawing and data visualization.
 ///
@@ -49,8 +49,10 @@ pub(super) fn define(global: &mut Scope) {
     global.define_elem::<CircleElem>();
     global.define_elem::<PolygonElem>();
     global.define_elem::<CurveElem>();
-    global.define_elem::<PathElem>();
-
-    // Compatibility.
-    global.define("pattern", Type::of::<Tiling>());
+    global
+        .define("path", Element::of::<PathElem>())
+        .deprecated("the `path` function is deprecated, use `curve` instead");
+    global
+        .define("pattern", Type::of::<Tiling>())
+        .deprecated("the name `pattern` is deprecated, use `tiling` instead");
 }

--- a/crates/typst-library/src/visualize/path.rs
+++ b/crates/typst-library/src/visualize/path.rs
@@ -23,7 +23,7 @@ use crate::visualize::{FillRule, Paint, Stroke};
 /// ```
 ///
 /// # Deprecation
-/// This element is deprecated. The [`curve`] element should be used instead.
+/// This function is deprecated. The [`curve`] function should be used instead.
 #[elem(Show)]
 pub struct PathElem {
     /// How to fill the path.

--- a/docs/src/link.rs
+++ b/docs/src/link.rs
@@ -69,7 +69,7 @@ fn resolve_definition(head: &str, base: &str) -> StrResult<String> {
     let Some(category) = category else { bail!("{head} has no category") };
 
     let name = parts.next().ok_or("link is missing first part")?;
-    let value = focus.field(name)?;
+    let value = focus.field(name, ())?;
 
     // Handle grouped functions.
     if let Some(group) = GROUPS.iter().find(|group| {
@@ -88,7 +88,7 @@ fn resolve_definition(head: &str, base: &str) -> StrResult<String> {
 
     let mut route = format!("{}reference/{}/{name}", base, category.name());
     if let Some(next) = parts.next() {
-        if let Ok(field) = value.field(next) {
+        if let Ok(field) = value.field(next, ()) {
             route.push_str("/#definitions-");
             route.push_str(next);
             if let Some(next) = parts.next() {

--- a/tests/suite/loading/cbor.typ
+++ b/tests/suite/loading/cbor.typ
@@ -1,0 +1,3 @@
+--- cbor-decode-deprecated ---
+// Warning: 15-21 `cbor.decode` is deprecated, directly pass bytes to `cbor` instead
+#let _ = cbor.decode

--- a/tests/suite/loading/csv.typ
+++ b/tests/suite/loading/csv.typ
@@ -29,3 +29,7 @@
 --- csv-invalid-delimiter ---
 // Error: 41-51 delimiter must be an ASCII character
 #csv("/assets/data/zoo.csv", delimiter: "\u{2008}")
+
+--- csv-decode-deprecated ---
+// Warning: 14-20 `csv.decode` is deprecated, directly pass bytes to `csv` instead
+#let _ = csv.decode

--- a/tests/suite/loading/json.typ
+++ b/tests/suite/loading/json.typ
@@ -9,6 +9,10 @@
 // Error: 7-30 failed to parse JSON (expected value at line 3 column 14)
 #json("/assets/data/bad.json")
 
+--- json-decode-deprecated ---
+// Warning: 15-21 `json.decode` is deprecated, directly pass bytes to `json` instead
+#let _ = json.decode
+
 --- issue-3363-json-large-number ---
 // Big numbers (larger than what i64 can store) should just lose some precision
 // but not overflow

--- a/tests/suite/loading/toml.typ
+++ b/tests/suite/loading/toml.typ
@@ -39,3 +39,7 @@
 --- toml-invalid ---
 // Error: 7-30 failed to parse TOML (expected `.`, `=` at line 1 column 16)
 #toml("/assets/data/bad.toml")
+
+--- toml-decode-deprecated ---
+// Warning: 15-21 `toml.decode` is deprecated, directly pass bytes to `toml` instead
+#let _ = toml.decode

--- a/tests/suite/loading/xml.typ
+++ b/tests/suite/loading/xml.typ
@@ -26,3 +26,7 @@
 --- xml-invalid ---
 // Error: 6-28 failed to parse XML (found closing tag 'data' instead of 'hello' in line 3)
 #xml("/assets/data/bad.xml")
+
+--- xml-decode-deprecated ---
+// Warning: 14-20 `xml.decode` is deprecated, directly pass bytes to `xml` instead
+#let _ = xml.decode

--- a/tests/suite/loading/yaml.typ
+++ b/tests/suite/loading/yaml.typ
@@ -15,3 +15,7 @@
 --- yaml-invalid ---
 // Error: 7-30 failed to parse YAML (did not find expected ',' or ']' at line 2 column 1, while parsing a flow sequence at line 1 column 18)
 #yaml("/assets/data/bad.yaml")
+
+--- yaml-decode-deprecated ---
+// Warning: 15-21 `yaml.decode` is deprecated, directly pass bytes to `yaml` instead
+#let _ = yaml.decode

--- a/tests/suite/visualize/image.typ
+++ b/tests/suite/visualize/image.typ
@@ -161,22 +161,27 @@ A #box(image("/assets/images/tiger.jpg", height: 1cm, width: 80%)) B
 
 --- image-decode-svg ---
 // Test parsing from svg data
+// Warning: 8-14 `image.decode` is deprecated, directly pass bytes to `image` instead
 #image.decode(`<svg xmlns="http://www.w3.org/2000/svg" height="140" width="500"><ellipse cx="200" cy="80" rx="100" ry="50" style="fill:yellow;stroke:purple;stroke-width:2" /></svg>`.text, format: "svg")
 
 --- image-decode-bad-svg ---
 // Error: 2-168 failed to parse SVG (missing root node)
+// Warning: 8-14 `image.decode` is deprecated, directly pass bytes to `image` instead
 #image.decode(`<svg height="140" width="500"><ellipse cx="200" cy="80" rx="100" ry="50" style="fill:yellow;stroke:purple;stroke-width:2" /></svg>`.text, format: "svg")
 
 --- image-decode-detect-format ---
 // Test format auto detect
+// Warning: 8-14 `image.decode` is deprecated, directly pass bytes to `image` instead
 #image.decode(read("/assets/images/tiger.jpg", encoding: none), width: 80%)
 
 --- image-decode-specify-format ---
 // Test format manual
+// Warning: 8-14 `image.decode` is deprecated, directly pass bytes to `image` instead
 #image.decode(read("/assets/images/tiger.jpg", encoding: none), format: "jpg", width: 80%)
 
 --- image-decode-specify-wrong-format ---
 // Error: 2-91 failed to decode image (Format error decoding Png: Invalid PNG signature.)
+// Warning: 8-14 `image.decode` is deprecated, directly pass bytes to `image` instead
 #image.decode(read("/assets/images/tiger.jpg", encoding: none), format: "png", width: 80%)
 
 --- image-pixmap-empty ---

--- a/tests/suite/visualize/path.typ
+++ b/tests/suite/visualize/path.typ
@@ -6,6 +6,7 @@
   columns: (1fr, 1fr),
   rows: (1fr, 1fr, 1fr),
   align: center + horizon,
+  // Warning: 3-7 the `path` function is deprecated, use `curve` instead
   path(
     fill: red,
     closed: true,
@@ -14,6 +15,7 @@
     ((0%, 50%), (4%, 4%)),
     ((50%, 0%), (4%, 4%)),
   ),
+  // Warning: 3-7 the `path` function is deprecated, use `curve` instead
   path(
     fill: purple,
     stroke: 1pt,
@@ -22,6 +24,7 @@
     (0pt, 30pt),
     (30pt, 0pt),
   ),
+  // Warning: 3-7 the `path` function is deprecated, use `curve` instead
   path(
     fill: blue,
     stroke: 1pt,
@@ -30,6 +33,7 @@
     ((30%, 60%), (-20%, 0%), (0%, 0%)),
     ((50%, 30%), (60%, -30%), (60%, 0%)),
   ),
+  // Warning: 3-7 the `path` function is deprecated, use `curve` instead
   path(
     stroke: 5pt,
     closed: true,
@@ -37,6 +41,7 @@
     (30pt, 30pt),
     (15pt, 0pt),
   ),
+  // Warning: 3-7 the `path` function is deprecated, use `curve` instead
   path(
     fill: red,
     fill-rule: "non-zero",
@@ -47,6 +52,7 @@
     (0pt, 20pt),
     (40pt, 50pt),
   ),
+  // Warning: 3-7 the `path` function is deprecated, use `curve` instead
   path(
     fill: red,
     fill-rule: "even-odd",
@@ -61,18 +67,22 @@
 
 --- path-bad-vertex ---
 // Error: 7-9 path vertex must have 1, 2, or 3 points
+// Warning: 2-6 the `path` function is deprecated, use `curve` instead
 #path(())
 
 --- path-bad-point-count ---
 // Error: 7-47 path vertex must have 1, 2, or 3 points
+// Warning: 2-6 the `path` function is deprecated, use `curve` instead
 #path(((0%, 0%), (0%, 0%), (0%, 0%), (0%, 0%)))
 
 --- path-bad-point-array ---
 // Error: 7-31 point array must contain exactly two entries
+// Warning: 2-6 the `path` function is deprecated, use `curve` instead
 #path(((0%, 0%), (0%, 0%, 0%)))
 
 --- path-infinite-length ---
 // Error: 2-42 cannot create path with infinite length
+// Warning: 2-6 the `path` function is deprecated, use `curve` instead
 #path((0pt, 0pt), (float.inf * 1pt, 0pt))
 
 --- issue-path-in-sized-container ---
@@ -82,6 +92,7 @@
   fill: aqua,
   width: 20pt,
   height: 15pt,
+  // Warning: 3-7 the `path` function is deprecated, use `curve` instead
   path(
     (0pt, 0pt),
     (10pt, 10pt),

--- a/tests/suite/visualize/tiling.typ
+++ b/tests/suite/visualize/tiling.typ
@@ -159,5 +159,7 @@
 
 --- tiling-pattern-compatibility ---
 #set page(width: auto, height: auto, margin: 0pt)
+
+// Warning: 10-17 the name `pattern` is deprecated, use `tiling` instead
 #let t = pattern(size: (10pt, 10pt), line(stroke: 4pt, start: (0%, 0%), end: (100%, 100%)))
 #rect(width: 50pt, height: 50pt, fill: t)


### PR DESCRIPTION
This PR adds support for deprecating arbitrary definition in a `Scope`. It is an alternative to https://github.com/typst/typst/pull/5582 that builds on the refactorings done in https://github.com/typst/typst/pull/5797.

Compared to #5582, the main differences are:

- There's no accumulation of `define_*` variants because with #5797 the existing define variants return an `&mut Binding` on which we can chain `.deprecated(..)`.

- Used a sink argument like proposed in https://github.com/typst/typst/pull/5582#issuecomment-2556736867. It's true that it's not less viral than a `MaybeDeprecated`, but it's still more lightweight because ignoring means just passing `()`. Also, we can skip the whole wrapper type with all its conversion methods. Probably it's also a bit more efficient, but that's more of a guess.

- I kept `binding.read()` (without deprecation check) and `binding.read_checked(..)` (with deprecation check) separate for now. That means one could accidentally use `read` where `read_checked` would be more apprioriate, but I wanted to keep the virality down for now. We can reconsider this in the future.

- Instead of `Arc<EcoString>` (which is double reference-counted), I used `&'static str` as we only have static messages for now. I also considered `&'static &'static str` to bring it from two down to one machine words, but I figured that might be annoying to integrate with `codex`. Since the message is only stored in a `Binding` and not in a `MaybeDeprecated`, having the absolute minimum memory size is also not as crucial as in the other PR.

- Added support for `#[deprecated = ".."]` in `#[scope]`.
