### PR TITLE
Document removals in changelog

### DIFF
--- a/docs/changelog/0.13.0.md
+++ b/docs/changelog/0.13.0.md
@@ -45,6 +45,7 @@ description: Changes slated to appear in Typst 0.13.0
     result in a warning
   - The default show rules of various built-in elements like lists, quotes, etc.
     were adjusted to ensure they produce/don't produce paragraphs as appropriate
+  - Removed support for booleans and content in [`outline.indent`]
 - The [`outline`] function was fully reworked to improve its out-of-the-box
   behavior **(Breaking change)**
   - [Outline entries]($outline.entry) are now [blocks]($block) and are thus
@@ -312,8 +313,20 @@ feature flag.
   functions directly accepting both paths and bytes
 - The `sect` and its variants in favor of `inter`, and `integral.sect` in favor
   of `integral.inter`
-- Fully removed type/str compatibility behavior (e.g. `{int == "integer"}`)
-  which was temporarily introduced in Typst 0.8 **(Breaking change)**
+
+## Removals
+- Removed `style` function and `styles` argument of [`measure`], use a [context]
+  expression instead **(Breaking change)**
+- Removed `state.display` function, use [`state.get`] instead
+  **(Breaking change)**
+- Removed `location` argument of [`state.at`], [`counter.at`], and [`query`]
+  **(Breaking change)**
+- Removed compatibility behavior where [`counter.display`] worked without
+  [context] **(Breaking change)**
+- Removed compatibility behavior of [`locate`] **(Breaking change)**
+- Removed compatibility behavior of type/str comparisons
+  (e.g. `{int == "integer"}`) which was temporarily introduced in Typst 0.8
+  **(Breaking change)**
 
 ## Development
 - The `typst::compile` function is now generic and can return either a


### PR DESCRIPTION
Somehow I managed to completely skip the rather crucial https://github.com/typst/typst/pull/5591 while writing the changelog ...