### PR TITLE
Fix unnecessary import rename warning

### DIFF
--- a/crates/typst-eval/src/import.rs
+++ b/crates/typst-eval/src/import.rs
@@ -44,11 +44,10 @@ impl Eval for ast::ModuleImport<'_> {
         }
 
         // If there is a rename, import the source itself under that name.
-        let bare_name = self.bare_name();
         let new_name = self.new_name();
         if let Some(new_name) = new_name {
-            if let Ok(source_name) = &bare_name {
-                if source_name == new_name.as_str() {
+            if let ast::Expr::Ident(ident) = self.source() {
+                if ident.as_str() == new_name.as_str() {
                     // Warn on `import x as x`
                     vm.engine.sink.warn(warning!(
                         new_name.span(),
@@ -57,6 +56,7 @@ impl Eval for ast::ModuleImport<'_> {
                 }
             }
 
+            // Define renamed module on the scope.
             vm.define(new_name, source.clone());
         }
 

--- a/tests/suite/scripting/import.typ
+++ b/tests/suite/scripting/import.typ
@@ -255,6 +255,10 @@
 // Warning: 17-21 unnecessary import rename to same name
 #import enum as enum
 
+--- import-rename-necessary ---
+#import "module.typ" as module: a
+#test(module.a, a)
+
 --- import-rename-unnecessary-mixed ---
 // Warning: 17-21 unnecessary import rename to same name
 #import enum as enum: item
@@ -262,10 +266,6 @@
 // Warning: 17-21 unnecessary import rename to same name
 // Warning: 31-35 unnecessary import rename to same name
 #import enum as enum: item as item
-
---- import-item-rename-unnecessary-string ---
-// Warning: 25-31 unnecessary import rename to same name
-#import "module.typ" as module
 
 --- import-item-rename-unnecessary-but-ok ---
 #import "modul" + "e.typ" as module


### PR DESCRIPTION
In https://github.com/typst/typst/pull/5773, I changed the unecessary import rename warning to also warn on unecessary string -> ident renames like `import "mymod.typ" as mymod`. However that change didn't take into account that the warning is unconditional on the import list, so `import "mymod.typ" as mymod: a, b, c` also warned. But in this case the rename is not unnecessary! 

This PR reverts to the original behavior. (I opted for the safe route of restoring the original behaviour rather than trying to fix the new behaviour since I wasn't 100% certain on the change in the first place and didn't want to build in yet another bug now.)