### PR TITLE
Don't crash on image with zero DPI

### DIFF
--- a/crates/typst-layout/src/image.rs
+++ b/crates/typst-layout/src/image.rs
@@ -95,6 +95,8 @@ pub fn layout_image(
     } else {
         // If neither is forced, take the natural image size at the image's
         // DPI bounded by the available space.
+        //
+        // Division by DPI is fine since it's guaranteed to be positive.
         let dpi = image.dpi().unwrap_or(Image::DEFAULT_DPI);
         let natural = Axes::new(pxw, pxh).map(|v| Abs::inches(v / dpi));
         Size::new(

--- a/crates/typst-library/src/visualize/image/raster.rs
+++ b/crates/typst-library/src/visualize/image/raster.rs
@@ -160,6 +160,8 @@ impl RasterImage {
     }
 
     /// The image's pixel density in pixels per inch, if known.
+    ///
+    /// This is guaranteed to be positive.
     pub fn dpi(&self) -> Option<f64> {
         self.0.dpi
     }
@@ -334,6 +336,9 @@ fn apply_rotation(image: &mut DynamicImage, rotation: u32) {
 }
 
 /// Try to determine the DPI (dots per inch) of the image.
+///
+/// This is guaranteed to be a positive value, or `None` if invalid or
+/// unspecified.
 fn determine_dpi(data: &[u8], exif: Option<&exif::Exif>) -> Option<f64> {
     // Try to extract the DPI from the EXIF metadata. If that doesn't yield
     // anything, fall back to specialized procedures for extracting JPEG or PNG
@@ -341,6 +346,7 @@ fn determine_dpi(data: &[u8], exif: Option<&exif::Exif>) -> Option<f64> {
     exif.and_then(exif_dpi)
         .or_else(|| jpeg_dpi(data))
         .or_else(|| png_dpi(data))
+        .filter(|&dpi| dpi > 0.0)
 }
 
 /// Try to get the DPI from the EXIF metadata.


### PR DESCRIPTION
Fixes https://github.com/typst/typst/issues/5830

I have no idea why their image reports having a DPI of zero, but either way we guard against that now. At least, prevents the crash, and the image renders OK using the default DPI.

Not sure if this is a problem in our implementation of `jpeg_dpi`, but it indicated that both `x` and `y` were zero.

To add a unit test, we'd need to include their image in typst-dev-assets. Let me know if that should be done.

(I have tried to create an artificial image for this using ImageMagick but couldn't get it to have zero DPI...)