### PR TITLE
Lazy parsing of the package index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2901,6 +2901,8 @@ dependencies = [
  "native-tls",
  "once_cell",
  "openssl",
+ "serde",
+ "serde_json",
  "tar",
  "typst-assets",
  "typst-library",

--- a/crates/typst-kit/Cargo.toml
+++ b/crates/typst-kit/Cargo.toml
@@ -23,6 +23,8 @@ flate2 = { workspace = true, optional = true }
 fontdb = { workspace = true, optional = true }
 native-tls = { workspace = true, optional = true }
 once_cell = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 tar = { workspace = true, optional = true }
 ureq = { workspace = true, optional = true }
 

--- a/crates/typst-kit/src/package.rs
+++ b/crates/typst-kit/src/package.rs
@@ -7,11 +7,10 @@ use std::path::{Path, PathBuf};
 use ecow::eco_format;
 use once_cell::sync::OnceCell;
 use serde::de::DeserializeOwned;
+use serde::Deserialize;
 use serde_json;
 use typst_library::diag::{bail, PackageError, PackageResult, StrResult};
-use typst_syntax::package::{
-    PackageInfo, PackageSpec, PackageVersion, VersionlessPackageSpec,
-};
+use typst_syntax::package::{PackageSpec, PackageVersion, VersionlessPackageSpec};
 
 use crate::download::{Downloader, Progress};
 
@@ -124,7 +123,7 @@ impl PackageStorage {
             // version.
             self.download_index()?
                 .iter()
-                .lazy_deser::<PackageInfo>()
+                .lazy_deser::<MinimalPackageInfo>()
                 .filter_map(|res| res.ok())
                 .filter(|package| package.name == spec.name)
                 .map(|package| package.version)
@@ -202,6 +201,14 @@ impl PackageStorage {
             PackageError::MalformedArchive(Some(eco_format!("{err}")))
         })
     }
+}
+
+/// Minimal information required about a package to determine its latest
+/// version.
+#[derive(Deserialize)]
+struct MinimalPackageInfo {
+    name: String,
+    version: PackageVersion,
 }
 
 /// An iterator that deserializes its items lazily.


### PR DESCRIPTION
To allow for future evolution of the format more easily. If a single package can't be parsed, the rest of the index is still valid and can be used normally.