### PR TITLE
Improve hints for show rule recursion depth

### DIFF
--- a/crates/typst-library/src/engine.rs
+++ b/crates/typst-library/src/engine.rs
@@ -312,7 +312,8 @@ impl Route<'_> {
         if !self.within(Route::MAX_SHOW_RULE_DEPTH) {
             bail!(
                 "maximum show rule depth exceeded";
-                hint: "check whether the show rule matches its own output"
+                hint: "check whether a show rule matches its own output";
+                hint: "this may be due to having too deeply nested elements"
             );
         }
         Ok(())

--- a/crates/typst-library/src/engine.rs
+++ b/crates/typst-library/src/engine.rs
@@ -312,8 +312,8 @@ impl Route<'_> {
         if !self.within(Route::MAX_SHOW_RULE_DEPTH) {
             bail!(
                 "maximum show rule depth exceeded";
-                hint: "check whether a show rule matches its own output";
-                hint: "this may be due to having too deeply nested elements"
+                hint: "maybe a show rule matches its own output";
+                hint: "maybe there are too deeply nested elements"
             );
         }
         Ok(())

--- a/tests/suite/scripting/recursion.typ
+++ b/tests/suite/scripting/recursion.typ
@@ -44,21 +44,21 @@
 --- recursion-via-include-in-layout ---
 // Test cyclic imports during layout.
 // Error: 2-38 maximum show rule depth exceeded
-// Hint: 2-38 check whether a show rule matches its own output
-// Hint: 2-38 this may be due to having too deeply nested elements
+// Hint: 2-38 maybe a show rule matches its own output
+// Hint: 2-38 maybe there are too deeply nested elements
 #layout(_ => include "recursion.typ")
 
 --- recursion-show-math ---
 // Test recursive show rules.
 // Error: 22-25 maximum show rule depth exceeded
-// Hint: 22-25 check whether a show rule matches its own output
-// Hint: 22-25 this may be due to having too deeply nested elements
+// Hint: 22-25 maybe a show rule matches its own output
+// Hint: 22-25 maybe there are too deeply nested elements
 #show math.equation: $x$
 $ x $
 
 --- recursion-show-math-realize ---
 // Error: 22-33 maximum show rule depth exceeded
-// Hint: 22-33 check whether a show rule matches its own output
-// Hint: 22-33 this may be due to having too deeply nested elements
+// Hint: 22-33 maybe a show rule matches its own output
+// Hint: 22-33 maybe there are too deeply nested elements
 #show heading: it => heading[it]
 $ #heading[hi] $

--- a/tests/suite/scripting/recursion.typ
+++ b/tests/suite/scripting/recursion.typ
@@ -44,18 +44,21 @@
 --- recursion-via-include-in-layout ---
 // Test cyclic imports during layout.
 // Error: 2-38 maximum show rule depth exceeded
-// Hint: 2-38 check whether the show rule matches its own output
+// Hint: 2-38 check whether a show rule matches its own output
+// Hint: 2-38 this may be due to having too deeply nested elements
 #layout(_ => include "recursion.typ")
 
 --- recursion-show-math ---
 // Test recursive show rules.
 // Error: 22-25 maximum show rule depth exceeded
-// Hint: 22-25 check whether the show rule matches its own output
+// Hint: 22-25 check whether a show rule matches its own output
+// Hint: 22-25 this may be due to having too deeply nested elements
 #show math.equation: $x$
 $ x $
 
 --- recursion-show-math-realize ---
 // Error: 22-33 maximum show rule depth exceeded
-// Hint: 22-33 check whether the show rule matches its own output
+// Hint: 22-33 check whether a show rule matches its own output
+// Hint: 22-33 this may be due to having too deeply nested elements
 #show heading: it => heading[it]
 $ #heading[hi] $


### PR DESCRIPTION
Fixes #4171.

This slightly alters the existing hint, and adds a new hint that mentions too deeply nested elements.