### PR TITLE
Add `deep-merge` function to dictionaries

### DIFF
--- a/tests/suite/foundations/dict.typ
+++ b/tests/suite/foundations/dict.typ
@@ -134,6 +134,39 @@
 #test("c" in dict, false)
 #test(dict, (a: 3, b: 1))
 
+--- dict-deep-merge ---
+#{
+  let dict = (
+    a: 1,
+    b: 2,
+    c: (x: 3, y: 4, z: (subz1: 5)),
+    d: (subd: 6)
+  )
+  let other1 = (
+    b: (:),
+    c: (y: "hello", z: (subz2: 0)),
+    d: "overwritten",
+    e: "new",
+  )
+  let other2 = (c: (y: "goodbye"))
+  let updated = dict.deep-merge(other1, other2)
+
+  test(updated, (
+    a: 1,
+    b: (:),
+    c: (x: 3, y: "goodbye", z: (subz1: 5, subz2: 0)),
+    d: "overwritten",
+    e: "new"
+  ))
+}
+
+--- dict-deep-merge-nothing ---
+#{
+  let dict = (a: 1, b: 2)
+  // Error: 3-20 expected at least one dictionary
+  dict.deep-merge()
+}
+
 --- dict-from-module ---
 // Test dictionary constructor
 #test(type(dictionary(sys).at("version")), version)


### PR DESCRIPTION
Closes #1957.

Only shallow merging dictionaries (using `+`) is supported currently. This adds a `deep-merge` method to dictionaries which merges nested dictionaries recursively.

After implementing this, I realized that I hadn't looked at what other languages have. I couldn't find any languages with a deep merge method in their standard library, but several third-party packages have one. Those libraries have three different behaviors regarding arrays at the same key path:

- Rails' [`deep_merge`](https://api.rubyonrails.org/v8.0.1/classes/Hash.html#method-i-deep_merge) and the [`deep_merge`](https://github.com/PragTob/deep_merge) Elixir library overwrite arrays at the same key path.
- The [`Hash::Merge`](https://metacpan.org/pod/Hash::Merge) Perl library and [deepmerge](https://github.com/toumorokoshi/deepmerge) Python library concatenate lists at the same key path.
- Lodash's [`mergeWith`](https://lodash.com/docs/4.17.15#mergeWith) and jQuery's [`extend`](https://api.jquery.com/jQuery.extend/) treat arrays exactly the same as objects, so elements at the same indices are overwritten or deep merged. 

Some of those methods also accept a function to customize the merging behavior:

- Lodash's `mergeWith`: the customizer function is called with arguments `(objValue, srcValue, key, object, source, stack)`. It's called for all keys—not just conflicting ones—and returning `undefined` from the customizer delegates to the default behavior for that key path.
- Rails' `deep_merge`: the customizer function is called with arguments `(key, this_val, other_val)` on conflicting keys when their values aren't deep mergeable.
- Elixir's `deep_merge` library: the customizer function is called with arguments `(key, original, override)` on all conflicting keys. Returning `DeepMerge.continue_deep_merge` from the customizer delegates to the default behavior for that key path.

Since all of those deep merge methods behave differently, I've left this `deep-merge` method simple (with no special behavior for arrays and no argument for a customizer function) since I'd like to hear what others think about how it should behave.