### PR TITLE
nested/ancestry .contains selector

### DIFF
--- a/crates/typst-library/src/foundations/content.rs
+++ b/crates/typst-library/src/foundations/content.rs
@@ -412,7 +412,7 @@ impl Content {
     /// Queries the content tree for all elements that match the given selector.
     ///
     /// Elements produced in `show` rules will not be included in the results.
-    pub fn query(&self, selector: Selector) -> Vec<Content> {
+    pub fn query(&self, selector: &Selector) -> Vec<Content> {
         let mut results = Vec::new();
         self.traverse(&mut |element| {
             if selector.matches(&element, None) {

--- a/crates/typst-library/src/introspection/introspector.rs
+++ b/crates/typst-library/src/introspection/introspector.rs
@@ -185,10 +185,10 @@ impl Introspector {
                 }
                 list
             }
-            Selector::Contains { selector, c } => self
+            Selector::Contains { selector, children_selector } => self
                 .query(selector)
                 .iter()
-                .flat_map(|children| children.query(c))
+                .flat_map(|children| children.query(children_selector))
                 .collect(),
             // Not supported here.
             Selector::Can(_) | Selector::Regex(_) => EcoVec::new(),

--- a/crates/typst-library/src/introspection/introspector.rs
+++ b/crates/typst-library/src/introspection/introspector.rs
@@ -185,6 +185,11 @@ impl Introspector {
                 }
                 list
             }
+            Selector::Contains { selector, c } => self
+                .query(selector)
+                .iter()
+                .flat_map(|children| children.query(c))
+                .collect(),
             // Not supported here.
             Selector::Can(_) | Selector::Regex(_) => EcoVec::new(),
         };


### PR DESCRIPTION
This implements a selector that gets all items within another item.

(originally was discussed as .contains, will rename it later, just PRing now to get feedback)

- [ ] Rename to `within`
- [ ] Tests