### PR TITLE
Bring back type/str compatibility for 0.13, with warnings and hints

### DIFF
--- a/crates/typst-eval/src/code.rs
+++ b/crates/typst-eval/src/code.rs
@@ -55,7 +55,7 @@ fn eval_code<'a>(
             _ => expr.eval(vm)?,
         };
 
-        output = ops::join(output, value).at(span)?;
+        output = ops::join(output, value, &mut (&mut vm.engine, span)).at(span)?;
 
         if let Some(event) = &vm.flow {
             warn_for_discarded_content(&mut vm.engine, event, &output);

--- a/crates/typst-eval/src/flow.rs
+++ b/crates/typst-eval/src/flow.rs
@@ -83,7 +83,8 @@ impl Eval for ast::WhileLoop<'_> {
             }
 
             let value = body.eval(vm)?;
-            output = ops::join(output, value).at(body.span())?;
+            let span = body.span();
+            output = ops::join(output, value, &mut (&mut vm.engine, span)).at(span)?;
 
             match vm.flow {
                 Some(FlowEvent::Break(_)) => {
@@ -129,7 +130,9 @@ impl Eval for ast::ForLoop<'_> {
 
                     let body = self.body();
                     let value = body.eval(vm)?;
-                    output = ops::join(output, value).at(body.span())?;
+                    let span = body.span();
+                    output =
+                        ops::join(output, value, &mut (&mut vm.engine, span)).at(span)?;
 
                     match vm.flow {
                         Some(FlowEvent::Break(_)) => {

--- a/crates/typst-eval/src/ops.rs
+++ b/crates/typst-eval/src/ops.rs
@@ -1,4 +1,4 @@
-use typst_library::diag::{At, HintedStrResult, SourceResult};
+use typst_library::diag::{At, DeprecationSink, HintedStrResult, SourceResult};
 use typst_library::foundations::{ops, IntoValue, Value};
 use typst_syntax::ast::{self, AstNode};
 
@@ -23,22 +23,22 @@ impl Eval for ast::Binary<'_> {
 
     fn eval(self, vm: &mut Vm) -> SourceResult<Self::Output> {
         match self.op() {
-            ast::BinOp::Add => apply_binary(self, vm, ops::add),
+            ast::BinOp::Add => apply_binary_with_sink(self, vm, ops::add),
             ast::BinOp::Sub => apply_binary(self, vm, ops::sub),
             ast::BinOp::Mul => apply_binary(self, vm, ops::mul),
             ast::BinOp::Div => apply_binary(self, vm, ops::div),
             ast::BinOp::And => apply_binary(self, vm, ops::and),
             ast::BinOp::Or => apply_binary(self, vm, ops::or),
-            ast::BinOp::Eq => apply_binary(self, vm, ops::eq),
-            ast::BinOp::Neq => apply_binary(self, vm, ops::neq),
+            ast::BinOp::Eq => apply_binary_with_sink(self, vm, ops::eq),
+            ast::BinOp::Neq => apply_binary_with_sink(self, vm, ops::neq),
             ast::BinOp::Lt => apply_binary(self, vm, ops::lt),
             ast::BinOp::Leq => apply_binary(self, vm, ops::leq),
             ast::BinOp::Gt => apply_binary(self, vm, ops::gt),
             ast::BinOp::Geq => apply_binary(self, vm, ops::geq),
-            ast::BinOp::In => apply_binary(self, vm, ops::in_),
-            ast::BinOp::NotIn => apply_binary(self, vm, ops::not_in),
+            ast::BinOp::In => apply_binary_with_sink(self, vm, ops::in_),
+            ast::BinOp::NotIn => apply_binary_with_sink(self, vm, ops::not_in),
             ast::BinOp::Assign => apply_assignment(self, vm, |_, b| Ok(b)),
-            ast::BinOp::AddAssign => apply_assignment(self, vm, ops::add),
+            ast::BinOp::AddAssign => apply_assignment_with_sink(self, vm, ops::add),
             ast::BinOp::SubAssign => apply_assignment(self, vm, ops::sub),
             ast::BinOp::MulAssign => apply_assignment(self, vm, ops::mul),
             ast::BinOp::DivAssign => apply_assignment(self, vm, ops::div),
@@ -65,6 +65,18 @@ fn apply_binary(
     op(lhs, rhs).at(binary.span())
 }
 
+/// Apply a basic binary operation, with the possiblity of deprecations.
+fn apply_binary_with_sink(
+    binary: ast::Binary,
+    vm: &mut Vm,
+    op: impl Fn(Value, Value, &mut dyn DeprecationSink) -> HintedStrResult<Value>,
+) -> SourceResult<Value> {
+    let span = binary.span();
+    let lhs = binary.lhs().eval(vm)?;
+    let rhs = binary.rhs().eval(vm)?;
+    op(lhs, rhs, &mut (&mut vm.engine, span)).at(span)
+}
+
 /// Apply an assignment operation.
 fn apply_assignment(
     binary: ast::Binary,
@@ -87,5 +99,25 @@ fn apply_assignment(
     let location = binary.lhs().access(vm)?;
     let lhs = std::mem::take(&mut *location);
     *location = op(lhs, rhs).at(binary.span())?;
+    Ok(Value::None)
+}
+
+/// Apply an assignment operation, with the possiblity of deprecations.
+fn apply_assignment_with_sink(
+    binary: ast::Binary,
+    vm: &mut Vm,
+    op: fn(Value, Value, &mut dyn DeprecationSink) -> HintedStrResult<Value>,
+) -> SourceResult<Value> {
+    let rhs = binary.rhs().eval(vm)?;
+    let location = binary.lhs().access(vm)?;
+    let lhs = std::mem::take(&mut *location);
+    let mut sink = vec![];
+    let span = binary.span();
+    *location = op(lhs, rhs, &mut (&mut sink, span)).at(span)?;
+    if !sink.is_empty() {
+        for warning in sink {
+            vm.engine.sink.warn(warning);
+        }
+    }
     Ok(Value::None)
 }

--- a/crates/typst-library/src/foundations/ops.rs
+++ b/crates/typst-library/src/foundations/ops.rs
@@ -5,7 +5,7 @@ use std::cmp::Ordering;
 use ecow::eco_format;
 use typst_utils::Numeric;
 
-use crate::diag::{bail, HintedStrResult, StrResult};
+use crate::diag::{bail, DeprecationSink, HintedStrResult, StrResult};
 use crate::foundations::{
     format_str, Datetime, IntoValue, Regex, Repr, SymbolElem, Value,
 };
@@ -21,7 +21,7 @@ macro_rules! mismatch {
 }
 
 /// Join a value with another value.
-pub fn join(lhs: Value, rhs: Value) -> StrResult<Value> {
+pub fn join(lhs: Value, rhs: Value, sink: &mut dyn DeprecationSink) -> StrResult<Value> {
     use Value::*;
     Ok(match (lhs, rhs) {
         (a, None) => a,
@@ -39,6 +39,17 @@ pub fn join(lhs: Value, rhs: Value) -> StrResult<Value> {
         (Array(a), Array(b)) => Array(a + b),
         (Dict(a), Dict(b)) => Dict(a + b),
         (Args(a), Args(b)) => Args(a + b),
+
+        // Type compatibility.
+        (Type(a), Str(b)) => {
+            warn_type_str_join(sink);
+            Str(format_str!("{a}{b}"))
+        }
+        (Str(a), Type(b)) => {
+            warn_type_str_join(sink);
+            Str(format_str!("{a}{b}"))
+        }
+
         (a, b) => mismatch!("cannot join {} with {}", a, b),
     })
 }
@@ -88,7 +99,11 @@ pub fn neg(value: Value) -> HintedStrResult<Value> {
 }
 
 /// Compute the sum of two values.
-pub fn add(lhs: Value, rhs: Value) -> HintedStrResult<Value> {
+pub fn add(
+    lhs: Value,
+    rhs: Value,
+    sink: &mut dyn DeprecationSink,
+) -> HintedStrResult<Value> {
     use Value::*;
     Ok(match (lhs, rhs) {
         (a, None) => a,
@@ -155,6 +170,16 @@ pub fn add(lhs: Value, rhs: Value) -> HintedStrResult<Value> {
         (Duration(a), Duration(b)) => Duration(a + b),
         (Datetime(a), Duration(b)) => Datetime(a + b),
         (Duration(a), Datetime(b)) => Datetime(b + a),
+
+        // Type compatibility.
+        (Type(a), Str(b)) => {
+            warn_type_str_add(sink);
+            Str(format_str!("{a}{b}"))
+        }
+        (Str(a), Type(b)) => {
+            warn_type_str_add(sink);
+            Str(format_str!("{a}{b}"))
+        }
 
         (Dyn(a), Dyn(b)) => {
             // Alignments can be summed.
@@ -394,13 +419,21 @@ pub fn or(lhs: Value, rhs: Value) -> HintedStrResult<Value> {
 }
 
 /// Compute whether two values are equal.
-pub fn eq(lhs: Value, rhs: Value) -> HintedStrResult<Value> {
-    Ok(Value::Bool(equal(&lhs, &rhs)))
+pub fn eq(
+    lhs: Value,
+    rhs: Value,
+    sink: &mut dyn DeprecationSink,
+) -> HintedStrResult<Value> {
+    Ok(Value::Bool(equal(&lhs, &rhs, sink)))
 }
 
 /// Compute whether two values are unequal.
-pub fn neq(lhs: Value, rhs: Value) -> HintedStrResult<Value> {
-    Ok(Value::Bool(!equal(&lhs, &rhs)))
+pub fn neq(
+    lhs: Value,
+    rhs: Value,
+    sink: &mut dyn DeprecationSink,
+) -> HintedStrResult<Value> {
+    Ok(Value::Bool(!equal(&lhs, &rhs, sink)))
 }
 
 macro_rules! comparison {
@@ -419,7 +452,7 @@ comparison!(gt, ">", Ordering::Greater);
 comparison!(geq, ">=", Ordering::Greater | Ordering::Equal);
 
 /// Determine whether two values are equal.
-pub fn equal(lhs: &Value, rhs: &Value) -> bool {
+pub fn equal(lhs: &Value, rhs: &Value, sink: &mut dyn DeprecationSink) -> bool {
     use Value::*;
     match (lhs, rhs) {
         // Compare reflexively.
@@ -461,6 +494,12 @@ pub fn equal(lhs: &Value, rhs: &Value) -> bool {
         }
         (&Ratio(rat), &Relative(rel)) | (&Relative(rel), &Ratio(rat)) => {
             rat == rel.rel && rel.abs.is_zero()
+        }
+
+        // Type compatibility.
+        (Type(ty), Str(str)) | (Str(str), Type(ty)) => {
+            warn_type_str_equal(sink);
+            ty.compat_name() == str.as_str()
         }
 
         _ => false,
@@ -534,8 +573,12 @@ fn try_cmp_arrays(a: &[Value], b: &[Value]) -> StrResult<Ordering> {
 }
 
 /// Test whether one value is "in" another one.
-pub fn in_(lhs: Value, rhs: Value) -> HintedStrResult<Value> {
-    if let Some(b) = contains(&lhs, &rhs) {
+pub fn in_(
+    lhs: Value,
+    rhs: Value,
+    sink: &mut dyn DeprecationSink,
+) -> HintedStrResult<Value> {
+    if let Some(b) = contains(&lhs, &rhs, sink) {
         Ok(Value::Bool(b))
     } else {
         mismatch!("cannot apply 'in' to {} and {}", lhs, rhs)
@@ -543,8 +586,12 @@ pub fn in_(lhs: Value, rhs: Value) -> HintedStrResult<Value> {
 }
 
 /// Test whether one value is "not in" another one.
-pub fn not_in(lhs: Value, rhs: Value) -> HintedStrResult<Value> {
-    if let Some(b) = contains(&lhs, &rhs) {
+pub fn not_in(
+    lhs: Value,
+    rhs: Value,
+    sink: &mut dyn DeprecationSink,
+) -> HintedStrResult<Value> {
+    if let Some(b) = contains(&lhs, &rhs, sink) {
         Ok(Value::Bool(!b))
     } else {
         mismatch!("cannot apply 'not in' to {} and {}", lhs, rhs)
@@ -552,13 +599,27 @@ pub fn not_in(lhs: Value, rhs: Value) -> HintedStrResult<Value> {
 }
 
 /// Test for containment.
-pub fn contains(lhs: &Value, rhs: &Value) -> Option<bool> {
+pub fn contains(
+    lhs: &Value,
+    rhs: &Value,
+    sink: &mut dyn DeprecationSink,
+) -> Option<bool> {
     use Value::*;
     match (lhs, rhs) {
         (Str(a), Str(b)) => Some(b.as_str().contains(a.as_str())),
         (Dyn(a), Str(b)) => a.downcast::<Regex>().map(|regex| regex.is_match(b)),
         (Str(a), Dict(b)) => Some(b.contains(a)),
-        (a, Array(b)) => Some(b.contains(a.clone())),
+        (a, Array(b)) => Some(b.contains_impl(a, sink)),
+
+        // Type compatibility.
+        (Type(a), Str(b)) => {
+            warn_type_in_str(sink);
+            Some(b.as_str().contains(a.compat_name()))
+        }
+        (Type(a), Dict(b)) => {
+            warn_type_in_dict(sink);
+            Some(b.contains(a.compat_name()))
+        }
 
         _ => Option::None,
     }
@@ -567,4 +628,47 @@ pub fn contains(lhs: &Value, rhs: &Value) -> Option<bool> {
 #[cold]
 fn too_large() -> &'static str {
     "value is too large"
+}
+
+#[cold]
+fn warn_type_str_add(sink: &mut dyn DeprecationSink) {
+    sink.emit_with_hints(
+        "adding strings and types is deprecated",
+        &["convert the type to a string with `str` first"],
+    );
+}
+
+#[cold]
+fn warn_type_str_join(sink: &mut dyn DeprecationSink) {
+    sink.emit_with_hints(
+        "joining strings and types is deprecated",
+        &["convert the type to a string with `str` first"],
+    );
+}
+
+#[cold]
+fn warn_type_str_equal(sink: &mut dyn DeprecationSink) {
+    sink.emit_with_hints(
+        "comparing strings with types is deprecated",
+        &[
+            "compare with the literal type instead",
+            "this comparison will always return `false` in future Typst releases",
+        ],
+    );
+}
+
+#[cold]
+fn warn_type_in_str(sink: &mut dyn DeprecationSink) {
+    sink.emit_with_hints(
+        "checking whether a type is contained in a string is deprecated",
+        &["this compatibility behavior only exists because `type` used to return a string"],
+    );
+}
+
+#[cold]
+fn warn_type_in_dict(sink: &mut dyn DeprecationSink) {
+    sink.emit_with_hints(
+        "checking whether a type is contained in a dictionary is deprecated",
+        &["this compatibility behavior only exists because `type` used to return a string"],
+    );
 }

--- a/crates/typst-library/src/foundations/scope.rs
+++ b/crates/typst-library/src/foundations/scope.rs
@@ -300,7 +300,7 @@ impl Binding {
     /// As the `sink`
     /// - pass `()` to ignore the message.
     /// - pass `(&mut engine, span)` to emit a warning into the engine.
-    pub fn read_checked(&self, sink: impl DeprecationSink) -> &Value {
+    pub fn read_checked(&self, mut sink: impl DeprecationSink) -> &Value {
         if let Some(message) = self.deprecation {
             sink.emit(message);
         }

--- a/crates/typst-library/src/foundations/ty.rs
+++ b/crates/typst-library/src/foundations/ty.rs
@@ -44,6 +44,16 @@ use crate::foundations::{
 /// #type(int) \
 /// #type(type)
 /// ```
+///
+/// # Compatibility
+/// In Typst 0.7 and lower, the `type` function returned a string instead of a
+/// type. Compatibility with the old way will remain until Typst 0.14 to give
+/// package authors time to upgrade.
+///
+/// - Checks like `{int == "integer"}` evaluate to `{true}`
+/// - Adding/joining a type and string will yield a string
+/// - The `{in}` operator on a type and a dictionary will evaluate to `{true}`
+///   if the dictionary has a string key matching the type's name
 #[ty(scope, cast)]
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Type(Static<NativeTypeData>);
@@ -103,6 +113,14 @@ impl Type {
             Some(binding) => Ok(binding.read_checked(sink)),
             None => bail!("type {self} does not contain field `{field}`"),
         }
+    }
+}
+
+// Type compatibility.
+impl Type {
+    /// The type's backward-compatible name.
+    pub fn compat_name(&self) -> &str {
+        self.long_name()
     }
 }
 

--- a/crates/typst-library/src/foundations/value.rs
+++ b/crates/typst-library/src/foundations/value.rs
@@ -292,7 +292,8 @@ impl Repr for Value {
 
 impl PartialEq for Value {
     fn eq(&self, other: &Self) -> bool {
-        ops::equal(self, other)
+        // No way to emit deprecation warnings here :(
+        ops::equal(self, other, &mut ())
     }
 }
 

--- a/docs/changelog/0.13.0.md
+++ b/docs/changelog/0.13.0.md
@@ -313,6 +313,9 @@ feature flag.
   functions directly accepting both paths and bytes
 - The `sect` and its variants in favor of `inter`, and `integral.sect` in favor
   of `integral.inter`
+- The compatibility behavior of type/str comparisons (e.g. `{int == "integer"}`)
+  which was temporarily introduced in Typst 0.8 now emits warnings. It will be
+  removed in Typst 0.14.
 
 ## Removals
 - Removed `style` function and `styles` argument of [`measure`], use a [context]
@@ -324,9 +327,6 @@ feature flag.
 - Removed compatibility behavior where [`counter.display`] worked without
   [context] **(Breaking change)**
 - Removed compatibility behavior of [`locate`] **(Breaking change)**
-- Removed compatibility behavior of type/str comparisons
-  (e.g. `{int == "integer"}`) which was temporarily introduced in Typst 0.8
-  **(Breaking change)**
 
 ## Development
 - The `typst::compile` function is now generic and can return either a

--- a/tests/src/world.rs
+++ b/tests/src/world.rs
@@ -251,6 +251,6 @@ fn lines(
     (1..=count)
         .map(|n| numbering.apply(engine, context, &[n]))
         .collect::<SourceResult<Array>>()?
-        .join(Some('\n'.into_value()), None)
+        .join(engine, span, Some('\n'.into_value()), None)
         .at(span)
 }

--- a/tests/suite/foundations/type.typ
+++ b/tests/suite/foundations/type.typ
@@ -2,6 +2,60 @@
 #test(type(1), int)
 #test(type(ltr), direction)
 #test(type(10 / 3), float)
+#test(type(10) == int, true)
+#test(type(10) != int, false)
+
+--- type-string-compatibility-add ---
+// Warning: 7-23 adding strings and types is deprecated
+// Hint: 7-23 convert the type to a string with `str` first
+#test("is " + type(10), "is integer")
+// Warning: 7-23 adding strings and types is deprecated
+// Hint: 7-23 convert the type to a string with `str` first
+#test(type(10) + " is", "integer is")
+
+--- type-string-compatibility-join ---
+// Warning: 16-24 joining strings and types is deprecated
+// Hint: 16-24 convert the type to a string with `str` first
+#test({ "is "; type(10) }, "is integer")
+// Warning: 19-24 joining strings and types is deprecated
+// Hint: 19-24 convert the type to a string with `str` first
+#test({ type(10); " is" }, "integer is")
+
+--- type-string-compatibility-equal ---
+// Warning: 7-28 comparing strings with types is deprecated
+// Hint: 7-28 compare with the literal type instead
+// Hint: 7-28 this comparison will always return `false` in future Typst releases
+#test(type(10) == "integer", true)
+// Warning: 7-26 comparing strings with types is deprecated
+// Hint: 7-26 compare with the literal type instead
+// Hint: 7-26 this comparison will always return `false` in future Typst releases
+#test(type(10) != "float", true)
+
+--- type-string-compatibility-in-array ---
+// Warning: 7-35 comparing strings with types is deprecated
+// Hint: 7-35 compare with the literal type instead
+// Hint: 7-35 this comparison will always return `false` in future Typst releases
+#test(int in ("integer", "string"), true)
+// Warning: 7-37 comparing strings with types is deprecated
+// Hint: 7-37 compare with the literal type instead
+// Hint: 7-37 this comparison will always return `false` in future Typst releases
+#test(float in ("integer", "string"), false)
+
+--- type-string-compatibility-in-str ---
+// Warning: 7-35 checking whether a type is contained in a string is deprecated
+// Hint: 7-35 this compatibility behavior only exists because `type` used to return a string
+#test(int in "integers or strings", true)
+// Warning: 7-35 checking whether a type is contained in a string is deprecated
+// Hint: 7-35 this compatibility behavior only exists because `type` used to return a string
+#test(str in "integers or strings", true)
+// Warning: 7-37 checking whether a type is contained in a string is deprecated
+// Hint: 7-37 this compatibility behavior only exists because `type` used to return a string
+#test(float in "integers or strings", false)
+
+--- type-string-compatibility-in-dict ---
+// Warning: 7-37 checking whether a type is contained in a dictionary is deprecated
+// Hint: 7-37 this compatibility behavior only exists because `type` used to return a string
+#test(int in (integer: 1, string: 2), true)
 
 --- issue-3110-type-constructor ---
 // Let the error message report the type name.


### PR DESCRIPTION
The PR https://github.com/typst/typst/pull/5591 removed various deprecated things from the compiler. Most things removed in that PR already warned in 0.12. An exception to this is the compatibility behaviour that lets `int == "integer"` evaluate to true since Typst 0.8. This behaviour was removed with 0.13-rc1 without any previous deprecation warnings (except in the docs and changelog). The reason I didn't implement warnings in the first place was that it wasn't possible to emit warnings in all cases (because nested comparisons go through `PartialEq for Value` and there's no way to pass a warning context) and the code for the cases that we can catch is quite ugly. I figured that, as it's superseded since Typst 0.8, removing it in 0.13 was fine.

However, @tingerrr demonstrated that [quite a large portion of the ecosystem did not migrate in time](https://github.com/typst/packages/issues/1725), leading to widespread breakage. For this reason, I'm temporarily bringing back the compatibility behaviour, but this time with warnings and hints for the cases that we _can_ catch. 

This is what the warning looks like that most people will see:
```
warning: comparing strings with types is deprecated
  ┌─ hi.typ:2:2
  │
2 │   type(10) == "integer"
  │   ^^^^^^^^^^^^^^^^^^^^^
  │
  = hint: compare with the literal type instead
  = hint: this comparison will always return `false` in future Typst releases
```

There are also warnings for 
- adding types and strings
- joining types and strings
- type in array
- type in str
- type in dictionary

----

Note that this PR is based on the 0.13 branch and will be merged into it. The temporary revival with warnings is for Typst 0.13 specifically. It won't be in the dev version and also not in Typst 0.14. (There isn't much of a point in merging this to main and then removing it immediately after the release, which is what I'd have done otherwise.)
