### PR TITLE
HTML export: Use `<code>` for inline `RawElem`

### DIFF
--- a/crates/typst-library/src/text/raw.rs
+++ b/crates/typst-library/src/text/raw.rs
@@ -446,10 +446,14 @@ impl Show for Packed<RawElem> {
         let mut realized = Content::sequence(seq);
 
         if TargetElem::target_in(styles).is_html() {
-            return Ok(HtmlElem::new(tag::pre)
-                .with_body(Some(realized))
-                .pack()
-                .spanned(self.span()));
+            return Ok(HtmlElem::new(if self.block(styles) {
+                tag::pre
+            } else {
+                tag::code
+            })
+            .with_body(Some(realized))
+            .pack()
+            .spanned(self.span()));
         }
 
         if self.block(styles) {


### PR DESCRIPTION
Fix #5881

![](https://github.com/user-attachments/assets/60add71e-4da0-4b07-80cd-81659ffb48e7)
