### PR TITLE
Documentation improvements

### DIFF
--- a/crates/typst-library/src/foundations/symbol.rs
+++ b/crates/typst-library/src/foundations/symbol.rs
@@ -21,6 +21,7 @@ use crate::foundations::{
 /// be accessed using [field access notation]($scripting/#fields):
 ///
 /// - General symbols are defined in the [`sym` module]($category/symbols/sym)
+///   and are accessible without the `sym.` prefix in math mode.
 /// - Emoji are defined in the [`emoji` module]($category/symbols/emoji)
 ///
 /// Moreover, you can define custom symbols with this type's constructor

--- a/crates/typst-library/src/visualize/color.rs
+++ b/crates/typst-library/src/visualize/color.rs
@@ -130,7 +130,7 @@ static TO_SRGB: LazyLock<qcms::Transform> = LazyLock::new(|| {
 ///
 /// # Predefined color maps
 /// Typst also includes a number of preset color maps that can be used for
-/// [gradients]($gradient.linear). These are simply arrays of colors defined in
+/// [gradients]($gradient/#stops). These are simply arrays of colors defined in
 /// the module `color.map`.
 ///
 /// ```example

--- a/crates/typst-library/src/visualize/gradient.rs
+++ b/crates/typst-library/src/visualize/gradient.rs
@@ -70,6 +70,9 @@ use crate::visualize::{Color, ColorSpace, WeightedColor};
 /// the offsets when defining a gradient. In this case, Typst will space all
 /// stops evenly.
 ///
+/// Typst predefines color maps that you can use as stops. See the
+/// [`color`]($color/#predefined-color-maps) documentation for more details.
+///
 /// # Relativeness
 /// The location of the `{0%}` and `{100%}` stops depends on the dimensions
 /// of a container. This container can either be the shape that it is being
@@ -156,10 +159,6 @@ use crate::visualize::{Color, ColorSpace, WeightedColor};
 ///   square(fill: gradient.linear(red, blue, angle: 270deg)),
 /// )
 /// ```
-///
-/// # Presets
-/// Typst predefines color maps that you can use with your gradients. See the
-/// [`color`]($color/#predefined-color-maps) documentation for more details.
 ///
 /// # Note on file sizes
 ///

--- a/crates/typst-library/src/visualize/gradient.rs
+++ b/crates/typst-library/src/visualize/gradient.rs
@@ -287,7 +287,7 @@ impl Gradient {
     ///   )),
     /// )
     /// ```
-    #[func]
+    #[func(title = "Radial Gradient")]
     fn radial(
         span: Span,
         /// The color [stops](#stops) of the gradient.
@@ -401,7 +401,7 @@ impl Gradient {
     ///   )),
     /// )
     /// ```
-    #[func]
+    #[func(title = "Conic Gradient")]
     pub fn conic(
         span: Span,
         /// The color [stops](#stops) of the gradient.

--- a/docs/reference/groups.yml
+++ b/docs/reference/groups.yml
@@ -170,8 +170,8 @@
   category: symbols
   path: ["emoji"]
   details: |
-    Named emoji.
+    Named emojis.
 
     For example, `#emoji.face` produces the 😀 emoji. If you frequently use
     certain emojis, you can also import them from the `emoji` module (`[#import
-    emoji: face]`) to use them without the `#emoji.` prefix.
+    emoji: face]`) to use them without the `emoji.` prefix.


### PR DESCRIPTION
This slightly improves the gradient stops documentation by mentioning predefined color maps there.

I also added a title to the `gradient.radial` and `gradient.conic` constructors, which makes them consistent with `gradient.linear`.

I also slightly improved the Emoji and Symbol Type documentation pages.