### PR TITLE
cli: Allow setting an output directory

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -224,6 +224,10 @@ pub struct CompileArgs {
     #[arg(long = "format", short = 'f')]
     pub format: Option<OutputFormat>,
 
+    /// Directory to write output to.
+    #[clap(long = "output-path", env = "TYPST_OUTPUT_PATH", value_name = "DIR")]
+    pub output_path: Option<PathBuf>,
+
     /// World arguments.
     #[clap(flatten)]
     pub world: WorldArgs,


### PR DESCRIPTION
This allows setting an output directory with a new `--output-path` argument which makes the CLI more convenient to use for me as I typically want to create build artifacts in a separate directory. 

Currently I have to specify a full output path when I want typst to generate the output in a certain directory:
```sh
typst compile test.typ build/test.pdf
```

With this change I can now write this:
```sh
typst compile -fpdf --output-path build test.typ
```

Setting `--output-path` to a dead symlink causes a panic. Is that ok?

The directory specified with the `--output-path` argument is created if it does not exist yet. Is this reasonable behavior?