### PR TITLE
HTML export: fix elem counting on classify_output

### DIFF
--- a/crates/typst-html/src/lib.rs
+++ b/crates/typst-html/src/lib.rs
@@ -307,21 +307,18 @@ fn head_element(info: &DocumentInfo) -> HtmlElement {
 
 /// Determine which kind of output the user generated.
 fn classify_output(mut output: Vec<HtmlNode>) -> SourceResult<OutputKind> {
-    let html_elem_count = output
-        .iter()
-        .filter(|node| matches!(node, HtmlNode::Element(_)))
-        .count();
+    let count = output.iter().filter(|node| !matches!(node, HtmlNode::Tag(_))).count();
     for node in &mut output {
         let HtmlNode::Element(elem) = node else { continue };
         let tag = elem.tag;
         let mut take = || std::mem::replace(elem, HtmlElement::new(tag::html));
-        match (tag, html_elem_count) {
+        match (tag, count) {
             (tag::html, 1) => return Ok(OutputKind::Html(take())),
             (tag::body, 1) => return Ok(OutputKind::Body(take())),
             (tag::html | tag::body, _) => bail!(
                 elem.span,
-                "`{}` element must be the only html element in the document, but there are {}",
-                elem.tag, html_elem_count
+                "`{}` element must be the only element in the document",
+                elem.tag,
             ),
             _ => {}
         }

--- a/crates/typst-html/src/lib.rs
+++ b/crates/typst-html/src/lib.rs
@@ -307,18 +307,21 @@ fn head_element(info: &DocumentInfo) -> HtmlElement {
 
 /// Determine which kind of output the user generated.
 fn classify_output(mut output: Vec<HtmlNode>) -> SourceResult<OutputKind> {
-    let len = output.len();
+    let html_elem_count = output
+        .iter()
+        .filter(|node| matches!(node, HtmlNode::Element(_)))
+        .count();
     for node in &mut output {
         let HtmlNode::Element(elem) = node else { continue };
         let tag = elem.tag;
         let mut take = || std::mem::replace(elem, HtmlElement::new(tag::html));
-        match (tag, len) {
+        match (tag, html_elem_count) {
             (tag::html, 1) => return Ok(OutputKind::Html(take())),
             (tag::body, 1) => return Ok(OutputKind::Body(take())),
             (tag::html | tag::body, _) => bail!(
                 elem.span,
-                "`{}` element must be the only element in the document",
-                elem.tag
+                "`{}` element must be the only html element in the document, but there are {}",
+                elem.tag, html_elem_count
             ),
             _ => {}
         }

--- a/tests/ref/html/html-elem-alone-context.html
+++ b/tests/ref/html/html-elem-alone-context.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html></html>

--- a/tests/suite/html/elem.typ
+++ b/tests/suite/html/elem.typ
@@ -1,0 +1,7 @@
+--- html-elem-alone-context html ---
+#context html.elem("html")
+
+--- html-elem-not-alone html ---
+// Error: 2-19 `<html>` element must be the only element in the document
+#html.elem("html")
+Text


### PR DESCRIPTION
The following code will not compile:
```typst
// a.typ
#context {
  if target() == "html" {
    html.elem("html")
  }
}
```

```console
$ typst c --features html a.typ a.html
warning: html export is under active development and incomplete
 = hint: its behaviour may change at any time
 = hint: do not rely on this feature for production use cases
 = hint: see https://github.com/typst/typst/issues/5512 for more information

error: `<html>` element must be the only element in the document
  ┌─ ../../../../tmp/a.typ:4:4
  │
3 │     html.elem("html")
  │     ^^^^^^^^^^^^^^^^^
```

Because currently the HTML exporter checks whether the `<html>` element is the sole element in the document. However, when `<html>` is wrapped in a `context` block, the `context` tag and the end of `context` are also counted, resulting in the element count being 3 instead of 1.

We fixed the problem by only counting elements being an `HtmlNode::Element`.

Fixes https://github.com/typst/typst/issues/5756