### PR TITLE
Mention `binstall` in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,10 @@ Typst's CLI is available from different sources:
   - Windows: `winget install --id Typst.Typst`
 
 - If you have a [Rust][rust] toolchain installed, you can install
-  - the latest released Typst version with
+  - the latest released Typst version from source with
     `cargo install --locked typst-cli`
+  - the latest released Typst version from binary with
+    `cargo binstall --locked typst-cli`
   - a development version with
     `cargo install --git https://github.com/typst/typst --locked typst-cli`
 


### PR DESCRIPTION
I just tested and `cargo` [binstall](https://github.com/cargo-bins/cargo-binstall) works here on MacOS Aarch64 (related issue https://github.com/typst/typst/issues/4388 was fixed in https://github.com/typst/typst/pull/4458).

This PR suggests to mention `binstall` in the README installation instructions.