### PR TITLE
Draft: introduce watermark element to make text non-selectable by `artifact` Tag (PDF 1.7 18.4.2.2.2)

### DIFF
--- a/crates/typst-layout/src/modifiers.rs
+++ b/crates/typst-layout/src/modifiers.rs
@@ -1,6 +1,6 @@
 use typst_library::foundations::StyleChain;
 use typst_library::layout::{Fragment, Frame, FrameItem, HideElem, Point};
-use typst_library::model::{Destination, LinkElem};
+use typst_library::model::{Destination, LinkElem, WatermarkElem};
 
 /// Frame-level modifications resulting from styles that do not impose any
 /// layout structure.
@@ -23,6 +23,8 @@ pub struct FrameModifiers {
     dest: Option<Destination>,
     /// Whether the contents of the frame should be hidden.
     hidden: bool,
+    /// Whether the contents should be watermarked (non-selectable).
+    watermarked: bool,
 }
 
 impl FrameModifiers {
@@ -31,6 +33,7 @@ impl FrameModifiers {
         Self {
             dest: LinkElem::current_in(styles),
             hidden: HideElem::hidden_in(styles),
+            watermarked: WatermarkElem::watermarked_in(styles),
         }
     }
 }
@@ -59,6 +62,10 @@ impl FrameModify for Frame {
 
         if modifiers.hidden {
             self.hide();
+        }
+
+        if modifiers.watermarked {
+            *self = self.clone().watermarked();
         }
     }
 }

--- a/crates/typst-library/src/layout/frame.rs
+++ b/crates/typst-library/src/layout/frame.rs
@@ -313,6 +313,17 @@ impl Frame {
         });
     }
 
+    /// Convert this frame into a watermarked (non-selectable) frame.
+    pub fn watermarked(self) -> Self {
+        if self.is_empty() {
+            return self;
+        }
+        let mut frame = Frame::soft(self.size());
+        frame.baseline = self.baseline;
+        frame.push(Point::zero(), FrameItem::Watermark(self));
+        frame
+    }
+
     /// Add a background fill.
     pub fn fill(&mut self, fill: impl Into<Paint>) {
         self.prepend(
@@ -476,6 +487,8 @@ pub enum FrameItem {
     Link(Destination, Size),
     /// An introspectable element that produced something within this frame.
     Tag(Tag),
+    /// A watermarked (non-selectable) frame.
+    Watermark(Frame),
 }
 
 impl Debug for FrameItem {
@@ -487,6 +500,7 @@ impl Debug for FrameItem {
             Self::Image(image, _, _) => write!(f, "{image:?}"),
             Self::Link(dest, _) => write!(f, "Link({dest:?})"),
             Self::Tag(tag) => write!(f, "{tag:?}"),
+            Self::Watermark(frame) => write!(f, "Watermark({frame:?})"),
         }
     }
 }

--- a/crates/typst-library/src/model/mod.rs
+++ b/crates/typst-library/src/model/mod.rs
@@ -6,6 +6,7 @@ mod document;
 mod emph;
 #[path = "enum.rs"]
 mod enum_;
+mod watermark;
 mod figure;
 mod footnote;
 mod heading;
@@ -26,6 +27,7 @@ pub use self::cite::*;
 pub use self::document::*;
 pub use self::emph::*;
 pub use self::enum_::*;
+pub use self::watermark::*;
 pub use self::figure::*;
 pub use self::footnote::*;
 pub use self::heading::*;
@@ -62,6 +64,7 @@ pub fn define(global: &mut Scope) {
     global.define_elem::<TableElem>();
     global.define_elem::<TermsElem>();
     global.define_elem::<EmphElem>();
+    global.define_elem::<WatermarkElem>();
     global.define_elem::<StrongElem>();
     global.define_func::<numbering>();
     global.reset_category();

--- a/crates/typst-library/src/model/watermark.rs
+++ b/crates/typst-library/src/model/watermark.rs
@@ -1,0 +1,37 @@
+use crate::diag::SourceResult;
+use crate::engine::Engine;
+use crate::foundations::{
+    elem, Content, Packed, Show, StyleChain,
+};
+
+/// Creates non-selectable content.
+///
+/// Makes the content non-selectable in both PDF and HTML output:
+/// - In PDF: Uses PDF artifacts (primarily supported in Adobe Acrobat Reader)
+/// - In HTML: Uses CSS user-select property, not implemented for now.
+///
+/// Note: While the text appears non-selectable in viewers, the text information
+/// remains in the document and can still be extracted programmatically.
+///
+/// # Example
+/// ```example
+/// #watermark[Confidential]
+/// ```
+#[elem(Show)]
+pub struct WatermarkElem {
+    /// The content to render as non-selectable.
+    #[required]
+    pub body: Content,
+
+    /// This style is set on the content contained in the `watermark` element.
+    #[internal]
+    #[ghost]
+    pub watermarked: bool,
+}
+
+impl Show for Packed<WatermarkElem> {
+    #[typst_macros::time(name = "watermark", span = self.span())]
+    fn show(&self, _: &mut Engine, _styles: StyleChain) -> SourceResult<Content> {
+        Ok(self.body.clone().styled(WatermarkElem::set_watermarked(true)))
+    }
+}

--- a/crates/typst-pdf/src/content.rs
+++ b/crates/typst-pdf/src/content.rs
@@ -381,8 +381,29 @@ pub(crate) fn write_frame(ctx: &mut Builder, frame: &Frame) -> SourceResult<()> 
             }
             FrameItem::Link(dest, size) => write_link(ctx, pos, dest, *size),
             FrameItem::Tag(_) => {}
+            FrameItem::Watermark(frame) => write_watermark(ctx, pos, frame)?,
         }
     }
+    Ok(())
+}
+
+/// Encode a watermarked frame into the content stream.
+fn write_watermark(ctx: &mut Builder, pos: Point, frame: &Frame) -> SourceResult<()> {
+    ctx.save_state()?;
+
+    // Begin PDF artifact marking
+    ctx.content.begin_marked_content(Name(b"Artifact"));
+
+    // Transform to position
+    ctx.transform(Transform::translate(pos.x, pos.y));
+
+    // Write the frame contents
+    write_frame(ctx, frame)?;
+
+    // End PDF artifact marking
+    ctx.content.end_marked_content();
+
+    ctx.restore_state();
     Ok(())
 }
 

--- a/crates/typst-render/src/lib.rs
+++ b/crates/typst-render/src/lib.rs
@@ -169,6 +169,11 @@ fn render_frame(canvas: &mut sk::Pixmap, state: State, frame: &Frame) {
             }
             FrameItem::Link(_, _) => {}
             FrameItem::Tag(_) => {}
+            FrameItem::Watermark(frame) => {
+                // For raster output, just render the frame normally since
+                // selectability doesn't apply
+                render_frame(canvas, state, frame);
+            }
         }
     }
 }

--- a/crates/typst-svg/src/lib.rs
+++ b/crates/typst-svg/src/lib.rs
@@ -230,6 +230,13 @@ impl SVGRenderer {
                 FrameItem::Image(image, size, _) => self.render_image(image, size),
                 FrameItem::Link(_, _) => unreachable!(),
                 FrameItem::Tag(_) => unreachable!(),
+                FrameItem::Watermark(frame) => {
+                    // Add user-select: none CSS property for SVG watermarks
+                    self.xml.start_element("g");
+                    self.xml.write_attribute("style", "user-select: none");
+                    self.render_frame(state.pre_translate(*pos), Transform::identity(), frame);
+                    self.xml.end_element();
+                }
             };
 
             self.xml.end_element();


### PR DESCRIPTION
As discussed in #2249 and particular https://github.com/typst/typst/issues/2249#issuecomment-1759930396
Introduce a watermark element so to make PDF outputs the text with a tag of artifact.

As the watermark element does not have any effect on the layout, so it is implemented as a frame modifier.

## NOTE:
However, it appears that the artifact tag does not really makes the text non selectable even for Adobe Acrobat.
Probably need to find a better solution.