### PR TITLE
Fix comparison of `Func` and `NativeFuncData`

### DIFF
--- a/crates/typst-library/src/foundations/func.rs
+++ b/crates/typst-library/src/foundations/func.rs
@@ -437,10 +437,10 @@ impl PartialEq for Func {
     }
 }
 
-impl PartialEq<&NativeFuncData> for Func {
-    fn eq(&self, other: &&NativeFuncData) -> bool {
+impl PartialEq<&'static NativeFuncData> for Func {
+    fn eq(&self, other: &&'static NativeFuncData) -> bool {
         match &self.repr {
-            Repr::Native(native) => native.function == other.function,
+            Repr::Native(native) => *native == Static(*other),
             _ => false,
         }
     }


### PR DESCRIPTION
Comparing function pointer is not guaranteed to produce meaningful results. We now compare addresses of statics like in normal `Func` comparisons. The `PartialEq` impl is only used in a few places in color.rs, but still.