### PR TITLE
Add `--max-layout-iterations` cli argument

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -326,6 +326,12 @@ pub struct ProcessArgs {
     /// The format to emit diagnostics in.
     #[clap(long, default_value_t)]
     pub diagnostic_format: DiagnosticFormat,
+
+    /// Determines the maximum number of layout iterations the compiler will perform in an attempt
+    /// to reach a stable state. If the document fails to stabilize within this limit, the compilation
+    /// process will give up with a warning.
+    #[arg(long = "max-layout-iterations", default_value_t = 5)]
+    pub max_iterations: usize,
 }
 
 /// Arguments related to where packages are stored in the system.

--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -48,6 +48,8 @@ pub struct SystemWorld {
     /// always the same within one compilation.
     /// Reset between compilations if not [`Now::Fixed`].
     now: Now,
+    /// The maximum number of layout iterations.
+    max_iterations: usize,
 }
 
 impl SystemWorld {
@@ -142,6 +144,7 @@ impl SystemWorld {
             slots: Mutex::new(HashMap::new()),
             package_storage: package::storage(&world_args.package),
             now,
+            max_iterations: process_args.max_iterations,
         })
     }
 
@@ -233,6 +236,10 @@ impl World for SystemWorld {
             with_offset.month().try_into().ok()?,
             with_offset.day().try_into().ok()?,
         )
+    }
+
+    fn max_iterations(&self) -> usize {
+        self.max_iterations
     }
 }
 

--- a/crates/typst-library/src/lib.rs
+++ b/crates/typst-library/src/lib.rs
@@ -84,6 +84,10 @@ pub trait World: Send + Sync {
     /// If this function returns `None`, Typst's `datetime` function will
     /// return an error.
     fn today(&self, offset: Option<i64>) -> Option<Datetime>;
+
+
+    /// Get the maximum number of layout iterations.
+    fn max_iterations(&self) -> usize;
 }
 
 macro_rules! world_impl {
@@ -115,6 +119,10 @@ macro_rules! world_impl {
 
             fn today(&self, offset: Option<i64>) -> Option<Datetime> {
                 self.deref().today(offset)
+            }
+            
+            fn max_iterations(&self) -> usize {
+                self.deref().max_iterations()
             }
         }
     };

--- a/crates/typst/src/lib.rs
+++ b/crates/typst/src/lib.rs
@@ -120,6 +120,7 @@ fn compile_impl<D: Document>(
     )?
     .content();
 
+    let max_iterations = world.max_iterations();
     let mut iter = 0;
     let mut subsink;
     let mut introspector = &empty_introspector;
@@ -129,9 +130,15 @@ fn compile_impl<D: Document>(
     // If that doesn't happen within five attempts, we give up.
     loop {
         // The name of the iterations for timing scopes.
+        
+        // TODO
+        // TimingScope expects a static slice, so we can't generate the names using format!.
+        //let iter_names = (1..=max_iterations).map(|i| format!("layout ({})", i)).collect::<Vec<_>>();
+        // For now % 5 does the trick, but we should consider a better solution.
+        
         const ITER_NAMES: &[&str] =
             &["layout (1)", "layout (2)", "layout (3)", "layout (4)", "layout (5)"];
-        let _scope = TimingScope::new(ITER_NAMES[iter]);
+        let _scope = TimingScope::new(ITER_NAMES[iter % 5]);
 
         subsink = Sink::new();
 
@@ -154,9 +161,9 @@ fn compile_impl<D: Document>(
             break;
         }
 
-        if iter >= 5 {
+        if iter >= max_iterations {
             subsink.warn(warning!(
-                Span::detached(), "layout did not converge within 5 attempts";
+                Span::detached(), "layout did not converge within {max_iterations} attempts";
                 hint: "check if any states or queries are updating themselves"
             ));
             break;


### PR DESCRIPTION
This pull request introduces a new CLI argument `--max-layout-iterations` to allow users to control the maximum number of layout iterations in the typst compiler.

As mentioned in various discussions (e.g., https://github.com/typst/typst/issues/4528), the "layout did not converge within 5 attempts" error can be tricky to debug.
While the [layout-ltd](https://typst.app/universe/package/layout-ltd) package by [davystrong](https://github.com/davystrong) ([see this comment](https://github.com/typst/typst/issues/4528#issuecomment-2665755004)) allows users to limit the iterations to below the default of 5, this PR lets users set any value - even above 5.

I've marked this PR as a draft because, as someone new to Typst, I'm not entirely sure if my changes align with the project's ideals. Additionally, there are a few unresolved issues:
- Is `ProcessArgs` the appropriate place for `max_iterations`? I chose it because it's shared between `QueryCommand` and `CompileArgs`.
- It doesn't feel ideal to include `max_iterations` in the `SystemWorld` struct, but I haven't found a better solution without passing it as a separate argument through multiple functions.
- `TimingScope` requires a `static` lifetime for the `name`. This forces me to either leak data from generated `String`s or to somehow lift the lifetime restriction. 
For now, I've kept the `const ITER_NAMES`and used a modulo operation (`% 5`) to keep values within bounds.

Please let me know if this CLI argument is of interest and if you have any suggestions on how to resolve these remaining concerns.