### PR TITLE
Make `array.chunks` example more readable

### DIFF
--- a/crates/typst-library/src/foundations/array.rs
+++ b/crates/typst-library/src/foundations/array.rs
@@ -751,7 +751,7 @@ impl Array {
     ///
     /// ```example
     /// #let array = (1, 2, 3, 4, 5, 6, 7, 8)
-    /// #array.chunks(3)
+    /// #array.chunks(3) \
     /// #array.chunks(3, exact: true)
     /// ```
     #[func]


### PR DESCRIPTION
In https://typst.app/docs/reference/foundations/array/#definitions-chunks the 2 arrays are compared, but in the output they go one after another horizontally and not vertically.
