### PR TITLE
Fix docs example with type/string comparison

### DIFF
--- a/crates/typst-library/src/loading/xml.rs
+++ b/crates/typst-library/src/loading/xml.rs
@@ -41,7 +41,7 @@ use crate::loading::{DataSource, Load, Readable};
 ///   ]
 ///
 ///   for p in pars.children {
-///     if (type(p) == "dictionary") {
+///     if (type(p) == dictionary) {
 ///       parbreak()
 ///       p.children.first()
 ///     }
@@ -50,7 +50,7 @@ use crate::loading::{DataSource, Load, Readable};
 ///
 /// #let data = xml("example.xml")
 /// #for elem in data.first().children {
-///   if (type(elem) == "dictionary") {
+///   if (type(elem) == dictionary) {
 ///     article(elem)
 ///   }
 /// }

--- a/crates/typst-library/src/loading/xml.rs
+++ b/crates/typst-library/src/loading/xml.rs
@@ -41,7 +41,7 @@ use crate::loading::{DataSource, Load, Readable};
 ///   ]
 ///
 ///   for p in pars.children {
-///     if (type(p) == dictionary) {
+///     if type(p) == dictionary {
 ///       parbreak()
 ///       p.children.first()
 ///     }
@@ -50,7 +50,7 @@ use crate::loading::{DataSource, Load, Readable};
 ///
 /// #let data = xml("example.xml")
 /// #for elem in data.first().children {
-///   if (type(elem) == dictionary) {
+///   if type(elem) == dictionary {
 ///     article(elem)
 ///   }
 /// }

--- a/crates/typst-library/src/loading/xml.rs
+++ b/crates/typst-library/src/loading/xml.rs
@@ -34,7 +34,7 @@ use crate::loading::{DataSource, Load, Readable};
 ///   let author = find-child(elem, "author")
 ///   let pars = find-child(elem, "content")
 ///
-///   heading(title.children.first())
+///   [= #title.children.first()]
 ///   text(10pt, weight: "medium")[
 ///     Published by
 ///     #author.children.first()


### PR DESCRIPTION
In v13 `type` doesn't return a string anymore, but a type. So it has to be changed from `type(it) == "dictionary"` to `type(it) == dictionary`.
