### PR TITLE
Fix debug implementation of Recipe

### DIFF
--- a/crates/typst-library/src/foundations/styles.rs
+++ b/crates/typst-library/src/foundations/styles.rs
@@ -471,7 +471,8 @@ impl Debug for Recipe {
             selector.fmt(f)?;
             f.write_str(", ")?;
         }
-        self.transform.fmt(f)
+        self.transform.fmt(f)?;
+        f.write_str(")")
     }
 }
 


### PR DESCRIPTION
While I was decrypting https://github.com/typst/typst/issues/5690, I added

```rs
        dbg!(&styled.child);
        dbg!(&styled.styles);
```

to

https://github.com/typst/typst/blob/16948bd712e9f3b93cf2a8c7739d9528e15f7a23/crates/typst-realize/src/lib.rs?plain=1#L261

Which showed:

```rs
[crates/typst-realize/src/lib.rs:265:9] &styled.styles = Styles [
    Show(Elem(
        Element(par),
        None,
    ), Func(box),
]
```

Which doesn't print the same amount of closing parentheses as opened ones.
