### PR TITLE
Mention that `sym.ohm` was removed in the 0.13.0 changelog

### DIFF
--- a/docs/changelog/0.13.0.md
+++ b/docs/changelog/0.13.0.md
@@ -294,7 +294,6 @@ feature flag.
     `errorbar.diamond.stroked`, `errorbar.diamond.filled`,
     `errorbar.circle.stroked`, `errorbar.circle.filled`
   - `numero`
-  - `Omega.inv`
 - Renamed
   - `ohm.inv` to `Omega.inv`
 - Changed codepoint

--- a/docs/changelog/0.13.0.md
+++ b/docs/changelog/0.13.0.md
@@ -308,6 +308,7 @@ feature flag.
   - `degree.c` in favor of `°C` (`[$upright(°C)$]` or `[$upright(degree C)$]` in math)
   - `degree.f` in favor of `°F` (`[$upright(°F)$]` or `[$upright(degree F)$]` in math)
   - `kelvin` in favor of just K (`[$upright(K)$]` in math)
+  - `ohm` in favor of `Omega`
 
 ## Deprecations
 - The [`path`] function in favor of the [`curve`] function


### PR DESCRIPTION
See https://github.com/typst/codex/issues/52#issuecomment-2703756070. This should be part of whatever the next version of Typst is, so likely 0.13.1.