### PR TITLE
Document exceptions and alternatives to using `type`

### DIFF
--- a/crates/typst-library/src/foundations/ty.rs
+++ b/crates/typst-library/src/foundations/ty.rs
@@ -45,21 +45,16 @@ use crate::foundations::{
 /// #type(type)
 /// ```
 ///
-/// [none]($none) and [auto]($auto) are more special. Because they are the only
-/// values of their type, their type isn't actually bound to any name.
-/// ```example
-/// type(none) == none: #{ type(none) == none } \
-/// type(auto) == auto: #{ type(auto) == auto }
-/// ```
-/// Instead, to test for these _values_, compare to them directly:
+/// [none]($none) and [auto]($auto) do not have a name representing them like other types such as
+/// `int`. To test a value to see if it is either of these, compare your value to them directly,
+/// eg:
 /// ```example
 /// #let empty = none
 /// empty is none: #{ empty == none }
 /// ```
 ///
-/// Note that `type` is used for "high level" comparisons, such as whether a variable is `content`
-/// vs `int`. See [func]($content.func) to programmatically determine which _element_ a variable
-/// is.
+/// Note that `type` is used to test for a variables type. To programmatically determine which
+/// _element_ a variable is, see [func]($content.func)
 #[ty(scope, cast)]
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Type(Static<NativeTypeData>);

--- a/crates/typst-library/src/foundations/ty.rs
+++ b/crates/typst-library/src/foundations/ty.rs
@@ -44,6 +44,22 @@ use crate::foundations::{
 /// #type(int) \
 /// #type(type)
 /// ```
+///
+/// [none]($none) and [auto]($auto) are more special. Because they are the only
+/// values of their type, their type isn't actually bound to any name.
+/// ```example
+/// type(none) == none: #{ type(none) == none } \
+/// type(auto) == auto: #{ type(auto) == auto }
+/// ```
+/// Instead, to test for these _values_, compare to them directly:
+/// ```example
+/// #let empty = none
+/// empty is none: #{ empty == none }
+/// ```
+///
+/// Note that `type` is used for "high level" comparisons, such as whether a variable is `content`
+/// vs `int`. See [func]($content.func) to programmatically determine which _element_ a variable
+/// is.
 #[ty(scope, cast)]
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Type(Static<NativeTypeData>);

--- a/crates/typst-library/src/foundations/ty.rs
+++ b/crates/typst-library/src/foundations/ty.rs
@@ -39,22 +39,25 @@ use crate::foundations::{
 /// #type(image("glacier.jpg")).
 /// ```
 ///
-/// The type of `10` is `int`. Now, what is the type of `int` or even `type`?
+/// The type of `{10}` is `int`. Now, what is the type of `int` or even `type`?
 /// ```example
 /// #type(int) \
 /// #type(type)
 /// ```
 ///
-/// [none]($none) and [auto]($auto) do not have a name representing them like other types such as
-/// `int`. To test a value to see if it is either of these, compare your value to them directly,
-/// eg:
+/// Unlike other types like `int`, [none] and [auto] do not have a name
+/// representing them. To test if a value is one of these, compare your value to
+/// them directly, e.g:
 /// ```example
-/// #let empty = none
-/// empty is none: #{ empty == none }
+/// #let val = none
+/// #if val == none [
+///   Yep, it's none.
+/// ]
 /// ```
 ///
-/// Note that `type` is used to test for a variables type. To programmatically determine which
-/// _element_ a variable is, see [func]($content.func)
+/// Note that `type` will return [`content`] for all document elements. To
+/// programmatically determine which kind of content you are dealing with, see
+/// [`content.func`].
 #[ty(scope, cast)]
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Type(Static<NativeTypeData>);


### PR DESCRIPTION
`none` and `auto` interact differently with `type` than other types. This adds documentation and examples making that clear.
Further, it explains when it is better to use other interrogation functions in Typst.
Closes #2177