### PR TITLE
Disallow empty font lists

### DIFF
--- a/crates/typst-library/src/text/mod.rs
+++ b/crates/typst-library/src/text/mod.rs
@@ -173,7 +173,7 @@ pub struct TextElem {
     /// for the most similar one that has the necessary glyphs.
     ///
     /// _Note:_ Currently, there are no warnings when fallback is disabled and
-    /// no glyphs are found. Instead, your text may shows up in the form of
+    /// no glyphs are found. Instead, your text may show up in the form of
     /// "tofus" (small boxes that indicate the lack of an appropriate glyph), or
     /// even just not show anything. In the future, you will be able to instruct
     /// Typst to issue warnings so you know something is up.

--- a/crates/typst-library/src/text/mod.rs
+++ b/crates/typst-library/src/text/mod.rs
@@ -173,10 +173,10 @@ pub struct TextElem {
     /// for the most similar one that has the necessary glyphs.
     ///
     /// _Note:_ Currently, there are no warnings when fallback is disabled and
-    /// no glyphs are found. Instead, your text may show up in the form of
-    /// "tofus" (small boxes that indicate the lack of an appropriate glyph), or
-    /// even just not show anything. In the future, you will be able to instruct
-    /// Typst to issue warnings so you know something is up.
+    /// no glyphs are found. Instead, your text shows up in the form of "tofus":
+    /// Small boxes that indicate the lack of an appropriate glyph. In the
+    /// future, you will be able to instruct Typst to issue warnings so you know
+    /// something is up.
     ///
     /// ```example
     /// #set text(font: "Inria Serif")

--- a/crates/typst-library/src/text/mod.rs
+++ b/crates/typst-library/src/text/mod.rs
@@ -899,7 +899,7 @@ pub struct FontList(pub Vec<FontFamily>);
 impl FontList {
     pub fn new(fonts: Vec<FontFamily>) -> StrResult<Self> {
         if fonts.is_empty() {
-            bail!("font fallback list should not be empty")
+            bail!("font fallback list must not be empty")
         } else {
             Ok(Self(fonts))
         }

--- a/crates/typst-library/src/text/mod.rs
+++ b/crates/typst-library/src/text/mod.rs
@@ -173,10 +173,10 @@ pub struct TextElem {
     /// for the most similar one that has the necessary glyphs.
     ///
     /// _Note:_ Currently, there are no warnings when fallback is disabled and
-    /// no glyphs are found. Instead, your text shows up in the form of "tofus":
-    /// Small boxes that indicate the lack of an appropriate glyph. In the
-    /// future, you will be able to instruct Typst to issue warnings so you know
-    /// something is up.
+    /// no glyphs are found. Instead, your text may shows up in the form of
+    /// "tofus" (small boxes that indicate the lack of an appropriate glyph), or
+    /// even just not show anything. In the future, you will be able to instruct
+    /// Typst to issue warnings so you know something is up.
     ///
     /// ```example
     /// #set text(font: "Inria Serif")

--- a/tests/suite/text/font.typ
+++ b/tests/suite/text/font.typ
@@ -151,5 +151,5 @@ The number 123.
 a
 
 --- empty-text-font-array ---
-// Error: 17-19 font fallback list should not be empty
+// Error: 17-19 font fallback list must not be empty
 #set text(font: ())

--- a/tests/suite/text/font.typ
+++ b/tests/suite/text/font.typ
@@ -149,3 +149,7 @@ The number 123.
 #set text(-1pt)
 
 a
+
+--- empty-text-font-array ---
+// Error: 17-19 font fallback list should not be empty
+#set text(font: ())


### PR DESCRIPTION
This PR disallows passing an empty array as `text.font`. I also improved the documentation for `text.fallback`: with the default text font (Libertinus Serif), there are no tofu glyphs.