### PR TITLE
Added Russian numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,34 +104,22 @@ Let's dissect what's going on:
 </details>
 
 ## Installation
+It is installation of my unofficial package.
+
 Typst's CLI is available from different sources:
 
 - You can get sources and pre-built binaries for the latest release of Typst
-  from the [releases page][releases]. Download the archive for your platform and
-  place it in a directory that is in your `PATH`. To stay up to date with future
-  releases, you can simply run `typst update`.
+  from the [releases](https://github.com/NoAIHelper/typst/releases). Download the archive for your platform and
+  place it in a directory that is in your `PATH`.
 
 - You can install Typst through different package managers. Note that the
   versions in the package managers might lag behind the latest release.
-  - Linux: 
-      - View [Typst on Repology][repology]
-      - View [Typst's Snap][snap]
-  - macOS: `brew install typst`
-  - Windows: `winget install --id Typst.Typst`
+  - Windows: download all files from [manifests folder](manifests/n/NoAIHelper/Typst/0.13.1) and install with command
+    `winget install -m path/to/manifests/folder/where/all/files`
 
 - If you have a [Rust][rust] toolchain installed, you can install
-  - the latest released Typst version with
-    `cargo install --locked typst-cli`
-  - a development version with
-    `cargo install --git https://github.com/typst/typst --locked typst-cli`
-
-- Nix users can
-  - use the `typst` package with `nix-shell -p typst`
-  - build and run a development version with
-    `nix run github:typst/typst -- --version`.
-
-- Docker users can run a prebuilt image with
-  `docker run ghcr.io/typst/typst:latest --help`.
+  - git clone or download zip and compile from source
+    `cargo build --release`
 
 ## Usage
 Once you have installed Typst, you can use it like this:

--- a/crates/typst-library/src/model/numbering.rs
+++ b/crates/typst-library/src/model/numbering.rs
@@ -257,6 +257,10 @@ pub enum NumberingKind {
     LowerLatin,
     /// Uppercase Latin letters (A, B, C, etc.). Items beyond Z use base-26.
     UpperLatin,
+    /// Lowercase Russian letters (а, б, в, etc.). Items beyond я use base-28. Excluding some letters (ё, й, ъ, ы, ь)
+    LowerRussian,
+    /// Uppercase Russian letters (А, Б, В, etc.). Items beyond Я use base-28. Excluding some letters (Ё, Й, Ъ, Ы, Ь)
+    UpperRussian,
     /// Lowercase Roman numerals (i, ii, iii, etc.).
     LowerRoman,
     /// Uppercase Roman numerals (I, II, III, etc.).
@@ -323,6 +327,8 @@ impl NumberingKind {
             '1' => NumberingKind::Arabic,
             'a' => NumberingKind::LowerLatin,
             'A' => NumberingKind::UpperLatin,
+            'а' => NumberingKind::LowerRussian,
+            'А' => NumberingKind::UpperRussian,
             'i' => NumberingKind::LowerRoman,
             'I' => NumberingKind::UpperRoman,
             'α' => NumberingKind::LowerGreek,
@@ -354,6 +360,8 @@ impl NumberingKind {
             Self::Arabic => '1',
             Self::LowerLatin => 'a',
             Self::UpperLatin => 'A',
+            Self::LowerRussian => 'а',
+            Self::UpperRussian => 'А',
             Self::LowerRoman => 'i',
             Self::UpperRoman => 'I',
             Self::LowerGreek => 'α',
@@ -409,6 +417,20 @@ impl NumberingKind {
                 [
                     'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N',
                     'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+                ],
+                n,
+            ),
+            Self::LowerRussian => zeroless(
+                [
+                    'а', 'б', 'в', 'г', 'д', 'е', 'ж', 'з', 'и', 'к', 'л', 'м', 'н', 'о',
+                    'п', 'р', 'с', 'т', 'у', 'ф', 'х', 'ц', 'ч', 'ш', 'щ', 'э', 'ю', 'я',
+                ],
+                n,
+            ),
+            Self::UpperRussian => zeroless(
+                [
+                    'А', 'Б', 'В', 'Г', 'Д', 'Е', 'Ж', 'З', 'И', 'К', 'Л', 'М', 'Н', 'О',
+                    'П', 'Р', 'С', 'Т', 'У', 'Ф', 'Х', 'Ц', 'Ч', 'Ш', 'Щ', 'Э', 'Ю', 'Я',
                 ],
                 n,
             ),

--- a/manifests/n/NoAIHelper/Typst/0.13.1/NoAIHelper.Typst.installer.yaml
+++ b/manifests/n/NoAIHelper/Typst/0.13.1/NoAIHelper.Typst.installer.yaml
@@ -1,0 +1,24 @@
+# Created using wingetcreate 1.9.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: NoAIHelper.Typst
+PackageVersion: 0.13.1
+InstallerType: zip
+NestedInstallerType: portable
+ArchiveBinariesDependOnPath: true
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: typst-x86_64-pc-windows-msvc\typst.exe
+    PortableCommandAlias: typst
+  InstallerUrl: https://github.com/NoAIHelper/typst/releases/download/v0.13.1/typst-x86_64-pc-windows-msvc.zip
+  InstallerSha256: E94B75BD3A07C50AC70327CA31B1922AC7CE3AECC84E800CC6E30F266C3BB890
+- Architecture: x86
+  NestedInstallerFiles:
+  - RelativeFilePath: typst-i686-pc-windows-msvc\typst.exe
+    PortableCommandAlias: typst
+  InstallerUrl: https://github.com/NoAIHelper/typst/releases/download/v0.13.1/typst-i686-pc-windows-msvc.zip
+  InstallerSha256: 3CEDE9260F1E51FDED020B0596CC39261F9F0AB4C68646A83749ABEFD37352F6
+ManifestType: installer
+ManifestVersion: 1.9.0
+ReleaseDate: 2025-03-15

--- a/manifests/n/NoAIHelper/Typst/0.13.1/NoAIHelper.Typst.locale.en-US.yaml
+++ b/manifests/n/NoAIHelper/Typst/0.13.1/NoAIHelper.Typst.locale.en-US.yaml
@@ -1,0 +1,15 @@
+# Created using wingetcreate 1.9.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: NoAIHelper.Typst
+PackageVersion: 0.13.1
+PackageLocale: en-US
+Publisher: NoAIHelper
+PublisherUrl: https://github.com/NoAIHelper
+PackageName: Typst
+PackageUrl: https://github.com/NoAIHelper/typst
+License: Apache-2.0
+ShortDescription: A new markup-based typesetting system that is powerful and easy to learn.
+ReleaseNotesUrl: https://github.com/NoAIHelper/typst/releases/tag/v0.13.1
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/n/NoAIHelper/Typst/0.13.1/NoAIHelper.Typst.yaml
+++ b/manifests/n/NoAIHelper/Typst/0.13.1/NoAIHelper.Typst.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.9.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: NoAIHelper.Typst
+PackageVersion: 0.13.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
There is of course a way of Russian numbering. For example, [this](https://github.com/typst/typst/issues/1595#issuecomment-1609971882). However, I think it's better to add native support.

In this case, it looks like you will have to make changes to custom packages. For example, in [subpar](https://github.com/tingerrr/subpar). However, this means that you only need to add one line of code [(this)](https://github.com/tingerrr/subpar/blob/c61eafeba2bcc7eedd65ff0870699250e70dcad1/src/util.typ#L144).

That is, replace
```typst
   let symbols = ("1", "a", "A", "i", "I", "い", "イ", "א", "가", "ㄱ", "\\*")
```
to
```typst
   let symbols = ("1", "a", "A", "а", "А", "i", "I", "い", "イ", "א", "가", "ㄱ", "\\*")
````