### PR TITLE
Add `input-file` CLI argument and `sys.input-files` variable

### DIFF
--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -112,6 +112,12 @@ impl SystemWorld {
                 .map(|(k, v)| (k.as_str().into(), v.as_str().into_value()))
                 .collect();
 
+            let input_files: Dict = world_args
+                .input_files
+                .iter()
+                .map(|(k, v)| (k.as_str().into(), Bytes::new(v.to_owned()).into_value()))
+                .collect();
+
             let features = process_args
                 .features
                 .iter()
@@ -120,7 +126,11 @@ impl SystemWorld {
                 })
                 .collect();
 
-            Library::builder().with_inputs(inputs).with_features(features).build()
+            Library::builder()
+                .with_inputs(inputs)
+                .with_input_files(input_files)
+                .with_features(features)
+                .build()
         };
 
         let fonts = Fonts::searcher()

--- a/crates/typst-library/src/foundations/mod.rs
+++ b/crates/typst-library/src/foundations/mod.rs
@@ -86,7 +86,12 @@ use crate::routines::EvalMode;
 use crate::{Feature, Features};
 
 /// Hook up all `foundations` definitions.
-pub(super) fn define(global: &mut Scope, inputs: Dict, features: &Features) {
+pub(super) fn define(
+    global: &mut Scope,
+    inputs: Dict,
+    input_files: Dict,
+    features: &Features,
+) {
     global.start_category(crate::Category::Foundations);
     global.define_type::<bool>();
     global.define_type::<i64>();
@@ -117,7 +122,7 @@ pub(super) fn define(global: &mut Scope, inputs: Dict, features: &Features) {
         global.define_func::<target>();
     }
     global.define("calc", calc::module());
-    global.define("sys", sys::module(inputs));
+    global.define("sys", sys::module(inputs, input_files));
     global.reset_category();
 }
 

--- a/crates/typst-library/src/foundations/sys.rs
+++ b/crates/typst-library/src/foundations/sys.rs
@@ -3,7 +3,7 @@
 use crate::foundations::{Dict, Module, Scope, Version};
 
 /// A module with system-related things.
-pub fn module(inputs: Dict) -> Module {
+pub fn module(inputs: Dict, input_files: Dict) -> Module {
     let mut scope = Scope::deduplicating();
     scope.define(
         "version",
@@ -14,5 +14,6 @@ pub fn module(inputs: Dict) -> Module {
         ]),
     );
     scope.define("inputs", inputs);
+    scope.define("input-files", input_files);
     Module::new("sys", scope)
 }

--- a/crates/typst-library/src/lib.rs
+++ b/crates/typst-library/src/lib.rs
@@ -174,6 +174,7 @@ impl Default for Library {
 #[derive(Debug, Clone, Default)]
 pub struct LibraryBuilder {
     inputs: Option<Dict>,
+    input_files: Option<Dict>,
     features: Features,
 }
 
@@ -181,6 +182,12 @@ impl LibraryBuilder {
     /// Configure the inputs visible through `sys.inputs`.
     pub fn with_inputs(mut self, inputs: Dict) -> Self {
         self.inputs = Some(inputs);
+        self
+    }
+
+    /// Configure the input files visible through `sys.input-files`.
+    pub fn with_input_files(mut self, input_files: Dict) -> Self {
+        self.input_files = Some(input_files);
         self
     }
 
@@ -196,7 +203,8 @@ impl LibraryBuilder {
     pub fn build(self) -> Library {
         let math = math::module();
         let inputs = self.inputs.unwrap_or_default();
-        let global = global(math.clone(), inputs, &self.features);
+        let input_files = self.input_files.unwrap_or_default();
+        let global = global(math.clone(), inputs, input_files, &self.features);
         Library {
             global: global.clone(),
             math,
@@ -278,10 +286,10 @@ impl Category {
 }
 
 /// Construct the module with global definitions.
-fn global(math: Module, inputs: Dict, features: &Features) -> Module {
+fn global(math: Module, inputs: Dict, input_files: Dict, features: &Features) -> Module {
     let mut global = Scope::deduplicating();
 
-    self::foundations::define(&mut global, inputs, features);
+    self::foundations::define(&mut global, inputs, input_files, features);
     self::model::define(&mut global);
     self::text::define(&mut global);
     self::layout::define(&mut global);

--- a/docs/reference/groups.yml
+++ b/docs/reference/groups.yml
@@ -151,6 +151,14 @@
       The value is always of type [string]($str). More complex data
       may be parsed manually using functions like [`json.decode`]($json.decode).
 
+    - The `sys.input-files` [dictionary], which makes external files
+      available to the project. An input specified in the command line as
+      `--input key=path` becomes available under `sys.input-files.key` as
+      the content of the specified file. To include spaces in the path, it may
+      be enclosed with single or double quotes.
+
+      The value is always of type [byte buffers]($bytes).
+
 - name: sym
   title: General
   category: symbols


### PR DESCRIPTION
### Details
- #5978

### Implementation
I followed the existing `inputs` implementation. However, there are no tests, so I put a manual test below.

One thing I noticed, is the missing file path resolution in the Fish shell (works for Bash). For example, when writing 

```sh
typst c --input-file el=~/test.el test.typ
```
and the file exists, then we can not resolve that path. `std::fs::canonicalize` does not resolve `~` for us. The command fails with the error code: `~/test.el ` does not exist. As a result, Fish users will get this rather unexpected error. Might also be a bug in the Fish shell so I am not sure.

### Manual Test
> test.typ
> ```typst
> #raw(str(sys.input-files.el), lang: "lisp")
> ```

> test.el
> ```elisp
> (message "hi")
> ```

```sh
typst c --input-file el=./test.el test.typ
```