### PR TITLE
Expand page breaks' triggers for page(height: auto) in docs

### DIFF
--- a/crates/typst-library/src/layout/page.rs
+++ b/crates/typst-library/src/layout/page.rs
@@ -75,9 +75,10 @@ pub struct PageElem {
     /// The height of the page.
     ///
     /// If this is set to `{auto}`, page breaks can only be triggered manually
-    /// by inserting a [page break]($pagebreak). Most examples throughout this
-    /// documentation use `{auto}` for the height of the page to dynamically
-    /// grow and shrink to fit their content.
+    /// by inserting a [page break]($pagebreak) or by adding another non-empty
+    /// page set rule. Most examples throughout this documentation use `{auto}`
+    /// for the height of the page to dynamically grow and shrink to fit their
+    /// content.
     #[resolve]
     #[parse(
         args.named("height")?


### PR DESCRIPTION
Page breaks can only be triggered with `pagebreak()` or `set page(a: b)`, but not with `set page()`.
