### PR TITLE
Warn on last show/set rule in block

### DIFF
--- a/tests/suite/styling/in-block.typ
+++ b/tests/suite/styling/in-block.typ
@@ -1,0 +1,12 @@
+--- warn-show-set-last-in-block ---
+#{
+// Warning: 1-14 show rule has no effect
+// Hint: 1-14 See https://typst.app/docs/tutorial/making-a-template/#set-and-show-rules
+show "a": "b"
+}
+
+#{
+// Warning: 1-15 set rule has no effect
+// Hint: 1-15 See https://typst.app/docs/tutorial/making-a-template/#set-and-show-rules
+set text(blue)
+}


### PR DESCRIPTION
Closes #6082

The warning itself may be a bit low quality, so some feedback on that would be greatly appreciated.

I wasn't sure where to put this test, so I made a new file for it. Any other suggestions are welcome too.

Also, this causes two tests to fail that didn't before, probably as part of the test suite putting stuff into a block; Not sure what to do about that.

Also Also, maybe this is too simple of an approach and it would be better to check if there's any content after the last show/set rule. But that could also be left to a future PR.