### PR TITLE
Fix typo

### DIFF
--- a/crates/typst-library/src/visualize/shape.rs
+++ b/crates/typst-library/src/visualize/shape.rs
@@ -106,7 +106,7 @@ pub struct RectElem {
     pub radius: Corners<Option<Rel<Length>>>,
 
     /// How much to pad the rectangle's content.
-    /// See the [box's documentation]($box.outset) for more details.
+    /// See the [box's documentation]($box.inset) for more details.
     #[resolve]
     #[fold]
     #[default(Sides::splat(Some(Abs::pt(5.0).into())))]


### PR DESCRIPTION
The docstring of the inset parameter should link to box's inset, not outset