### PR TITLE
fix(ci): include rust-src in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,11 @@
         pname = "typst";
         version = cargoToml.workspace.package.version;
 
-        rust-toolchain = (fenix.packages.${system}.fromManifestFile rust-manifest).defaultToolchain;
+        rust-toolchain = fenix.packages.${system}.combine [
+            (fenix.packages.${system}.fromManifestFile
+              rust-manifest).defaultToolchain
+            (fenix.packages.${system}.fromManifestFile rust-manifest).rust-src
+        ];
 
         # Crane-based Nix flake configuration.
         # Based on https://github.com/ipetkov/crane/blob/master/examples/trunk-workspace/flake.nix
@@ -126,6 +130,12 @@
         devShells.default = craneLib.devShell {
           checks = self'.checks;
           inputsFrom = [ typst ];
+
+          # Set environment variables for rust-analyzer
+          shellHook = ''
+            export RUST_SRC_PATH="${rust-toolchain}/lib/rustlib/src/rust/library"
+            export RUST_BACKTRACE=1
+          '';
 
           packages = [
             # A script for quickly running tests.


### PR DESCRIPTION
rust-src was not available in the flake.nix, breaking rust-analyzer when using nix develop. 
I tried to capture the before and after here, but the red squiggly lines did not show up, you will notice that I cannot do lsp actions before and then can after. 
https://asciinema.org/a/XzG8hoWcLV5NLPSkIgKGSo80i
Fixes #6105 
