### PR TITLE
Added callsite to func calls in tracing

### DIFF
--- a/crates/typst-library/src/foundations/func.rs
+++ b/crates/typst-library/src/foundations/func.rs
@@ -298,7 +298,7 @@ impl Func {
     }
 
     /// Non-generic implementation of `call`.
-    #[typst_macros::time(name = "func call", span = self.span())]
+    #[typst_macros::time(name = "func call", span = self.span(), callsite = args.span)]
     fn call_impl(
         &self,
         engine: &mut Engine,

--- a/crates/typst-macros/src/time.rs
+++ b/crates/typst-macros/src/time.rs
@@ -8,12 +8,13 @@ use crate::util::{kw, parse_key_value, parse_string};
 /// Expand the `#[time(..)]` macro.
 pub fn time(stream: TokenStream, item: syn::ItemFn) -> Result<TokenStream> {
     let meta: Meta = syn::parse2(stream)?;
-    Ok(create(meta, item))
+    create(meta, item)
 }
 
 /// The `..` in `#[time(..)]`.
 pub struct Meta {
     pub span: Option<syn::Expr>,
+    pub callsite: Option<syn::Expr>,
     pub name: Option<String>,
 }
 
@@ -22,15 +23,24 @@ impl Parse for Meta {
         Ok(Self {
             name: parse_string::<kw::name>(input)?,
             span: parse_key_value::<kw::span, syn::Expr>(input)?,
+            callsite: parse_key_value::<kw::callsite, syn::Expr>(input)?,
         })
     }
 }
 
-fn create(meta: Meta, mut item: syn::ItemFn) -> TokenStream {
+fn create(meta: Meta, mut item: syn::ItemFn) -> Result<TokenStream> {
     let name = meta.name.unwrap_or_else(|| item.sig.ident.to_string());
-    let construct = match meta.span.as_ref() {
-        Some(span) => quote! { with_span(#name, Some(#span.into_raw())) },
-        None => quote! { new(#name) },
+    let construct = match (meta.span.as_ref(), meta.callsite.as_ref()) {
+        (Some(span), Some(callsite)) => quote! {
+            with_callsite(#name, Some(#span.into_raw()), Some(#callsite.into_raw()))
+        },
+        (Some(span), None) => quote! {
+            with_span(#name, Some(#span.into_raw()))
+        },
+        (None, Some(expr)) => {
+            bail!(expr, "cannot have a callsite span without a main span")
+        }
+        (None, None) => quote! { new(#name) },
     };
 
     item.block.stmts.insert(
@@ -40,5 +50,5 @@ fn create(meta: Meta, mut item: syn::ItemFn) -> TokenStream {
         },
     );
 
-    item.into_token_stream()
+    Ok(item.into_token_stream())
 }

--- a/crates/typst-macros/src/util.rs
+++ b/crates/typst-macros/src/util.rs
@@ -254,6 +254,7 @@ impl Parse for BareType {
 pub mod kw {
     syn::custom_keyword!(name);
     syn::custom_keyword!(span);
+    syn::custom_keyword!(callsite);
     syn::custom_keyword!(title);
     syn::custom_keyword!(scope);
     syn::custom_keyword!(contextual);


### PR DESCRIPTION
Adds callsite information in tracing of function calls.

Not sure how useful this is to others, but I needed it for optimizing codly, figured it could be useful more generally. It's a bit bigger than I would have liked :/

![image](https://github.com/user-attachments/assets/7fe29377-e14c-45de-a561-3da2e3131be6)
