### PR TITLE
Make `World::font` implementations safe

### DIFF
--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -210,7 +210,9 @@ impl World for SystemWorld {
     }
 
     fn font(&self, index: usize) -> Option<Font> {
-        self.fonts[index].get()
+        // comemo's validation may invoke this function with an invalid index. This is
+        // impossible in typst-cli but possible if a custom tool mutates the fonts.
+        self.fonts.get(index)?.get()
     }
 
     fn today(&self, offset: Option<i64>) -> Option<Datetime> {

--- a/crates/typst-ide/src/tests.rs
+++ b/crates/typst-ide/src/tests.rs
@@ -97,7 +97,7 @@ impl World for TestWorld {
     }
 
     fn font(&self, index: usize) -> Option<Font> {
-        Some(self.base.fonts[index].clone())
+        self.base.fonts.get(index).cloned()
     }
 
     fn today(&self, _: Option<i64>) -> Option<Datetime> {

--- a/docs/src/html.rs
+++ b/docs/src/html.rs
@@ -498,7 +498,7 @@ impl World for DocWorld {
     }
 
     fn font(&self, index: usize) -> Option<Font> {
-        Some(FONTS.1[index].clone())
+        FONTS.1.get(index).cloned()
     }
 
     fn today(&self, _: Option<i64>) -> Option<Datetime> {

--- a/tests/src/world.rs
+++ b/tests/src/world.rs
@@ -67,7 +67,7 @@ impl World for TestWorld {
     }
 
     fn font(&self, index: usize) -> Option<Font> {
-        Some(self.base.fonts[index].clone())
+        self.base.fonts.get(index).cloned()
     }
 
     fn today(&self, _: Option<i64>) -> Option<Datetime> {


### PR DESCRIPTION
This is not a fix because typst-cli doesn't watch and mutate fonts, but people usually start their world implementation from copying code from typst-cli. Considering this, it is worth to adding some educational comment. Not sure whether we should update `trait World`'s comment, because all of such functions has similar pitfall.