### PR TITLE
Precisely find label definition

### DIFF
--- a/crates/typst-eval/src/markup.rs
+++ b/crates/typst-eval/src/markup.rs
@@ -62,7 +62,7 @@ fn eval_markup<'a>(
                             ));
                         }
 
-                        *elem = std::mem::take(elem).labelled(label);
+                        *elem = std::mem::take(elem).labelled(label, expr.span());
                     } else {
                         vm.engine.sink.warn(warning!(
                             expr.span(),

--- a/crates/typst-ide/src/definition.rs
+++ b/crates/typst-ide/src/definition.rs
@@ -182,6 +182,12 @@ mod tests {
     #[test]
     fn test_definition_ref() {
         test("#figure[] <hi> See @hi", -2, Side::After).must_be_at("main.typ", 1..9);
+        let source =
+            r#"#let test1(body) = figure(body); #test1([Test1]) <fig:test1> @fig:test1"#;
+        test(source, -2, Side::After).must_be_at("main.typ", 19..31);
+        let source = r#"#let test1(body) = figure(body); #test1([Test1]) <fig:test1> @fig:test1
+#let test2(body) = test1(body); #test2([Test2]) <fig:test2>; @fig:test2"#;
+        test(source, -2, Side::After).must_be_at("main.typ", 19..31);
     }
 
     #[test]

--- a/crates/typst-ide/src/definition.rs
+++ b/crates/typst-ide/src/definition.rs
@@ -75,7 +75,10 @@ pub fn definition(
             let label = Label::new(PicoStr::intern(node.cast::<ast::Ref>()?.target()));
             let selector = Selector::Label(label);
             let elem = document?.introspector.query_first(&selector)?;
-            return Some(Definition::Span(elem.span()));
+            let labelled_at = elem.labelled_at().or(elem.span());
+            if !labelled_at.is_detached() {
+                return Some(Definition::Span(labelled_at));
+            }
         }
 
         _ => {}

--- a/crates/typst-ide/src/definition.rs
+++ b/crates/typst-ide/src/definition.rs
@@ -184,13 +184,13 @@ mod tests {
 
     #[test]
     fn test_definition_ref() {
-        test("#figure[] <hi> See @hi", -2, Side::After).must_be_at("main.typ", 1..9);
+        test("#figure[] <hi> See @hi", -2, Side::After).must_be_at("main.typ", 10..14);
         let source =
             r#"#let test1(body) = figure(body); #test1([Test1]) <fig:test1> @fig:test1"#;
-        test(source, -2, Side::After).must_be_at("main.typ", 19..31);
+        test(source, -2, Side::After).must_be_at("main.typ", 49..60);
         let source = r#"#let test1(body) = figure(body); #test1([Test1]) <fig:test1> @fig:test1
 #let test2(body) = test1(body); #test2([Test2]) <fig:test2>; @fig:test2"#;
-        test(source, -2, Side::After).must_be_at("main.typ", 19..31);
+        test(source, -2, Side::After).must_be_at("main.typ", 120..131);
     }
 
     #[test]

--- a/crates/typst-library/src/foundations/content.rs
+++ b/crates/typst-library/src/foundations/content.rs
@@ -82,6 +82,8 @@ pub struct Content {
 struct Inner<T: ?Sized + 'static> {
     /// An optional label attached to the element.
     label: Option<Label>,
+    /// The span where the label is attached.
+    labelled_at: Span,
     /// The element's location which identifies it in the layouted output.
     location: Option<Location>,
     /// Manages the element during realization.
@@ -101,6 +103,7 @@ impl Content {
                 label: None,
                 location: None,
                 lifecycle: SmallBitSet::new(),
+                labelled_at: Span::detached(),
                 elem: elem.into(),
             }),
             span: Span::detached(),
@@ -135,9 +138,16 @@ impl Content {
         self.inner.label
     }
 
-    /// Attach a label to the content.
-    pub fn labelled(mut self, label: Label) -> Self {
-        self.set_label(label);
+    /// Get the span where the label is attached.
+    pub fn labelled_at(&self) -> Span {
+        self.inner.labelled_at
+    }
+
+    /// Set the label of the content.
+    pub fn labelled(mut self, label: Label, labelled_at: Span) -> Self {
+        let m = self.make_mut();
+        m.label = Some(label);
+        m.labelled_at = labelled_at;
         self
     }
 
@@ -742,6 +752,7 @@ impl<T: NativeElement> Bounds for T {
                 location: inner.location,
                 lifecycle: inner.lifecycle.clone(),
                 elem: LazyHash::reuse(self.clone(), &inner.elem),
+                labelled_at: inner.labelled_at,
             }),
             span,
         }


### PR DESCRIPTION
https://github.com/Myriad-Dreamin/tinymist/issues/550 Proved that it is not quite precise to estimate the source location of a label by the span of the labelled element. This PR records and uses the spans where the labels are assigned.

See test cases to be more specific. Before the PR, the finder will give following results:

```typ
#figure[] <hi> See @hi
 ^^^^^^^^ <------- ^^^
#let test1(body) = figure(body); #test1([Test1]) <fig:test1> @fig:test1
                   ^^^^^^^^^^^^^ <-------------------------- ^^^^^^^^^^

#let test1(body) = figure(body);
                   ^^^^^^^^^^^^^ <-------------------------------------- 
#let test2(body) = test1(body); #test2([Test2]) <fig:test2>; @fig:test2|
                                                             ^^^^^^^^^^|
```

Now, we will tell the precise source location of the labels

```typ
#figure[] <hi> See @hi
          ^^^^ <-- ^^^
#let test1(body) = figure(body); #test1([Test1]) <fig:test1>    @fig:test1
                                                 ^^^^^^^^^^^ <- ^^^^^^^^^^

#let test1(body) = figure(body);
#let test2(body) = test1(body); #test2([Test2]) <fig:test2>;   @fig:test2
                                                ^^^^^^^^^^^ <- ^^^^^^^^^^
```

I also added the above examples as tests to prevent regression.

