### PR TITLE
Expose function representation

### DIFF
--- a/crates/typst-library/src/foundations/func.rs
+++ b/crates/typst-library/src/foundations/func.rs
@@ -144,7 +144,7 @@ pub struct Func {
 
 /// The different kinds of function representations.
 #[derive(Clone, PartialEq, Hash)]
-enum Repr {
+pub enum Repr {
     /// A native Rust function.
     Native(Static<NativeFuncData>),
     /// A function for an element.
@@ -352,6 +352,11 @@ impl Func {
             self.span = span;
         }
         self
+    }
+
+    /// The function's repr
+    pub fn inner(&self) -> &Repr {
+        &self.repr
     }
 }
 

--- a/crates/typst-library/src/foundations/mod.rs
+++ b/crates/typst-library/src/foundations/mod.rs
@@ -20,7 +20,7 @@ mod duration;
 mod element;
 mod fields;
 mod float;
-mod func;
+pub mod func;
 mod int;
 mod label;
 mod module;


### PR DESCRIPTION
This is required by analyzers to check functions case by case. Specifically, we can improve `param_completions` and `named_param_value_completions` then. It will definitely to provide more accessors on `Func` to avoid exposing the underlying func representation but it is harder to design. Therefore, simply exposing the func repr might be a good way to simplify. Only the downside imo is that functionalities depending on it will have to pay for future breaking changes.