### PR TITLE
Use the right multiplication symbol in expression tooltip

### DIFF
--- a/crates/typst-ide/src/tooltip.rs
+++ b/crates/typst-ide/src/tooltip.rs
@@ -86,7 +86,7 @@ fn expr_tooltip(world: &dyn IdeWorld, leaf: &LinkedNode) -> Option<Tooltip> {
                 *count += 1;
                 continue;
             } else if *count > 1 {
-                write!(pieces.last_mut().unwrap(), " (x{count})").unwrap();
+                write!(pieces.last_mut().unwrap(), " (×{count})").unwrap();
             }
         }
         pieces.push(value.repr());
@@ -95,7 +95,7 @@ fn expr_tooltip(world: &dyn IdeWorld, leaf: &LinkedNode) -> Option<Tooltip> {
 
     if let Some((_, count)) = last {
         if count > 1 {
-            write!(pieces.last_mut().unwrap(), " (x{count})").unwrap();
+            write!(pieces.last_mut().unwrap(), " (×{count})").unwrap();
         }
     }
 


### PR DESCRIPTION
When hovering over an expression, Typst can show a tooltip displaying its value. When the expression takes multiple values at runtime (such as within a loop, or within a function called multiple times), the first ten are displayed. In case multiple consecutive values are equal, they are displayed once with a "(×<i>n</i>)" mention.

Prior to this PR, the multiplication symbol was actually not a multiplication sign, but a lower case X. In addition to the actual multiplication sign looking better, it may also improve accessibility because × carries semantics that may be used by screen readers (I haven't tested, though).