### PR TITLE
Allow TYPST_PACKAGE_PATH to have a list of paths to search.

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -332,8 +332,8 @@ pub struct ProcessArgs {
 #[derive(Debug, Clone, Args)]
 pub struct PackageArgs {
     /// Custom path to local packages, defaults to system-dependent location.
-    #[clap(long = "package-path", env = "TYPST_PACKAGE_PATH", value_name = "DIR")]
-    pub package_path: Option<PathBuf>,
+    #[clap(long = "package-path", env = "TYPST_PACKAGE_PATH", value_name = "DIR", value_delimiter = ENV_PATH_SEP)]
+    pub package_path: Option<Vec<PathBuf>>,
 
     /// Custom path to package cache, defaults to system-dependent location.
     #[clap(


### PR DESCRIPTION
This allows for better modularity with wrappers and such.