### PR TITLE
Add an example of show-set `place.clearance` for figures in the doc

### DIFF
--- a/crates/typst-library/src/model/figure.rs
+++ b/crates/typst-library/src/model/figure.rs
@@ -132,6 +132,9 @@ pub struct FigureElem {
     ///   caption: [A glacier],
     ///   image("glacier.jpg", width: 60%),
     /// )
+    /// #show figure: set place(
+    ///   clearance: 1em,
+    /// )
     /// #lorem(60)
     /// ```
     pub placement: Option<Smart<VAlignment>>,

--- a/crates/typst-library/src/model/figure.rs
+++ b/crates/typst-library/src/model/figure.rs
@@ -125,15 +125,15 @@ pub struct FigureElem {
     ///
     /// ```example
     /// #set page(height: 200pt)
+    /// #show figure: set place(
+    ///   clearance: 1em,
+    /// )
     ///
     /// = Introduction
     /// #figure(
     ///   placement: bottom,
     ///   caption: [A glacier],
     ///   image("glacier.jpg", width: 60%),
-    /// )
-    /// #show figure: set place(
-    ///   clearance: 1em,
     /// )
     /// #lorem(60)
     /// ```


### PR DESCRIPTION
The doc reads:

> The gap between the main flow content and the floating figure is controlled by the [`clearance`](https://typst.app/docs/reference/layout/place/#parameters-clearance) argument on the `place` function.

This should be illustrated in the following example, because I doubt many users will intuitively understand that this means they can use this show-set rule.