### PR TITLE
Fix text overhang example in docs

### DIFF
--- a/crates/typst-library/src/text/mod.rs
+++ b/crates/typst-library/src/text/mod.rs
@@ -348,15 +348,17 @@ pub struct TextElem {
     /// This can make justification visually more pleasing.
     ///
     /// ```example
+    /// #set page(width: 220pt)
+    ///
     /// #set par(justify: true)
     /// This justified text has a hyphen in
-    /// the paragraph's first line. Hanging
+    /// the paragraph's second line. Hanging
     /// the hyphen slightly into the margin
     /// results in a clearer paragraph edge.
     ///
     /// #set text(overhang: false)
     /// This justified text has a hyphen in
-    /// the paragraph's first line. Hanging
+    /// the paragraph's second line. Hanging
     /// the hyphen slightly into the margin
     /// results in a clearer paragraph edge.
     /// ```


### PR DESCRIPTION
Closes #6050.

| Old | Current | New |
| - | - | - |
| ![old](https://github.com/user-attachments/assets/46f24fc2-a022-4696-9393-9c9b776b2a34) | ![cur](https://github.com/user-attachments/assets/9103b370-1430-4ea0-a3a6-b8bef835e3bf) | ![new](https://github.com/user-attachments/assets/171455bc-5b9e-4f78-9cdf-579a0bcb78ae) |
