### PR TITLE
Use the right field name for `figure.caption.position`

### DIFF
--- a/crates/typst-library/src/model/figure.rs
+++ b/crates/typst-library/src/model/figure.rs
@@ -457,7 +457,7 @@ impl Outlinable for Packed<FigureElem> {
 /// customize the appearance of captions for all figures or figures of a
 /// specific kind.
 ///
-/// In addition to its `pos` and `body`, the `caption` also provides the
+/// In addition to its `position` and `body`, the `caption` also provides the
 /// figure's `kind`, `supplement`, `counter`, and `numbering` as fields. These
 /// parts can be used in [`where`]($function.where) selectors and show rules to
 /// build a completely custom caption.


### PR DESCRIPTION
It's a bit annoying that synthesized fields are not listed automatically in the documentation (https://github.com/typst/typst/issues/6227), but at least for now let's make sure we list them under the right name.

Also, the documentation for `body` reads: "Can be used alongside `kind`, `supplement`, `counter`, `numbering`, and `location` to completely customize the caption." But there is no `location` field on `figure.caption`. Actually, there is no way to reproduce the default `figure.caption` show rule in Typst right now, because the `figure_location` field is internal.