### PR TITLE
Fix tracing of most field call expressions

### DIFF
--- a/crates/typst-eval/src/call.rs
+++ b/crates/typst-eval/src/call.rs
@@ -37,7 +37,12 @@ impl Eval for ast::FuncCall<'_> {
             let target = access.target();
             let field = access.field();
             match eval_field_call(target, field, args, span, vm)? {
-                FieldCall::Normal(callee, args) => (callee, args),
+                FieldCall::Normal(callee, args) => {
+                    if vm.inspected == Some(callee_span) {
+                        vm.trace(callee.clone());
+                    }
+                    (callee, args)
+                }
                 FieldCall::Resolved(value) => return Ok(value),
             }
         } else {

--- a/crates/typst-ide/src/tooltip.rs
+++ b/crates/typst-ide/src/tooltip.rs
@@ -371,4 +371,11 @@ mod tests {
         test(&world, -2, Side::Before).must_be_none();
         test(&world, -2, Side::After).must_be_text("This star imports `a`, `b`, and `c`");
     }
+
+    #[test]
+    fn test_tooltip_field_call() {
+        let world = TestWorld::new("#import \"other.typ\"\n#other.f()")
+            .with_source("other.typ", "#let f = (x) => 1");
+        test(&world, -4, Side::After).must_be_code("(..) => ..");
+    }
 }


### PR DESCRIPTION
Attempt to fix #6115 in the most straightforward way I could think of.

Since the `Eval` implementation for `typst_syntax::ast::FuncCall` evaluates all elements of a field call directly without returning to the general `Eval` implementation for expressions - it misses the trace point there. To compensate, add a separate trace point for field function calls specifically.

It is still unable to trace calls to the hard coded mutating methods on arrays and dicts.