### PR TITLE
Prohibit line breaks for UAX 14 Combining Marks (CM)

### DIFF
--- a/crates/typst-layout/src/inline/linebreak.rs
+++ b/crates/typst-layout/src/inline/linebreak.rs
@@ -693,6 +693,9 @@ fn breakpoints(p: &Preparation, mut f: impl FnMut(usize, Breakpoint)) {
             match lb.get(c) {
                 // Fix for: https://github.com/unicode-org/icu4x/issues/4146
                 LineBreak::Glue | LineBreak::WordJoiner | LineBreak::ZWJ => continue,
+                // From: https://www.unicode.org/reports/tr14/
+                // > Prohibit a line break between the character and the preceding character
+                LineBreak::CombiningMark => continue,
                 LineBreak::MandatoryBreak
                 | LineBreak::CarriageReturn
                 | LineBreak::LineFeed


### PR DESCRIPTION
Fixes #5489.

The `icu_segmentation` segmenter can return a `LineBreak::CombiningMark` (`CM`) which should in fact prohibit a line break between two characters.

See https://www.unicode.org/reports/tr14/
