### PR TITLE
Expand text link boxes by 0.25em in height

### DIFF
--- a/crates/typst-layout/src/inline/shaping.rs
+++ b/crates/typst-layout/src/inline/shaping.rs
@@ -327,7 +327,7 @@ impl<'a> ShapedText<'a> {
             offset += width;
         }
 
-        frame.modify(&FrameModifiers::get_in(self.styles));
+        frame.modify(&FrameModifiers::get_in(self.styles).set_text(self.styles));
         frame
     }
 

--- a/crates/typst-library/src/model/link.rs
+++ b/crates/typst-library/src/model/link.rs
@@ -10,7 +10,7 @@ use crate::foundations::{
 };
 use crate::html::{attr, tag, HtmlElem};
 use crate::introspection::Location;
-use crate::layout::{Em, Length, Position, Rel, Sides};
+use crate::layout::Position;
 use crate::text::TextElem;
 
 /// Links to a URL or a location in the document.
@@ -93,13 +93,6 @@ pub struct LinkElem {
     #[internal]
     #[ghost]
     pub current: Option<Destination>,
-
-    /// How much to expand the link box size without affecting the layout. See
-    /// the [box's documentation]($box.outset) for more details.
-    #[resolve]
-    #[fold]
-    #[default(Sides::splat(Some(Em::new(0.25).into())))]
-    pub box_outset: Sides<Option<Rel<Length>>>,
 }
 
 impl LinkElem {

--- a/crates/typst-library/src/model/link.rs
+++ b/crates/typst-library/src/model/link.rs
@@ -10,7 +10,7 @@ use crate::foundations::{
 };
 use crate::html::{attr, tag, HtmlElem};
 use crate::introspection::Location;
-use crate::layout::Position;
+use crate::layout::{Em, Length, Position, Rel, Sides};
 use crate::text::TextElem;
 
 /// Links to a URL or a location in the document.
@@ -93,6 +93,13 @@ pub struct LinkElem {
     #[internal]
     #[ghost]
     pub current: Option<Destination>,
+
+    /// How much to expand the link box size without affecting the layout. See
+    /// the [box's documentation]($box.outset) for more details.
+    #[resolve]
+    #[fold]
+    #[default(Sides::splat(Some(Em::new(0.25).into())))]
+    pub box_outset: Sides<Option<Rel<Length>>>,
 }
 
 impl LinkElem {


### PR DESCRIPTION
This improves #3620, altough completely "fixing" it would require expanding the link boxes to such a size they would overlap by default. 

```typ
= Introduction

#lorem(10)

Source @very_long_source

// #set link(box-outset: (top: 0.5em, bottom: 0.5em))

#bibliography("literature.yml")

#link("https://example.com", table(
  columns: (50pt, 50pt),
  [1], [2],
  [3], [4],
))
```

Before:
![image](https://github.com/user-attachments/assets/bb3ca188-5dc2-4db9-af58-daf60da79a4b)
After:
![image](https://github.com/user-attachments/assets/0203fa9e-c44f-4422-a465-d7ea9370647e)
