### PR TITLE
Use the infer crate to determine if pdf embeds should be compressed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfb"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
+dependencies = [
+ "byteorder",
+ "fnv",
+ "uuid",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,6 +1268,15 @@ dependencies = [
  "hashbrown 0.15.2",
  "rayon",
  "serde",
+]
+
+[[package]]
+name = "infer"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
+dependencies = [
+ "cfb",
 ]
 
 [[package]]
@@ -3127,6 +3147,7 @@ dependencies = [
  "comemo",
  "ecow",
  "image",
+ "infer",
  "krilla",
  "krilla-svg",
  "serde",
@@ -3429,6 +3450,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,17 +256,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cfb"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
-dependencies = [
- "byteorder",
- "fnv",
- "uuid",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1275,9 +1264,6 @@ name = "infer"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
-dependencies = [
- "cfb",
-]
 
 [[package]]
 name = "inotify"
@@ -3450,12 +3436,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "uuid"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ icu_segmenter = { version = "1.4", features = ["serde"] }
 if_chain = "1"
 image = { version = "0.25.5", default-features = false, features = ["png", "jpeg", "gif"] }
 indexmap = { version = "2", features = ["serde"] }
-infer = "0.19.0"
+infer = { version = "0.19.0", default-features = false }
 kamadak-exif = "0.6"
 krilla = { version = "0.4.0", default-features = false, features = ["raster-images", "comemo", "rayon"] }
 krilla-svg = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ icu_segmenter = { version = "1.4", features = ["serde"] }
 if_chain = "1"
 image = { version = "0.25.5", default-features = false, features = ["png", "jpeg", "gif"] }
 indexmap = { version = "2", features = ["serde"] }
+infer = "0.19.0"
 kamadak-exif = "0.6"
 krilla = { version = "0.4.0", default-features = false, features = ["raster-images", "comemo", "rayon"] }
 krilla-svg = "0.1.0"

--- a/crates/typst-pdf/Cargo.toml
+++ b/crates/typst-pdf/Cargo.toml
@@ -23,6 +23,7 @@ bytemuck = { workspace = true }
 comemo = { workspace = true }
 ecow = { workspace = true }
 image = { workspace = true }
+infer = { workspace = true }
 krilla = { workspace = true }
 krilla-svg = { workspace = true }
 serde = { workspace = true }

--- a/crates/typst-pdf/src/embed.rs
+++ b/crates/typst-pdf/src/embed.rs
@@ -56,7 +56,7 @@ pub(crate) fn embed_files(
 
 fn should_compress(data: &[u8]) -> bool {
     let Some(ty) = infer::get(data) else {
-        return false;
+        return true;
     };
     match ty.matcher_type() {
         infer::MatcherType::App => true,

--- a/crates/typst-pdf/src/embed.rs
+++ b/crates/typst-pdf/src/embed.rs
@@ -60,14 +60,64 @@ fn should_compress(data: &[u8]) -> bool {
     };
     match ty.matcher_type() {
         infer::MatcherType::App => true,
-        infer::MatcherType::Archive => false,
-        infer::MatcherType::Audio => false,
+        infer::MatcherType::Archive => match ty.mime_type() {
+            #[rustfmt::skip]
+            "application/zip"
+            | "application/vnd.rar"
+            | "application/gzip"
+            | "application/x-bzip2"
+            | "application/vnd.bzip3"
+            | "application/x-7z-compressed"
+            | "application/x-xz"
+            | "application/vnd.ms-cab-compressed"
+            | "application/vnd.debian.binary-package"
+            | "application/x-compress"
+            | "application/x-lzip"
+            | "application/x-rpm"
+            | "application/zstd"
+            | "application/x-lz4"
+            | "application/x-ole-storage" => false,
+            _ => true,
+        },
+        infer::MatcherType::Audio => match ty.mime_type() {
+            #[rustfmt::skip]
+            "audio/mpeg"
+            | "audio/m4a"
+            | "audio/opus"
+            | "audio/ogg"
+            | "audio/x-flac"
+            | "audio/amr"
+            | "audio/aac"
+            | "audio/x-ape" => false,
+            _ => true,
+        },
         infer::MatcherType::Book => true,
         infer::MatcherType::Doc => true,
         infer::MatcherType::Font => true,
-        infer::MatcherType::Image => false,
+        infer::MatcherType::Image => match ty.mime_type() {
+            #[rustfmt::skip]
+            "image/jpeg"
+            | "image/jp2"
+            | "image/png"
+            | "image/webp"
+            | "image/vnd.ms-photo"
+            | "image/heif"
+            | "image/avif"
+            | "image/jxl"
+            | "image/vnd.djvu" => false,
+            _ => true,
+        },
         infer::MatcherType::Text => true,
-        infer::MatcherType::Video => false,
+        infer::MatcherType::Video => match ty.mime_type() {
+            #[rustfmt::skip]
+            "video/mp4"
+            | "video/x-m4v"
+            | "video/x-matroska"
+            | "video/webm"
+            | "video/quicktime"
+            | "video/x-flv" => false,
+            _ => true,
+        },
         infer::MatcherType::Custom => true,
     }
 }

--- a/crates/typst-pdf/src/embed.rs
+++ b/crates/typst-pdf/src/embed.rs
@@ -34,6 +34,7 @@ pub(crate) fn embed_files(
             },
         };
         let data: Arc<dyn AsRef<[u8]> + Send + Sync> = Arc::new(embed.data.clone());
+        let compress = should_compress(&embed.data);
 
         let file = EmbeddedFile {
             path,
@@ -41,7 +42,7 @@ pub(crate) fn embed_files(
             description,
             association_kind,
             data: data.into(),
-            compress: true,
+            compress,
             location: Some(span.into_raw().get()),
         };
 
@@ -51,4 +52,22 @@ pub(crate) fn embed_files(
     }
 
     Ok(())
+}
+
+fn should_compress(data: &[u8]) -> bool {
+    let Some(ty) = infer::get(data) else {
+        return false;
+    };
+    match ty.matcher_type() {
+        infer::MatcherType::App => true,
+        infer::MatcherType::Archive => false,
+        infer::MatcherType::Audio => false,
+        infer::MatcherType::Book => true,
+        infer::MatcherType::Doc => true,
+        infer::MatcherType::Font => true,
+        infer::MatcherType::Image => false,
+        infer::MatcherType::Text => true,
+        infer::MatcherType::Video => false,
+        infer::MatcherType::Custom => true,
+    }
 }


### PR DESCRIPTION
Implements the first step of #5762. Uses the `infer` crate to roughly filter which file types should be compressed when embedded into pdfs.