### PR TITLE
Add remaining height example for layout

### DIFF
--- a/crates/typst-library/src/layout/layout.rs
+++ b/crates/typst-library/src/layout/layout.rs
@@ -41,6 +41,23 @@ use crate::layout::{BlockElem, Size};
 /// receives the page's dimensions minus its margins. This is mostly useful in
 /// combination with [measurement]($measure).
 ///
+/// If you want to, for example, get the remaining of the page height after some
+/// content was already added to the page, wrap the `layout` call in
+/// `block(height: 1fr)`. But note that adding multiple blocks with height of
+/// `1fr` together will put them all on the same page, which can be fixed with
+/// [`pagebreak`].
+///
+/// ```example
+/// #lorem(10)
+/// #block(height: 1fr, layout(size => {
+///   block(..size, stroke: 1pt)[
+///     #align(center + horizon)[
+///       Remaining height: #size.height
+///     ]
+///   ]
+/// }))
+/// ```
+///
 /// You can also use this function to resolve [`ratio`] to fixed lengths. This
 /// might come in handy if you're building your own layout abstractions.
 ///


### PR DESCRIPTION
Today I wanted to get the remaining page height, so I just used `layout(size => size.height)`, but apparently it doesn't compensate for any added on the page content, it will show the same page height regardless. But thankfully I do remember the quirky `1fr` thingy, that sometimes help a lot, and this is one of those cases. Just wrap it in block with fractional height and you are good to go.

Use of fractions is probably not easy for new users, so this example should be very helpful.
