### PR TITLE
Report errors in external files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3111,6 +3111,7 @@ dependencies = [
  "unicode-segmentation",
  "unscanny",
  "usvg",
+ "utf8_iter",
  "wasmi",
  "xmlwriter",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3111,7 +3111,6 @@ dependencies = [
  "unicode-segmentation",
  "unscanny",
  "usvg",
- "utf8_iter",
  "wasmi",
  "xmlwriter",
 ]
@@ -3200,6 +3199,7 @@ dependencies = [
 name = "typst-syntax"
 version = "0.13.1"
 dependencies = [
+ "comemo",
  "ecow",
  "serde",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3038,6 +3038,7 @@ dependencies = [
  "icu_provider_blob",
  "icu_segmenter",
  "kurbo",
+ "memchr",
  "rustybuzz",
  "smallvec",
  "ttf-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,6 @@ unicode-segmentation = "1"
 unscanny = "0.1"
 ureq = { version = "2", default-features = false, features = ["native-tls", "gzip", "json"] }
 usvg = { version = "0.45", default-features = false, features = ["text"] }
-utf8_iter = "1.0.4"
 walkdir = "2"
 wasmi = "0.40.0"
 web-sys = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,7 @@ unicode-segmentation = "1"
 unscanny = "0.1"
 ureq = { version = "2", default-features = false, features = ["native-tls", "gzip", "json"] }
 usvg = { version = "0.45", default-features = false, features = ["text"] }
+utf8_iter = "1.0.4"
 walkdir = "2"
 wasmi = "0.40.0"
 web-sys = "0.3"

--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -16,7 +16,7 @@ use typst::diag::{
 use typst::foundations::{Datetime, Smart};
 use typst::html::HtmlDocument;
 use typst::layout::{Frame, Page, PageRanges, PagedDocument};
-use typst::syntax::{FileId, Source, Span};
+use typst::syntax::{FileId, Lines, Span};
 use typst::WorldExt;
 use typst_pdf::{PdfOptions, PdfStandards, Timestamp};
 
@@ -696,7 +696,7 @@ fn label(world: &SystemWorld, span: Span) -> Option<Label<FileId>> {
 impl<'a> codespan_reporting::files::Files<'a> for SystemWorld {
     type FileId = FileId;
     type Name = String;
-    type Source = Source;
+    type Source = Lines<String>;
 
     fn name(&'a self, id: FileId) -> CodespanResult<Self::Name> {
         let vpath = id.vpath();

--- a/crates/typst-cli/src/timings.rs
+++ b/crates/typst-cli/src/timings.rs
@@ -85,6 +85,6 @@ fn resolve_span(world: &SystemWorld, span: Span) -> Option<(String, u32)> {
     let id = span.id()?;
     let source = world.source(id).ok()?;
     let range = source.range(span)?;
-    let line = source.byte_to_line(range.start)?;
+    let line = source.lines().byte_to_line(range.start)?;
     Some((format!("{id:?}"), line as u32 + 1))
 }

--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -181,7 +181,7 @@ impl SystemWorld {
         }
     }
 
-    /// Lookup a source file by id.
+    /// Lookup line metadata for a file by id.
     #[track_caller]
     pub fn lookup(&self, id: FileId) -> Lines<String> {
         self.slot(id, |slot| {

--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -9,7 +9,7 @@ use ecow::{eco_format, EcoString};
 use parking_lot::Mutex;
 use typst::diag::{FileError, FileResult};
 use typst::foundations::{Bytes, Datetime, Dict, IntoValue};
-use typst::syntax::{FileId, Source, VirtualPath};
+use typst::syntax::{FileId, Lines, Source, VirtualPath};
 use typst::text::{Font, FontBook};
 use typst::utils::LazyHash;
 use typst::{Library, World};
@@ -183,8 +183,18 @@ impl SystemWorld {
 
     /// Lookup a source file by id.
     #[track_caller]
-    pub fn lookup(&self, id: FileId) -> Source {
-        self.source(id).expect("file id does not point to any source file")
+    pub fn lookup(&self, id: FileId) -> Lines<String> {
+        self.slot(id, |slot| {
+            if let Some(source) = slot.source.get() {
+                let source = source.as_ref().expect("file is not valid");
+                source.lines()
+            } else if let Some(bytes) = slot.file.get() {
+                let bytes = bytes.as_ref().expect("file is not valid");
+                Lines::from_bytes(bytes.as_slice()).expect("file is not valid utf-8")
+            } else {
+                panic!("file id does not point to any source file");
+            }
+        })
     }
 }
 
@@ -337,6 +347,11 @@ impl<T: Clone> SlotCell<T> {
     /// compilation.
     fn reset(&mut self) {
         self.accessed = false;
+    }
+
+    /// Gets the contents of the cell.
+    fn get(&self) -> Option<&FileResult<T>> {
+        self.data.as_ref()
     }
 
     /// Gets the contents of the cell or initialize them.

--- a/crates/typst-layout/Cargo.toml
+++ b/crates/typst-layout/Cargo.toml
@@ -30,6 +30,7 @@ icu_provider_adapters = { workspace = true }
 icu_provider_blob = { workspace = true }
 icu_segmenter = { workspace = true }
 kurbo = { workspace = true }
+memchr = { workspace = true }
 rustybuzz = { workspace = true }
 smallvec = { workspace = true }
 ttf-parser = { workspace = true }

--- a/crates/typst-layout/src/image.rs
+++ b/crates/typst-layout/src/image.rs
@@ -65,7 +65,7 @@ pub fn layout_image(
                 engine.world,
                 &families(styles).map(|f| f.as_str()).collect::<Vec<_>>(),
             )
-            .in_text(&data)?,
+            .in_text(data)?,
         ),
     };
 

--- a/crates/typst-library/Cargo.toml
+++ b/crates/typst-library/Cargo.toml
@@ -66,7 +66,6 @@ unicode-normalization = { workspace = true }
 unicode-segmentation = { workspace = true }
 unscanny = { workspace = true }
 usvg = { workspace = true }
-utf8_iter = { workspace = true }
 wasmi = { workspace = true }
 xmlwriter = { workspace = true }
 

--- a/crates/typst-library/Cargo.toml
+++ b/crates/typst-library/Cargo.toml
@@ -66,6 +66,7 @@ unicode-normalization = { workspace = true }
 unicode-segmentation = { workspace = true }
 unscanny = { workspace = true }
 usvg = { workspace = true }
+utf8_iter = { workspace = true }
 wasmi = { workspace = true }
 xmlwriter = { workspace = true }
 

--- a/crates/typst-library/src/diag.rs
+++ b/crates/typst-library/src/diag.rs
@@ -151,7 +151,7 @@ pub struct Warned<T> {
     pub warnings: EcoVec<SourceDiagnostic>,
 }
 
-/// An error or warning in a source file.
+/// An error or warning in a source or text file.
 ///
 /// The contained spans will only be detached if any of the input source files
 /// were detached.
@@ -574,8 +574,11 @@ impl From<PackageError> for EcoString {
 pub type LoadResult<T> = Result<T, LoadError>;
 
 /// A callsite independent error that occurred during data loading.
+/// This avoids polluting the memoization with [`Span`]s and [`FileId`]s from source files.
 /// Can be turned into a [`SourceDiagnostic`] using the [`LoadedAt::in_text`]
 /// or [`LoadedAt::in_invalid_text`] methods available on [`LoadResult`].
+///
+/// [`FileId`]: typst_syntax::FileId
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct LoadError {
     pub pos: ReportPos,

--- a/crates/typst-library/src/diag.rs
+++ b/crates/typst-library/src/diag.rs
@@ -12,7 +12,7 @@ use typst_syntax::package::{PackageSpec, PackageVersion};
 use typst_syntax::{Span, Spanned, SyntaxError};
 
 use crate::engine::Engine;
-use crate::loading::{Data, LineCol};
+use crate::loading::{Loaded, LineCol};
 use crate::{World, WorldExt};
 
 /// Early-return with a [`StrResult`] or [`SourceResult`].
@@ -572,7 +572,7 @@ impl From<PackageError> for EcoString {
 /// Format a user-facing error message for an XML-like file format.
 pub fn format_xml_like_error(
     format: &str,
-    data: &Data,
+    data: &Loaded,
     error: roxmltree::Error,
 ) -> EcoVec<SourceDiagnostic> {
     let pos = LineCol::one_based(error.pos().row as usize, error.pos().col as usize);

--- a/crates/typst-library/src/diag.rs
+++ b/crates/typst-library/src/diag.rs
@@ -593,5 +593,5 @@ pub fn format_xml_like_error(
         err => err.to_string(),
     };
 
-    data.err_at(pos, msg, err)
+    data.err_in_text(pos, msg, err)
 }

--- a/crates/typst-library/src/foundations/plugin.rs
+++ b/crates/typst-library/src/foundations/plugin.rs
@@ -152,7 +152,7 @@ pub fn plugin(
     source: Spanned<DataSource>,
 ) -> SourceResult<Module> {
     let data = source.load(engine.world)?;
-    Plugin::module(data).at(source.span)
+    Plugin::module(data.bytes).at(source.span)
 }
 
 #[scope]

--- a/crates/typst-library/src/loading/cbor.rs
+++ b/crates/typst-library/src/loading/cbor.rs
@@ -24,7 +24,7 @@ pub fn cbor(
     source: Spanned<DataSource>,
 ) -> SourceResult<Value> {
     let data = source.load(engine.world)?;
-    ciborium::from_reader(data.as_slice())
+    ciborium::from_reader(data.bytes.as_slice())
         .map_err(|err| eco_format!("failed to parse CBOR ({err})"))
         .at(source.span)
 }

--- a/crates/typst-library/src/loading/csv.rs
+++ b/crates/typst-library/src/loading/csv.rs
@@ -4,7 +4,7 @@ use typst_syntax::Spanned;
 use crate::diag::{bail, SourceDiagnostic, SourceResult};
 use crate::engine::Engine;
 use crate::foundations::{cast, func, scope, Array, Dict, IntoValue, Type, Value};
-use crate::loading::{Data, DataSource, LineCol, Load, Readable, ReportPos};
+use crate::loading::{Loaded, DataSource, LineCol, Load, Readable, ReportPos};
 
 /// Reads structured data from a CSV file.
 ///
@@ -164,7 +164,7 @@ cast! {
 
 /// Format the user-facing CSV error message.
 fn format_csv_error(
-    data: &Data,
+    data: &Loaded,
     err: ::csv::Error,
     line: usize,
 ) -> EcoVec<SourceDiagnostic> {

--- a/crates/typst-library/src/loading/csv.rs
+++ b/crates/typst-library/src/loading/csv.rs
@@ -176,12 +176,12 @@ fn format_csv_error(
         })
         .unwrap_or(LineCol::one_based(line, 1).into());
     match err.kind() {
-        ::csv::ErrorKind::Utf8 { .. } => data.err_at(pos, msg, "file is not valid utf-8"),
+        ::csv::ErrorKind::Utf8 { .. } => data.err_in_text(pos, msg, "file is not valid utf-8"),
         ::csv::ErrorKind::UnequalLengths { expected_len, len, .. } => {
             let err =
                 format!("found {len} instead of {expected_len} fields in line {line}");
-            data.err_at(pos, msg, err)
+            data.err_in_text(pos, msg, err)
         }
-        _ => data.err_at(pos, "failed to parse CSV", err),
+        _ => data.err_in_text(pos, "failed to parse CSV", err),
     }
 }

--- a/crates/typst-library/src/loading/csv.rs
+++ b/crates/typst-library/src/loading/csv.rs
@@ -1,3 +1,4 @@
+use az::SaturatingAs;
 use ecow::EcoVec;
 use typst_syntax::Spanned;
 
@@ -171,8 +172,8 @@ fn format_csv_error(
     let msg = "failed to parse CSV";
     let pos = (err.kind().position())
         .map(|pos| {
-            let start = pos.byte() as usize;
-            ReportPos::Range(start..start)
+            let start = pos.byte().saturating_as();
+            ReportPos::from(start..start)
         })
         .unwrap_or(LineCol::one_based(line, 1).into());
     match err.kind() {

--- a/crates/typst-library/src/loading/csv.rs
+++ b/crates/typst-library/src/loading/csv.rs
@@ -1,10 +1,10 @@
 use ecow::EcoVec;
 use typst_syntax::Spanned;
 
-use crate::diag::{bail, SourceDiagnostic, SourceResult};
+use crate::diag::{bail, LineCol, ReportPos, SourceDiagnostic, SourceResult};
 use crate::engine::Engine;
 use crate::foundations::{cast, func, scope, Array, Dict, IntoValue, Type, Value};
-use crate::loading::{Loaded, DataSource, LineCol, Load, Readable, ReportPos};
+use crate::loading::{DataSource, Load, Loaded, Readable};
 
 /// Reads structured data from a CSV file.
 ///
@@ -176,7 +176,9 @@ fn format_csv_error(
         })
         .unwrap_or(LineCol::one_based(line, 1).into());
     match err.kind() {
-        ::csv::ErrorKind::Utf8 { .. } => data.err_in_text(pos, msg, "file is not valid utf-8"),
+        ::csv::ErrorKind::Utf8 { .. } => {
+            data.err_in_text(pos, msg, "file is not valid utf-8")
+        }
         ::csv::ErrorKind::UnequalLengths { expected_len, len, .. } => {
             let err =
                 format!("found {len} instead of {expected_len} fields in line {line}");

--- a/crates/typst-library/src/loading/json.rs
+++ b/crates/typst-library/src/loading/json.rs
@@ -1,10 +1,10 @@
 use ecow::eco_format;
 use typst_syntax::Spanned;
 
-use crate::diag::{At, SourceResult};
+use crate::diag::{At, LineCol, SourceResult};
 use crate::engine::Engine;
 use crate::foundations::{func, scope, Str, Value};
-use crate::loading::{DataSource, LineCol, Load, Readable};
+use crate::loading::{DataSource, Load, Readable};
 
 /// Reads structured data from a JSON file.
 ///

--- a/crates/typst-library/src/loading/json.rs
+++ b/crates/typst-library/src/loading/json.rs
@@ -57,7 +57,7 @@ pub fn json(
     let data = source.load(engine.world)?;
     serde_json::from_slice(data.bytes.as_slice()).map_err(|err| {
         let pos = LineCol::one_based(err.line(), err.column());
-        data.err_at(pos, "failed to parse JSON", err)
+        data.err_in_text(pos, "failed to parse JSON", err)
     })
 }
 

--- a/crates/typst-library/src/loading/mod.rs
+++ b/crates/typst-library/src/loading/mod.rs
@@ -16,9 +16,8 @@ mod xml_;
 mod yaml_;
 
 use comemo::Tracked;
-use ecow::{eco_vec, EcoString, EcoVec};
+use ecow::EcoString;
 use typst_syntax::{FileId, Span, Spanned};
-use utf8_iter::ErrorReportingUtf8Chars;
 
 pub use self::cbor_::*;
 pub use self::csv_::*;
@@ -28,7 +27,7 @@ pub use self::toml_::*;
 pub use self::xml_::*;
 pub use self::yaml_::*;
 
-use crate::diag::{error, At, FileError, SourceDiagnostic, SourceResult};
+use crate::diag::{At, FileError, SourceResult};
 use crate::foundations::OneOrMultiple;
 use crate::foundations::{cast, Bytes, Scope, Str};
 use crate::World;
@@ -129,6 +128,7 @@ pub struct Loaded {
 }
 
 impl Loaded {
+    /// FIXME: remove this?
     pub fn dummy() -> Self {
         Loaded::new(
             typst_syntax::Spanned::new(LoadSource::Bytes, Span::detached()),
@@ -142,49 +142,15 @@ impl Loaded {
 
     pub fn as_str(&self) -> SourceResult<&str> {
         self.bytes.as_str().map_err(|err| {
-            // TODO: should the error even be reported in the file if it's possibly binary?
             let start = err.valid_up_to();
             let end = start + err.error_len().unwrap_or(0);
-            self.err_in_text(start..end, "failed to convert to string", FileError::from(err))
+            // always report this error in the source file.
+            self.err_in_bytes(
+                start..end,
+                "failed to convert to string",
+                FileError::from(err),
+            )
         })
-    }
-
-    /// Report an error, possibly in an external file.
-    pub fn err_in_text(
-        &self,
-        pos: impl Into<ReportPos>,
-        msg: impl std::fmt::Display,
-        error: impl std::fmt::Display,
-    ) -> EcoVec<SourceDiagnostic> {
-        let pos = pos.into();
-        let error = match self.source.v {
-            LoadSource::Path(file_id) => {
-                if let Some(range) = pos.range(self.bytes.as_slice()) {
-                    let span = Span::from_range(file_id, range);
-                    return eco_vec!(error!(span, "{msg} ({error})"));
-                }
-
-                // Either there was no range provided, or resolving the range
-                // from the line/column failed. If present report the possibly
-                // wrong line/column anyway.
-                let span = Span::from_range(file_id, 0..self.bytes.len());
-                if let Some(pair) = pos.line_col(self.bytes.as_slice()) {
-                    let (line, col) = pair.numbers();
-                    error!(span, "{msg} ({error} at {line}:{col})")
-                } else {
-                    error!(span, "{msg} ({error})")
-                }
-            }
-            LoadSource::Bytes => {
-                if let Some(pair) = pos.line_col(self.bytes.as_slice()) {
-                    let (line, col) = pair.numbers();
-                    error!(self.source.span, "{msg} ({error} at {line}:{col})")
-                } else {
-                    error!(self.source.span, "{msg} ({error})")
-                }
-            }
-        };
-        eco_vec![error]
     }
 }
 
@@ -193,142 +159,6 @@ impl Loaded {
 pub enum LoadSource {
     Path(FileId),
     Bytes,
-}
-
-#[derive(Debug, Default)]
-pub enum ReportPos {
-    /// Contains the range, and the 0-based line/column.
-    Full(std::ops::Range<usize>, LineCol),
-    /// Contains the range.
-    Range(std::ops::Range<usize>),
-    /// Contains the 0-based line/column.
-    LineCol(LineCol),
-    #[default]
-    None,
-}
-
-impl From<std::ops::Range<usize>> for ReportPos {
-    fn from(value: std::ops::Range<usize>) -> Self {
-        Self::Range(value)
-    }
-}
-
-impl From<LineCol> for ReportPos {
-    fn from(value: LineCol) -> Self {
-        Self::LineCol(value)
-    }
-}
-
-impl ReportPos {
-    fn range(&self, bytes: &[u8]) -> Option<std::ops::Range<usize>> {
-        match self {
-            ReportPos::Full(range, _) => Some(range.clone()),
-            ReportPos::Range(range) => Some(range.clone()),
-            &ReportPos::LineCol(pair) => pair.byte_pos(bytes).map(|i| i..i),
-            ReportPos::None => None,
-        }
-    }
-
-    fn line_col(&self, bytes: &[u8]) -> Option<LineCol> {
-        match self {
-            &ReportPos::Full(_, pair) => Some(pair),
-            ReportPos::Range(range) => LineCol::from_byte_pos(range.start, bytes),
-            &ReportPos::LineCol(pair) => Some(pair),
-            ReportPos::None => None,
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-pub struct LineCol {
-    /// The 0-based line.
-    line: usize,
-    /// The 0-based column.
-    col: usize,
-}
-
-impl LineCol {
-    /// Constructs the line/column pair from 0-based indices.
-    pub fn zero_based(line: usize, col: usize) -> Self {
-        Self { line, col }
-    }
-
-    /// Constructs the line/column pair from 1-based numbers.
-    pub fn one_based(line: usize, col: usize) -> Self {
-        Self {
-            line: line.saturating_sub(1),
-            col: col.saturating_sub(1),
-        }
-    }
-
-    pub fn from_byte_pos(pos: usize, bytes: &[u8]) -> Option<Self> {
-        let bytes = &bytes[..pos];
-        let mut line = 0;
-        let line_start = memchr::memchr_iter(b'\n', bytes)
-            .inspect(|_| line += 1)
-            .last()
-            .map(|i| i + 1)
-            .unwrap_or(bytes.len());
-
-        // Try to compute a column even if the string isn't valid utf-8.
-        let col = ErrorReportingUtf8Chars::new(&bytes[line_start..]).count();
-        Some(LineCol::zero_based(line, col))
-    }
-
-    pub fn byte_pos(&self, bytes: &[u8]) -> Option<usize> {
-        let line_offset = if let Some(idx) = self.line.checked_sub(1) {
-            memchr::memchr_iter(b'\n', bytes).nth(idx).map(|i| i + 1)?
-        } else {
-            0
-        };
-
-        let col_offset = col_offset(line_offset, self.col, bytes)?;
-        let pos = line_offset + col_offset;
-        Some(pos)
-    }
-
-    pub fn byte_range(
-        range: std::ops::Range<Self>,
-        bytes: &[u8],
-    ) -> Option<std::ops::Range<usize>> {
-        let mut line_iter = memchr::memchr_iter(b'\n', bytes);
-        let start_line_offset = if let Some(idx) = range.start.line.checked_sub(1) {
-            line_iter.nth(idx).map(|i| i + 1)?
-        } else {
-            0
-        };
-        let line_delta = range.end.line - range.start.line;
-        let end_line_offset = if let Some(idx) = line_delta.checked_sub(1) {
-            line_iter.nth(idx).map(|i| i + 1)?
-        } else {
-            start_line_offset
-        };
-
-        let start_col_offset = col_offset(start_line_offset, range.start.col, bytes)?;
-        let end_col_offset = col_offset(end_line_offset, range.end.col, bytes)?;
-
-        let start = start_line_offset + start_col_offset;
-        let end = end_line_offset + end_col_offset;
-        Some(start..end)
-    }
-
-    pub fn numbers(&self) -> (usize, usize) {
-        (self.line + 1, self.col + 1)
-    }
-}
-
-fn col_offset(line_offset: usize, col: usize, bytes: &[u8]) -> Option<usize> {
-    let line = &bytes[line_offset..];
-    // TODO: streaming-utf8 decoding ignore invalid characters
-    // might neeed to update error reporting too (use utf8_iter)
-    if let Some(idx) = col.checked_sub(1) {
-        // Try to compute position even if the string isn't valid utf-8.
-        let mut iter = ErrorReportingUtf8Chars::new(line);
-        _ = iter.nth(idx)?;
-        Some(line.len() - iter.as_slice().len())
-    } else {
-        Some(0)
-    }
 }
 
 /// A value that can be read from a file.

--- a/crates/typst-library/src/loading/mod.rs
+++ b/crates/typst-library/src/loading/mod.rs
@@ -16,8 +16,8 @@ mod xml_;
 mod yaml_;
 
 use comemo::Tracked;
-use ecow::EcoString;
-use typst_syntax::Spanned;
+use ecow::{eco_vec, EcoString, EcoVec};
+use typst_syntax::{FileId, Span, Spanned};
 
 pub use self::cbor_::*;
 pub use self::csv_::*;
@@ -27,7 +27,7 @@ pub use self::toml_::*;
 pub use self::xml_::*;
 pub use self::yaml_::*;
 
-use crate::diag::{At, SourceResult};
+use crate::diag::{error, At, FileError, SourceDiagnostic, SourceResult};
 use crate::foundations::OneOrMultiple;
 use crate::foundations::{cast, Bytes, Scope, Str};
 use crate::World;
@@ -74,45 +74,266 @@ pub trait Load {
 }
 
 impl Load for Spanned<DataSource> {
-    type Output = Bytes;
+    type Output = Data;
 
-    fn load(&self, world: Tracked<dyn World + '_>) -> SourceResult<Bytes> {
+    fn load(&self, world: Tracked<dyn World + '_>) -> SourceResult<Self::Output> {
         self.as_ref().load(world)
     }
 }
 
 impl Load for Spanned<&DataSource> {
-    type Output = Bytes;
+    type Output = Data;
 
-    fn load(&self, world: Tracked<dyn World + '_>) -> SourceResult<Bytes> {
+    fn load(&self, world: Tracked<dyn World + '_>) -> SourceResult<Self::Output> {
         match &self.v {
             DataSource::Path(path) => {
                 let file_id = self.span.resolve_path(path).at(self.span)?;
-                world.file(file_id).at(self.span)
+                let bytes = world.file(file_id).at(self.span)?;
+                let source = Spanned::new(LoadSource::Path(file_id), self.span);
+                Ok(Data::new(source, bytes))
             }
-            DataSource::Bytes(bytes) => Ok(bytes.clone()),
+            DataSource::Bytes(bytes) => {
+                let source = Spanned::new(LoadSource::Bytes, self.span);
+                Ok(Data::new(source, bytes.clone()))
+            }
         }
     }
 }
 
 impl Load for Spanned<OneOrMultiple<DataSource>> {
-    type Output = Vec<Bytes>;
+    type Output = Vec<Data>;
 
-    fn load(&self, world: Tracked<dyn World + '_>) -> SourceResult<Vec<Bytes>> {
+    fn load(&self, world: Tracked<dyn World + '_>) -> SourceResult<Self::Output> {
         self.as_ref().load(world)
     }
 }
 
 impl Load for Spanned<&OneOrMultiple<DataSource>> {
-    type Output = Vec<Bytes>;
+    type Output = Vec<Data>;
 
-    fn load(&self, world: Tracked<dyn World + '_>) -> SourceResult<Vec<Bytes>> {
+    fn load(&self, world: Tracked<dyn World + '_>) -> SourceResult<Self::Output> {
         self.v
             .0
             .iter()
             .map(|source| Spanned::new(source, self.span).load(world))
             .collect()
     }
+}
+
+/// Data loaded from a [`DataSource`].
+#[derive(Clone, Hash)]
+pub struct Data {
+    pub source: Spanned<LoadSource>,
+    pub bytes: Bytes,
+}
+
+impl Data {
+    pub fn dummy() -> Self {
+        Data::new(
+            typst_syntax::Spanned::new(LoadSource::Bytes, Span::detached()),
+            Bytes::new([]),
+        )
+    }
+
+    pub fn new(source: Spanned<LoadSource>, bytes: Bytes) -> Self {
+        Self { source, bytes }
+    }
+
+    pub fn as_str(&self) -> SourceResult<&str> {
+        self.bytes.as_str().map_err(|err| {
+            // TODO: should the error even be reported in the file if it's possibly binary?
+            let start = err.valid_up_to();
+            let end = start + err.error_len().unwrap_or(0);
+            self.err_at(start..end, "failed to convert to string", FileError::from(err))
+        })
+    }
+
+    /// Report an error, possibly in an external file.
+    pub fn err_at(
+        &self,
+        pos: impl Into<ReportPos>,
+        msg: impl std::fmt::Display,
+        error: impl std::fmt::Display,
+    ) -> EcoVec<SourceDiagnostic> {
+        let pos = pos.into();
+        let error = match self.source.v {
+            LoadSource::Path(file_id) => {
+                if let Some(range) = pos.range(self.bytes.as_slice()) {
+                    let span = Span::from_range(file_id, range);
+                    return eco_vec!(error!(span, "{msg} ({error})"));
+                }
+
+                // Either there was no range provided, or resolving the range
+                // from the line/column failed. If present report the possibly
+                // wrong line/column anyway.
+                let span = Span::from_range(file_id, 0..self.bytes.len());
+                if let Some(pair) = pos.line_col(self.bytes.as_slice()) {
+                    let (line, col) = pair.numbers();
+                    error!(span, "{msg} ({error} at {line}:{col})")
+                } else {
+                    error!(span, "{msg} ({error})")
+                }
+            }
+            LoadSource::Bytes => {
+                if let Some(pair) = pos.line_col(self.bytes.as_slice()) {
+                    let (line, col) = pair.numbers();
+                    error!(self.source.span, "{msg} ({error} at {line}:{col})")
+                } else {
+                    error!(self.source.span, "{msg} ({error})")
+                }
+            }
+        };
+        eco_vec![error]
+    }
+}
+
+#[derive(Debug, Default)]
+pub enum ReportPos {
+    /// Contains the range, and the 0-based line/column.
+    Full(std::ops::Range<usize>, LineCol),
+    /// Contains the range.
+    Range(std::ops::Range<usize>),
+    /// Contains the 0-based line/column.
+    LineCol(LineCol),
+    #[default]
+    None,
+}
+
+impl From<std::ops::Range<usize>> for ReportPos {
+    fn from(value: std::ops::Range<usize>) -> Self {
+        Self::Range(value)
+    }
+}
+
+impl From<LineCol> for ReportPos {
+    fn from(value: LineCol) -> Self {
+        Self::LineCol(value)
+    }
+}
+
+impl ReportPos {
+    fn range(&self, bytes: &[u8]) -> Option<std::ops::Range<usize>> {
+        match self {
+            ReportPos::Full(range, _) => Some(range.clone()),
+            ReportPos::Range(range) => Some(range.clone()),
+            &ReportPos::LineCol(pair) => pair.byte_pos(bytes).map(|i| i..i),
+            ReportPos::None => None,
+        }
+    }
+
+    fn line_col(&self, bytes: &[u8]) -> Option<LineCol> {
+        match self {
+            &ReportPos::Full(_, pair) => Some(pair),
+            ReportPos::Range(range) => LineCol::from_byte_pos(range.start, bytes),
+            &ReportPos::LineCol(pair) => Some(pair),
+            ReportPos::None => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct LineCol {
+    /// The 0-based line.
+    line: usize,
+    /// The 0-based column.
+    col: usize,
+}
+
+impl LineCol {
+    /// Constructs the line/column pair from 0-based indices.
+    pub fn zero_based(line: usize, col: usize) -> Self {
+        Self { line, col }
+    }
+
+    /// Constructs the line/column pair from 1-based numbers.
+    pub fn one_based(line: usize, col: usize) -> Self {
+        Self {
+            line: line.saturating_sub(1),
+            col: col.saturating_sub(1),
+        }
+    }
+
+    // TODO: this function should only return None if the position is out of
+    // bounds not if there is invalid utf-8
+    pub fn from_byte_pos(pos: usize, bytes: &[u8]) -> Option<Self> {
+        let bytes = &bytes[..pos];
+        let mut line = 0;
+        let line_start = memchr::memchr_iter(b'\n', bytes)
+            .inspect(|_| line += 1)
+            .last()
+            .map(|i| i + 1)
+            .unwrap_or(bytes.len());
+        // TODO: streaming-utf8 decoding ignore invalid characters
+        // might neeed to update error reporting too (use utf8_iter)
+        let str = std::str::from_utf8(&bytes[line_start..]).ok()?;
+        let col = str.chars().count();
+        Some(LineCol::zero_based(line, col))
+    }
+
+    pub fn byte_pos(&self, bytes: &[u8]) -> Option<usize> {
+        let line_offset = if let Some(idx) = self.line.checked_sub(1) {
+            memchr::memchr_iter(b'\n', bytes).nth(idx).map(|i| i + 1)?
+        } else {
+            0
+        };
+
+        let col_offset = col_offset(line_offset, self.col, bytes)?;
+        let pos = line_offset + col_offset;
+        Some(pos)
+    }
+
+    pub fn byte_range(
+        range: std::ops::Range<Self>,
+        bytes: &[u8],
+    ) -> Option<std::ops::Range<usize>> {
+        let mut line_iter = memchr::memchr_iter(b'\n', bytes);
+        let start_line_offset = if let Some(idx) = range.start.line.checked_sub(1) {
+            line_iter.nth(idx).map(|i| i + 1)?
+        } else {
+            0
+        };
+        let line_delta = range.end.line - range.start.line;
+        let end_line_offset = if let Some(idx) = line_delta.checked_sub(1) {
+            line_iter.nth(idx).map(|i| i + 1)?
+        } else {
+            start_line_offset
+        };
+
+        let start_col_offset = col_offset(start_line_offset, range.start.col, bytes)?;
+        let end_col_offset = col_offset(end_line_offset, range.end.col, bytes)?;
+
+        let start = start_line_offset + start_col_offset;
+        let end = end_line_offset + end_col_offset;
+        Some(start..end)
+    }
+
+    pub fn numbers(&self) -> (usize, usize) {
+        (self.line + 1, self.col + 1)
+    }
+}
+
+// TODO: this function should only return None if the position is out of
+// bounds not if there is invalid utf-8
+fn col_offset(line_offset: usize, col: usize, bytes: &[u8]) -> Option<usize> {
+    let line = &bytes[line_offset..];
+    // TODO: streaming-utf8 decoding ignore invalid characters
+    // might neeed to update error reporting too (use utf8_iter)
+
+    // validate the whole line, so it can be displayed
+    let len = memchr::memchr(b'\n', line).unwrap_or(line.len());
+    let str = std::str::from_utf8(&line[..len]).ok()?;
+    if let Some(idx) = col.checked_sub(1) {
+        str.char_indices().nth(idx).map(|(i, c)| i + c.len_utf8())
+    } else {
+        Some(0)
+    }
+}
+
+/// A loaded [`DataSource`].
+#[derive(Clone, Copy, Hash)]
+pub enum LoadSource {
+    Path(FileId),
+    Bytes,
 }
 
 /// A value that can be read from a file.

--- a/crates/typst-library/src/loading/mod.rs
+++ b/crates/typst-library/src/loading/mod.rs
@@ -145,7 +145,7 @@ impl Loaded {
             let start = err.valid_up_to();
             let end = start + err.error_len().unwrap_or(0);
             // always report this error in the source file.
-            self.err_in_bytes(
+            self.err_in_invalid_text(
                 start..end,
                 "failed to convert to string",
                 FileError::from(err),

--- a/crates/typst-library/src/loading/mod.rs
+++ b/crates/typst-library/src/loading/mod.rs
@@ -145,12 +145,12 @@ impl Loaded {
             // TODO: should the error even be reported in the file if it's possibly binary?
             let start = err.valid_up_to();
             let end = start + err.error_len().unwrap_or(0);
-            self.err_at(start..end, "failed to convert to string", FileError::from(err))
+            self.err_in_text(start..end, "failed to convert to string", FileError::from(err))
         })
     }
 
     /// Report an error, possibly in an external file.
-    pub fn err_at(
+    pub fn err_in_text(
         &self,
         pos: impl Into<ReportPos>,
         msg: impl std::fmt::Display,

--- a/crates/typst-library/src/loading/read.rs
+++ b/crates/typst-library/src/loading/read.rs
@@ -1,11 +1,10 @@
 use ecow::EcoString;
 use typst_syntax::Spanned;
 
-use crate::diag::{At, FileError, SourceResult};
+use crate::diag::SourceResult;
 use crate::engine::Engine;
 use crate::foundations::{func, Cast};
-use crate::loading::Readable;
-use crate::World;
+use crate::loading::{DataSource, Load, Readable};
 
 /// Reads plain text or data from a file.
 ///
@@ -36,14 +35,10 @@ pub fn read(
     #[default(Some(Encoding::Utf8))]
     encoding: Option<Encoding>,
 ) -> SourceResult<Readable> {
-    let Spanned { v: path, span } = path;
-    let id = span.resolve_path(&path).at(span)?;
-    let data = engine.world.file(id).at(span)?;
+    let data = path.map(DataSource::Path).load(engine.world)?;
     Ok(match encoding {
-        None => Readable::Bytes(data),
-        Some(Encoding::Utf8) => {
-            Readable::Str(data.to_str().map_err(FileError::from).at(span)?)
-        }
+        None => Readable::Bytes(data.bytes),
+        Some(Encoding::Utf8) => Readable::Str(data.as_str()?.into()),
     })
 }
 

--- a/crates/typst-library/src/loading/read.rs
+++ b/crates/typst-library/src/loading/read.rs
@@ -38,7 +38,7 @@ pub fn read(
     let data = path.map(DataSource::Path).load(engine.world)?;
     Ok(match encoding {
         None => Readable::Bytes(data.bytes),
-        Some(Encoding::Utf8) => Readable::Str(data.as_str()?.into()),
+        Some(Encoding::Utf8) => Readable::Str(data.load_str()?.into()),
     })
 }
 

--- a/crates/typst-library/src/loading/toml.rs
+++ b/crates/typst-library/src/loading/toml.rs
@@ -4,7 +4,7 @@ use typst_syntax::Spanned;
 use crate::diag::{At, SourceDiagnostic, SourceResult};
 use crate::engine::Engine;
 use crate::foundations::{func, scope, Str, Value};
-use crate::loading::{Data, DataSource, Load, Readable, ReportPos};
+use crate::loading::{Loaded, DataSource, Load, Readable, ReportPos};
 
 /// Reads structured data from a TOML file.
 ///
@@ -69,7 +69,7 @@ impl toml {
 }
 
 /// Format the user-facing TOML error message.
-fn format_toml_error(data: &Data, error: ::toml::de::Error) -> EcoVec<SourceDiagnostic> {
+fn format_toml_error(data: &Loaded, error: ::toml::de::Error) -> EcoVec<SourceDiagnostic> {
     let pos = error.span().map(ReportPos::Range).unwrap_or_default();
     data.err_at(pos, "failed to parse TOML", error.message())
 }

--- a/crates/typst-library/src/loading/toml.rs
+++ b/crates/typst-library/src/loading/toml.rs
@@ -1,10 +1,10 @@
 use ecow::{eco_format, EcoVec};
 use typst_syntax::Spanned;
 
-use crate::diag::{At, SourceDiagnostic, SourceResult};
+use crate::diag::{At, ReportPos, SourceDiagnostic, SourceResult};
 use crate::engine::Engine;
 use crate::foundations::{func, scope, Str, Value};
-use crate::loading::{Loaded, DataSource, Load, Readable, ReportPos};
+use crate::loading::{DataSource, Load, Loaded, Readable};
 
 /// Reads structured data from a TOML file.
 ///
@@ -69,7 +69,10 @@ impl toml {
 }
 
 /// Format the user-facing TOML error message.
-fn format_toml_error(data: &Loaded, error: ::toml::de::Error) -> EcoVec<SourceDiagnostic> {
+fn format_toml_error(
+    data: &Loaded,
+    error: ::toml::de::Error,
+) -> EcoVec<SourceDiagnostic> {
     let pos = error.span().map(ReportPos::Range).unwrap_or_default();
     data.err_in_text(pos, "failed to parse TOML", error.message())
 }

--- a/crates/typst-library/src/loading/toml.rs
+++ b/crates/typst-library/src/loading/toml.rs
@@ -71,5 +71,5 @@ impl toml {
 /// Format the user-facing TOML error message.
 fn format_toml_error(data: &Loaded, error: ::toml::de::Error) -> EcoVec<SourceDiagnostic> {
     let pos = error.span().map(ReportPos::Range).unwrap_or_default();
-    data.err_at(pos, "failed to parse TOML", error.message())
+    data.err_in_text(pos, "failed to parse TOML", error.message())
 }

--- a/crates/typst-library/src/loading/xml.rs
+++ b/crates/typst-library/src/loading/xml.rs
@@ -5,7 +5,7 @@ use typst_syntax::Spanned;
 use crate::diag::{format_xml_like_error, SourceDiagnostic, SourceResult};
 use crate::engine::Engine;
 use crate::foundations::{dict, func, scope, Array, Dict, IntoValue, Str, Value};
-use crate::loading::{Loaded, DataSource, Load, Readable};
+use crate::loading::{DataSource, Load, Loaded, Readable};
 
 /// Reads structured data from an XML file.
 ///

--- a/crates/typst-library/src/loading/xml.rs
+++ b/crates/typst-library/src/loading/xml.rs
@@ -5,7 +5,7 @@ use typst_syntax::Spanned;
 use crate::diag::{format_xml_like_error, SourceDiagnostic, SourceResult};
 use crate::engine::Engine;
 use crate::foundations::{dict, func, scope, Array, Dict, IntoValue, Str, Value};
-use crate::loading::{Data, DataSource, Load, Readable};
+use crate::loading::{Loaded, DataSource, Load, Readable};
 
 /// Reads structured data from an XML file.
 ///
@@ -110,6 +110,6 @@ fn convert_xml(node: roxmltree::Node) -> Value {
 }
 
 /// Format the user-facing XML error message.
-fn format_xml_error(data: &Data, error: roxmltree::Error) -> EcoVec<SourceDiagnostic> {
+fn format_xml_error(data: &Loaded, error: roxmltree::Error) -> EcoVec<SourceDiagnostic> {
     format_xml_like_error("XML", data, error)
 }

--- a/crates/typst-library/src/loading/yaml.rs
+++ b/crates/typst-library/src/loading/yaml.rs
@@ -4,7 +4,7 @@ use typst_syntax::Spanned;
 use crate::diag::{At, SourceDiagnostic, SourceResult};
 use crate::engine::Engine;
 use crate::foundations::{func, scope, Str, Value};
-use crate::loading::{Data, DataSource, LineCol, Load, Readable, ReportPos};
+use crate::loading::{Loaded, DataSource, LineCol, Load, Readable, ReportPos};
 
 /// Reads structured data from a YAML file.
 ///
@@ -77,7 +77,7 @@ impl yaml {
 }
 
 pub fn format_yaml_error(
-    data: &Data,
+    data: &Loaded,
     error: serde_yaml::Error,
 ) -> EcoVec<SourceDiagnostic> {
     let pos = error

--- a/crates/typst-library/src/loading/yaml.rs
+++ b/crates/typst-library/src/loading/yaml.rs
@@ -85,7 +85,7 @@ pub fn format_yaml_error(
         .map(|loc| {
             let line_col = LineCol::one_based(loc.line(), loc.column());
             let range = loc.index()..loc.index();
-            ReportPos::Full(range, line_col)
+            ReportPos::full(range, line_col)
         })
         .unwrap_or_default();
     data.err_in_text(pos, "failed to parse YAML", error)

--- a/crates/typst-library/src/loading/yaml.rs
+++ b/crates/typst-library/src/loading/yaml.rs
@@ -88,5 +88,5 @@ pub fn format_yaml_error(
             ReportPos::Full(range, line_col)
         })
         .unwrap_or_default();
-    data.err_at(pos, "failed to parse YAML", error)
+    data.err_in_text(pos, "failed to parse YAML", error)
 }

--- a/crates/typst-library/src/loading/yaml.rs
+++ b/crates/typst-library/src/loading/yaml.rs
@@ -1,10 +1,10 @@
 use ecow::{eco_format, EcoVec};
 use typst_syntax::Spanned;
 
-use crate::diag::{At, SourceDiagnostic, SourceResult};
+use crate::diag::{At, LineCol, ReportPos, SourceDiagnostic, SourceResult};
 use crate::engine::Engine;
 use crate::foundations::{func, scope, Str, Value};
-use crate::loading::{Loaded, DataSource, LineCol, Load, Readable, ReportPos};
+use crate::loading::{DataSource, Load, Loaded, Readable};
 
 /// Reads structured data from a YAML file.
 ///

--- a/crates/typst-library/src/model/bibliography.rs
+++ b/crates/typst-library/src/model/bibliography.rs
@@ -20,7 +20,8 @@ use typst_syntax::{Span, Spanned};
 use typst_utils::{Get, ManuallyHash, NonZeroExt, PicoStr};
 
 use crate::diag::{
-    bail, error, At, HintedStrResult, SourceDiagnostic, SourceResult, StrResult,
+    bail, error, At, HintedStrResult, ReportPos, SourceDiagnostic, SourceResult,
+    StrResult,
 };
 use crate::engine::{Engine, Sink};
 use crate::foundations::{
@@ -33,7 +34,7 @@ use crate::layout::{
     BlockBody, BlockElem, Em, GridCell, GridChild, GridElem, GridItem, HElem, PadElem,
     Sides, Sizing, TrackSizings,
 };
-use crate::loading::{format_yaml_error, Loaded, DataSource, Load, LoadSource, ReportPos};
+use crate::loading::{format_yaml_error, DataSource, Load, LoadSource, Loaded};
 use crate::model::{
     CitationForm, CiteGroup, Destination, FootnoteElem, HeadingElem, LinkElem, ParElem,
     Url,
@@ -480,7 +481,9 @@ impl CslStyle {
                     typst_utils::hash128(&(TypeId::of::<Bytes>(), data)),
                 )))
             })
-            .map_err(|err| data.err_in_text(ReportPos::None, "failed to load CSL style", err))
+            .map_err(|err| {
+                data.err_in_text(ReportPos::None, "failed to load CSL style", err)
+            })
     }
 
     /// Get the underlying independent style.

--- a/crates/typst-library/src/model/bibliography.rs
+++ b/crates/typst-library/src/model/bibliography.rs
@@ -33,7 +33,7 @@ use crate::layout::{
     BlockBody, BlockElem, Em, GridCell, GridChild, GridElem, GridItem, HElem, PadElem,
     Sides, Sizing, TrackSizings,
 };
-use crate::loading::{format_yaml_error, Data, DataSource, Load, LoadSource, ReportPos};
+use crate::loading::{format_yaml_error, Loaded, DataSource, Load, LoadSource, ReportPos};
 use crate::model::{
     CitationForm, CiteGroup, Destination, FootnoteElem, HeadingElem, LinkElem, ParElem,
     Url,
@@ -304,7 +304,7 @@ impl Bibliography {
     /// Decode a bibliography from loaded data sources.
     #[comemo::memoize]
     #[typst_macros::time(name = "load bibliography")]
-    fn decode(data: &[Data]) -> SourceResult<Bibliography> {
+    fn decode(data: &[Loaded]) -> SourceResult<Bibliography> {
         let mut map = IndexMap::new();
         // TODO: store spans of entries for duplicate key error messages
         let mut duplicates = Vec::<EcoString>::new();
@@ -354,7 +354,7 @@ impl Debug for Bibliography {
 }
 
 /// Decode on library from one data source.
-fn decode_library(data: &Data) -> SourceResult<Library> {
+fn decode_library(data: &Loaded) -> SourceResult<Library> {
     let str = data.as_str()?;
 
     if let LoadSource::Path(file_id) = data.source.v {
@@ -419,7 +419,7 @@ fn decode_library(data: &Data) -> SourceResult<Library> {
 
 /// Format a BibLaTeX loading error.
 fn format_biblatex_error(
-    data: &Data,
+    data: &Loaded,
     errors: Vec<BibLaTeXError>,
 ) -> EcoVec<SourceDiagnostic> {
     // TODO: return multiple errors?
@@ -471,7 +471,7 @@ impl CslStyle {
 
     /// Load a CSL style from file contents.
     #[comemo::memoize]
-    pub fn from_data(data: &Data) -> SourceResult<CslStyle> {
+    pub fn from_data(data: &Loaded) -> SourceResult<CslStyle> {
         let text = data.as_str()?;
         citationberg::IndependentStyle::from_xml(text)
             .map(|style| {

--- a/crates/typst-library/src/model/bibliography.rs
+++ b/crates/typst-library/src/model/bibliography.rs
@@ -307,7 +307,6 @@ impl Bibliography {
     #[typst_macros::time(name = "load bibliography")]
     fn decode(data: &[Loaded]) -> SourceResult<Bibliography> {
         let mut map = IndexMap::new();
-        // TODO: store spans of entries for duplicate key error messages
         let mut duplicates = Vec::<EcoString>::new();
 
         // We might have multiple bib/yaml files
@@ -326,8 +325,9 @@ impl Bibliography {
         }
 
         if !duplicates.is_empty() {
-            // TODO: errors with spans of source files,
-            // requires hayagriva entries to store the range
+            // TODO: Store spans of entries for duplicate key error messages.
+            // Requires hayagriva entries to store their location, which should
+            // be fine, since they are 1kb anyway.
             let span = data.first().unwrap().source.span;
             bail!(span, "duplicate bibliography keys: {}", duplicates.join(", "));
         }

--- a/crates/typst-library/src/model/bibliography.rs
+++ b/crates/typst-library/src/model/bibliography.rs
@@ -425,7 +425,7 @@ fn format_biblatex_error(
     // TODO: return multiple errors?
     let Some(error) = errors.into_iter().next() else {
         // TODO: can this even happen, should we just unwrap?
-        return data.err_at(ReportPos::None, "failed to parse BibLaTeX", "???");
+        return data.err_in_text(ReportPos::None, "failed to parse BibLaTeX", "???");
     };
 
     let (range, msg) = match error {
@@ -433,7 +433,7 @@ fn format_biblatex_error(
         BibLaTeXError::Type(error) => (error.span, error.kind.to_string()),
     };
 
-    data.err_at(range, "failed to parse BibLaTeX", msg)
+    data.err_in_text(range, "failed to parse BibLaTeX", msg)
 }
 
 /// A loaded CSL style.
@@ -480,7 +480,7 @@ impl CslStyle {
                     typst_utils::hash128(&(TypeId::of::<Bytes>(), data)),
                 )))
             })
-            .map_err(|err| data.err_at(ReportPos::None, "failed to load CSL style", err))
+            .map_err(|err| data.err_in_text(ReportPos::None, "failed to load CSL style", err))
     }
 
     /// Get the underlying independent style.

--- a/crates/typst-library/src/text/raw.rs
+++ b/crates/typst-library/src/text/raw.rs
@@ -11,7 +11,7 @@ use typst_utils::ManuallyHash;
 use unicode_segmentation::UnicodeSegmentation;
 
 use super::Lang;
-use crate::diag::{SourceDiagnostic, SourceResult};
+use crate::diag::{LineCol, ReportPos, SourceDiagnostic, SourceResult};
 use crate::engine::Engine;
 use crate::foundations::{
     cast, elem, scope, Content, Derived, NativeElement, OneOrMultiple, Packed, PlainText,
@@ -19,7 +19,7 @@ use crate::foundations::{
 };
 use crate::html::{tag, HtmlElem};
 use crate::layout::{BlockBody, BlockElem, Em, HAlignment};
-use crate::loading::{DataSource, LineCol, Load, Loaded, ReportPos};
+use crate::loading::{DataSource, Load, Loaded};
 use crate::model::{Figurable, ParElem};
 use crate::text::{FontFamily, FontList, LinebreakElem, LocalName, TextElem, TextSize};
 use crate::visualize::Color;

--- a/crates/typst-library/src/text/raw.rs
+++ b/crates/typst-library/src/text/raw.rs
@@ -580,7 +580,7 @@ fn syntax_error_pos(error: &ParseSyntaxError) -> ReportPos {
     match error {
         ParseSyntaxError::InvalidYaml(scan_error) => {
             let m = scan_error.marker();
-            ReportPos::Full(
+            ReportPos::full(
                 m.index()..m.index(),
                 LineCol::one_based(m.line(), m.col() + 1),
             )

--- a/crates/typst-library/src/text/raw.rs
+++ b/crates/typst-library/src/text/raw.rs
@@ -19,7 +19,7 @@ use crate::foundations::{
 };
 use crate::html::{tag, HtmlElem};
 use crate::layout::{BlockBody, BlockElem, Em, HAlignment};
-use crate::loading::{Data, DataSource, LineCol, Load, ReportPos};
+use crate::loading::{Loaded, DataSource, LineCol, Load, ReportPos};
 use crate::model::{Figurable, ParElem};
 use crate::text::{FontFamily, FontList, LinebreakElem, LocalName, TextElem, TextSize};
 use crate::visualize::Color;
@@ -547,7 +547,7 @@ impl RawSyntax {
     /// Decode a syntax from a loaded source.
     #[comemo::memoize]
     #[typst_macros::time(name = "load syntaxes")]
-    fn decode(data: &Data) -> SourceResult<RawSyntax> {
+    fn decode(data: &Loaded) -> SourceResult<RawSyntax> {
         let str = data.as_str()?;
 
         let syntax = SyntaxDefinition::load_from_str(str, false, None)
@@ -568,7 +568,7 @@ impl RawSyntax {
     }
 }
 
-fn format_syntax_error(data: &Data, error: ParseSyntaxError) -> EcoVec<SourceDiagnostic> {
+fn format_syntax_error(data: &Loaded, error: ParseSyntaxError) -> EcoVec<SourceDiagnostic> {
     let pos = syntax_error_pos(&error);
     data.err_at(pos, "failed to parse syntax", error)
 }
@@ -603,7 +603,7 @@ impl RawTheme {
 
     /// Decode a theme from bytes.
     #[comemo::memoize]
-    fn decode(data: &Data) -> SourceResult<RawTheme> {
+    fn decode(data: &Loaded) -> SourceResult<RawTheme> {
         let mut cursor = std::io::Cursor::new(data.bytes.as_slice());
         let theme = synt::ThemeSet::load_from_reader(&mut cursor)
             .map_err(|err| format_theme_error(data, err))?;
@@ -617,7 +617,7 @@ impl RawTheme {
 }
 
 fn format_theme_error(
-    data: &Data,
+    data: &Loaded,
     error: syntect::LoadingError,
 ) -> EcoVec<SourceDiagnostic> {
     let pos = match &error {

--- a/crates/typst-library/src/text/raw.rs
+++ b/crates/typst-library/src/text/raw.rs
@@ -19,7 +19,7 @@ use crate::foundations::{
 };
 use crate::html::{tag, HtmlElem};
 use crate::layout::{BlockBody, BlockElem, Em, HAlignment};
-use crate::loading::{Loaded, DataSource, LineCol, Load, ReportPos};
+use crate::loading::{DataSource, LineCol, Load, Loaded, ReportPos};
 use crate::model::{Figurable, ParElem};
 use crate::text::{FontFamily, FontList, LinebreakElem, LocalName, TextElem, TextSize};
 use crate::visualize::Color;
@@ -568,9 +568,12 @@ impl RawSyntax {
     }
 }
 
-fn format_syntax_error(data: &Loaded, error: ParseSyntaxError) -> EcoVec<SourceDiagnostic> {
+fn format_syntax_error(
+    data: &Loaded,
+    error: ParseSyntaxError,
+) -> EcoVec<SourceDiagnostic> {
     let pos = syntax_error_pos(&error);
-    data.err_at(pos, "failed to parse syntax", error)
+    data.err_in_text(pos, "failed to parse syntax", error)
 }
 
 fn syntax_error_pos(error: &ParseSyntaxError) -> ReportPos {
@@ -624,7 +627,7 @@ fn format_theme_error(
         syntect::LoadingError::ParseSyntax(err, _) => syntax_error_pos(err),
         _ => ReportPos::None,
     };
-    data.err_at(pos, "failed to parse theme", error)
+    data.err_in_text(pos, "failed to parse theme", error)
 }
 
 /// A highlighted line of raw text.

--- a/crates/typst-library/src/visualize/image/mod.rs
+++ b/crates/typst-library/src/visualize/image/mod.rs
@@ -22,7 +22,7 @@ use crate::foundations::{
     Smart, StyleChain,
 };
 use crate::layout::{BlockElem, Length, Rel, Sizing};
-use crate::loading::{DataSource, Load, Readable};
+use crate::loading::{DataSource, Load, LoadSource, Loaded, Readable};
 use crate::model::Figurable;
 use crate::text::LocalName;
 
@@ -66,9 +66,9 @@ pub struct ImageElem {
     #[parse(
         let source = args.expect::<Spanned<DataSource>>("source")?;
         let data = source.load(engine.world)?;
-        Derived::new(source.v, data.bytes)
+        Derived::new(source.v, data)
     )]
-    pub source: Derived<DataSource, Bytes>,
+    pub source: Derived<DataSource, Loaded>,
 
     /// The image's format.
     ///
@@ -173,7 +173,7 @@ impl ImageElem {
     pub fn decode(
         span: Span,
         /// The data to decode as an image. Can be a string for SVGs.
-        data: Readable,
+        data: Spanned<Readable>,
         /// The image's format. Detected automatically by default.
         #[named]
         format: Option<Smart<ImageFormat>>,
@@ -193,8 +193,9 @@ impl ImageElem {
         #[named]
         scaling: Option<Smart<ImageScaling>>,
     ) -> StrResult<Content> {
-        let bytes = data.into_bytes();
-        let source = Derived::new(DataSource::Bytes(bytes.clone()), bytes);
+        let bytes = data.v.into_bytes();
+        let data = Loaded::new(Spanned::new(LoadSource::Bytes, data.span), bytes.clone());
+        let source = Derived::new(DataSource::Bytes(bytes), data);
         let mut elem = ImageElem::new(source);
         if let Some(format) = format {
             elem.push_format(format);

--- a/crates/typst-library/src/visualize/image/mod.rs
+++ b/crates/typst-library/src/visualize/image/mod.rs
@@ -66,7 +66,7 @@ pub struct ImageElem {
     #[parse(
         let source = args.expect::<Spanned<DataSource>>("source")?;
         let data = source.load(engine.world)?;
-        Derived::new(source.v, data)
+        Derived::new(source.v, data.bytes)
     )]
     pub source: Derived<DataSource, Bytes>,
 
@@ -155,7 +155,7 @@ pub struct ImageElem {
     #[parse(match args.named::<Spanned<Smart<DataSource>>>("icc")? {
         Some(Spanned { v: Smart::Custom(source), span }) => Some(Smart::Custom({
             let data = Spanned::new(&source, span).load(engine.world)?;
-            Derived::new(source, data)
+            Derived::new(source, data.bytes)
         })),
         Some(Spanned { v: Smart::Auto, .. }) => Some(Smart::Auto),
         None => None,

--- a/crates/typst-library/src/visualize/image/svg.rs
+++ b/crates/typst-library/src/visualize/image/svg.rs
@@ -9,6 +9,7 @@ use siphasher::sip128::{Hasher128, SipHasher13};
 use crate::diag::{format_xml_like_error, StrResult};
 use crate::foundations::Bytes;
 use crate::layout::Axes;
+use crate::loading::Data;
 use crate::text::{
     Font, FontBook, FontFlags, FontStretch, FontStyle, FontVariant, FontWeight,
 };
@@ -133,7 +134,12 @@ fn format_usvg_error(error: usvg::Error) -> EcoString {
         usvg::Error::InvalidSize => {
             "failed to parse SVG (width, height, or viewbox is invalid)".into()
         }
-        usvg::Error::ParsingFailed(error) => format_xml_like_error("SVG", error),
+        usvg::Error::ParsingFailed(error) => {
+            format_xml_like_error("SVG", &Data::dummy(), error)
+                .pop()
+                .unwrap()
+                .message
+        }
     }
 }
 

--- a/crates/typst-library/src/visualize/image/svg.rs
+++ b/crates/typst-library/src/visualize/image/svg.rs
@@ -137,7 +137,7 @@ fn format_usvg_error(error: usvg::Error) -> EcoString {
         usvg::Error::ParsingFailed(error) => {
             format_xml_like_error("SVG", &Loaded::dummy(), error)
                 .pop()
-                .unwrap()
+                .expect("at least one error")
                 .message
         }
     }

--- a/crates/typst-library/src/visualize/image/svg.rs
+++ b/crates/typst-library/src/visualize/image/svg.rs
@@ -3,13 +3,11 @@ use std::hash::{Hash, Hasher};
 use std::sync::{Arc, Mutex};
 
 use comemo::Tracked;
-use ecow::EcoString;
 use siphasher::sip128::{Hasher128, SipHasher13};
 
-use crate::diag::{format_xml_like_error, StrResult};
+use crate::diag::{format_xml_like_error, LoadError, LoadResult, ReportPos};
 use crate::foundations::Bytes;
 use crate::layout::Axes;
-use crate::loading::Loaded;
 use crate::text::{
     Font, FontBook, FontFlags, FontStretch, FontStyle, FontVariant, FontWeight,
 };
@@ -31,7 +29,7 @@ impl SvgImage {
     /// Decode an SVG image without fonts.
     #[comemo::memoize]
     #[typst_macros::time(name = "load svg")]
-    pub fn new(data: Bytes) -> StrResult<SvgImage> {
+    pub fn new(data: Bytes) -> LoadResult<SvgImage> {
         let tree =
             usvg::Tree::from_data(&data, &base_options()).map_err(format_usvg_error)?;
         Ok(Self(Arc::new(Repr { data, size: tree_size(&tree), font_hash: 0, tree })))
@@ -44,7 +42,7 @@ impl SvgImage {
         data: Bytes,
         world: Tracked<dyn World + '_>,
         families: &[&str],
-    ) -> StrResult<SvgImage> {
+    ) -> LoadResult<SvgImage> {
         let book = world.book();
         let resolver = Mutex::new(FontResolver::new(world, book, families));
         let tree = usvg::Tree::from_data(
@@ -126,21 +124,15 @@ fn tree_size(tree: &usvg::Tree) -> Axes<f64> {
 }
 
 /// Format the user-facing SVG decoding error message.
-fn format_usvg_error(error: usvg::Error) -> EcoString {
-    match error {
-        usvg::Error::NotAnUtf8Str => "file is not valid utf-8".into(),
-        usvg::Error::MalformedGZip => "file is not compressed correctly".into(),
-        usvg::Error::ElementsLimitReached => "file is too large".into(),
-        usvg::Error::InvalidSize => {
-            "failed to parse SVG (width, height, or viewbox is invalid)".into()
-        }
-        usvg::Error::ParsingFailed(error) => {
-            format_xml_like_error("SVG", &Loaded::dummy(), error)
-                .pop()
-                .expect("at least one error")
-                .message
-        }
-    }
+fn format_usvg_error(error: usvg::Error) -> LoadError {
+    let error = match error {
+        usvg::Error::NotAnUtf8Str => "file is not valid utf-8",
+        usvg::Error::MalformedGZip => "file is not compressed correctly",
+        usvg::Error::ElementsLimitReached => "file is too large",
+        usvg::Error::InvalidSize => "width, height, or viewbox is invalid",
+        usvg::Error::ParsingFailed(error) => return format_xml_like_error("SVG", error),
+    };
+    LoadError::new(ReportPos::None, "failed to parse SVG", error)
 }
 
 /// Provides Typst's fonts to usvg.

--- a/crates/typst-library/src/visualize/image/svg.rs
+++ b/crates/typst-library/src/visualize/image/svg.rs
@@ -9,7 +9,7 @@ use siphasher::sip128::{Hasher128, SipHasher13};
 use crate::diag::{format_xml_like_error, StrResult};
 use crate::foundations::Bytes;
 use crate::layout::Axes;
-use crate::loading::Data;
+use crate::loading::Loaded;
 use crate::text::{
     Font, FontBook, FontFlags, FontStretch, FontStyle, FontVariant, FontWeight,
 };
@@ -135,7 +135,7 @@ fn format_usvg_error(error: usvg::Error) -> EcoString {
             "failed to parse SVG (width, height, or viewbox is invalid)".into()
         }
         usvg::Error::ParsingFailed(error) => {
-            format_xml_like_error("SVG", &Data::dummy(), error)
+            format_xml_like_error("SVG", &Loaded::dummy(), error)
                 .pop()
                 .unwrap()
                 .message

--- a/crates/typst-syntax/Cargo.toml
+++ b/crates/typst-syntax/Cargo.toml
@@ -15,6 +15,7 @@ readme = { workspace = true }
 [dependencies]
 typst-timing = { workspace = true }
 typst-utils = { workspace = true }
+comemo = { workspace = true }
 ecow = { workspace = true }
 serde = { workspace = true }
 toml = { workspace = true }

--- a/crates/typst-syntax/src/lib.rs
+++ b/crates/typst-syntax/src/lib.rs
@@ -7,6 +7,7 @@ mod file;
 mod highlight;
 mod kind;
 mod lexer;
+mod lines;
 mod node;
 mod parser;
 mod path;
@@ -22,6 +23,7 @@ pub use self::lexer::{
     is_id_continue, is_id_start, is_ident, is_newline, is_valid_label_literal_id,
     link_prefix, split_newlines,
 };
+pub use self::lines::Lines;
 pub use self::node::{LinkedChildren, LinkedNode, Side, SyntaxError, SyntaxNode};
 pub use self::parser::{parse, parse_code, parse_math};
 pub use self::path::VirtualPath;

--- a/crates/typst-syntax/src/lines.rs
+++ b/crates/typst-syntax/src/lines.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use crate::is_newline;
 
-/// Metadata about lines.
+/// A text buffer and metadata about lines.
 #[derive(Clone)]
 pub struct Lines<S>(Arc<Repr<S>>);
 

--- a/crates/typst-syntax/src/lines.rs
+++ b/crates/typst-syntax/src/lines.rs
@@ -230,6 +230,18 @@ impl Lines<String> {
     }
 }
 
+impl<S: Hash> Hash for Lines<S> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.str.hash(state);
+    }
+}
+
+impl<S: AsRef<str>> AsRef<str> for Lines<S> {
+    fn as_ref(&self) -> &str {
+        self.0.str.as_ref()
+    }
+}
+
 /// Create a line vector.
 fn lines(text: &str) -> Vec<Line> {
     std::iter::once(Line { byte_idx: 0, utf16_idx: 0 })
@@ -391,17 +403,5 @@ mod tests {
 
         // Test removing everything.
         test(TEST, 0..21, "", "");
-    }
-}
-
-impl<S: Hash> Hash for Lines<S> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0.str.hash(state);
-    }
-}
-
-impl<S: AsRef<str>> AsRef<str> for Lines<S> {
-    fn as_ref(&self) -> &str {
-        self.0.str.as_ref()
     }
 }

--- a/crates/typst-syntax/src/lines.rs
+++ b/crates/typst-syntax/src/lines.rs
@@ -1,0 +1,407 @@
+use std::hash::{Hash, Hasher};
+use std::iter::zip;
+use std::ops::Range;
+use std::str::Utf8Error;
+use std::sync::Arc;
+
+use crate::is_newline;
+
+/// Metadata about lines.
+#[derive(Clone)]
+pub struct Lines<S>(Arc<Repr<S>>);
+
+#[derive(Clone)]
+struct Repr<S> {
+    lines: Vec<Line>,
+    str: S,
+}
+
+/// Metadata about a line.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct Line {
+    /// The UTF-8 byte offset where the line starts.
+    byte_idx: usize,
+    /// The UTF-16 codepoint offset where the line starts.
+    utf16_idx: usize,
+}
+
+impl<S: AsRef<str>> Lines<S> {
+    /// TODO: memoize this?
+    pub fn new(str: S) -> Self {
+        let lines = lines(str.as_ref());
+        Lines(Arc::new(Repr { lines, str }))
+    }
+
+    pub fn text(&self) -> &str {
+        self.0.str.as_ref()
+    }
+
+    /// Get the length of the file in UTF-8 encoded bytes.
+    pub fn len_bytes(&self) -> usize {
+        self.0.str.as_ref().len()
+    }
+
+    /// Get the length of the file in UTF-16 code units.
+    pub fn len_utf16(&self) -> usize {
+        let last = self.0.lines.last().unwrap();
+        last.utf16_idx + len_utf16(&self.text()[last.byte_idx..])
+    }
+
+    /// Get the length of the file in lines.
+    pub fn len_lines(&self) -> usize {
+        self.0.lines.len()
+    }
+
+    /// Return the index of the UTF-16 code unit at the byte index.
+    pub fn byte_to_utf16(&self, byte_idx: usize) -> Option<usize> {
+        let line_idx = self.byte_to_line(byte_idx)?;
+        let line = self.0.lines.get(line_idx)?;
+        let head = self.text().get(line.byte_idx..byte_idx)?;
+        Some(line.utf16_idx + len_utf16(head))
+    }
+
+    /// Return the index of the line that contains the given byte index.
+    pub fn byte_to_line(&self, byte_idx: usize) -> Option<usize> {
+        (byte_idx <= self.text().len()).then(|| {
+            match self.0.lines.binary_search_by_key(&byte_idx, |line| line.byte_idx) {
+                Ok(i) => i,
+                Err(i) => i - 1,
+            }
+        })
+    }
+
+    /// Return the index of the column at the byte index.
+    ///
+    /// The column is defined as the number of characters in the line before the
+    /// byte index.
+    pub fn byte_to_column(&self, byte_idx: usize) -> Option<usize> {
+        let line = self.byte_to_line(byte_idx)?;
+        let start = self.line_to_byte(line)?;
+        let head = self.text().get(start..byte_idx)?;
+        Some(head.chars().count())
+    }
+
+    /// Return the index of the line and column at the byte index.
+    pub fn byte_to_line_column(&self, byte_idx: usize) -> Option<(usize, usize)> {
+        let line = self.byte_to_line(byte_idx)?;
+        let start = self.line_to_byte(line)?;
+        let head = self.text().get(start..byte_idx)?;
+        let col = head.chars().count();
+        Some((line, col))
+    }
+
+    /// Return the byte index at the UTF-16 code unit.
+    pub fn utf16_to_byte(&self, utf16_idx: usize) -> Option<usize> {
+        let line = self.0.lines.get(
+            match self.0.lines.binary_search_by_key(&utf16_idx, |line| line.utf16_idx) {
+                Ok(i) => i,
+                Err(i) => i - 1,
+            },
+        )?;
+
+        let text = self.text();
+        let mut k = line.utf16_idx;
+        for (i, c) in text[line.byte_idx..].char_indices() {
+            if k >= utf16_idx {
+                return Some(line.byte_idx + i);
+            }
+            k += c.len_utf16();
+        }
+
+        (k == utf16_idx).then_some(text.len())
+    }
+
+    /// Return the byte position at which the given line starts.
+    pub fn line_to_byte(&self, line_idx: usize) -> Option<usize> {
+        self.0.lines.get(line_idx).map(|line| line.byte_idx)
+    }
+
+    /// Return the range which encloses the given line.
+    pub fn line_to_range(&self, line_idx: usize) -> Option<Range<usize>> {
+        let start = self.line_to_byte(line_idx)?;
+        let end = self.line_to_byte(line_idx + 1).unwrap_or(self.text().len());
+        Some(start..end)
+    }
+
+    /// Return the byte index of the given (line, column) pair.
+    ///
+    /// The column defines the number of characters to go beyond the start of
+    /// the line.
+    pub fn line_column_to_byte(
+        &self,
+        line_idx: usize,
+        column_idx: usize,
+    ) -> Option<usize> {
+        let range = self.line_to_range(line_idx)?;
+        let line = self.text().get(range.clone())?;
+        let mut chars = line.chars();
+        for _ in 0..column_idx {
+            chars.next();
+        }
+        Some(range.start + (line.len() - chars.as_str().len()))
+    }
+}
+
+impl Lines<String> {
+    /// Tries to convert the bytes
+    #[comemo::memoize]
+    pub fn from_bytes(bytes: &[u8]) -> Result<Lines<String>, Utf8Error> {
+        let str = std::str::from_utf8(bytes)?;
+        Ok(Lines::new(str.to_string()))
+    }
+
+    /// Fully replace the source text.
+    ///
+    /// This performs a naive (suffix/prefix-based) diff of the old and new text
+    /// to produce the smallest single edit that transforms old into new and
+    /// then calls [`edit`](Self::edit) with it.
+    ///
+    /// Returns whether any changes were made.
+    pub fn replace(&mut self, new: &str) -> bool {
+        let Some((prefix, suffix)) = self.replacement_range(new) else {
+            return false;
+        };
+
+        let old = self.text();
+        let replace = prefix..old.len() - suffix;
+        let with = &new[prefix..new.len() - suffix];
+        self.edit(replace, with);
+
+        true
+    }
+
+    /// Returns the common prefix and suffix lengths.
+    /// Returns [`None`] if the old and new strings are equal.
+    pub fn replacement_range(&self, new: &str) -> Option<(usize, usize)> {
+        let old = self.text();
+
+        let mut prefix =
+            zip(old.bytes(), new.bytes()).take_while(|(x, y)| x == y).count();
+
+        if prefix == old.len() && prefix == new.len() {
+            return None;
+        }
+
+        while !old.is_char_boundary(prefix) || !new.is_char_boundary(prefix) {
+            prefix -= 1;
+        }
+
+        let mut suffix = zip(old[prefix..].bytes().rev(), new[prefix..].bytes().rev())
+            .take_while(|(x, y)| x == y)
+            .count();
+
+        while !old.is_char_boundary(old.len() - suffix)
+            || !new.is_char_boundary(new.len() - suffix)
+        {
+            suffix += 1;
+        }
+
+        Some((prefix, suffix))
+    }
+
+    /// Edit the source file by replacing the given range.
+    ///
+    /// Returns the range in the new source that was ultimately reparsed.
+    ///
+    /// The method panics if the `replace` range is out of bounds.
+    #[track_caller]
+    pub fn edit(&mut self, replace: Range<usize>, with: &str) {
+        let start_byte = replace.start;
+        let start_utf16 = self.byte_to_utf16(start_byte).unwrap();
+        let line = self.byte_to_line(start_byte).unwrap();
+
+        let inner = Arc::make_mut(&mut self.0);
+
+        // Update the text itself.
+        inner.str.replace_range(replace.clone(), with);
+
+        // Remove invalidated line starts.
+        inner.lines.truncate(line + 1);
+
+        // Handle adjoining of \r and \n.
+        if inner.str[..start_byte].ends_with('\r') && with.starts_with('\n') {
+            inner.lines.pop();
+        }
+
+        // Recalculate the line starts after the edit.
+        inner
+            .lines
+            .extend(lines_from(start_byte, start_utf16, &inner.str[start_byte..]));
+    }
+}
+
+/// Create a line vector.
+fn lines(text: &str) -> Vec<Line> {
+    std::iter::once(Line { byte_idx: 0, utf16_idx: 0 })
+        .chain(lines_from(0, 0, text))
+        .collect()
+}
+
+/// Compute a line iterator from an offset.
+fn lines_from(
+    byte_offset: usize,
+    utf16_offset: usize,
+    text: &str,
+) -> impl Iterator<Item = Line> + '_ {
+    let mut s = unscanny::Scanner::new(text);
+    let mut utf16_idx = utf16_offset;
+
+    std::iter::from_fn(move || {
+        s.eat_until(|c: char| {
+            utf16_idx += c.len_utf16();
+            is_newline(c)
+        });
+
+        if s.done() {
+            return None;
+        }
+
+        if s.eat() == Some('\r') && s.eat_if('\n') {
+            utf16_idx += 1;
+        }
+
+        Some(Line { byte_idx: byte_offset + s.cursor(), utf16_idx })
+    })
+}
+
+/// The number of code units this string would use if it was encoded in
+/// UTF16. This runs in linear time.
+fn len_utf16(string: &str) -> usize {
+    string.chars().map(char::len_utf16).sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST: &str = "ä\tcde\nf💛g\r\nhi\rjkl";
+
+    #[test]
+    fn test_source_file_new() {
+        let lines = Lines::new(TEST);
+        assert_eq!(
+            lines.0.lines,
+            [
+                Line { byte_idx: 0, utf16_idx: 0 },
+                Line { byte_idx: 7, utf16_idx: 6 },
+                Line { byte_idx: 15, utf16_idx: 12 },
+                Line { byte_idx: 18, utf16_idx: 15 },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_source_file_pos_to_line() {
+        let lines = Lines::new(TEST);
+        assert_eq!(lines.byte_to_line(0), Some(0));
+        assert_eq!(lines.byte_to_line(2), Some(0));
+        assert_eq!(lines.byte_to_line(6), Some(0));
+        assert_eq!(lines.byte_to_line(7), Some(1));
+        assert_eq!(lines.byte_to_line(8), Some(1));
+        assert_eq!(lines.byte_to_line(12), Some(1));
+        assert_eq!(lines.byte_to_line(21), Some(3));
+        assert_eq!(lines.byte_to_line(22), None);
+    }
+
+    #[test]
+    fn test_source_file_pos_to_column() {
+        let lines = Lines::new(TEST);
+        assert_eq!(lines.byte_to_column(0), Some(0));
+        assert_eq!(lines.byte_to_column(2), Some(1));
+        assert_eq!(lines.byte_to_column(6), Some(5));
+        assert_eq!(lines.byte_to_column(7), Some(0));
+        assert_eq!(lines.byte_to_column(8), Some(1));
+        assert_eq!(lines.byte_to_column(12), Some(2));
+    }
+
+    #[test]
+    fn test_source_file_utf16() {
+        #[track_caller]
+        fn roundtrip(lines: &Lines<&str>, byte_idx: usize, utf16_idx: usize) {
+            let middle = lines.byte_to_utf16(byte_idx).unwrap();
+            let result = lines.utf16_to_byte(middle).unwrap();
+            assert_eq!(middle, utf16_idx);
+            assert_eq!(result, byte_idx);
+        }
+
+        let lines = Lines::new(TEST);
+        roundtrip(&lines, 0, 0);
+        roundtrip(&lines, 2, 1);
+        roundtrip(&lines, 3, 2);
+        roundtrip(&lines, 8, 7);
+        roundtrip(&lines, 12, 9);
+        roundtrip(&lines, 21, 18);
+        assert_eq!(lines.byte_to_utf16(22), None);
+        assert_eq!(lines.utf16_to_byte(19), None);
+    }
+
+    #[test]
+    fn test_source_file_roundtrip() {
+        #[track_caller]
+        fn roundtrip(lines: &Lines<&str>, byte_idx: usize) {
+            let line = lines.byte_to_line(byte_idx).unwrap();
+            let column = lines.byte_to_column(byte_idx).unwrap();
+            let result = lines.line_column_to_byte(line, column).unwrap();
+            assert_eq!(result, byte_idx);
+        }
+
+        let lines = Lines::new(TEST);
+        roundtrip(&lines, 0);
+        roundtrip(&lines, 7);
+        roundtrip(&lines, 12);
+        roundtrip(&lines, 21);
+    }
+
+    #[test]
+    fn test_source_file_edit() {
+        // This tests only the non-parser parts. The reparsing itself is
+        // tested separately.
+        #[track_caller]
+        fn test(prev: &str, range: Range<usize>, with: &str, after: &str) {
+            let reference = Lines::new(after);
+
+            let mut edited = Lines::new(prev.to_string());
+            edited.edit(range.clone(), with);
+            assert_eq!(edited.text(), reference.text());
+            assert_eq!(edited.0.lines, reference.0.lines);
+
+            let mut replaced = Lines::new(prev.to_string());
+            replaced.replace(&{
+                let mut s = prev.to_string();
+                s.replace_range(range, with);
+                s
+            });
+            assert_eq!(replaced.text(), reference.text());
+            assert_eq!(replaced.0.lines, reference.0.lines);
+        }
+
+        // Test inserting at the beginning.
+        test("abc\n", 0..0, "hi\n", "hi\nabc\n");
+        test("\nabc", 0..0, "hi\r", "hi\r\nabc");
+
+        // Test editing in the middle.
+        test(TEST, 4..16, "❌", "ä\tc❌i\rjkl");
+
+        // Test appending.
+        test("abc\ndef", 7..7, "hi", "abc\ndefhi");
+        test("abc\ndef\n", 8..8, "hi", "abc\ndef\nhi");
+
+        // Test appending with adjoining \r and \n.
+        test("abc\ndef\r", 8..8, "\nghi", "abc\ndef\r\nghi");
+
+        // Test removing everything.
+        test(TEST, 0..21, "", "");
+    }
+}
+
+impl<S: Hash> Hash for Lines<S> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.str.hash(state);
+    }
+}
+
+impl<S: AsRef<str>> AsRef<str> for Lines<S> {
+    fn as_ref(&self) -> &str {
+        self.0.str.as_ref()
+    }
+}

--- a/crates/typst-syntax/src/source.rs
+++ b/crates/typst-syntax/src/source.rs
@@ -2,14 +2,14 @@
 
 use std::fmt::{self, Debug, Formatter};
 use std::hash::{Hash, Hasher};
-use std::iter::zip;
 use std::ops::Range;
 use std::sync::Arc;
 
 use typst_utils::LazyHash;
 
+use crate::lines::Lines;
 use crate::reparser::reparse;
-use crate::{is_newline, parse, FileId, LinkedNode, Span, SyntaxNode, VirtualPath};
+use crate::{parse, FileId, LinkedNode, Span, SyntaxNode, VirtualPath};
 
 /// A source file.
 ///
@@ -24,9 +24,8 @@ pub struct Source(Arc<Repr>);
 #[derive(Clone)]
 struct Repr {
     id: FileId,
-    text: LazyHash<String>,
     root: LazyHash<SyntaxNode>,
-    lines: Vec<Line>,
+    lines: LazyHash<Lines<String>>,
 }
 
 impl Source {
@@ -37,8 +36,7 @@ impl Source {
         root.numberize(id, Span::FULL).unwrap();
         Self(Arc::new(Repr {
             id,
-            lines: lines(&text),
-            text: LazyHash::new(text),
+            lines: LazyHash::new(Lines::new(text)),
             root: LazyHash::new(root),
         }))
     }
@@ -59,8 +57,13 @@ impl Source {
     }
 
     /// The whole source as a string slice.
+    pub fn lines(&self) -> Lines<String> {
+        Lines::clone(&self.0.lines)
+    }
+
+    /// The whole source as a string slice.
     pub fn text(&self) -> &str {
-        &self.0.text
+        &self.0.lines.text()
     }
 
     /// Slice out the part of the source code enclosed by the range.
@@ -77,29 +80,12 @@ impl Source {
     /// Returns the range in the new source that was ultimately reparsed.
     pub fn replace(&mut self, new: &str) -> Range<usize> {
         let _scope = typst_timing::TimingScope::new("replace source");
-        let old = self.text();
 
-        let mut prefix =
-            zip(old.bytes(), new.bytes()).take_while(|(x, y)| x == y).count();
-
-        if prefix == old.len() && prefix == new.len() {
+        let Some((prefix, suffix)) = self.0.lines.replacement_range(new) else {
             return 0..0;
-        }
+        };
 
-        while !old.is_char_boundary(prefix) || !new.is_char_boundary(prefix) {
-            prefix -= 1;
-        }
-
-        let mut suffix = zip(old[prefix..].bytes().rev(), new[prefix..].bytes().rev())
-            .take_while(|(x, y)| x == y)
-            .count();
-
-        while !old.is_char_boundary(old.len() - suffix)
-            || !new.is_char_boundary(new.len() - suffix)
-        {
-            suffix += 1;
-        }
-
+        let old = self.text();
         let replace = prefix..old.len() - suffix;
         let with = &new[prefix..new.len() - suffix];
         self.edit(replace, with)
@@ -112,48 +98,28 @@ impl Source {
     /// The method panics if the `replace` range is out of bounds.
     #[track_caller]
     pub fn edit(&mut self, replace: Range<usize>, with: &str) -> Range<usize> {
-        let start_byte = replace.start;
-        let start_utf16 = self.byte_to_utf16(start_byte).unwrap();
-        let line = self.byte_to_line(start_byte).unwrap();
-
         let inner = Arc::make_mut(&mut self.0);
 
-        // Update the text itself.
-        inner.text.replace_range(replace.clone(), with);
-
-        // Remove invalidated line starts.
-        inner.lines.truncate(line + 1);
-
-        // Handle adjoining of \r and \n.
-        if inner.text[..start_byte].ends_with('\r') && with.starts_with('\n') {
-            inner.lines.pop();
-        }
-
-        // Recalculate the line starts after the edit.
-        inner.lines.extend(lines_from(
-            start_byte,
-            start_utf16,
-            &inner.text[start_byte..],
-        ));
+        // Update the text and lines.
+        inner.lines.edit(replace.clone(), with);
 
         // Incrementally reparse the replaced range.
-        reparse(&mut inner.root, &inner.text, replace, with.len())
+        reparse(&mut inner.root, inner.lines.text(), replace, with.len())
     }
 
     /// Get the length of the file in UTF-8 encoded bytes.
     pub fn len_bytes(&self) -> usize {
-        self.text().len()
+        self.0.lines.len_bytes()
     }
 
     /// Get the length of the file in UTF-16 code units.
     pub fn len_utf16(&self) -> usize {
-        let last = self.0.lines.last().unwrap();
-        last.utf16_idx + len_utf16(&self.0.text[last.byte_idx..])
+        self.0.lines.len_utf16()
     }
 
     /// Get the length of the file in lines.
     pub fn len_lines(&self) -> usize {
-        self.0.lines.len()
+        self.0.lines.len_lines()
     }
 
     /// Find the node with the given span.
@@ -171,85 +137,6 @@ impl Source {
     pub fn range(&self, span: Span) -> Option<Range<usize>> {
         Some(self.find(span)?.range())
     }
-
-    /// Return the index of the UTF-16 code unit at the byte index.
-    pub fn byte_to_utf16(&self, byte_idx: usize) -> Option<usize> {
-        let line_idx = self.byte_to_line(byte_idx)?;
-        let line = self.0.lines.get(line_idx)?;
-        let head = self.0.text.get(line.byte_idx..byte_idx)?;
-        Some(line.utf16_idx + len_utf16(head))
-    }
-
-    /// Return the index of the line that contains the given byte index.
-    pub fn byte_to_line(&self, byte_idx: usize) -> Option<usize> {
-        (byte_idx <= self.0.text.len()).then(|| {
-            match self.0.lines.binary_search_by_key(&byte_idx, |line| line.byte_idx) {
-                Ok(i) => i,
-                Err(i) => i - 1,
-            }
-        })
-    }
-
-    /// Return the index of the column at the byte index.
-    ///
-    /// The column is defined as the number of characters in the line before the
-    /// byte index.
-    pub fn byte_to_column(&self, byte_idx: usize) -> Option<usize> {
-        let line = self.byte_to_line(byte_idx)?;
-        let start = self.line_to_byte(line)?;
-        let head = self.get(start..byte_idx)?;
-        Some(head.chars().count())
-    }
-
-    /// Return the byte index at the UTF-16 code unit.
-    pub fn utf16_to_byte(&self, utf16_idx: usize) -> Option<usize> {
-        let line = self.0.lines.get(
-            match self.0.lines.binary_search_by_key(&utf16_idx, |line| line.utf16_idx) {
-                Ok(i) => i,
-                Err(i) => i - 1,
-            },
-        )?;
-
-        let mut k = line.utf16_idx;
-        for (i, c) in self.0.text[line.byte_idx..].char_indices() {
-            if k >= utf16_idx {
-                return Some(line.byte_idx + i);
-            }
-            k += c.len_utf16();
-        }
-
-        (k == utf16_idx).then_some(self.0.text.len())
-    }
-
-    /// Return the byte position at which the given line starts.
-    pub fn line_to_byte(&self, line_idx: usize) -> Option<usize> {
-        self.0.lines.get(line_idx).map(|line| line.byte_idx)
-    }
-
-    /// Return the range which encloses the given line.
-    pub fn line_to_range(&self, line_idx: usize) -> Option<Range<usize>> {
-        let start = self.line_to_byte(line_idx)?;
-        let end = self.line_to_byte(line_idx + 1).unwrap_or(self.0.text.len());
-        Some(start..end)
-    }
-
-    /// Return the byte index of the given (line, column) pair.
-    ///
-    /// The column defines the number of characters to go beyond the start of
-    /// the line.
-    pub fn line_column_to_byte(
-        &self,
-        line_idx: usize,
-        column_idx: usize,
-    ) -> Option<usize> {
-        let range = self.line_to_range(line_idx)?;
-        let line = self.get(range.clone())?;
-        let mut chars = line.chars();
-        for _ in 0..column_idx {
-            chars.next();
-        }
-        Some(range.start + (line.len() - chars.as_str().len()))
-    }
 }
 
 impl Debug for Source {
@@ -261,7 +148,7 @@ impl Debug for Source {
 impl Hash for Source {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.0.id.hash(state);
-        self.0.text.hash(state);
+        self.0.lines.hash(state);
         self.0.root.hash(state);
     }
 }
@@ -269,178 +156,5 @@ impl Hash for Source {
 impl AsRef<str> for Source {
     fn as_ref(&self) -> &str {
         self.text()
-    }
-}
-
-/// Metadata about a line.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-struct Line {
-    /// The UTF-8 byte offset where the line starts.
-    byte_idx: usize,
-    /// The UTF-16 codepoint offset where the line starts.
-    utf16_idx: usize,
-}
-
-/// Create a line vector.
-fn lines(text: &str) -> Vec<Line> {
-    std::iter::once(Line { byte_idx: 0, utf16_idx: 0 })
-        .chain(lines_from(0, 0, text))
-        .collect()
-}
-
-/// Compute a line iterator from an offset.
-fn lines_from(
-    byte_offset: usize,
-    utf16_offset: usize,
-    text: &str,
-) -> impl Iterator<Item = Line> + '_ {
-    let mut s = unscanny::Scanner::new(text);
-    let mut utf16_idx = utf16_offset;
-
-    std::iter::from_fn(move || {
-        s.eat_until(|c: char| {
-            utf16_idx += c.len_utf16();
-            is_newline(c)
-        });
-
-        if s.done() {
-            return None;
-        }
-
-        if s.eat() == Some('\r') && s.eat_if('\n') {
-            utf16_idx += 1;
-        }
-
-        Some(Line { byte_idx: byte_offset + s.cursor(), utf16_idx })
-    })
-}
-
-/// The number of code units this string would use if it was encoded in
-/// UTF16. This runs in linear time.
-fn len_utf16(string: &str) -> usize {
-    string.chars().map(char::len_utf16).sum()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    const TEST: &str = "ä\tcde\nf💛g\r\nhi\rjkl";
-
-    #[test]
-    fn test_source_file_new() {
-        let source = Source::detached(TEST);
-        assert_eq!(
-            source.0.lines,
-            [
-                Line { byte_idx: 0, utf16_idx: 0 },
-                Line { byte_idx: 7, utf16_idx: 6 },
-                Line { byte_idx: 15, utf16_idx: 12 },
-                Line { byte_idx: 18, utf16_idx: 15 },
-            ]
-        );
-    }
-
-    #[test]
-    fn test_source_file_pos_to_line() {
-        let source = Source::detached(TEST);
-        assert_eq!(source.byte_to_line(0), Some(0));
-        assert_eq!(source.byte_to_line(2), Some(0));
-        assert_eq!(source.byte_to_line(6), Some(0));
-        assert_eq!(source.byte_to_line(7), Some(1));
-        assert_eq!(source.byte_to_line(8), Some(1));
-        assert_eq!(source.byte_to_line(12), Some(1));
-        assert_eq!(source.byte_to_line(21), Some(3));
-        assert_eq!(source.byte_to_line(22), None);
-    }
-
-    #[test]
-    fn test_source_file_pos_to_column() {
-        let source = Source::detached(TEST);
-        assert_eq!(source.byte_to_column(0), Some(0));
-        assert_eq!(source.byte_to_column(2), Some(1));
-        assert_eq!(source.byte_to_column(6), Some(5));
-        assert_eq!(source.byte_to_column(7), Some(0));
-        assert_eq!(source.byte_to_column(8), Some(1));
-        assert_eq!(source.byte_to_column(12), Some(2));
-    }
-
-    #[test]
-    fn test_source_file_utf16() {
-        #[track_caller]
-        fn roundtrip(source: &Source, byte_idx: usize, utf16_idx: usize) {
-            let middle = source.byte_to_utf16(byte_idx).unwrap();
-            let result = source.utf16_to_byte(middle).unwrap();
-            assert_eq!(middle, utf16_idx);
-            assert_eq!(result, byte_idx);
-        }
-
-        let source = Source::detached(TEST);
-        roundtrip(&source, 0, 0);
-        roundtrip(&source, 2, 1);
-        roundtrip(&source, 3, 2);
-        roundtrip(&source, 8, 7);
-        roundtrip(&source, 12, 9);
-        roundtrip(&source, 21, 18);
-        assert_eq!(source.byte_to_utf16(22), None);
-        assert_eq!(source.utf16_to_byte(19), None);
-    }
-
-    #[test]
-    fn test_source_file_roundtrip() {
-        #[track_caller]
-        fn roundtrip(source: &Source, byte_idx: usize) {
-            let line = source.byte_to_line(byte_idx).unwrap();
-            let column = source.byte_to_column(byte_idx).unwrap();
-            let result = source.line_column_to_byte(line, column).unwrap();
-            assert_eq!(result, byte_idx);
-        }
-
-        let source = Source::detached(TEST);
-        roundtrip(&source, 0);
-        roundtrip(&source, 7);
-        roundtrip(&source, 12);
-        roundtrip(&source, 21);
-    }
-
-    #[test]
-    fn test_source_file_edit() {
-        // This tests only the non-parser parts. The reparsing itself is
-        // tested separately.
-        #[track_caller]
-        fn test(prev: &str, range: Range<usize>, with: &str, after: &str) {
-            let reference = Source::detached(after);
-
-            let mut edited = Source::detached(prev);
-            edited.edit(range.clone(), with);
-            assert_eq!(edited.text(), reference.text());
-            assert_eq!(edited.0.lines, reference.0.lines);
-
-            let mut replaced = Source::detached(prev);
-            replaced.replace(&{
-                let mut s = prev.to_string();
-                s.replace_range(range, with);
-                s
-            });
-            assert_eq!(replaced.text(), reference.text());
-            assert_eq!(replaced.0.lines, reference.0.lines);
-        }
-
-        // Test inserting at the beginning.
-        test("abc\n", 0..0, "hi\n", "hi\nabc\n");
-        test("\nabc", 0..0, "hi\r", "hi\r\nabc");
-
-        // Test editing in the middle.
-        test(TEST, 4..16, "❌", "ä\tc❌i\rjkl");
-
-        // Test appending.
-        test("abc\ndef", 7..7, "hi", "abc\ndefhi");
-        test("abc\ndef\n", 8..8, "hi", "abc\ndef\nhi");
-
-        // Test appending with adjoining \r and \n.
-        test("abc\ndef\r", 8..8, "\nghi", "abc\ndef\r\nghi");
-
-        // Test removing everything.
-        test(TEST, 0..21, "", "");
     }
 }

--- a/crates/typst-syntax/src/source.rs
+++ b/crates/typst-syntax/src/source.rs
@@ -63,7 +63,7 @@ impl Source {
 
     /// The whole source as a string slice.
     pub fn text(&self) -> &str {
-        &self.0.lines.text()
+        self.0.lines.text()
     }
 
     /// Slice out the part of the source code enclosed by the range.

--- a/tests/src/collect.rs
+++ b/tests/src/collect.rs
@@ -12,8 +12,6 @@ use typst_syntax::{
 };
 use unscanny::Scanner;
 
-use crate::world::{read, system_path};
-
 /// Collects all tests from all files.
 ///
 /// Returns:
@@ -390,9 +388,17 @@ impl<'a> Parser<'a> {
         })
     }
 
+    #[cfg(not(feature = "default"))]
+    fn parse_range_external(&mut self, _file: FileId) -> Option<Range<usize>> {
+        panic!("external file ranges are not expected when testing `typst_syntax`");
+    }
+
     /// Parse a range in an external file, optionally abbreviated as just a position
     /// if the range is empty.
+    #[cfg(feature = "default")]
     fn parse_range_external(&mut self, file: FileId) -> Option<Range<usize>> {
+        use crate::world::{read, system_path};
+
         let path = match system_path(file) {
             Ok(path) => path,
             Err(err) => {

--- a/tests/src/run.rs
+++ b/tests/src/run.rs
@@ -269,8 +269,8 @@ impl<'a> Runner<'a> {
         if range != note.range {
             let note_range = self.format_range(note.file, &note.range);
             let note_text = self.text_for_range(note.file, &note.range);
-            let diag_range = self.format_range(note.file, &range);
-            let diag_text = self.text_for_range(note.file, &range);
+            let diag_range = self.format_range(file, &range);
+            let diag_text = self.text_for_range(file, &range);
             log!(self, "mismatched range ({}):", note.pos);
             log!(self, "  message   | {}", note.message);
             log!(self, "  annotated | {note_range:<9} | {note_text}");
@@ -299,7 +299,7 @@ impl<'a> Runner<'a> {
             )
         } else {
             let bytes = self.world.file(file).unwrap();
-            let text = String::from_utf8_lossy(&bytes);
+            let text = std::str::from_utf8(&bytes).unwrap();
             format!("`{}`", text[range.clone()].replace('\n', "\\n").replace('\r', "\\r"))
         }
     }

--- a/tests/src/run.rs
+++ b/tests/src/run.rs
@@ -8,7 +8,7 @@ use typst::diag::{SourceDiagnostic, Warned};
 use typst::html::HtmlDocument;
 use typst::layout::{Abs, Frame, FrameItem, PagedDocument, Transform};
 use typst::visualize::Color;
-use typst::{Document, World, WorldExt};
+use typst::{Document, WorldExt};
 use typst_pdf::PdfOptions;
 use typst_syntax::FileId;
 
@@ -289,19 +289,11 @@ impl<'a> Runner<'a> {
     fn text_for_range(&self, file: FileId, range: &Option<Range<usize>>) -> String {
         let Some(range) = range else { return "No text".into() };
         if range.is_empty() {
-            "(empty)".into()
-        } else if file == self.test.source.id() {
-            format!(
-                "`{}`",
-                self.test.source.text()[range.clone()]
-                    .replace('\n', "\\n")
-                    .replace('\r', "\\r")
-            )
-        } else {
-            let bytes = self.world.file(file).unwrap();
-            let text = std::str::from_utf8(&bytes).unwrap();
-            format!("`{}`", text[range.clone()].replace('\n', "\\n").replace('\r', "\\r"))
+            return "(empty)".into();
         }
+
+        let lines = self.world.lookup(file);
+        lines.text()[range.clone()].replace('\n', "\\n").replace('\r', "\\r")
     }
 
     /// Display a byte range as a line:column range.

--- a/tests/src/run.rs
+++ b/tests/src/run.rs
@@ -10,7 +10,7 @@ use typst::layout::{Abs, Frame, FrameItem, PagedDocument, Transform};
 use typst::visualize::Color;
 use typst::{Document, World, WorldExt};
 use typst_pdf::PdfOptions;
-use typst_syntax::{FileId, Lines};
+use typst_syntax::FileId;
 
 use crate::collect::{Attr, FileSize, NoteKind, Test};
 use crate::logger::TestResult;
@@ -326,15 +326,9 @@ impl<'a> Runner<'a> {
 
     /// Display a position as a line:column pair.
     fn format_pos(&self, file: FileId, pos: usize) -> String {
-        let res = if file != self.test.source.id() {
-            let bytes = self.world.file(file).unwrap();
-            let lines = Lines::from_bytes(&bytes).unwrap();
-            lines.byte_to_line_column(pos).map(|(line, col)| (line + 1, col + 1))
-        } else {
-            (self.test.source.lines())
-                .byte_to_line_column(pos)
-                .map(|(line, col)| (line + 1, col + 1))
-        };
+        let lines = self.world.lookup(file);
+
+        let res = lines.byte_to_line_column(pos).map(|(line, col)| (line + 1, col + 1));
         let Some((line, col)) = res else {
             return "oob".into();
         };

--- a/tests/src/world.rs
+++ b/tests/src/world.rs
@@ -149,7 +149,7 @@ impl FileSlot {
 }
 
 /// The file system path for a file ID.
-fn system_path(id: FileId) -> FileResult<PathBuf> {
+pub(crate) fn system_path(id: FileId) -> FileResult<PathBuf> {
     let root: PathBuf = match id.package() {
         Some(spec) => format!("tests/packages/{}-{}", spec.name, spec.version).into(),
         None => PathBuf::new(),
@@ -159,7 +159,7 @@ fn system_path(id: FileId) -> FileResult<PathBuf> {
 }
 
 /// Read a file.
-fn read(path: &Path) -> FileResult<Cow<'static, [u8]>> {
+pub(crate) fn read(path: &Path) -> FileResult<Cow<'static, [u8]>> {
     // Resolve asset.
     if let Ok(suffix) = path.strip_prefix("assets/") {
         return typst_dev_assets::get(&suffix.to_string_lossy())

--- a/tests/suite/loading/csv.typ
+++ b/tests/suite/loading/csv.typ
@@ -18,12 +18,12 @@
 #csv("nope.csv")
 
 --- csv-invalid ---
-// Error: 6-28 failed to parse CSV (found 3 instead of 2 fields in line 3)
+// Error: "/assets/data/bad.csv" 3:1 failed to parse CSV (found 3 instead of 2 fields in line 3)
 #csv("/assets/data/bad.csv")
 
 --- csv-invalid-row-type-dict ---
 // Test error numbering with dictionary rows.
-// Error: 6-28 failed to parse CSV (found 3 instead of 2 fields in line 3)
+// Error: "/assets/data/bad.csv" 3:1 failed to parse CSV (found 3 instead of 2 fields in line 3)
 #csv("/assets/data/bad.csv", row-type: dictionary)
 
 --- csv-invalid-delimiter ---

--- a/tests/suite/loading/json.typ
+++ b/tests/suite/loading/json.typ
@@ -6,7 +6,7 @@
 #test(data.at(2).weight, 150)
 
 --- json-invalid ---
-// Error: 7-30 failed to parse JSON (expected value at line 3 column 14)
+// Error: "/assets/data/bad.json" 3:14 failed to parse JSON (expected value at line 3 column 14)
 #json("/assets/data/bad.json")
 
 --- json-decode-deprecated ---

--- a/tests/suite/loading/read.typ
+++ b/tests/suite/loading/read.typ
@@ -8,5 +8,5 @@
 #let data = read("/assets/text/missing.txt")
 
 --- read-invalid-utf-8 ---
-// Error: 18-40 failed to convert to string (file is not valid utf-8 at 1:1)
+// Error: 18-40 failed to convert to string (file is not valid utf-8 in assets/text/bad.txt:1:1)
 #let data = read("/assets/text/bad.txt")

--- a/tests/suite/loading/read.typ
+++ b/tests/suite/loading/read.typ
@@ -8,5 +8,5 @@
 #let data = read("/assets/text/missing.txt")
 
 --- read-invalid-utf-8 ---
-// Error: 18-40 file is not valid utf-8
+// Error: 18-40 failed to convert to string (file is not valid utf-8 at 1:1)
 #let data = read("/assets/text/bad.txt")

--- a/tests/suite/loading/toml.typ
+++ b/tests/suite/loading/toml.typ
@@ -37,7 +37,7 @@
 ))
 
 --- toml-invalid ---
-// Error: "/assets/data/bad.toml" #15-#16 failed to parse TOML (expected `.`, `=`)
+// Error: "/assets/data/bad.toml" 1:16-2:1 failed to parse TOML (expected `.`, `=`)
 #toml("/assets/data/bad.toml")
 
 --- toml-decode-deprecated ---

--- a/tests/suite/loading/toml.typ
+++ b/tests/suite/loading/toml.typ
@@ -37,7 +37,7 @@
 ))
 
 --- toml-invalid ---
-// Error: 7-30 failed to parse TOML (expected `.`, `=` at line 1 column 16)
+// Error: "/assets/data/bad.toml" #15-#16 failed to parse TOML (expected `.`, `=`)
 #toml("/assets/data/bad.toml")
 
 --- toml-decode-deprecated ---

--- a/tests/suite/loading/xml.typ
+++ b/tests/suite/loading/xml.typ
@@ -24,7 +24,7 @@
 ),))
 
 --- xml-invalid ---
-// Error: 6-28 failed to parse XML (found closing tag 'data' instead of 'hello' in line 3)
+// Error: "/assets/data/bad.xml" 3:0 failed to parse XML (found closing tag 'data' instead of 'hello')
 #xml("/assets/data/bad.xml")
 
 --- xml-decode-deprecated ---

--- a/tests/suite/loading/yaml.typ
+++ b/tests/suite/loading/yaml.typ
@@ -13,7 +13,7 @@
 #test(data.at("1"), "ok")
 
 --- yaml-invalid ---
-// Error: 7-30 failed to parse YAML (did not find expected ',' or ']' at line 2 column 1, while parsing a flow sequence at line 1 column 18)
+// Error: "/assets/data/bad.yaml" 2:1 failed to parse YAML (did not find expected ',' or ']' at line 2 column 1, while parsing a flow sequence at line 1 column 18)
 #yaml("/assets/data/bad.yaml")
 
 --- yaml-decode-deprecated ---

--- a/tests/suite/scripting/import.typ
+++ b/tests/suite/scripting/import.typ
@@ -334,6 +334,7 @@
 
 --- import-cyclic-in-other-file ---
 // Cyclic import in other file.
+// error: "./modules/cycle1.typ" 2:29-2:51 file is not valid utf-8
 #import "./modules/cycle1.typ": *
 
 This is never reached.

--- a/tests/suite/scripting/import.typ
+++ b/tests/suite/scripting/import.typ
@@ -334,7 +334,7 @@
 
 --- import-cyclic-in-other-file ---
 // Cyclic import in other file.
-// error: "./modules/cycle1.typ" 2:29-2:51 file is not valid utf-8
+// Error: "tests/suite/scripting/modules/cycle2.typ" 2:9-2:21 cyclic import
 #import "./modules/cycle1.typ": *
 
 This is never reached.

--- a/tests/suite/visualize/image.typ
+++ b/tests/suite/visualize/image.typ
@@ -167,7 +167,7 @@ A #box(image("/assets/images/tiger.jpg", height: 1cm, width: 80%)) B
 #image("/assets/plugins/hello.wasm")
 
 --- image-bad-svg ---
-// Error: 2-33 failed to parse SVG (found closing tag 'g' instead of 'style' in line 4)
+// Error: "/assets/images/bad.svg" 4:0 failed to parse SVG (found closing tag 'g' instead of 'style' at 4:3)
 #image("/assets/images/bad.svg")
 
 --- image-decode-svg ---

--- a/tests/suite/visualize/image.typ
+++ b/tests/suite/visualize/image.typ
@@ -167,7 +167,7 @@ A #box(image("/assets/images/tiger.jpg", height: 1cm, width: 80%)) B
 #image("/assets/plugins/hello.wasm")
 
 --- image-bad-svg ---
-// Error: "/assets/images/bad.svg" 4:0 failed to parse SVG (found closing tag 'g' instead of 'style' at 4:3)
+// Error: "/assets/images/bad.svg" 4:3 failed to parse SVG (found closing tag 'g' instead of 'style')
 #image("/assets/images/bad.svg")
 
 --- image-decode-svg ---
@@ -176,7 +176,7 @@ A #box(image("/assets/images/tiger.jpg", height: 1cm, width: 80%)) B
 #image.decode(`<svg xmlns="http://www.w3.org/2000/svg" height="140" width="500"><ellipse cx="200" cy="80" rx="100" ry="50" style="fill:yellow;stroke:purple;stroke-width:2" /></svg>`.text, format: "svg")
 
 --- image-decode-bad-svg ---
-// Error: 2-168 failed to parse SVG (missing root node)
+// Error: 15-152 failed to parse SVG (missing root node at 1:1)
 // Warning: 8-14 `image.decode` is deprecated, directly pass bytes to `image` instead
 #image.decode(`<svg height="140" width="500"><ellipse cx="200" cy="80" rx="100" ry="50" style="fill:yellow;stroke:purple;stroke-width:2" /></svg>`.text, format: "svg")
 


### PR DESCRIPTION
This builds on the work from #5415 (thank you @Dherse :heart:), and closes #6175.

The PR changes a lot of things and introduces a few new types to deal with errors that might have occurred inside the file of a `DataSource::Path`.

The `Loaded` struct contains a `LoadSource` which is analogous to a loaded `DataSource` and only stores the `FileId` of a path for error reporting.
Then there are `LoadResult` and `LoadError` to address [this comment](https://github.com/typst/typst/pull/5415/files#r1875845487). Which can be turned into a `SourceDiagnostic` after the fact, to avoid polluting the memoization with `FileId`s and `Span`s. `LoadError` is currently 56 bytes large (on 64 bit architectures), maybe it should be internally wrapped in an `Arc`?

The `lines` metadata from `Source` has been factored out into a generalized `Lines` struct which is reused when dealing with `SourceDiagnostic` that reference non typst files, such as when loading `yaml`, `json`, etc.

(All dependencies added are already present in the dependency tree)

Also improves #6030, by rejecting empty bibtex files if the format was chosen implicitly.