### PR TITLE
Add support for WebP images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,6 +1215,7 @@ dependencies = [
  "byteorder-lite",
  "color_quant",
  "gif",
+ "image-webp",
  "num-traits",
  "png",
  "zune-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ icu_provider_adapters = "1.4"
 icu_provider_blob = "1.4"
 icu_segmenter = { version = "1.4", features = ["serde"] }
 if_chain = "1"
-image = { version = "0.25.5", default-features = false, features = ["png", "jpeg", "gif"] }
+image = { version = "0.25.5", default-features = false, features = ["png", "jpeg", "gif", "webp"] }
 indexmap = { version = "2", features = ["serde"] }
 infer = { version = "0.19.0", default-features = false }
 kamadak-exif = "0.6"

--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -841,7 +841,9 @@ fn param_value_completions<'a>(
 /// Returns which file extensions to complete for the given parameter if any.
 fn path_completion(func: &Func, param: &ParamInfo) -> Option<&'static [&'static str]> {
     Some(match (func.name(), param.name) {
-        (Some("image"), "source") => &["png", "jpg", "jpeg", "gif", "svg", "svgz"],
+        (Some("image"), "source") => {
+            &["png", "jpg", "jpeg", "gif", "svg", "svgz", "webp"]
+        }
         (Some("csv"), "source") => &["csv"],
         (Some("plugin"), "source") => &["wasm"],
         (Some("cbor"), "source") => &["cbor"],

--- a/crates/typst-layout/src/image.rs
+++ b/crates/typst-layout/src/image.rs
@@ -147,6 +147,7 @@ fn determine_format(source: &DataSource, data: &Bytes) -> StrResult<ImageFormat>
             "jpg" | "jpeg" => return Ok(ExchangeFormat::Jpg.into()),
             "gif" => return Ok(ExchangeFormat::Gif.into()),
             "svg" | "svgz" => return Ok(VectorFormat::Svg.into()),
+            "webp" => return Ok(ExchangeFormat::Webp.into()),
             _ => {}
         }
     }

--- a/crates/typst-library/src/visualize/image/mod.rs
+++ b/crates/typst-library/src/visualize/image/mod.rs
@@ -77,8 +77,8 @@ pub struct ImageElem {
     /// [`source`]($image.source) (even then, Typst will try to figure out the
     /// format automatically, but that's not always possible).
     ///
-    /// Supported formats are `{"png"}`, `{"jpg"}`, `{"gif"}`, `{"svg"}` as well
-    /// as raw pixel data. Embedding PDFs as images is
+    /// Supported formats are `{"png"}`, `{"jpg"}`, `{"gif"}`, `{"svg"}`,
+    /// `{"webp"}` as well as raw pixel data. Embedding PDFs as images is
     /// [not currently supported](https://github.com/typst/typst/issues/145).
     ///
     /// When providing raw pixel data as the `source`, you must specify a

--- a/crates/typst-library/src/visualize/image/raster.rs
+++ b/crates/typst-library/src/visualize/image/raster.rs
@@ -9,6 +9,7 @@ use ecow::{eco_format, EcoString};
 use image::codecs::gif::GifDecoder;
 use image::codecs::jpeg::JpegDecoder;
 use image::codecs::png::PngDecoder;
+use image::codecs::webp::WebPDecoder;
 use image::{
     guess_format, DynamicImage, ImageBuffer, ImageDecoder, ImageResult, Limits, Pixel,
 };
@@ -77,6 +78,7 @@ impl RasterImage {
                     ExchangeFormat::Jpg => decode(JpegDecoder::new(cursor), icc),
                     ExchangeFormat::Png => decode(PngDecoder::new(cursor), icc),
                     ExchangeFormat::Gif => decode(GifDecoder::new(cursor), icc),
+                    ExchangeFormat::Webp => decode(WebPDecoder::new(cursor), icc),
                 }
                 .map_err(format_image_error)?;
 
@@ -242,6 +244,8 @@ pub enum ExchangeFormat {
     /// Raster format that is typically used for short animated clips. Typst can
     /// load GIFs, but they will become static.
     Gif,
+    /// Raster format that supports both lossy and lossless compression.
+    Webp,
 }
 
 impl ExchangeFormat {
@@ -257,6 +261,7 @@ impl From<ExchangeFormat> for image::ImageFormat {
             ExchangeFormat::Png => image::ImageFormat::Png,
             ExchangeFormat::Jpg => image::ImageFormat::Jpeg,
             ExchangeFormat::Gif => image::ImageFormat::Gif,
+            ExchangeFormat::Webp => image::ImageFormat::WebP,
         }
     }
 }
@@ -269,6 +274,7 @@ impl TryFrom<image::ImageFormat> for ExchangeFormat {
             image::ImageFormat::Png => ExchangeFormat::Png,
             image::ImageFormat::Jpeg => ExchangeFormat::Jpg,
             image::ImageFormat::Gif => ExchangeFormat::Gif,
+            image::ImageFormat::WebP => ExchangeFormat::Webp,
             _ => bail!("format not yet supported"),
         })
     }

--- a/crates/typst-svg/src/image.rs
+++ b/crates/typst-svg/src/image.rs
@@ -45,6 +45,7 @@ pub fn convert_image_to_base64_url(image: &Image) -> EcoString {
                     ExchangeFormat::Png => "png",
                     ExchangeFormat::Jpg => "jpeg",
                     ExchangeFormat::Gif => "gif",
+                    ExchangeFormat::Webp => "webp",
                 },
                 raster.data(),
             ),

--- a/docs/tutorial/1-writing.md
+++ b/docs/tutorial/1-writing.md
@@ -69,7 +69,7 @@ the first item of the list above by indenting it.
 
 ## Adding a figure { #figure }
 You think that your report would benefit from a figure. Let's add one. Typst
-supports images in the formats PNG, JPEG, GIF, and SVG. To add an image file to
+supports images in the formats PNG, JPEG, GIF, SVG, and WebP. To add an image file to
 your project, first open the _file panel_ by clicking the box icon in the left
 sidebar. Here, you can see a list of all files in your project. Currently, there
 is only one: The main Typst file you are writing in. To upload another file,

--- a/tests/suite/visualize/image.typ
+++ b/tests/suite/visualize/image.typ
@@ -243,7 +243,7 @@ A #box(image("/assets/images/tiger.jpg", height: 1cm, width: 80%)) B
 --- image-png-but-pixmap-format ---
 #image(
   read("/assets/images/tiger.jpg", encoding: none),
-  // Error: 11-18 expected "png", "jpg", "gif", dictionary, "svg", or auto
+  // Error: 11-18 expected "png", "jpg", "gif", "webp", dictionary, "svg", or auto
   format: "rgba8",
 )
 


### PR DESCRIPTION
This adds support for loading WebP images, the same way that any other images is loaded.

I'd be happy to add a test for this, but I think that we first need to add a WebP image to the assets package, similar to how it's done with "rhino.png" or "tiger.jpg". Also, I couldn't find any test for GIF files, so maybe the same should be done for a GIF file as well?

As can be seen in the diff over `Cargo.lock`, this doesn't add any new dependencies! `image-webp` is already included in the build (via `krilla`).

Some background on why I'm submitting this can be found here: https://github.com/typst/typst/pull/2925#issuecomment-2897588927

I have also made a version that gates this behind a feature flag, it can be found here: https://github.com/typst/typst/compare/main...LinusU:typst:webp