### PR TITLE
More precise math font autocomplete suggestions

### DIFF
--- a/crates/typst-ide/src/tooltip.rs
+++ b/crates/typst-ide/src/tooltip.rs
@@ -269,7 +269,7 @@ fn font_tooltip(world: &dyn IdeWorld, leaf: &LinkedNode) -> Option<Tooltip> {
             .find(|&(family, _)| family.to_lowercase().as_str() == lower.as_str());
 
         then {
-            let detail = summarize_font_family(iter);
+            let detail = summarize_font_family(iter.collect());
             return Some(Tooltip::Text(detail));
         }
     };

--- a/crates/typst-ide/src/utils.rs
+++ b/crates/typst-ide/src/utils.rs
@@ -77,7 +77,7 @@ pub fn plain_docs_sentence(docs: &str) -> EcoString {
 }
 
 /// Create a short description of a font family.
-pub fn summarize_font_family<'a>(mut variants: Vec<&'a FontInfo>) -> EcoString {
+pub fn summarize_font_family(mut variants: Vec<&FontInfo>) -> EcoString {
     variants.sort_by_key(|info| info.variant);
 
     let mut has_italic = false;

--- a/crates/typst-ide/src/utils.rs
+++ b/crates/typst-ide/src/utils.rs
@@ -77,23 +77,20 @@ pub fn plain_docs_sentence(docs: &str) -> EcoString {
 }
 
 /// Create a short description of a font family.
-pub fn summarize_font_family<'a>(
-    variants: impl Iterator<Item = &'a FontInfo>,
-) -> EcoString {
-    let mut infos: Vec<_> = variants.collect();
-    infos.sort_by_key(|info| info.variant);
+pub fn summarize_font_family<'a>(mut variants: Vec<&'a FontInfo>) -> EcoString {
+    variants.sort_by_key(|info| info.variant);
 
     let mut has_italic = false;
     let mut min_weight = u16::MAX;
     let mut max_weight = 0;
-    for info in &infos {
+    for info in &variants {
         let weight = info.variant.weight.to_number();
         has_italic |= info.variant.style == FontStyle::Italic;
         min_weight = min_weight.min(weight);
         max_weight = min_weight.max(weight);
     }
 
-    let count = infos.len();
+    let count = variants.len();
     let mut detail = eco_format!("{count} variant{}.", if count == 1 { "" } else { "s" });
 
     if min_weight == max_weight {

--- a/crates/typst-library/src/text/font/book.rs
+++ b/crates/typst-library/src/text/font/book.rs
@@ -194,6 +194,8 @@ bitflags::bitflags! {
         const MONOSPACE = 1 << 0;
         /// Glyphs have short strokes at their stems.
         const SERIF = 1 << 1;
+        /// Font face has a MATH table
+        const MATH = 1 << 2;
     }
 }
 
@@ -272,6 +274,7 @@ impl FontInfo {
 
         let mut flags = FontFlags::empty();
         flags.set(FontFlags::MONOSPACE, ttf.is_monospaced());
+        flags.set(FontFlags::MATH, ttf.tables().math.is_some());
 
         // Determine whether this is a serif or sans-serif font.
         if let Some(panose) = ttf


### PR DESCRIPTION
A stab at fixing #2732.

Try to detect a `math.equation` show-set rule via the AST rather than by heuristics, and determine if a font is a math font based on the presence of a MATH table rather than the family name.