### PR TITLE
Disallow empty labels and references (#5776)

### DIFF
--- a/crates/typst-library/src/foundations/label.rs
+++ b/crates/typst-library/src/foundations/label.rs
@@ -54,7 +54,9 @@ pub struct Label(PicoStr);
 
 impl Label {
     /// Creates a label from an interned string.
+    /// Callers need to ensure the given string is not empty.
     pub fn new(name: PicoStr) -> Self {
+        debug_assert!(name != PicoStr::EMPTY);
         Self(name)
     }
 

--- a/crates/typst-library/src/foundations/label.rs
+++ b/crates/typst-library/src/foundations/label.rs
@@ -1,7 +1,10 @@
 use ecow::{eco_format, EcoString};
 use typst_utils::{PicoStr, ResolvedPicoStr};
 
-use crate::foundations::{func, scope, ty, Repr, Str};
+use crate::{
+    diag::StrResult,
+    foundations::{bail, func, scope, ty, Repr, Str},
+};
 
 /// A label for an element.
 ///
@@ -27,7 +30,8 @@ use crate::foundations::{func, scope, ty, Repr, Str};
 /// # Syntax
 /// This function also has dedicated syntax: You can create a label by enclosing
 /// its name in angle brackets. This works both in markup and code. A label's
-/// name can contain letters, numbers, `_`, `-`, `:`, and `.`.
+/// name can contain letters, numbers, `_`, `-`, `:`, and `.`. Empty label names
+/// get rejected.
 ///
 /// Note that there is a syntactical difference when using the dedicated syntax
 /// for this function. In the code below, the `[<a>]` terminates the heading and
@@ -67,13 +71,17 @@ impl Label {
 
 #[scope]
 impl Label {
-    /// Creates a label from a string.
+    /// Creates a label from a string. Fails for empty strings.
     #[func(constructor)]
     pub fn construct(
         /// The name of the label.
         name: Str,
-    ) -> Label {
-        Self(PicoStr::intern(name.as_str()))
+    ) -> StrResult<Label> {
+        if name.is_empty() {
+            bail!("expected non-empty label name");
+        }
+
+        Ok(Self(PicoStr::intern(name.as_str())))
     }
 }
 

--- a/crates/typst-library/src/model/bibliography.rs
+++ b/crates/typst-library/src/model/bibliography.rs
@@ -313,12 +313,17 @@ impl Bibliography {
         for (source, data) in sources.0.iter().zip(data) {
             let library = decode_library(source, data)?;
             for entry in library {
-                match map.entry(Label::new(PicoStr::intern(entry.key()))) {
+                let key = entry.key();
+                if key.is_empty() {
+                    bail!("empty bibliography key found");
+                }
+
+                match map.entry(Label::new(PicoStr::intern(key))) {
                     indexmap::map::Entry::Vacant(vacant) => {
                         vacant.insert(entry);
                     }
                     indexmap::map::Entry::Occupied(_) => {
-                        duplicates.push(entry.key().into());
+                        duplicates.push(key.into());
                     }
                 }
             }

--- a/crates/typst-syntax/src/lexer.rs
+++ b/crates/typst-syntax/src/lexer.rs
@@ -196,7 +196,7 @@ impl Lexer<'_> {
             'h' if self.s.eat_if("ttp://") => self.link(),
             'h' if self.s.eat_if("ttps://") => self.link(),
             '<' if self.s.at(is_id_continue) => self.label(),
-            '@' => self.ref_marker(),
+            '@' if self.s.at(is_id_continue) => self.ref_marker(),
 
             '.' if self.s.eat_if("..") => SyntaxKind::Shorthand,
             '-' if self.s.eat_if("--") => SyntaxKind::Shorthand,

--- a/crates/typst-utils/src/pico.rs
+++ b/crates/typst-utils/src/pico.rs
@@ -38,6 +38,9 @@ struct Interner {
 pub struct PicoStr(NonZeroU64);
 
 impl PicoStr {
+    /// Empty string as PicoStr
+    pub const EMPTY: PicoStr = PicoStr::constant("");
+
     /// Intern a string at runtime.
     pub fn intern(string: &str) -> PicoStr {
         // Try to use bitcode or exception representations.

--- a/tests/suite/foundations/label.typ
+++ b/tests/suite/foundations/label.typ
@@ -92,3 +92,12 @@ _Visible_
 --- label-non-existent-error ---
 // Error: 5-10 sequence does not have field "label"
 #[].label
+
+--- label-not-named-error ---
+// Error: 23-32 expected non-empty label name
+= Something to label #label("")
+
+--- label-not-named-with-variable-error ---
+#let var = ""
+// Error: 18-28 expected non-empty label name
+= Another label #label(var)

--- a/tests/suite/model/ref.typ
+++ b/tests/suite/model/ref.typ
@@ -85,3 +85,12 @@ Text seen on #ref(<text>, form: "page", supplement: "Page").
 // Test reference with non-whitespace before it.
 #figure[] <1>
 #test([(#ref(<1>))], [(@1)])
+
+--- ref-to-empty-label-not-possible ---
+// @ without any following label should just produce the symbol in the output
+// and not produce a reference to a label with an empty name.
+@ \<- this should show up
+// using ref() should also not be possible
+// Error: 6-7 unexpected less-than operator
+// Error: 7-8 unexpected greater-than operator
+#ref(<>)


### PR DESCRIPTION
Closes #5776.

This PR makes it no longer possible to create "empty" labels, meaning that their name is an empty string.
Previously using
```typst
#label("")
```
created a label that could be referenced with just `@`.

This is now consistent with `<>` not creating a label with no name but instead just emitting the same characters verbatim.

I went over all the calling code of `Label::new()` to see if any other places could introduce empty labels.
I don't know if bibliographies can even contain empty keys, but I added a guard there to be sure.
All other call sites are expected to produce a valid label, with one exception:
An `@` without any following identifier.

If we deem an empty name label as invalid, we should follow that same logic for references. Producing a label with no reference is valid but being able to produce a reference where the label is not representable is invalid.

The result: The last commit changes the syntax/lexer to force an `@` to be followed by identifier characters or else it won't be resolved into a reference. Because we can't produce empty labels anymore we also can't produce empty references with `ref()`.

As a result of all changes it should no longer be possible to produce empty labels and references.

If I missed any edge cases or if this PR is too big of a breaking change, please let me know.
I had the impression from the discussion on the issue that this would be the most consistent solution. 