### PR TITLE
Add Latvian translations

### DIFF
--- a/crates/typst-library/src/text/lang.rs
+++ b/crates/typst-library/src/text/lang.rs
@@ -14,7 +14,7 @@ macro_rules! translation {
     };
 }
 
-const TRANSLATIONS: [(&str, &str); 39] = [
+const TRANSLATIONS: [(&str, &str); 40] = [
     translation!("ar"),
     translation!("bg"),
     translation!("ca"),
@@ -36,6 +36,7 @@ const TRANSLATIONS: [(&str, &str); 39] = [
     translation!("it"),
     translation!("ja"),
     translation!("la"),
+    translation!("lv"),
     translation!("nb"),
     translation!("nl"),
     translation!("nn"),
@@ -87,6 +88,7 @@ impl Lang {
     pub const ITALIAN: Self = Self(*b"it ", 2);
     pub const JAPANESE: Self = Self(*b"ja ", 2);
     pub const LATIN: Self = Self(*b"la ", 2);
+    pub const LATVIAN: Self = Self(*b"lv ", 2);
     pub const LOWER_SORBIAN: Self = Self(*b"dsb", 3);
     pub const NYNORSK: Self = Self(*b"nn ", 2);
     pub const POLISH: Self = Self(*b"pl ", 2);

--- a/crates/typst-library/translations/lv.txt
+++ b/crates/typst-library/translations/lv.txt
@@ -1,0 +1,8 @@
+figure = Attēls
+table = Tabula
+equation = Vienādojums
+bibliography = Izmantotā literatūra un avoti
+heading = Virsraksts
+outline = Saturs
+raw = Koda fragments
+page = lpp.

--- a/crates/typst-library/translations/lv.txt
+++ b/crates/typst-library/translations/lv.txt
@@ -1,8 +1,8 @@
 figure = Attēls
 table = Tabula
 equation = Vienādojums
-bibliography = Izmantotā literatūra un avoti
-heading = Virsraksts
+bibliography = Literatūra
+heading = Sadaļa
 outline = Saturs
-raw = Koda fragments
+raw = Saraksts
 page = lpp.


### PR DESCRIPTION
Adds Latvian translations for various document element labels.

- **figure**: `Attēls`
- **table**: `Tabula`
- **equation**: `Vienādojums`
- **bibliography**: `Izmantotā literatūra un avoti`
- **heading**: `Virsraksts`
- **outline**: `Saturs`
- **raw**: `Koda fragments`
- **page**: `lpp.`