### PR TITLE
Replace non-`#[internal]` `#[synthesized]` fields with getter methods

### DIFF
--- a/crates/typst-library/src/model/bibliography.rs
+++ b/crates/typst-library/src/model/bibliography.rs
@@ -142,12 +142,10 @@ pub struct BibliographyElem {
     pub style: Derived<CslSource, CslStyle>,
 
     /// The language setting where the bibliography is.
-    #[internal]
     #[synthesized]
     pub lang: Lang,
 
     /// The region setting where the bibliography is.
-    #[internal]
     #[synthesized]
     pub region: Option<Region>,
 }

--- a/crates/typst-library/src/model/cite.rs
+++ b/crates/typst-library/src/model/cite.rs
@@ -110,12 +110,10 @@ pub struct CiteElem {
     pub style: Smart<Derived<CslSource, CslStyle>>,
 
     /// The text language setting where the citation is.
-    #[internal]
     #[synthesized]
     pub lang: Lang,
 
     /// The text region setting where the citation is.
-    #[internal]
     #[synthesized]
     pub region: Option<Region>,
 }

--- a/crates/typst-library/src/model/figure.rs
+++ b/crates/typst-library/src/model/figure.rs
@@ -463,13 +463,17 @@ impl Outlinable for Packed<FigureElem> {
 /// customize the appearance of captions for all figures or figures of a
 /// specific kind.
 ///
-/// In addition to its `position` and `body`, the `caption` also provides the
-/// figure's `kind`, `supplement`, `counter`, and `numbering` as fields. These
-/// parts can be used in [`where`]($function.where) selectors and show rules to
+/// In addition to its `position` and `body`, it is possible to retrieve the
+/// corresponding figure's `kind`, `supplement`, `counter`, and `numbering` by
+/// using the corresponding methods. These parts can be used in show rules to
 /// build a completely custom caption.
 ///
 /// ```example
-/// #show figure.caption: emph
+/// #show figure.caption: it => [
+///   #underline(it.body) |
+///   #it.supplement()
+///   #context it.counter().display(it.numbering())
+/// ]
 ///
 /// #figure(
 ///   rect[Hello],
@@ -522,22 +526,6 @@ pub struct FigureCaption {
     pub separator: Smart<Content>,
 
     /// The caption's body.
-    ///
-    /// Can be used alongside `kind`, `supplement`, `counter`, `numbering`, and
-    /// `location` to completely customize the caption.
-    ///
-    /// ```example
-    /// #show figure.caption: it => [
-    ///   #underline(it.body) |
-    ///   #it.supplement
-    ///   #context it.counter.display(it.numbering)
-    /// ]
-    ///
-    /// #figure(
-    ///   rect[Hello],
-    ///   caption: [A rectangle],
-    /// )
-    /// ```
     #[required]
     pub body: Content,
 

--- a/crates/typst-library/src/model/figure.rs
+++ b/crates/typst-library/src/model/figure.rs
@@ -546,7 +546,6 @@ pub struct FigureCaption {
     pub counter: Counter,
 
     /// The figure's location.
-    #[internal]
     #[synthesized]
     pub figure_location: Location,
 }

--- a/crates/typst-library/src/model/reference.rs
+++ b/crates/typst-library/src/model/reference.rs
@@ -92,7 +92,7 @@ use typst_macros::scope;
 ///
 /// #show ref: it => {
 ///   let eq = math.equation
-///   let el = it.element
+///   let el = it.element()
 ///   if el != none and el.func() == eq {
 ///     // Override equation references.
 ///     link(el.location(),numbering(

--- a/crates/typst-macros/src/lib.rs
+++ b/crates/typst-macros/src/lib.rs
@@ -201,7 +201,9 @@ pub fn ty(stream: BoundaryStream, item: BoundaryStream) -> BoundaryStream {
 ///   flexibility.
 /// - `#[synthesized]`: The field cannot be specified in a constructor or set
 ///   rule. Instead, it is added to an element before its show rule runs
-///   through the `Synthesize` trait.
+///   through the `Synthesize` trait. This implies `#[internal]`. If a
+///   synthesized field needs to be exposed to the user, that should be done via
+///   a getter method.
 /// - `#[ghost]`: Allows creating fields that are only present in the style chain,
 ///   this means that they *cannot* be accessed by the user, they cannot be set
 ///   on an individual instantiated element, and must be set via the style chain.

--- a/tests/suite/math/interactions.typ
+++ b/tests/suite/math/interactions.typ
@@ -58,8 +58,7 @@ $x$$y$
 --- issue-2821-missing-fields ---
 // Issue #2821: Setting a figure's supplement to none removes the field
 #show figure.caption: it => {
-  assert(it.has("supplement"))
-  assert(it.supplement == none)
+  assert(it.supplement() == none)
 }
 #figure([], caption: [], supplement: none)
 

--- a/tests/suite/model/figure.typ
+++ b/tests/suite/model/figure.typ
@@ -97,7 +97,7 @@ We can clearly see that @fig-cylinder and
   if not it.numbering == none {
     title = it.supplement
     if not it.numbering == none {
-      title += " " +  it.counter.display(it.numbering)
+      title += " " + counter(figure.where(kind: it.kind)).display(it.numbering)
     }
   }
   title = strong(title)
@@ -168,7 +168,10 @@ We can clearly see that @fig-cylinder and
 
 --- figure-caption-where-selector ---
 // Test figure.caption element for specific figure kinds
-#show figure.caption.where(kind: table): underline
+#show figure.where(kind: table): it => {
+  show figure.caption: underline
+  it
+}
 
 #figure(
   [Not a table],
@@ -212,8 +215,8 @@ We can clearly see that @fig-cylinder and
 
 #show figure.caption: it => emph[
   #it.body
-  (#it.supplement
-   #context it.counter.display(it.numbering))
+  (#it.supplement()
+   #context it.counter().display(it.numbering()))
 ]
 
 #figure(

--- a/tests/suite/text/raw.typ
+++ b/tests/suite/text/raw.typ
@@ -513,7 +513,7 @@ fn main() {
 
 --- raw-line-alternating-fill ---
 #set page(width: 200pt)
-#show raw: it => stack(dir: ttb, ..it.lines)
+#show raw: it => stack(dir: ttb, ..it.lines())
 #show raw.line: it => {
   box(
     width: 100%,
@@ -564,21 +564,21 @@ print(y)
 // Test line extraction works.
 
 #show raw: code => {
-  for i in code.lines {
+  for i in code.lines() {
     test(i.count, 10)
   }
 
-  test(code.lines.at(0).text, "import numpy as np")
-  test(code.lines.at(1).text, "")
-  test(code.lines.at(2).text, "def f(x):")
-  test(code.lines.at(3).text, "    return x**2")
-  test(code.lines.at(4).text, "")
-  test(code.lines.at(5).text, "x = np.linspace(0, 10, 100)")
-  test(code.lines.at(6).text, "y = f(x)")
-  test(code.lines.at(7).text, "")
-  test(code.lines.at(8).text, "print(x)")
-  test(code.lines.at(9).text, "print(y)")
-  test(code.lines.at(10, default: none), none)
+  test(code.lines().at(0).text, "import numpy as np")
+  test(code.lines().at(1).text, "")
+  test(code.lines().at(2).text, "def f(x):")
+  test(code.lines().at(3).text, "    return x**2")
+  test(code.lines().at(4).text, "")
+  test(code.lines().at(5).text, "x = np.linspace(0, 10, 100)")
+  test(code.lines().at(6).text, "y = f(x)")
+  test(code.lines().at(7).text, "")
+  test(code.lines().at(8).text, "print(x)")
+  test(code.lines().at(9).text, "print(y)")
+  test(code.lines().at(10, default: none), none)
 }
 
 ```py


### PR DESCRIPTION
Fixes https://github.com/typst/typst/issues/6227.

I think this goes in the direction Typst is taking when it comes to show rules.

There is a single drawback I could think of: previously, synthesized fields could be used in `where` selectors. This is no longer possible. Given that they were mostly undocumented—appart for the `figure.caption` fields, which can be obtained anyway with nested rules (`show figure.where(..): it => { show figure.caption: ..; it }` and `show figure.where(..): set figure.caption(..)`, as illustrated in the change to test `figure-caption-where-selector`)—I think this is not too big of an issue.

For now, there is no deprecation mechanism for fields, so this is a breaking change.