### PR TITLE
Mention types of supported bibliography formats for citing

### DIFF
--- a/crates/typst-library/src/model/bibliography.rs
+++ b/crates/typst-library/src/model/bibliography.rs
@@ -76,6 +76,10 @@ use crate::World;
 /// | Physics         | `{"american-physics-society"}`                         |
 ///
 /// # Example
+/// Link to the BibLaTeX file from example:
+/// [`works.bib`](https://github.com/typst/typst-dev-assets/blob/main/files/bib/works.bib).
+/// For more Hayagriva examples see [this](https://github.com/typst/hayagriva/blob/main/tests/data/basic.yml).
+///
 /// ```example
 /// This was already noted by
 /// pirates long ago. @arrgh

--- a/crates/typst-library/src/model/cite.rs
+++ b/crates/typst-library/src/model/cite.rs
@@ -14,7 +14,8 @@ use crate::text::{Lang, Region, TextElem};
 /// Cite a work from the bibliography.
 ///
 /// Before you starting citing, you need to add a [bibliography] somewhere in
-/// your document.
+/// your document. Note that you can cite using BibLaTeX or Hayagriva
+/// bibliography file. For more information see [bibliography.summary].
 ///
 /// # Example
 /// ```example

--- a/crates/typst-library/src/model/cite.rs
+++ b/crates/typst-library/src/model/cite.rs
@@ -18,6 +18,10 @@ use crate::text::{Lang, Region, TextElem};
 /// bibliography file. For more information see [bibliography.summary].
 ///
 /// # Example
+/// Link to the BibLaTeX file from example:
+/// [`works.bib`](https://github.com/typst/typst-dev-assets/blob/main/files/bib/works.bib).
+/// For more Hayagriva examples see [this](https://github.com/typst/hayagriva/blob/main/tests/data/basic.yml).
+///
 /// ```example
 /// This was already noted by
 /// pirates long ago. @arrgh


### PR DESCRIPTION
I think since there [was an instance](https://forum.typst.app/t/how-do-i-use-a-hayagriva-yml-bibliography-file-with-a-typst-typ-document/4359/5?u=andrew) of confusion, the documentation should clarify this point.

The problem is that there are 2 close bibliography links, and I don't know if it's possible/better to link to a specific section for that page. Also adding a separate `.yaml` example is probably too much. But the current one can include a commented line with `works.yaml`.

P.S. I feel like https://typst.app/docs/reference/model/bibliography/#summary should probably acknowledge that you can use 2 extensions. Well actually, the [`yaml` should be preferred](https://www.iana.org/assignments/media-types/application/yaml#:~:text=File%20extension(s):%20%22yaml%22%20(preferred)%20and%20%22yml%22.). Should we change it? Might also need changes to the https://github.com/typst/hayagriva.
