### PR TITLE
Add XHTML support to the HTML output

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -271,6 +271,10 @@ pub struct CompileArgs {
     /// apart from file names and line numbers.
     #[arg(long = "timings", value_name = "OUTPUT_JSON")]
     pub timings: Option<Option<PathBuf>>,
+
+    /// Whether to output valid XML for HTML export
+    #[clap(long = "xml")]
+    pub xml: bool,
 }
 
 /// Arguments for the construction of a world. Shared by compile, watch, and

--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -75,6 +75,8 @@ pub struct CompileConfig {
     /// Server for `typst watch` to HTML.
     #[cfg(feature = "http-server")]
     pub server: Option<HtmlServer>,
+    /// Whether to create valid XML in HTML output
+    pub xml: bool,
 }
 
 impl CompileConfig {
@@ -158,6 +160,7 @@ impl CompileConfig {
             export_cache: ExportCache::new(),
             #[cfg(feature = "http-server")]
             server,
+            xml: args.xml,
         })
     }
 }
@@ -237,7 +240,7 @@ fn compile_and_export(
 
 /// Export to HTML.
 fn export_html(document: &HtmlDocument, config: &CompileConfig) -> SourceResult<()> {
-    let html = typst_html::html(document)?;
+    let html = typst_html::html(document, config.xml)?;
     let result = config.output.write(html.as_bytes());
 
     #[cfg(feature = "http-server")]

--- a/crates/typst-html/src/encode.rs
+++ b/crates/typst-html/src/encode.rs
@@ -7,8 +7,8 @@ use typst_library::layout::Frame;
 use typst_syntax::Span;
 
 /// Encodes an HTML document into a string.
-pub fn html(document: &HtmlDocument) -> SourceResult<String> {
-    let mut w = Writer { pretty: true, ..Writer::default() };
+pub fn html(document: &HtmlDocument, xml: bool) -> SourceResult<String> {
+    let mut w = Writer { pretty: true, xml, ..Writer::default() };
     w.buf.push_str("<!DOCTYPE html>");
     write_indent(&mut w);
     write_element(&mut w, &document.root)?;
@@ -26,6 +26,8 @@ struct Writer {
     level: usize,
     /// Whether pretty printing is enabled.
     pretty: bool,
+    /// Whether to create 'XHTML' style output
+    xml: bool,
 }
 
 /// Write a newline and indent, if pretty printing is enabled.
@@ -81,10 +83,16 @@ fn write_element(w: &mut Writer, element: &HtmlElement) -> SourceResult<()> {
         w.buf.push('"');
     }
 
-    w.buf.push('>');
-
     if tag::is_void(element.tag) {
+        if w.xml {
+            w.buf.push_str("/>");
+        } else {
+            w.buf.push('>');
+        }
+
         return Ok(());
+    } else {
+        w.buf.push('>');
     }
 
     let pretty = w.pretty;

--- a/tests/src/run.rs
+++ b/tests/src/run.rs
@@ -454,7 +454,7 @@ impl OutputType for HtmlDocument {
 
     fn make_live(&self) -> Self::Live {
         // TODO: Do this earlier to be able to process export errors.
-        typst_html::html(self).unwrap()
+        typst_html::html(self, false).unwrap()
     }
 
     fn save_live(&self, name: &str, live: &Self::Live) {


### PR DESCRIPTION
This is a minimal PR to implement an XML variant to the HTML output.

I have put it in Draft status until the "Questions" below are answered.

### Use Case

XHTML, whilst still being valid HTML, is much easier to use with other tools/libraries --- for practically every language has a high quality XML library, but not all have as good a HTML library.

### The PR

- This PR makes minimal changes.
- Currently it introduces a `--xml` option which is used in conjunction with `--format=html` to ensure that all HTML tags close or self-close.
- The `typst_html::html` function now takes an `xml` argument. This is set as `typst_html::Writer::xml`, which introduces an if gate in `write_element` to prevent frestanding null tags (e.g. non-closed `meta` tags; in the future `img` tags as well.)

### Questions

- Is the CLI interface good? Would it make more sense to be implemented as a `--format=xhtml`? My current thinking is "no", just simply because of how similar the two outputs are and how they share nearly all of their code.
- Rather than take a `xml: bool` argument, should `typst_html::html` instead take some struct as its arguments which would be more extensible to future variants on the html format.
- Should there be tests implemented to check this feature. My thought would be yes; but I am not sure how you would like this implemented with the current `OutputType` api, given there is no `XhtmlDocument` struct or the like. Should there be one?

### Example

Consider the following Typst document:

```typ
= Hello, World!

Here is some text.
```

Compiled with `typst c --features=html --format=html`

```html
<!DOCTYPE html>
<html>
  <head>
    <meta charset="utf-8">
    <meta name="viewport" content="width=device-width, initial-scale=1">
  </head>
  <body>
    <h2>Hello, World!</h2>
    <p>Here is some text.</p>
  </body>
</html>
```

Compiled with `typst c --features=html --format=html --xml`:

```xhtml
<!DOCTYPE html>
<html>
  <head>
    <meta charset="utf-8"/>
    <meta name="viewport" content="width=device-width, initial-scale=1"/>
  </head>
  <body>
    <h2>Hello, World!</h2>
    <p>Here is some text.</p>
  </body>
</html>
```

Notice the `meta` tags self closed. I can now read this with an XML library.