### PR TITLE
Add `typst-html` to architecture crates list

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -12,6 +12,7 @@ Let's start with a broad overview of the directories in this repository:
 - `crates/typst-cli`: Typst's command line interface. This is a relatively small
   layer on top of the compiler and the exporters.
 - `crates/typst-eval`: The interpreter for the Typst language.
+- `crates/typst-html`: The HTML exporter.
 - `crates/typst-ide`: Exposes IDE functionality.
 - `crates/typst-kit`: Contains various default implementation of
   functionality used in `typst-cli`.


### PR DESCRIPTION
Thanks for this great project! 

The `typst-html` crate was added by
https://github.com/typst/typst/commit/e0122a5b509d151b7e0197d37a120fd965a055d5, but has not yet been updated in the architecture docs.