### PR TITLE
Turn dictionaries into modules, and accept dictionaries as import sources

### DIFF
--- a/crates/typst-eval/src/import.rs
+++ b/crates/typst-eval/src/import.rs
@@ -34,6 +34,7 @@ impl Eval for ast::ModuleImport<'_> {
                 source = Value::Module(import(&mut vm.engine, path, source_span)?);
                 is_str = true;
             }
+            Value::Dict(dict) => source = Value::Module(dict.clone().module()),
             v => {
                 bail!(
                     source_span,

--- a/crates/typst-library/src/foundations/dict.rs
+++ b/crates/typst-library/src/foundations/dict.rs
@@ -11,7 +11,7 @@ use typst_utils::ArcExt;
 
 use crate::diag::{Hint, HintedStrResult, StrResult};
 use crate::foundations::{
-    array, cast, func, repr, scope, ty, Array, Module, Repr, Str, Value,
+    array, cast, func, repr, scope, ty, Array, Binding, Module, Repr, Scope, Str, Value,
 };
 
 /// Create a new [`Dict`] from key-value pairs.
@@ -215,6 +215,22 @@ impl Dict {
         value: Value,
     ) {
         Arc::make_mut(&mut self.0).insert(key, value);
+    }
+
+    /// Converts the dictionary into an anonymous module.
+    ///
+    /// ```example
+    /// #let my-dict = (double: (x) => [#x #x], triple: (x) => [#x #x #x]);
+    /// #let my-module = my-dict.module();
+    /// #my-module.double[hello]  // instead of having to do (my-dict.double)[hello]
+    /// ```
+    #[func]
+    pub fn module(self) -> Module {
+        let mut scope = Scope::new();
+        for (name, value) in self {
+            scope.bind(name.into(), Binding::detached(value));
+        }
+        Module::anonymous(scope)
     }
 
     /// Removes a pair from the dictionary by key and return the value.


### PR DESCRIPTION
Hello,

  After a short discussion with @SillyFreak on discord, I had a go at trying to address #2636.

 I first attempted to add a `module()` constructor, but I wasn't sure how to add a constructor without adding a `#[ty(scope)]` on `module`, which I doubt is correct.

  Instead, I added a `.module()` method on dicts (exposed as a typst method so far, but that is debatable)
and added a clause for dict-valued import sources.

  Here's a simple example:
```typ
#let pdict(left, right) = {
    (wrap: (x) => [#left #x #right],
     unit: [#left #right])
}

#let pmod = pdict.module()

// equivalent to let (wrap, unit) = parametric([\(], [\)])
#import pmod([\(], [\)]): wrap, unit

// Pulls all dict keys into scope without having to repeat the names
#import pmod([\(], [\)]): *
```

How does that look ?

Cheers,