### PR TITLE
Bump New CM fonts to version 7.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2863,7 +2863,7 @@ dependencies = [
 [[package]]
 name = "typst-assets"
 version = "0.13.1"
-source = "git+https://github.com/typst/typst-assets?rev=ab1295f#ab1295ff896444e51902e03c2669955e1d73604a"
+source = "git+https://github.com/typst/typst-assets?rev=c74e539#c74e539b090070a0c66fd007c550f5b6d3b724bd"
 
 [[package]]
 name = "typst-cli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ typst-svg = { path = "crates/typst-svg", version = "0.13.1" }
 typst-syntax = { path = "crates/typst-syntax", version = "0.13.1" }
 typst-timing = { path = "crates/typst-timing", version = "0.13.1" }
 typst-utils = { path = "crates/typst-utils", version = "0.13.1" }
-typst-assets = { git = "https://github.com/typst/typst-assets", rev = "ab1295f" }
+typst-assets = { git = "https://github.com/typst/typst-assets", rev = "c74e539" }
 typst-dev-assets = { git = "https://github.com/typst/typst-dev-assets", rev = "fddbf8b" }
 arrayvec = "0.7.4"
 az = "1.2"


### PR DESCRIPTION
#5913

![playground](https://github.com/user-attachments/assets/32ae82b6-1515-4fbe-9c07-d1240e99cf13)

```typ
--- playground ---
*$cal(A B C D E F G H I J K L M N O P Q R S T U V W X Y Z) $*
```