### PR TITLE
Replace "inset" with "shifted" in outline.indented docs

### DIFF
--- a/crates/typst-library/src/model/outline.rs
+++ b/crates/typst-library/src/model/outline.rs
@@ -450,8 +450,8 @@ impl OutlineEntry {
     /// at the same level are aligned.
     ///
     /// If the outline's indent is a fixed value or a function, the prefixes are
-    /// indented, but the inner contents are simply inset from the prefix by the
-    /// specified `gap`, rather than aligning outline-wide.
+    /// indented, but the inner contents are simply shifted from the prefix by
+    /// the specified `gap`, rather than aligning outline-wide.
     #[func(contextual)]
     pub fn indented(
         &self,


### PR DESCRIPTION
<https://typst.app/docs/reference/model/outline/#definitions-entry-definitions-indented>:
> If the outline's indent is a fixed value or a function, the prefixes are indented, but the inner contents are simply inset from the prefix by the specified gap, rather than aligning outline-wide.

I didn't understand what that last part means until I tried

```typ
#set heading(numbering: "1.")
#set outline(indent: 2em)
#outline()
= #lorem(20)
== #lorem(20)
== #lorem(20)
== #lorem(20)
== #lorem(20)
== #lorem(20)
== #lorem(20)
== #lorem(20)
== #lorem(20)
== #lorem(20)
== #lorem(20)
```

which confirmed my hunch. So this part might also need rewording.

"Inset" is used for containers as "inner padding", while in this case the content is just intended/shifted to the right/left. Unfortunately the "indented" term is probably bad because it's already used elsewhere and is the name of the method. So "shifted" is the only one I can come up with. Maybe "padded"/"spread", I don't know...
