### PR TITLE
Add `module(dict)` constructor

### DIFF
--- a/crates/typst-library/src/foundations/module.rs
+++ b/crates/typst-library/src/foundations/module.rs
@@ -2,7 +2,7 @@ use std::fmt::{self, Debug, Formatter};
 use std::sync::Arc;
 
 use ecow::{eco_format, EcoString};
-use typst_syntax::FileId;
+use typst_syntax::{FileId, Spanned};
 
 use crate::diag::{bail, DeprecationSink, StrResult};
 use crate::foundations::{func, repr, scope, ty, Binding, Content, Dict, Scope, Value};
@@ -63,10 +63,10 @@ impl Module {
     /// m.hello[World]
     /// ```
     #[func(constructor)]
-    pub fn construct(dict: Dict) -> Module {
+    pub fn construct(dict: Spanned<Dict>) -> Module {
         let mut scope = Scope::new();
-        for (name, value) in dict {
-            scope.bind(name.into(), Binding::detached(value));
+        for (name, value) in dict.v {
+            scope.bind(name.into(), Binding::new(value, dict.span));
         }
         Module::anonymous(scope)
     }

--- a/crates/typst-library/src/foundations/module.rs
+++ b/crates/typst-library/src/foundations/module.rs
@@ -5,7 +5,7 @@ use ecow::{eco_format, EcoString};
 use typst_syntax::FileId;
 
 use crate::diag::{bail, DeprecationSink, StrResult};
-use crate::foundations::{repr, ty, Content, Scope, Value};
+use crate::foundations::{func, repr, scope, ty, Binding, Content, Dict, Scope, Value};
 
 /// A module of definitions.
 ///
@@ -33,7 +33,7 @@ use crate::foundations::{repr, ty, Content, Scope, Value};
 /// >>>
 /// >>> #(-3)
 /// ```
-#[ty(cast)]
+#[ty(scope, cast)]
 #[derive(Clone, Hash)]
 #[allow(clippy::derived_hash_with_manual_eq)]
 pub struct Module {
@@ -52,6 +52,24 @@ struct Repr {
     content: Content,
     /// The id of the file which defines the module, if any.
     file_id: Option<FileId>,
+}
+
+#[scope]
+impl Module {
+    /// Build a module from a dictionary.
+    ///
+    /// ```example
+    /// #let m = module((hello: (who) => [Hello, #who !]))
+    /// m.hello[World]
+    /// ```
+    #[func(constructor)]
+    pub fn construct(dict: Dict) -> Module {
+        let mut scope = Scope::new();
+        for (name, value) in dict {
+            scope.bind(name.into(), Binding::detached(value));
+        }
+        Module::anonymous(scope)
+    }
 }
 
 impl Module {

--- a/tests/suite/foundations/module.typ
+++ b/tests/suite/foundations/module.typ
@@ -1,0 +1,15 @@
+--- module-constructor ---
+#let m = module((key: "value"))
+#test(m.key, "value")
+
+--- module-dynamic-import-list ---
+#let m = module((key: "value", other: "bad"))
+#let other = "good"
+#import m: key
+#test(key,"value")
+#test(other, "good")
+
+--- module-dynamic-import-wildcard ---
+#let m = module((key: "value"))
+#import m: *
+#test(key, "value")


### PR DESCRIPTION
Give `module` a constructor that takes a single dictionary as an argument.

Closes https://github.com/typst/typst/issues/6419