### PR TITLE
Don't wrap html.elem at document root in <p>

### DIFF
--- a/crates/typst-html/src/lib.rs
+++ b/crates/typst-html/src/lib.rs
@@ -193,12 +193,18 @@ fn handle(
     } else if let Some(elem) = child.to_packed::<ParElem>() {
         let children =
             html_fragment(engine, &elem.body, locator.next(&elem.span()), styles)?;
-        output.push(
-            HtmlElement::new(tag::p)
-                .with_children(children)
-                .spanned(elem.span())
-                .into(),
-        );
+        // If the body is already an HtmlElem, then the user has directly specified it via
+        // `html.elem`, and it shouldn't be wrapped in a <p> tag.
+        if elem.body.is::<HtmlElem>() {
+            output.extend(children);
+        } else {
+            output.push(
+                HtmlElement::new(tag::p)
+                    .with_children(children)
+                    .spanned(elem.span())
+                    .into(),
+            );
+        };
     } else if let Some(elem) = child.to_packed::<BoxElem>() {
         // TODO: This is rather incomplete.
         if let Some(body) = elem.body(styles) {
@@ -257,6 +263,7 @@ fn handle(
             child.elem().name()
         ));
     }
+
     Ok(())
 }
 

--- a/tests/ref/html/issue-5907-html-elem-at-root.html
+++ b/tests/ref/html/issue-5907-html-elem-at-root.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body>
+    <span>Not wrapped in p tag</span>
+    <p>Wrapped in p tag</p>
+  </body>
+</html>

--- a/tests/ref/html/issue-5907-html-elem-at-root.html
+++ b/tests/ref/html/issue-5907-html-elem-at-root.html
@@ -5,7 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body>
-    <span>Not wrapped in p tag</span>
-    <p>Wrapped in p tag</p>
+    <span>Not wrapped in p tag</p></span>
+    <span><p>Wrapped in p tag</p></span>
+    <div>Not wrapped in p tag</div>
+    <p><strong>Wrapped</strong> in p tag</p>
   </body>
 </html>

--- a/tests/suite/html/elem.typ
+++ b/tests/suite/html/elem.typ
@@ -13,3 +13,8 @@ Text
   val
 })
 #metadata("Hi") <l>
+
+--- issue-5907-html-elem-at-root html ---
+#html.elem("span", [Not wrapped in p tag])
+
+Wrapped in p tag

--- a/tests/suite/html/elem.typ
+++ b/tests/suite/html/elem.typ
@@ -17,4 +17,8 @@ Text
 --- issue-5907-html-elem-at-root html ---
 #html.elem("span", [Not wrapped in p tag])
 
-Wrapped in p tag
+#html.elem("span", html.elem("p", [Wrapped in p tag]))
+#html.elem("div", [Not wrapped in p tag])
+
+#html.elem("p", [*Wrapped* in p tag])
+


### PR DESCRIPTION
Fixes #5907.

The issue here seems to be related to #5746, in the sense that not _all_ content should be wrapped in a `<p>` tag when rendered to HTML.

Please note that this is my first contribution that modifies code, and so I am not sure whether this conditional is in the ideal place in compilation. It seems to me that this nuance is somewhat specific to HTML, in the sense that there should be an exception to the 'wrap all root content in paragraph elements' rule in the case of user-specified HTML. But please tell me if this is not the correct level of abstraction at which to make the change, and I will be happy to update this PR accordingly.

I have also added a test according to the apparent pattern of the test suite, but again would appreciate any pointers on whether this is appropriate and idiomatic.

Thanks!