### PR TITLE
Autocomplete fixes for math mode

### DIFF
--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -1676,8 +1676,8 @@ mod tests {
     /// Test that autocomplete in math uses the correct global scope.
     #[test]
     fn test_autocomplete_math_scope() {
-        test("$ #col $", -3).must_include(["colbreak"]).must_exclude(["colon"]);
-        test("$ col $", -3).must_include(["colon"]).must_exclude(["colbreak"]);
+        test("$#col$", -2).must_include(["colbreak"]).must_exclude(["colon"]);
+        test("$col$", -2).must_include(["colon"]).must_exclude(["colbreak"]);
     }
 
     /// Test that the `before_window` doesn't slice into invalid byte

--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -298,9 +298,16 @@ fn complete_math(ctx: &mut CompletionContext) -> bool {
         return false;
     }
 
-    // Start of an interpolated identifier: "#|".
+    // Start of an interpolated identifier: "$#|$".
     if ctx.leaf.kind() == SyntaxKind::Hash {
         ctx.from = ctx.cursor;
+        code_completions(ctx, true);
+        return true;
+    }
+
+    // Behind existing interpolated identifier: "$#pa|$".
+    if ctx.leaf.kind() == SyntaxKind::Ident {
+        ctx.from = ctx.leaf.offset();
         code_completions(ctx, true);
         return true;
     }

--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -1673,6 +1673,13 @@ mod tests {
         test("#{() .a}", -2).must_include(["at", "any", "all"]);
     }
 
+    /// Test that autocomplete in math uses the correct global scope.
+    #[test]
+    fn test_autocomplete_math_scope() {
+        test("$ #col $", -3).must_include(["colbreak"]).must_exclude(["colon"]);
+        test("$ col $", -3).must_include(["colon"]).must_exclude(["colbreak"]);
+    }
+
     /// Test that the `before_window` doesn't slice into invalid byte
     /// boundaries.
     #[test]

--- a/crates/typst-ide/src/utils.rs
+++ b/crates/typst-ide/src/utils.rs
@@ -114,7 +114,9 @@ pub fn globals<'a>(world: &'a dyn IdeWorld, leaf: &LinkedNode) -> &'a Scope {
             | Some(SyntaxKind::Math)
             | Some(SyntaxKind::MathFrac)
             | Some(SyntaxKind::MathAttach)
-    );
+    ) && leaf
+        .prev_leaf()
+        .is_none_or(|prev| !matches!(prev.kind(), SyntaxKind::Hash));
 
     let library = world.library();
     if in_math {


### PR DESCRIPTION
hi! this PR seeks to fix two logic bugs that i found while developing a little Typst+CM6-powered math editor. for reference, this is what the current autocomplete looks like for this piece of math (the text is wrapped in `$`s before being passed to the compiler):

<details>
<summary>current</summary>
<img src="https://github.com/user-attachments/assets/b1292d43-6a27-4fb1-a41e-5d0d8ac51d3e" height="200px"></img>
</details>

clearly the returned position is equal to the provided `cursor` ([↗](https://github.com/typst/typst/blob/494e6a64225261add59c3c9b1cd923bfdfa77961/crates/typst-ide/src/complete.rs#L318-L323)), which results in a contextless autocompletion result. the first fix involves copying the part of `complete_markup` that handles interpolated identifiers ([↗](https://github.com/typst/typst/blob/494e6a64225261add59c3c9b1cd923bfdfa77961/crates/typst-ide/src/complete.rs#L126-L131)) into `complete_math`. given that hash-related completions are essentially the same in math as in markup, i wonder if this + the other cases (let bindings etc.) should be extracted to a `complete_math_or_markup`—this would also help avoid this gap in the future. anyway, the result looks like this after that:

<details>
<summary>with interpolated identifier handling</summary>
<img src="https://github.com/user-attachments/assets/91048d35-2543-45dc-bcca-296b047ae732" height="200px"></img>
</details>

better but still wrong, because the scope used for completions ([↗](https://github.com/typst/typst/blob/494e6a64225261add59c3c9b1cd923bfdfa77961/crates/typst-ide/src/utils.rs#L110-L125)) is the global scope rather than the math scope. so i changed `globals()`'s `in_math` to also verify that the math-child isn't preceded by a hash (which makes it no longer math). not sure how robust this is; are there other cases where math children aren't math? anyway, after this fix the result is correct:

<details>
<summary>with correct math scope</summary>
<img src="https://github.com/user-attachments/assets/b2e8b24e-18af-4d10-bdff-0385b6b9907c" height="200px"></img>
</details>

i added a test for the second fix, but the first fix is only kinda sorta implicitly tested for, given that the suite doesn't currently test for correctness of the returned position (e.g. `must_start_at()`). should this be added?