### PR TITLE
standardize trailing slashes in docs route paths

### DIFF
--- a/docs/src/lib.rs
+++ b/docs/src/lib.rs
@@ -622,7 +622,7 @@ fn group_page(
     });
 
     let model = PageModel {
-        route: eco_format!("{parent}{}", group.name),
+        route: eco_format!("{parent}{}/", group.name),
         title: group.title.clone(),
         description: eco_format!("Documentation for the {} functions.", group.name),
         part: None,


### PR DESCRIPTION
Fixed missing trailing slash for group pages in documentation.

All other pages in the documentation have trailing slashes in their routes, but pages managed by `groups.yml` were being generated without trailing slashes. This PR fixes the inconsistency by adding the missing trailing slash to group page routes.

This ensures consistent URL patterns across all documentation pages and maintains proper routing behavior.