### PR TITLE
Renders #underline style as <u> in HTML

### DIFF
--- a/crates/typst-library/src/text/deco.rs
+++ b/crates/typst-library/src/text/deco.rs
@@ -86,7 +86,7 @@ impl Show for Packed<UnderlineElem> {
     fn show(&self, _: &mut Engine, styles: StyleChain) -> SourceResult<Content> {
         let body = self.body.clone();
         Ok(if TargetElem::target_in(styles).is_html() {
-            HtmlElem::new(tag::sub)
+            HtmlElem::new(tag::u)
                 .with_body(Some(body))
                 .pack()
                 .spanned(self.span())

--- a/tests/ref/html/basic-underline.html
+++ b/tests/ref/html/basic-underline.html
@@ -5,6 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body>
-    <p><sub>This text should be wrapped in sub.</sub></p>
+    <p><u>This text should be wrapped in u.</u></p>
   </body>
 </html>

--- a/tests/suite/text/deco.typ
+++ b/tests/suite/text/deco.typ
@@ -20,7 +20,7 @@
 
 --- basic-underline html ---
 // Basic underline for HTML.
-#underline[This text should be wrapped in sub.]
+#underline[This text should be wrapped in u.]
 
 --- strike-with ---
 #let redact = strike.with(stroke: 10pt, extent: 0.05em)


### PR DESCRIPTION
As per [discussion in Discord](https://discord.com/channels/1054443721975922748/1269208488978939946/1380168455331774474), here is a PR to render `#underline[some text]` as ~`<sub>some text</sub>`~ `<u>some text</u>` when exported to HTML.

None of the more sophisticated styling (such as `offset`) is taken into account yet as I understand that there is not yet inline CSS included in HTML export.

Please let me know if this is the right way to add HTML export capabilities, and if this is sufficient test coverage, as I intend to submit similar PRs for other styling elements.