### PR TITLE
Adjust source file API surface

### DIFF
--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -187,7 +187,7 @@ impl SystemWorld {
         self.slot(id, |slot| {
             if let Some(source) = slot.source.get() {
                 let source = source.as_ref().expect("file is not valid");
-                source.lines()
+                source.lines().clone()
             } else if let Some(bytes) = slot.file.get() {
                 let bytes = bytes.as_ref().expect("file is not valid");
                 Lines::try_from(bytes).expect("file is not valid utf-8")

--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -1698,7 +1698,7 @@ mod tests {
 
         // Then, add the invalid `#cite` call. Had the document been invalid
         // initially, we would have no populated document to autocomplete with.
-        let end = world.main.len_bytes();
+        let end = world.main.text().len();
         world.main.edit(end..end, " #cite()");
 
         test_with_doc(&world, -2, doc.as_ref())

--- a/crates/typst-ide/src/tests.rs
+++ b/crates/typst-ide/src/tests.rs
@@ -228,7 +228,7 @@ impl FilePos for (&str, isize) {
 #[track_caller]
 fn cursor(source: &Source, cursor: isize) -> usize {
     if cursor < 0 {
-        source.len_bytes().checked_add_signed(cursor + 1).unwrap()
+        source.text().len().checked_add_signed(cursor + 1).unwrap()
     } else {
         cursor as usize
     }

--- a/crates/typst-syntax/src/lines.rs
+++ b/crates/typst-syntax/src/lines.rs
@@ -6,6 +6,8 @@ use std::sync::Arc;
 use crate::is_newline;
 
 /// A text buffer and metadata about lines.
+///
+/// This is internally reference-counted and thus cheap to clone.
 #[derive(Clone)]
 pub struct Lines<S>(Arc<Repr<S>>);
 

--- a/crates/typst-syntax/src/reparser.rs
+++ b/crates/typst-syntax/src/reparser.rs
@@ -259,10 +259,10 @@ mod tests {
             panic!("test failed");
         }
         if incremental {
-            assert_ne!(source.len_bytes(), range.len(), "should have been incremental");
+            assert_ne!(source.text().len(), range.len(), "should have been incremental");
         } else {
             assert_eq!(
-                source.len_bytes(),
+                source.text().len(),
                 range.len(),
                 "shouldn't have been incremental"
             );

--- a/crates/typst-syntax/src/source.rs
+++ b/crates/typst-syntax/src/source.rs
@@ -57,18 +57,14 @@ impl Source {
     }
 
     /// The whole source as a string slice.
-    pub fn lines(&self) -> Lines<String> {
-        Lines::clone(&self.0.lines)
-    }
-
-    /// The whole source as a string slice.
     pub fn text(&self) -> &str {
         self.0.lines.text()
     }
 
-    /// Slice out the part of the source code enclosed by the range.
-    pub fn get(&self, range: Range<usize>) -> Option<&str> {
-        self.text().get(range)
+    /// An acceleration structure for conversion of UTF-8, UTF-16 and
+    /// line/column indices.
+    pub fn lines(&self) -> &Lines<String> {
+        &self.0.lines
     }
 
     /// Fully replace the source text.
@@ -105,21 +101,6 @@ impl Source {
 
         // Incrementally reparse the replaced range.
         reparse(&mut inner.root, inner.lines.text(), replace, with.len())
-    }
-
-    /// Get the length of the file in UTF-8 encoded bytes.
-    pub fn len_bytes(&self) -> usize {
-        self.0.lines.len_bytes()
-    }
-
-    /// Get the length of the file in UTF-16 code units.
-    pub fn len_utf16(&self) -> usize {
-        self.0.lines.len_utf16()
-    }
-
-    /// Get the length of the file in lines.
-    pub fn len_lines(&self) -> usize {
-        self.0.lines.len_lines()
     }
 
     /// Find the node with the given span.

--- a/tests/src/world.rs
+++ b/tests/src/world.rs
@@ -92,7 +92,7 @@ impl TestWorld {
         self.slot(id, |slot| {
             if let Some(source) = slot.source.get() {
                 let source = source.as_ref().expect("file is not valid");
-                source.lines()
+                source.lines().clone()
             } else if let Some(bytes) = slot.file.get() {
                 let bytes = bytes.as_ref().expect("file is not valid");
                 Lines::try_from(bytes).expect("file is not valid utf-8")


### PR DESCRIPTION
- `lines()` can return a reference instead of always cloning
- `get(r)` is not in use and also less flexible than `.text().get(r)`
- `len_*` functions are enough to have on `Lines`