### PR TITLE
List both YAML file extensions in bibliography docs

### DIFF
--- a/crates/typst-library/src/model/bibliography.rs
+++ b/crates/typst-library/src/model/bibliography.rs
@@ -48,8 +48,8 @@ use crate::World;
 /// You can create a new bibliography by calling this function with a path
 /// to a bibliography file in either one of two formats:
 ///
-/// - A Hayagriva `.yml` file. Hayagriva is a new bibliography file format
-///   designed for use with Typst. Visit its
+/// - A Hayagriva `.yaml`/`.yml` file. Hayagriva is a new bibliography
+///   file format designed for use with Typst. Visit its
 ///   [documentation](https://github.com/typst/hayagriva/blob/main/docs/file-format.md)
 ///   for more details.
 /// - A BibLaTeX `.bib` file.


### PR DESCRIPTION
https://github.com/typst/typst/pull/6354#issuecomment-2939994835

Since not https://spec.commonmark.org/0.31.2/#link-reference-definitions nor Typst docs is supported, it's rather weird to have long links inline.

But if it's bad, I can strip it to https://www.iana.org/assignments/media-types/application/yaml#:~:text=File%20extension(s):.
