### PR TITLE
Unify `EvalMode` and `LexMode` into `SyntaxMode`

### DIFF
--- a/crates/typst-cli/src/query.rs
+++ b/crates/typst-cli/src/query.rs
@@ -5,9 +5,9 @@ use typst::diag::{bail, HintedStrResult, StrResult, Warned};
 use typst::engine::Sink;
 use typst::foundations::{Content, IntoValue, LocatableSelector, Scope};
 use typst::layout::PagedDocument;
-use typst::syntax::Span;
+use typst::syntax::{Span, SyntaxMode};
 use typst::World;
-use typst_eval::{eval_string, EvalMode};
+use typst_eval::eval_string;
 
 use crate::args::{QueryCommand, SerializationFormat};
 use crate::compile::print_diagnostics;
@@ -63,7 +63,7 @@ fn retrieve(
         Sink::new().track_mut(),
         &command.selector,
         Span::detached(),
-        EvalMode::Code,
+        SyntaxMode::Code,
         Scope::default(),
     )
     .map_err(|errors| {

--- a/crates/typst-library/src/foundations/cast.rs
+++ b/crates/typst-library/src/foundations/cast.rs
@@ -9,7 +9,7 @@ use std::ops::Add;
 
 use ecow::eco_format;
 use smallvec::SmallVec;
-use typst_syntax::{Span, Spanned};
+use typst_syntax::{Span, Spanned, SyntaxMode};
 use unicode_math_class::MathClass;
 
 use crate::diag::{At, HintedStrResult, HintedString, SourceResult, StrResult};
@@ -457,6 +457,21 @@ impl FromValue for Never {
     fn from_value(value: Value) -> HintedStrResult<Self> {
         Err(Self::error(&value))
     }
+}
+
+cast! {
+    SyntaxMode,
+    self => IntoValue::into_value(match self {
+        SyntaxMode::Markup => "markup",
+        SyntaxMode::Math => "math",
+        SyntaxMode::Code => "code",
+    }),
+    /// Evaluate as markup, as in a Typst file.
+    "markup" => SyntaxMode::Markup,
+    /// Evaluate as math, as in an equation.
+    "math" => SyntaxMode::Math,
+    /// Evaluate as code, as after a hash.
+    "code" => SyntaxMode::Code,
 }
 
 cast! {

--- a/crates/typst-library/src/foundations/mod.rs
+++ b/crates/typst-library/src/foundations/mod.rs
@@ -250,18 +250,6 @@ impl assert {
     }
 }
 
-cast! {
-    SyntaxMode,
-    self => match self {
-        SyntaxMode::Markup => "markup".into_value(),
-        SyntaxMode::Math => "math".into_value(),
-        SyntaxMode::Code => "code".into_value(),
-    },
-    "markup" => SyntaxMode::Markup,
-    "math" => SyntaxMode::Math,
-    "code" => SyntaxMode::Code,
-}
-
 /// Evaluates a string as Typst code.
 ///
 /// This function should only be used as a last resort.

--- a/crates/typst-library/src/foundations/mod.rs
+++ b/crates/typst-library/src/foundations/mod.rs
@@ -69,6 +69,7 @@ pub use self::ty::*;
 pub use self::value::*;
 pub use self::version::*;
 pub use typst_macros::{scope, ty};
+use typst_syntax::SyntaxMode;
 
 #[rustfmt::skip]
 #[doc(hidden)]
@@ -83,7 +84,6 @@ use typst_syntax::Spanned;
 
 use crate::diag::{bail, SourceResult, StrResult};
 use crate::engine::Engine;
-use crate::routines::EvalMode;
 use crate::{Feature, Features};
 
 /// Hook up all `foundations` definitions.
@@ -250,6 +250,18 @@ impl assert {
     }
 }
 
+cast! {
+    SyntaxMode,
+    self => match self {
+        SyntaxMode::Markup => "markup".into_value(),
+        SyntaxMode::Math => "math".into_value(),
+        SyntaxMode::Code => "code".into_value(),
+    },
+    "markup" => SyntaxMode::Markup,
+    "math" => SyntaxMode::Math,
+    "code" => SyntaxMode::Code,
+}
+
 /// Evaluates a string as Typst code.
 ///
 /// This function should only be used as a last resort.
@@ -273,8 +285,8 @@ pub fn eval(
     /// #eval("1_2^3", mode: "math")
     /// ```
     #[named]
-    #[default(EvalMode::Code)]
-    mode: EvalMode,
+    #[default(SyntaxMode::Code)]
+    mode: SyntaxMode,
     /// A scope of definitions that are made available.
     ///
     /// ```example

--- a/crates/typst-library/src/model/bibliography.rs
+++ b/crates/typst-library/src/model/bibliography.rs
@@ -16,7 +16,7 @@ use hayagriva::{
 };
 use indexmap::IndexMap;
 use smallvec::{smallvec, SmallVec};
-use typst_syntax::{Span, Spanned};
+use typst_syntax::{Span, Spanned, SyntaxMode};
 use typst_utils::{Get, ManuallyHash, NonZeroExt, PicoStr};
 
 use crate::diag::{
@@ -39,7 +39,7 @@ use crate::model::{
     CitationForm, CiteGroup, Destination, FootnoteElem, HeadingElem, LinkElem, ParElem,
     Url,
 };
-use crate::routines::{EvalMode, Routines};
+use crate::routines::Routines;
 use crate::text::{
     FontStyle, Lang, LocalName, Region, Smallcaps, SubElem, SuperElem, TextElem,
     WeightDelta,
@@ -1024,7 +1024,7 @@ impl ElemRenderer<'_> {
             Sink::new().track_mut(),
             math,
             self.span,
-            EvalMode::Math,
+            SyntaxMode::Math,
             Scope::new(),
         )
         .map(Value::display)

--- a/crates/typst-library/src/routines.rs
+++ b/crates/typst-library/src/routines.rs
@@ -4,7 +4,7 @@ use std::hash::{Hash, Hasher};
 use std::num::NonZeroUsize;
 
 use comemo::{Tracked, TrackedMut};
-use typst_syntax::Span;
+use typst_syntax::{Span, SyntaxMode};
 use typst_utils::LazyHash;
 
 use crate::diag::SourceResult;
@@ -58,7 +58,7 @@ routines! {
         sink: TrackedMut<Sink>,
         string: &str,
         span: Span,
-        mode: EvalMode,
+        mode: SyntaxMode,
         scope: Scope,
     ) -> SourceResult<Value>
 
@@ -310,17 +310,6 @@ routines! {
         styles: StyleChain,
         regions: Regions,
     ) -> SourceResult<Fragment>
-}
-
-/// In which mode to evaluate a string.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Cast)]
-pub enum EvalMode {
-    /// Evaluate as code, as after a hash.
-    Code,
-    /// Evaluate as markup, like in a Typst file.
-    Markup,
-    /// Evaluate as math, as in an equation.
-    Math,
 }
 
 /// Defines what kind of realization we are performing.

--- a/crates/typst-syntax/src/lib.rs
+++ b/crates/typst-syntax/src/lib.rs
@@ -8,6 +8,7 @@ mod highlight;
 mod kind;
 mod lexer;
 mod lines;
+mod mode;
 mod node;
 mod parser;
 mod path;
@@ -24,11 +25,12 @@ pub use self::lexer::{
     link_prefix, split_newlines,
 };
 pub use self::lines::Lines;
+pub use self::mode::SyntaxMode;
 pub use self::node::{LinkedChildren, LinkedNode, Side, SyntaxError, SyntaxNode};
 pub use self::parser::{parse, parse_code, parse_math};
 pub use self::path::VirtualPath;
 pub use self::source::Source;
 pub use self::span::{Span, Spanned};
 
-use self::lexer::{LexMode, Lexer};
+use self::lexer::Lexer;
 use self::parser::{reparse_block, reparse_markup};

--- a/crates/typst-syntax/src/lib.rs
+++ b/crates/typst-syntax/src/lib.rs
@@ -25,10 +25,21 @@ pub use self::lexer::{
 };
 pub use self::lines::Lines;
 pub use self::node::{LinkedChildren, LinkedNode, Side, SyntaxError, SyntaxNode};
-pub use self::parser::{parse, parse_code, parse_math, SyntaxMode};
+pub use self::parser::{parse, parse_code, parse_math};
 pub use self::path::VirtualPath;
 pub use self::source::Source;
 pub use self::span::{Span, Spanned};
 
 use self::lexer::Lexer;
 use self::parser::{reparse_block, reparse_markup};
+
+/// The syntax mode of a portion of Typst code.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum SyntaxMode {
+    /// Text and markup, as in the top level.
+    Markup,
+    /// Math atoms, operators, etc., as in equations.
+    Math,
+    /// Keywords, literals and operators, as after hashes.
+    Code,
+}

--- a/crates/typst-syntax/src/lib.rs
+++ b/crates/typst-syntax/src/lib.rs
@@ -8,7 +8,6 @@ mod highlight;
 mod kind;
 mod lexer;
 mod lines;
-mod mode;
 mod node;
 mod parser;
 mod path;
@@ -25,9 +24,8 @@ pub use self::lexer::{
     link_prefix, split_newlines,
 };
 pub use self::lines::Lines;
-pub use self::mode::SyntaxMode;
 pub use self::node::{LinkedChildren, LinkedNode, Side, SyntaxError, SyntaxNode};
-pub use self::parser::{parse, parse_code, parse_math};
+pub use self::parser::{parse, parse_code, parse_math, SyntaxMode};
 pub use self::path::VirtualPath;
 pub use self::source::Source;
 pub use self::span::{Span, Spanned};

--- a/crates/typst-syntax/src/mode.rs
+++ b/crates/typst-syntax/src/mode.rs
@@ -1,9 +1,0 @@
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum SyntaxMode {
-    /// Text and markup, as in the top level.
-    Markup,
-    /// Math atoms, operators, etc., as in equations.
-    Math,
-    /// Keywords, literals and operators, as after hashes.
-    Code,
-}

--- a/crates/typst-syntax/src/mode.rs
+++ b/crates/typst-syntax/src/mode.rs
@@ -1,0 +1,9 @@
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum SyntaxMode {
+    /// Text and markup, as in the top level.
+    Markup,
+    /// Math atoms, operators, etc., as in equations.
+    Math,
+    /// Keywords, literals and operators, as after hashes.
+    Code,
+}

--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -7,7 +7,7 @@ use typst_utils::default_math_class;
 use unicode_math_class::MathClass;
 
 use crate::set::{syntax_set, SyntaxSet};
-use crate::{ast, set, Lexer, SyntaxError, SyntaxKind, SyntaxNode};
+use crate::{ast, set, Lexer, SyntaxError, SyntaxKind, SyntaxMode, SyntaxNode};
 
 /// Parses a source file as top-level markup.
 pub fn parse(text: &str) -> SyntaxNode {
@@ -1578,17 +1578,6 @@ struct Newline {
     column: Option<usize>,
     /// Whether any of our newlines were paragraph breaks.
     parbreak: bool,
-}
-
-/// The syntax mode of a portion of Typst code.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum SyntaxMode {
-    /// Text and markup, as in the top level.
-    Markup,
-    /// Math atoms, operators, etc., as in equations.
-    Math,
-    /// Keywords, literals and operators, as after hashes.
-    Code,
 }
 
 /// How to proceed with parsing when at a newline.

--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -7,7 +7,7 @@ use typst_utils::default_math_class;
 use unicode_math_class::MathClass;
 
 use crate::set::{syntax_set, SyntaxSet};
-use crate::{ast, set, Lexer, SyntaxError, SyntaxKind, SyntaxMode, SyntaxNode};
+use crate::{ast, set, Lexer, SyntaxError, SyntaxKind, SyntaxNode};
 
 /// Parses a source file as top-level markup.
 pub fn parse(text: &str) -> SyntaxNode {
@@ -1578,6 +1578,17 @@ struct Newline {
     column: Option<usize>,
     /// Whether any of our newlines were paragraph breaks.
     parbreak: bool,
+}
+
+/// The syntax mode of a portion of Typst code.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum SyntaxMode {
+    /// Text and markup, as in the top level.
+    Markup,
+    /// Math atoms, operators, etc., as in equations.
+    Math,
+    /// Keywords, literals and operators, as after hashes.
+    Code,
 }
 
 /// How to proceed with parsing when at a newline.

--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -7,12 +7,12 @@ use typst_utils::default_math_class;
 use unicode_math_class::MathClass;
 
 use crate::set::{syntax_set, SyntaxSet};
-use crate::{ast, set, LexMode, Lexer, SyntaxError, SyntaxKind, SyntaxNode};
+use crate::{ast, set, Lexer, SyntaxError, SyntaxKind, SyntaxMode, SyntaxNode};
 
 /// Parses a source file as top-level markup.
 pub fn parse(text: &str) -> SyntaxNode {
     let _scope = typst_timing::TimingScope::new("parse");
-    let mut p = Parser::new(text, 0, LexMode::Markup);
+    let mut p = Parser::new(text, 0, SyntaxMode::Markup);
     markup_exprs(&mut p, true, syntax_set!(End));
     p.finish_into(SyntaxKind::Markup)
 }
@@ -20,7 +20,7 @@ pub fn parse(text: &str) -> SyntaxNode {
 /// Parses top-level code.
 pub fn parse_code(text: &str) -> SyntaxNode {
     let _scope = typst_timing::TimingScope::new("parse code");
-    let mut p = Parser::new(text, 0, LexMode::Code);
+    let mut p = Parser::new(text, 0, SyntaxMode::Code);
     code_exprs(&mut p, syntax_set!(End));
     p.finish_into(SyntaxKind::Code)
 }
@@ -28,7 +28,7 @@ pub fn parse_code(text: &str) -> SyntaxNode {
 /// Parses top-level math.
 pub fn parse_math(text: &str) -> SyntaxNode {
     let _scope = typst_timing::TimingScope::new("parse math");
-    let mut p = Parser::new(text, 0, LexMode::Math);
+    let mut p = Parser::new(text, 0, SyntaxMode::Math);
     math_exprs(&mut p, syntax_set!(End));
     p.finish_into(SyntaxKind::Math)
 }
@@ -63,7 +63,7 @@ pub(super) fn reparse_markup(
     nesting: &mut usize,
     top_level: bool,
 ) -> Option<Vec<SyntaxNode>> {
-    let mut p = Parser::new(text, range.start, LexMode::Markup);
+    let mut p = Parser::new(text, range.start, SyntaxMode::Markup);
     *at_start |= p.had_newline();
     while !p.end() && p.current_start() < range.end {
         // If not top-level and at a new RightBracket, stop the reparse.
@@ -205,7 +205,7 @@ fn reference(p: &mut Parser) {
 /// Parses a mathematical equation: `$x$`, `$ x^2 $`.
 fn equation(p: &mut Parser) {
     let m = p.marker();
-    p.enter_modes(LexMode::Math, AtNewline::Continue, |p| {
+    p.enter_modes(SyntaxMode::Math, AtNewline::Continue, |p| {
         p.assert(SyntaxKind::Dollar);
         math(p, syntax_set!(Dollar, End));
         p.expect_closing_delimiter(m, SyntaxKind::Dollar);
@@ -615,7 +615,7 @@ fn code_exprs(p: &mut Parser, stop_set: SyntaxSet) {
 
 /// Parses an atomic code expression embedded in markup or math.
 fn embedded_code_expr(p: &mut Parser) {
-    p.enter_modes(LexMode::Code, AtNewline::Stop, |p| {
+    p.enter_modes(SyntaxMode::Code, AtNewline::Stop, |p| {
         p.assert(SyntaxKind::Hash);
         if p.had_trivia() || p.end() {
             p.expected("expression");
@@ -777,7 +777,7 @@ fn code_primary(p: &mut Parser, atomic: bool) {
 
 /// Reparses a full content or code block.
 pub(super) fn reparse_block(text: &str, range: Range<usize>) -> Option<SyntaxNode> {
-    let mut p = Parser::new(text, range.start, LexMode::Code);
+    let mut p = Parser::new(text, range.start, SyntaxMode::Code);
     assert!(p.at(SyntaxKind::LeftBracket) || p.at(SyntaxKind::LeftBrace));
     block(&mut p);
     (p.balanced && p.prev_end() == range.end)
@@ -796,7 +796,7 @@ fn block(p: &mut Parser) {
 /// Parses a code block: `{ let x = 1; x + 2 }`.
 fn code_block(p: &mut Parser) {
     let m = p.marker();
-    p.enter_modes(LexMode::Code, AtNewline::Continue, |p| {
+    p.enter_modes(SyntaxMode::Code, AtNewline::Continue, |p| {
         p.assert(SyntaxKind::LeftBrace);
         code(p, syntax_set!(RightBrace, RightBracket, RightParen, End));
         p.expect_closing_delimiter(m, SyntaxKind::RightBrace);
@@ -807,7 +807,7 @@ fn code_block(p: &mut Parser) {
 /// Parses a content block: `[*Hi* there!]`.
 fn content_block(p: &mut Parser) {
     let m = p.marker();
-    p.enter_modes(LexMode::Markup, AtNewline::Continue, |p| {
+    p.enter_modes(SyntaxMode::Markup, AtNewline::Continue, |p| {
         p.assert(SyntaxKind::LeftBracket);
         markup(p, true, true, syntax_set!(RightBracket, End));
         p.expect_closing_delimiter(m, SyntaxKind::RightBracket);
@@ -1516,10 +1516,10 @@ fn pattern_leaf<'s>(
 /// ### Modes
 ///
 /// The parser manages the transitions between the three modes of Typst through
-/// [lexer modes](`LexMode`) and [newline modes](`AtNewline`).
+/// [syntax modes](`SyntaxMode`) and [newline modes](`AtNewline`).
 ///
-/// The lexer modes map to the three Typst modes and are stored in the lexer,
-/// changing which`SyntaxKind`s it will generate.
+/// The syntax modes map to the three Typst modes and are stored in the lexer,
+/// changing which `SyntaxKind`s it will generate.
 ///
 /// The newline mode is used to determine whether a newline should end the
 /// current expression. If so, the parser temporarily changes `token`'s kind to
@@ -1529,7 +1529,7 @@ struct Parser<'s> {
     /// The source text shared with the lexer.
     text: &'s str,
     /// A lexer over the source text with multiple modes. Defines the boundaries
-    /// of tokens and determines their [`SyntaxKind`]. Contains the [`LexMode`]
+    /// of tokens and determines their [`SyntaxKind`]. Contains the [`SyntaxMode`]
     /// defining our current Typst mode.
     lexer: Lexer<'s>,
     /// The newline mode: whether to insert a temporary end at newlines.
@@ -1612,7 +1612,7 @@ impl AtNewline {
             AtNewline::RequireColumn(min_col) => {
                 // When the column is `None`, the newline doesn't start a
                 // column, and we continue parsing. This may happen on the
-                // boundary of lexer modes, since we only report a column in
+                // boundary of syntax modes, since we only report a column in
                 // Markup.
                 column.is_some_and(|column| column <= min_col)
             }
@@ -1643,8 +1643,8 @@ impl IndexMut<Marker> for Parser<'_> {
 
 /// Creating/Consuming the parser and getting info about the current token.
 impl<'s> Parser<'s> {
-    /// Create a new parser starting from the given text offset and lexer mode.
-    fn new(text: &'s str, offset: usize, mode: LexMode) -> Self {
+    /// Create a new parser starting from the given text offset and syntax mode.
+    fn new(text: &'s str, offset: usize, mode: SyntaxMode) -> Self {
         let mut lexer = Lexer::new(text, mode);
         lexer.jump(offset);
         let nl_mode = AtNewline::Continue;
@@ -1825,13 +1825,13 @@ impl<'s> Parser<'s> {
         self.nodes.insert(from, SyntaxNode::inner(kind, children));
     }
 
-    /// Parse within the [`LexMode`] for subsequent tokens (does not change the
+    /// Parse within the [`SyntaxMode`] for subsequent tokens (does not change the
     /// current token). This may re-lex the final token on exit.
     ///
     /// This function effectively repurposes the call stack as a stack of modes.
     fn enter_modes(
         &mut self,
-        mode: LexMode,
+        mode: SyntaxMode,
         stop: AtNewline,
         func: impl FnOnce(&mut Parser<'s>),
     ) {
@@ -1891,7 +1891,8 @@ impl<'s> Parser<'s> {
         }
 
         let newline = if had_newline {
-            let column = (lexer.mode() == LexMode::Markup).then(|| lexer.column(start));
+            let column =
+                (lexer.mode() == SyntaxMode::Markup).then(|| lexer.column(start));
             let newline = Newline { column, parbreak };
             if nl_mode.stop_at(newline, kind) {
                 // Insert a temporary `SyntaxKind::End` to halt the parser.
@@ -1938,7 +1939,7 @@ struct Checkpoint {
 #[derive(Clone)]
 struct PartialState {
     cursor: usize,
-    lex_mode: LexMode,
+    lex_mode: SyntaxMode,
     token: Token,
 }
 


### PR DESCRIPTION
hi, this PR does that ↑, as described in #6415, in preparation for beautiful refactorings. i'm not sure if the location of the new `cast!` invocation is right ([↗](https://github.com/typst/typst/pull/6432/files#diff-4824f02b317a637a17ede1b1bd170b4339f7476477b7f31c5412b697add4ded7R253-R264)).