### PR TITLE
Allow deprecating symbol variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,7 +413,7 @@ dependencies = [
 [[package]]
 name = "codex"
 version = "0.1.1"
-source = "git+https://github.com/typst/codex?rev=56eb217#56eb2172fc0670f4c1c8b79a63d11f9354e5babe"
+source = "git+https://github.com/typst/codex?rev=a5428cb#a5428cb9c81a41354d44b44dbd5a16a710bbd928"
 
 [[package]]
 name = "color-print"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ clap = { version = "4.4", features = ["derive", "env", "wrap_help"] }
 clap_complete = "4.2.1"
 clap_mangen = "0.2.10"
 codespan-reporting = "0.11"
-codex = { git = "https://github.com/typst/codex", rev = "56eb217" }
+codex = { git = "https://github.com/typst/codex", rev = "a5428cb" }
 color-print = "0.3.6"
 comemo = "0.4"
 csv = "1"

--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -448,7 +448,7 @@ fn field_access_completions(
     match value {
         Value::Symbol(symbol) => {
             for modifier in symbol.modifiers() {
-                if let Ok(modified) = symbol.clone().modified(modifier) {
+                if let Ok(modified) = symbol.clone().modified((), modifier) {
                     ctx.completions.push(Completion {
                         kind: CompletionKind::Symbol(modified.get()),
                         label: modifier.into(),

--- a/crates/typst-library/src/foundations/value.rs
+++ b/crates/typst-library/src/foundations/value.rs
@@ -157,7 +157,9 @@ impl Value {
     /// Try to access a field on the value.
     pub fn field(&self, field: &str, sink: impl DeprecationSink) -> StrResult<Value> {
         match self {
-            Self::Symbol(symbol) => symbol.clone().modified(field).map(Self::Symbol),
+            Self::Symbol(symbol) => {
+                symbol.clone().modified(sink, field).map(Self::Symbol)
+            }
             Self::Version(version) => version.component(field).map(Self::Int),
             Self::Dict(dict) => dict.get(field).cloned(),
             Self::Content(content) => content.field_by_name(field),

--- a/docs/src/lib.rs
+++ b/docs/src/lib.rs
@@ -720,18 +720,12 @@ fn symbols_model(resolver: &dyn Resolver, group: &GroupData) -> SymbolsModel {
             }
         };
 
-        for (variant, c) in symbol.variants() {
+        for (variant, c, deprecation) in symbol.variants() {
             let shorthand = |list: &[(&'static str, char)]| {
                 list.iter().copied().find(|&(_, x)| x == c).map(|(s, _)| s)
             };
 
             let name = complete(variant);
-            let deprecation = match name.as_str() {
-                "integral.sect" => {
-                    Some("`integral.sect` is deprecated, use `integral.inter` instead")
-                }
-                _ => binding.deprecation(),
-            };
 
             list.push(SymbolModel {
                 name,
@@ -742,10 +736,10 @@ fn symbols_model(resolver: &dyn Resolver, group: &GroupData) -> SymbolsModel {
                 accent: typst::math::Accent::combine(c).is_some(),
                 alternates: symbol
                     .variants()
-                    .filter(|(other, _)| other != &variant)
-                    .map(|(other, _)| complete(other))
+                    .filter(|(other, _, _)| other != &variant)
+                    .map(|(other, _, _)| complete(other))
                     .collect(),
-                deprecation,
+                deprecation: deprecation.or_else(|| binding.deprecation()),
             });
         }
     }

--- a/tests/suite/math/attach.typ
+++ b/tests/suite/math/attach.typ
@@ -121,8 +121,8 @@ $a scripts(=)^"def" b quad a scripts(lt.eq)_"really" b quad a scripts(arrow.r.lo
 
 --- math-attach-integral ---
 // Test default of scripts attachments on integrals at display size.
-$ integral.sect_a^b  quad \u{2a1b}_a^b quad limits(\u{2a1b})_a^b $
-$integral.sect_a^b quad \u{2a1b}_a^b quad limits(\u{2a1b})_a^b$
+$ integral.inter_a^b  quad \u{2a1b}_a^b quad limits(\u{2a1b})_a^b $
+$integral.inter_a^b quad \u{2a1b}_a^b quad limits(\u{2a1b})_a^b$
 
 --- math-attach-large-operator ---
 // Test default of limit attachments on large operators at display size only.
@@ -179,7 +179,7 @@ $ a0 + a1 + a0_2 \
 #{
   let var = $x^1$
   for i in range(24) {
-    var = $var$    
+    var = $var$
   }
   $var_2$
 }


### PR DESCRIPTION
This is the companion PR to https://github.com/typst/codex/pull/86.

The deprecation message is emitted when the symbol is modified. This means accessing the variant is what triggers the warning (i.e., the symbol does not need to be inserted in the document, and in fact once the variant has been accessed, no further warning will be emitted when the symbol is used). It spans over each modifier that forces the symbol to resolve to a deprecated variant. For example, consider the following symbol:

```
symbol
  .modifier
  @deprecated: ...
  .modifier.alt
```

When accessed in Typst, the warnings appear at the place indicated in the comments:

```typ
#let x = symbol.modifier.alt
//                       ^^^

#x // No warning

#symbol.modifier.alt
//               ^^^

#symbol.modifier // No warning

#symbol.alt
//      ^^^

#symbol.alt.modifier
//      ^^^ ^^^^^^^^ (two warnings)
```

The last example is unfortunate. I will try to fix it in the upcoming days.