### PR TITLE
Reorder FigureCaption fields for nicer PlainText representation

### DIFF
--- a/crates/typst-library/src/model/figure.rs
+++ b/crates/typst-library/src/model/figure.rs
@@ -503,6 +503,10 @@ pub struct FigureCaption {
     #[default(OuterVAlignment::Bottom)]
     pub position: OuterVAlignment,
 
+    /// The figure's supplement.
+    #[synthesized]
+    pub supplement: Option<Content>,
+
     /// The separator which will appear between the number and body.
     ///
     /// If set to `{auto}`, the separator will be adapted to the current
@@ -541,10 +545,6 @@ pub struct FigureCaption {
     /// The figure's supplement.
     #[synthesized]
     pub kind: FigureKind,
-
-    /// The figure's supplement.
-    #[synthesized]
-    pub supplement: Option<Content>,
 
     /// How to number the figure.
     #[synthesized]


### PR DESCRIPTION
hi, i noticed that the plaintext representation of figure captions was off, for example in tooltips:
![image](https://github.com/user-attachments/assets/7ea55aea-1950-46a3-a8e9-ccb8d4d85959)

i fixed this by just reordering the fields of `FigureCaption` (moving `supplement` before `kind`). code looks a bit weird with the `#[synthesized]`s out of order buuut anyway here's how it looks now, for example in a completion:

```rs
Completion {
    kind: Label,
    label: "yea",
    apply: None,
    detail: Some(
        "Figure: hi",
    ),
}
```
