### PR TITLE
Fix align link in layout documentation

### DIFF
--- a/crates/typst-library/src/layout/align.rs
+++ b/crates/typst-library/src/layout/align.rs
@@ -104,7 +104,7 @@ impl Show for Packed<AlignElem> {
     }
 }
 
-/// Where to [align]($align) something along an axis.
+/// Where to align something along an axis.
 ///
 /// Possible values are:
 /// - `start`: Aligns at the [start]($direction.start) of the [text

--- a/crates/typst-library/src/layout/align.rs
+++ b/crates/typst-library/src/layout/align.rs
@@ -104,7 +104,7 @@ impl Show for Packed<AlignElem> {
     }
 }
 
-/// Where to [align] something along an axis.
+/// Where to [align]($align) something along an axis.
 ///
 /// Possible values are:
 /// - `start`: Aligns at the [start]($direction.start) of the [text


### PR DESCRIPTION
Fixes #6427.

I would love to try to create something that automatically checks if links are broken, if that seems like a good idea.