### PR TITLE
CLI: Allow specifying output directory

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::fmt::{self, Display, Formatter};
 use std::num::NonZeroUsize;
 use std::ops::RangeInclusive;
@@ -441,6 +442,27 @@ pub enum OutputFormat {
     Png,
     Svg,
     Html,
+}
+
+impl OutputFormat {
+    pub fn from_file_ext(ext: &OsStr) -> Option<Self> {
+        match ext {
+            ext if ext.eq_ignore_ascii_case("pdf") => Some(OutputFormat::Pdf),
+            ext if ext.eq_ignore_ascii_case("png") => Some(OutputFormat::Png),
+            ext if ext.eq_ignore_ascii_case("svg") => Some(OutputFormat::Svg),
+            ext if ext.eq_ignore_ascii_case("html") => Some(OutputFormat::Html),
+            _ => None,
+        }
+    }
+
+    pub fn as_file_ext(&self) -> &'static str {
+        match self {
+            Self::Pdf => "pdf",
+            Self::Png => "png",
+            Self::Svg => "svg",
+            Self::Html => "html",
+        }
+    }
 }
 
 display_possible_values!(OutputFormat);

--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -137,6 +137,14 @@ impl CompileConfig {
                     panic!("input path must be non-empty, as guarded by the CLI");
                 };
 
+                // create directory if doesn't exist yet
+                std::fs::create_dir_all(&path).map_err(|err| {
+                    eco_format!(
+                        "failed to create output directory at {path}: {err}",
+                        path = path.display()
+                    )
+                })?;
+
                 path.push(file_name);
                 path.set_extension(match output_format {
                     OutputFormat::Pdf => "pdf",


### PR DESCRIPTION
This adds the feature to specify an output *directory* using an explicit trailing `/`.
(example: `build/`)

That makes it possible to use
```bash
typst compile -f pdf main.typ build/
```
where the output is then written to `build/main.pdf`.

---

My primary usecase for this is to make it easy to change either input file, or output format, without also having to change the output file.