### PR TITLE
Fix param autocompletion false positive

### DIFF
--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -701,7 +701,10 @@ fn complete_params(ctx: &mut CompletionContext) -> bool {
     let mut deciding = ctx.leaf.clone();
     while !matches!(
         deciding.kind(),
-        SyntaxKind::LeftParen | SyntaxKind::Comma | SyntaxKind::Colon
+        SyntaxKind::LeftParen
+            | SyntaxKind::RightParen
+            | SyntaxKind::Comma
+            | SyntaxKind::Colon
     ) {
         let Some(prev) = deciding.prev_leaf() else { break };
         deciding = prev;
@@ -1734,6 +1737,8 @@ mod tests {
         test("#numbering(\"foo\", 1, )", -2)
             .must_include(["integer"])
             .must_exclude(["string"]);
+        // After argument list no completions.
+        test("#numbering()", -1).must_exclude(["string"]);
     }
 
     /// Test that autocompletion for values of known type picks up nested
@@ -1829,17 +1834,17 @@ mod tests {
 
     #[test]
     fn test_autocomplete_fonts() {
-        test("#text(font:)", -1)
+        test("#text(font:)", -2)
             .must_include(["\"Libertinus Serif\"", "\"New Computer Modern Math\""]);
 
-        test("#show link: set text(font: )", -1)
+        test("#show link: set text(font: )", -2)
             .must_include(["\"Libertinus Serif\"", "\"New Computer Modern Math\""]);
 
-        test("#show math.equation: set text(font: )", -1)
+        test("#show math.equation: set text(font: )", -2)
             .must_include(["\"New Computer Modern Math\""])
             .must_exclude(["\"Libertinus Serif\""]);
 
-        test("#show math.equation: it => { set text(font: )\nit }", -6)
+        test("#show math.equation: it => { set text(font: )\nit }", -7)
             .must_include(["\"New Computer Modern Math\""])
             .must_exclude(["\"Libertinus Serif\""]);
     }

--- a/crates/typst-ide/src/tests.rs
+++ b/crates/typst-ide/src/tests.rs
@@ -202,7 +202,8 @@ impl WorldLike for &str {
     }
 }
 
-/// Specifies a position in a file for a test.
+/// Specifies a position in a file for a test. Negative numbers index from the
+/// back. `-1` is at the very back.
 pub trait FilePos {
     fn resolve(self, world: &TestWorld) -> (Source, usize);
 }


### PR DESCRIPTION
With the cursor _after_ a parameter list (`#text(font:)|`), we would still emit completions, they just wouldn't typically show up in an editor because the emitted cursor position was after the colon and no completion started with `)`. This let the autocompletion fonts test pass even though the indices are wrong.