### PR TITLE
Also fix encoding of `<textarea>`

### DIFF
--- a/crates/typst-html/src/encode.rs
+++ b/crates/typst-html/src/encode.rs
@@ -113,7 +113,7 @@ fn write_element(w: &mut Writer, element: &HtmlElement) -> SourceResult<()> {
 /// Encodes the children of an element.
 fn write_children(w: &mut Writer, element: &HtmlElement) -> SourceResult<()> {
     // See HTML spec § 13.1.2.5.
-    if element.tag == tag::pre && starts_with_newline(element) {
+    if matches!(element.tag, tag::pre | tag::textarea) && starts_with_newline(element) {
         w.buf.push('\n');
     }
 

--- a/tests/ref/html/html-textarea-starting-with-newline.html
+++ b/tests/ref/html/html-textarea-starting-with-newline.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body><textarea>
+
+enter</textarea></body>
+</html>

--- a/tests/suite/html/syntax.typ
+++ b/tests/suite/html/syntax.typ
@@ -11,6 +11,9 @@
 #html.pre("\nhello")
 #html.pre("\n\nhello")
 
+--- html-textarea-starting-with-newline html ---
+#html.textarea("\nenter")
+
 --- html-script html ---
 // This should be pretty and indented.
 #html.script(


### PR DESCRIPTION
HTML spec § 13.1.2.5 also applies to `<textarea>`. For some reason, I didn't realize this while working on #6487.