### PR TITLE
Support `in` operator on strings and modules

### DIFF
--- a/crates/typst-library/src/foundations/module.rs
+++ b/crates/typst-library/src/foundations/module.rs
@@ -19,11 +19,8 @@ use crate::foundations::{repr, ty, Content, Scope, Value};
 ///
 /// You can access definitions from the module using [field access
 /// notation]($scripting/#fields) and interact with it using the [import and
-/// include syntaxes]($scripting/#modules). Alternatively, it is possible to
-/// convert a module to a dictionary, and therefore access its contents
-/// dynamically, using the [dictionary constructor]($dictionary/#constructor).
+/// include syntaxes]($scripting/#modules).
 ///
-/// # Example
 /// ```example
 /// <<< #import "utils.typ"
 /// <<< #utils.add(2, 5)
@@ -34,6 +31,20 @@ use crate::foundations::{repr, ty, Content, Scope, Value};
 /// >>>
 /// >>> #(-3)
 /// ```
+///
+/// You can check whether a definition is present in a module using the `{in}`
+/// operator, with a string on the left-hand side. This can be useful to
+/// [conditionally access]($category/foundations/std/#conditional-access)
+/// definitions in a module.
+///
+/// ```example
+/// #("table" in std) \
+/// #("nope" in std)
+/// ```
+///
+/// Alternatively, it is possible to convert a module to a dictionary, and
+/// therefore access its contents dynamically, using the [dictionary
+/// constructor]($dictionary/#constructor).
 #[ty(cast)]
 #[derive(Clone, Hash)]
 #[allow(clippy::derived_hash_with_manual_eq)]

--- a/crates/typst-library/src/foundations/ops.rs
+++ b/crates/typst-library/src/foundations/ops.rs
@@ -558,6 +558,7 @@ pub fn contains(lhs: &Value, rhs: &Value) -> Option<bool> {
         (Str(a), Str(b)) => Some(b.as_str().contains(a.as_str())),
         (Dyn(a), Str(b)) => a.downcast::<Regex>().map(|regex| regex.is_match(b)),
         (Str(a), Dict(b)) => Some(b.contains(a)),
+        (Str(a), Module(b)) => Some(b.scope().get(a).is_some()),
         (a, Array(b)) => Some(b.contains(a.clone())),
 
         _ => Option::None,

--- a/docs/reference/groups.yml
+++ b/docs/reference/groups.yml
@@ -181,11 +181,7 @@
     [`sys.version`]($category/foundations/sys) can also be very useful.
 
     ```typ
-    #let tiling = if "tiling" in dictionary(std) {
-      tiling
-    } else {
-      pattern
-    }
+    #let tiling = if "tiling" in std { tiling } else { pattern }
 
     ...
     ```

--- a/tests/suite/scripting/ops.typ
+++ b/tests/suite/scripting/ops.typ
@@ -264,6 +264,8 @@
 #test("Hey" not in "abheyCd", true)
 #test("a" not
 /* fun comment? */ in "abc", false)
+#test("sys" in std, true)
+#test("system" in std, false)
 
 --- ops-not-trailing ---
 // Error: 10 expected keyword `in`


### PR DESCRIPTION
This is a small language change to support operations of the form `string in module`, e.g. `"sys" in std`. This is already possible today via `"sys" in dictionary(std)`, it's just a little nicer and faster this way. It can be used in code that gracefully deals with the absence of a new feature on an older version without hardcoding a check against `sys.version` and without the the syntactical and performance overhead of the dictionary conversion. I don't really see any downsides to this, but I'm curious to hear opinions on it.