### PR TITLE
Fix typos in page-setup.md

### DIFF
--- a/docs/guides/page-setup.md
+++ b/docs/guides/page-setup.md
@@ -206,7 +206,6 @@ label exists on the current page:
 ```typ
 >>> #set page("a5", margin: (x: 2.5cm, y: 3cm))
 #set page(header: context {
-  let page-counter =
   let matches = query(<big-table>)
   let current = counter(page).get()
   let has-table = matches.any(m =>
@@ -218,7 +217,7 @@ label exists on the current page:
     #h(1fr)
     National Academy of Sciences
   ]
-}))
+})
 
 #lorem(100)
 #pagebreak()


### PR DESCRIPTION
fixes #6492 

looks like it was blapped in [#3497](https://github.com/typst/typst/commit/145723b1ef4fa23f1f6665b8907dfe79d0bf83cf#diff-592c5402412395532c8da63d5a87e1da2df3cb04d907df7fe35ef29dcd75d7daL210)

Remove `let page-counter =`
Remove a trailing `)`