### PR TITLE
Fix typo in PDF standard docs

### DIFF
--- a/crates/typst-pdf/src/lib.rs
+++ b/crates/typst-pdf/src/lib.rs
@@ -172,7 +172,7 @@ pub enum PdfStandard {
     /// PDF/A-2u.
     #[serde(rename = "a-2u")]
     A_2u,
-    /// PDF/A-3u.
+    /// PDF/A-3b.
     #[serde(rename = "a-3b")]
     A_3b,
     /// PDF/A-3u.


### PR DESCRIPTION
Fix what seems to be a copy-paste mistake.
I found the bug while reading the output from `typst compile --help`.