### PR TITLE
Fix: Container Running with Dangerous Root User Privileges in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,10 @@ LABEL org.opencontainers.image.url="https://typst.app"
 LABEL org.opencontainers.image.vendor="Typst"
 
 COPY --from=build  /app/target/release/typst /bin
+# Create a non-root user for security
+RUN adduser --system --no-create-home --shell /bin/false typst
+
+# Switch to non-root user
+USER typst
+
 ENTRYPOINT [ "/bin/typst" ]


### PR DESCRIPTION
**Context and Purpose:**

This PR automatically remediates a security vulnerability:
- **Description:** By not specifying a USER, a program in the container may run as 'root'. This is a security hazard. If an attacker can control a process running as root, they may have control over the container. Ensure that the last USER in a Dockerfile is a USER other than 'root'.
- **Rule ID:** dockerfile.security.missing-user-entrypoint.missing-user-entrypoint
- **Severity:** MEDIUM
- **File:** Dockerfile
- **Lines Affected:** 42 - 42

This change is necessary to protect the application from potential security risks associated with this vulnerability.

**Solution Implemented:**

The automated remediation process has applied the necessary changes to the affected code in `Dockerfile` to resolve the identified issue.

Please review the changes to ensure they are correct and integrate as expected.