### PR TITLE
Fix typo in PDF standard CLI help part 2

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -491,7 +491,7 @@ pub enum PdfStandard {
     /// PDF/A-2u.
     #[value(name = "a-2u")]
     A_2u,
-    /// PDF/A-3u.
+    /// PDF/A-3b.
     #[value(name = "a-3b")]
     A_3b,
     /// PDF/A-3u.


### PR DESCRIPTION
I missed another instance of the same typo I fixed in #6518