### PR TITLE
Add `default` argument for `str.first` and `str.last`

### DIFF
--- a/crates/typst-library/src/foundations/str.rs
+++ b/crates/typst-library/src/foundations/str.rs
@@ -178,9 +178,10 @@ impl Str {
         self.0.len()
     }
 
-    /// Extracts the first grapheme cluster of the string. Fails with an error
-    /// if the string is empty. Returns the default value if the string is empty
-    /// or fails with an error is no default value was specified.
+    /// Extracts the first grapheme cluster of the string.
+    ///
+    /// Returns the provided default value if the string is empty or fails with
+    /// an error if no default value was specified.
     #[func]
     pub fn first(
         &self,
@@ -196,9 +197,10 @@ impl Str {
             .ok_or_else(string_is_empty)
     }
 
-    /// Extracts the last grapheme cluster of the string. Fails with an error if
-    /// the string is empty. Returns the default value if the string is empty or
-    /// fails with an error is no default value was specified.
+    /// Extracts the last grapheme cluster of the string.
+    ///
+    /// Returns the provided default value if the string is empty or fails with
+    /// an error if no default value was specified.
     #[func]
     pub fn last(
         &self,

--- a/crates/typst-library/src/foundations/str.rs
+++ b/crates/typst-library/src/foundations/str.rs
@@ -178,25 +178,39 @@ impl Str {
         self.0.len()
     }
 
-    /// Extracts the first grapheme cluster of the string.
-    /// Fails with an error if the string is empty.
+    /// Extracts the first grapheme cluster of the string. Fails with an error
+    /// if the string is empty. Returns the default value if the string is empty
+    /// or fails with an error is no default value was specified.
     #[func]
-    pub fn first(&self) -> StrResult<Str> {
+    pub fn first(
+        &self,
+        /// A default value to return if the string is empty.
+        #[named]
+        default: Option<Str>,
+    ) -> StrResult<Str> {
         self.0
             .graphemes(true)
             .next()
             .map(Into::into)
+            .or(default)
             .ok_or_else(string_is_empty)
     }
 
-    /// Extracts the last grapheme cluster of the string.
-    /// Fails with an error if the string is empty.
+    /// Extracts the last grapheme cluster of the string. Fails with an error if
+    /// the string is empty. Returns the default value if the string is empty or
+    /// fails with an error is no default value was specified.
     #[func]
-    pub fn last(&self) -> StrResult<Str> {
+    pub fn last(
+        &self,
+        /// A default value to return if the string is empty.
+        #[named]
+        default: Option<Str>,
+    ) -> StrResult<Str> {
         self.0
             .graphemes(true)
             .next_back()
             .map(Into::into)
+            .or(default)
             .ok_or_else(string_is_empty)
     }
 

--- a/tests/suite/foundations/str.typ
+++ b/tests/suite/foundations/str.typ
@@ -103,6 +103,10 @@
 #test("Hello".last(), "o")
 #test("🏳️‍🌈A🏳️‍⚧️".first(), "🏳️‍🌈")
 #test("🏳️‍🌈A🏳️‍⚧️".last(), "🏳️‍⚧️")
+#test("hey".first(default: "d"), "h")
+#test("".first(default: "d"), "d")
+#test("hey".last(default: "d"), "y")
+#test("".last(default: "d"), "d")
 
 --- string-first-empty ---
 // Error: 2-12 string is empty


### PR DESCRIPTION
Following https://github.com/typst/typst/pull/5970, this PR adds `default` to `str.first` and `str.last` as well for consistency.

As mentioned in https://github.com/typst/typst/pull/5970#issuecomment-2765611974, the accumulation of `default` parameters is not ideal, but it's the best we've got for now.