### PR TITLE
Ignore spans when checking for RawElem equality

### DIFF
--- a/crates/typst-library/src/text/raw.rs
+++ b/crates/typst-library/src/text/raw.rs
@@ -500,7 +500,11 @@ impl PlainText for Packed<RawElem> {
 }
 
 /// The content of the raw text.
-#[derive(Debug, Clone, Hash, PartialEq)]
+#[derive(Debug, Clone, Hash)]
+#[allow(
+    clippy::derived_hash_with_manual_eq,
+    reason = "https://github.com/typst/typst/pull/6560#issuecomment-3045393640"
+)]
 pub enum RawContent {
     /// From a string.
     Text(EcoString),
@@ -521,6 +525,22 @@ impl RawContent {
                     lines.collect::<Vec<_>>().join("\n").into()
                 }
             }
+        }
+    }
+}
+
+impl PartialEq for RawContent {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (RawContent::Text(a), RawContent::Text(b)) => a == b,
+            (lines @ RawContent::Lines(_), RawContent::Text(text))
+            | (RawContent::Text(text), lines @ RawContent::Lines(_)) => {
+                *text == lines.get()
+            }
+            (RawContent::Lines(a), RawContent::Lines(b)) => Iterator::eq(
+                a.iter().map(|(line, _)| line),
+                b.iter().map(|(line, _)| line),
+            ),
         }
     }
 }

--- a/tests/suite/text/raw.typ
+++ b/tests/suite/text/raw.typ
@@ -687,6 +687,11 @@ a b c --------------------
 #let hi = "你好world"
 ```
 
+--- issue-6559-equality-between-raws ---
+
+#test(`foo`, `foo`)
+#assert.ne(`foo`, `bar`)
+
 --- raw-theme-set-to-auto ---
 ```typ
 #let hi = "Hello World"


### PR DESCRIPTION
Fixes #6559.

The check could be optimized a bit more, but I don't think this is much of a bottleneck.