### PR TITLE
Use "displayed" instead of "repeated" to avoid ambiguity in numbering docs

### DIFF
--- a/crates/typst-library/src/model/numbering.rs
+++ b/crates/typst-library/src/model/numbering.rs
@@ -18,7 +18,7 @@ use crate::foundations::{cast, func, Context, Func, Str, Value};
 ///
 /// A numbering pattern consists of counting symbols, for which the actual
 /// number is substituted, their prefixes, and one suffix. The prefixes and the
-/// suffix are repeated as-is.
+/// suffix are displayed as-is.
 ///
 /// # Example
 /// ```example
@@ -66,10 +66,10 @@ pub fn numbering(
     /// items, the number is represented using repeated symbols.
     ///
     /// **Suffixes** are all characters after the last counting symbol. They are
-    /// repeated as-is at the end of any rendered number.
+    /// displayed as-is at the end of any rendered number.
     ///
     /// **Prefixes** are all characters that are neither counting symbols nor
-    /// suffixes. They are repeated as-is at in front of their rendered
+    /// suffixes. They are displayed as-is at in front of their rendered
     /// equivalent of their counting symbol.
     ///
     /// This parameter can also be an arbitrary function that gets each number


### PR DESCRIPTION
This is to clarify that the prefix/suffix is not repeated a number of times but rather shown verbatim without modification.

In particular, this helps avoid ambiguity when compared with the use of "repeated" for symbols that are cycled through and repeated, e.g. `**`, `††`, `‡‡`, `§§`, `¶¶`, `‖‖`.

Furthermore, it also helps remove ambiguity when compared with the use of "repeated" for counting symbols that are re-used, as seen in the following docs:

> If `numbering` is a pattern and more numbers than counting symbols are
> given, the last counting symbol with its prefix is repeated.