### PR TITLE
Implement smartquotes for HTML export

### DIFF
--- a/crates/typst-html/src/convert.rs
+++ b/crates/typst-html/src/convert.rs
@@ -1,3 +1,5 @@
+use crate::fragment::html_fragment;
+use crate::{attr, tag, FrameElem, HtmlElem, HtmlElement, HtmlFrame, HtmlNode};
 use typst_library::diag::{warning, SourceResult};
 use typst_library::engine::Engine;
 use typst_library::foundations::{Content, StyleChain, Target, TargetElem};
@@ -5,10 +7,10 @@ use typst_library::introspection::{SplitLocator, TagElem};
 use typst_library::layout::{Abs, Axes, BlockBody, BlockElem, BoxElem, Region, Size};
 use typst_library::model::ParElem;
 use typst_library::routines::Pair;
-use typst_library::text::{LinebreakElem, SmartQuoteElem, SpaceElem, TextElem};
-
-use crate::fragment::html_fragment;
-use crate::{attr, tag, FrameElem, HtmlElem, HtmlElement, HtmlFrame, HtmlNode};
+use typst_library::text::{
+    is_default_ignorable, LinebreakElem, SmartQuoteElem, SmartQuoter, SmartQuotes,
+    SpaceElem, TextElem,
+};
 
 /// Converts realized content into HTML nodes.
 pub fn convert_to_nodes<'a>(
@@ -16,9 +18,10 @@ pub fn convert_to_nodes<'a>(
     locator: &mut SplitLocator,
     children: impl IntoIterator<Item = Pair<'a>>,
 ) -> SourceResult<Vec<HtmlNode>> {
+    let mut quoter = SmartQuoter::new();
     let mut output = Vec::new();
     for (child, styles) in children {
-        handle(engine, child, locator, styles, &mut output)?;
+        handle(engine, child, locator, styles, &mut quoter, &mut output)?;
     }
     Ok(output)
 }
@@ -29,6 +32,7 @@ fn handle(
     child: &Content,
     locator: &mut SplitLocator,
     styles: StyleChain,
+    quoter: &mut SmartQuoter,
     output: &mut Vec<HtmlNode>,
 ) -> SourceResult<()> {
     if let Some(elem) = child.to_packed::<TagElem>() {
@@ -95,10 +99,20 @@ fn handle(
     } else if let Some(elem) = child.to_packed::<LinebreakElem>() {
         output.push(HtmlElement::new(tag::br).spanned(elem.span()).into());
     } else if let Some(elem) = child.to_packed::<SmartQuoteElem>() {
-        output.push(HtmlNode::text(
-            if elem.double.get(styles) { '"' } else { '\'' },
-            child.span(),
-        ));
+        let double = elem.double.get(styles);
+        if elem.enabled.get(styles) {
+            let before = last_char(output);
+            let quotes = SmartQuotes::get(
+                elem.quotes.get_ref(styles),
+                styles.get(TextElem::lang),
+                styles.get(TextElem::region),
+                elem.alternative.get(styles),
+            );
+            let quote = quoter.quote(before, &quotes, double);
+            output.push(HtmlNode::text(quote, child.span()));
+        } else {
+            output.push(HtmlNode::text(if double { '"' } else { '\'' }, child.span()));
+        }
     } else if let Some(elem) = child.to_packed::<FrameElem>() {
         let locator = locator.next(&elem.span());
         let style = TargetElem::target.set(Target::Paged).wrap();
@@ -121,6 +135,20 @@ fn handle(
         ));
     }
     Ok(())
+}
+
+/// Returns the last non-default ignorable character from the passed nodes.
+fn last_char(nodes: &[HtmlNode]) -> Option<char> {
+    for node in nodes.iter().rev() {
+        if let Some(c) = match node {
+            HtmlNode::Text(s, _) => s.chars().rev().find(|&c| !is_default_ignorable(c)),
+            HtmlNode::Element(e) => last_char(&e.children),
+            _ => None,
+        } {
+            return Some(c);
+        }
+    }
+    None
 }
 
 /// Checks whether the given element is an inline-level HTML element.

--- a/tests/ref/html/par-semantic-html.html
+++ b/tests/ref/html/par-semantic-html.html
@@ -6,8 +6,8 @@
   </head>
   <body>
     <h2>Heading is no paragraph</h2>
-    <p>I'm a paragraph.</p>
-    <div>I'm not.</div>
+    <p>I’m a paragraph.</p>
+    <div>I’m not.</div>
     <div>
       <p>We are two.</p>
       <p>So we are paragraphs.</p>

--- a/tests/ref/html/quote-nesting-html.html
+++ b/tests/ref/html/quote-nesting-html.html
@@ -5,6 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body>
-    <p>When you said that “he surely meant that ‘she intended to say “I'm sorry”’”, I was quite confused.</p>
+    <p>When you said that “he surely meant that ‘she intended to say “I’m sorry”’”, I was quite confused.</p>
   </body>
 </html>

--- a/tests/ref/html/smartquotes-html.html
+++ b/tests/ref/html/smartquotes-html.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body>
+    <p>When you said that “he surely meant that ‘she intended to say “I’m sorry”’”, I was quite confused.</p>
+    <p>‘<span style="display: inline-block;">box</span>’</p>
+  </body>
+</html>

--- a/tests/suite/text/smartquote.typ
+++ b/tests/suite/text/smartquote.typ
@@ -172,3 +172,8 @@ Some people's thought on this would be #[#set smartquote(enabled: false); "stran
 
 --- issue-5146-smartquotes-after-equations ---
 $i$'s $i$ 's
+
+--- smartquotes-html html ---
+When you said that "he surely meant that 'she intended to say "I'm sorry"'", I was quite confused.
+
+'#box[box]'


### PR DESCRIPTION
Fixes https://github.com/typst/typst/issues/6337.

I'm not sure if iterating over the previous nodes is the best way to get the last character. This is similar to the way it's done for paged export though:

https://github.com/typst/typst/blob/0264534928864c7aed0466d670824ac0ce5ca1a8/crates/typst-layout/src/inline/collect.rs#L194-L195