### PR TITLE
Support for outline in HTML

### DIFF
--- a/tests/ref/html/outline-figure-html.html
+++ b/tests/ref/html/outline-figure-html.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body>
+    <nav role="doc-toc">
+      <h2>List of Figures</h2>
+      <ol style="list-style-type: none">
+        <li><a href="#loc-1"><span class="prefix">Figure 1</span>: The A</a></li>
+        <li><a href="#loc-2"><span class="prefix">Fig. 2</span>. – Le B</a></li>
+        <li><a href="#loc-3"><span class="prefix">Abbildung 3</span> ~ Das C</a></li>
+      </ol>
+    </nav>
+    <figure id="loc-1">
+      <p>A</p>
+      <figcaption>Figure 1: The A</figcaption>
+    </figure>
+    <figure id="loc-2">
+      <p>B</p>
+      <figcaption>Fig. 2. – Le B</figcaption>
+    </figure>
+    <figure id="loc-3">
+      <p>C</p>
+      <figcaption>Abbildung 3 ~ Das C</figcaption>
+    </figure>
+  </body>
+</html>

--- a/tests/ref/html/outline-html.html
+++ b/tests/ref/html/outline-html.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body>
+    <nav role="doc-toc">
+      <h2>Contents</h2>
+      <ol style="list-style-type: none">
+        <li><a href="#a"><span class="prefix">1.</span> A</a></li>
+        <li><a href="#b"><span class="prefix">2.</span> B</a></li>
+        <li><a href="#c"><span class="prefix">3.</span> C</a></li>
+        <li>
+          <div><a href="#d"><span class="prefix">4.</span> D</a></div>
+          <ol style="list-style-type: none">
+            <li><a href="#e"><span class="prefix">4.1.</span> E</a></li>
+            <li><a href="#f"><span class="prefix">4.2.</span> F</a></li>
+          </ol>
+        </li>
+        <li>
+          <div><a href="#loc-1"><span class="prefix">5.0.1.</span> H</a></div>
+          <ol style="list-style-type: none">
+            <li><a href="#loc-2"><span class="prefix">5.0.1.0.1.</span> I</a></li>
+            <li><a href="#loc-3"><span class="prefix">5.0.1.1.</span> J</a></li>
+          </ol>
+        </li>
+        <li><a href="#loc-4"><span class="prefix">6.</span> K</a></li>
+      </ol>
+    </nav>
+    <h2 id="a">1. A</h2>
+    <h2 id="b">2. B</h2>
+    <h2 id="c">3. C</h2>
+    <h2 id="d">4. D</h2>
+    <h3 id="e">4.1. E</h3>
+    <h3 id="f">4.2. F</h3>
+    <h2>5. G</h2>
+    <h4 id="loc-1">5.0.1. H</h4>
+    <h6 id="loc-2">5.0.1.0.1. I</h6>
+    <h5 id="loc-3">5.0.1.1. J</h5>
+    <h2 id="loc-4">6. K</h2>
+  </body>
+</html>

--- a/tests/suite/model/outline.typ
+++ b/tests/suite/model/outline.typ
@@ -252,6 +252,31 @@ A
 = B
 = C
 
+--- outline-html html ---
+#set heading(numbering: "1.1.")
+
+#outline()
+
+= A <a>
+= B <b>
+= C <c>
+= D <d>
+== E <e>
+== F <f>
+#heading(outlined: false, [G])
+=== H // Should not be nested under F
+===== I
+#heading(level: 4, bookmarked: false)[J] // `bookmarked` has no effect
+= K
+
+--- outline-figure-html html ---
+#outline(target: figure, title: [List of Figures])
+#figure([A], caption: [The A])
+#set text(lang: "fr")
+#figure([B], caption: [Le B])
+#set text(lang: "de")
+#figure([C], caption: figure.caption(separator: " ~ ")[Das C])
+
 --- issue-2048-outline-multiline ---
 // Without the word joiner between the dots and the page number,
 // the page number would be alone in its line.


### PR DESCRIPTION
This PR adds support for the `outline` in HTML export. Here's an example:

```typ
#set heading(numbering: "1.1")

#outline()

= A <a>
= B <b>
= C <c>
= D <d>
== E <e>
== F <f>
```
```html
<nav role="doc-toc">
  <h2>Contents</h2>
  <ol style="list-style-type: none">
    <li><a href="#a"><span class="prefix">1</span> A</a></li>
    <li><a href="#b"><span class="prefix">2</span> B</a></li>
    <li><a href="#c"><span class="prefix">3</span> C</a></li>
    <li>
      <div><a href="#d"><span class="prefix">4</span> D</a></div>
      <ol style="list-style-type: none">
        <li><a href="#e"><span class="prefix">4.1</span> E</a></li>
        <li><a href="#f"><span class="prefix">4.2</span> F</a></li>
      </ol>
    </li>
  </ol>
</nav>
<h2 id="a">1 A</h2>
<h2 id="b">2 B</h2>
<h2 id="c">3 C</h2>
<h2 id="d">4 D</h2>
<h3 id="e">4.1 E</h3>
<h3 id="f">4.2 F</h3>
```

The DOM structure largely follows what is being done in https://www.w3.org/TR/dpub-aria-1.1/#doc-toc, with a bit of https://html.spec.whatwg.org/#table-of-contents mixed in. Like in the latter, I've wrapped the prefix in a separate span to make it a bit more accessible and easier to style. We should consider doing the same for headings.

Closes #6148