### PR TITLE
Partially automate span assignment in native show rule

### DIFF
--- a/crates/typst-html/src/rules.rs
+++ b/crates/typst-html/src/rules.rs
@@ -59,19 +59,11 @@ pub fn register(rules: &mut NativeRuleMap) {
     rules.register::<FrameElem>(Paged, |elem, _, _| Ok(elem.body.clone()));
 }
 
-const STRONG_RULE: ShowFn<StrongElem> = |elem, _, _| {
-    Ok(HtmlElem::new(tag::strong)
-        .with_body(Some(elem.body.clone()))
-        .pack()
-        .spanned(elem.span()))
-};
+const STRONG_RULE: ShowFn<StrongElem> =
+    |elem, _, _| Ok(HtmlElem::new(tag::strong).with_body(Some(elem.body.clone())).pack());
 
-const EMPH_RULE: ShowFn<EmphElem> = |elem, _, _| {
-    Ok(HtmlElem::new(tag::em)
-        .with_body(Some(elem.body.clone()))
-        .pack()
-        .spanned(elem.span()))
-};
+const EMPH_RULE: ShowFn<EmphElem> =
+    |elem, _, _| Ok(HtmlElem::new(tag::em).with_body(Some(elem.body.clone())).pack());
 
 const LIST_RULE: ShowFn<ListElem> = |elem, _, styles| {
     Ok(HtmlElem::new(tag::ul)
@@ -86,8 +78,7 @@ const LIST_RULE: ShowFn<ListElem> = |elem, _, styles| {
                 .pack()
                 .spanned(item.span())
         }))))
-        .pack()
-        .spanned(elem.span()))
+        .pack())
 };
 
 const ENUM_RULE: ShowFn<EnumElem> = |elem, _, styles| {
@@ -114,7 +105,7 @@ const ENUM_RULE: ShowFn<EnumElem> = |elem, _, styles| {
         li.with_body(Some(body)).pack().spanned(item.span())
     }));
 
-    Ok(ol.with_body(Some(body)).pack().spanned(elem.span()))
+    Ok(ol.with_body(Some(body)).pack())
 };
 
 const TERMS_RULE: ShowFn<TermsElem> = |elem, _, styles| {
@@ -166,8 +157,7 @@ const LINK_RULE: ShowFn<LinkElem> = |elem, engine, _| {
     Ok(HtmlElem::new(tag::a)
         .with_optional_attr(attr::href, href)
         .with_body(Some(elem.body.clone()))
-        .pack()
-        .spanned(elem.span()))
+        .pack())
 };
 
 const HEADING_RULE: ShowFn<HeadingElem> = |elem, engine, styles| {
@@ -203,10 +193,9 @@ const HEADING_RULE: ShowFn<HeadingElem> = |elem, engine, styles| {
             .with_attr(attr::role, "heading")
             .with_attr(attr::aria_level, eco_format!("{}", level + 1))
             .pack()
-            .spanned(span)
     } else {
         let t = [tag::h2, tag::h3, tag::h4, tag::h5, tag::h6][level - 1];
-        HtmlElem::new(t).with_body(Some(realized)).pack().spanned(span)
+        HtmlElem::new(t).with_body(Some(realized)).pack()
     })
 };
 
@@ -225,17 +214,13 @@ const FIGURE_RULE: ShowFn<FigureElem> = |elem, _, styles| {
     // Ensure that the body is considered a paragraph.
     realized += ParbreakElem::shared().clone().spanned(span);
 
-    Ok(HtmlElem::new(tag::figure)
-        .with_body(Some(realized))
-        .pack()
-        .spanned(span))
+    Ok(HtmlElem::new(tag::figure).with_body(Some(realized)).pack())
 };
 
 const FIGURE_CAPTION_RULE: ShowFn<FigureCaption> = |elem, engine, styles| {
     Ok(HtmlElem::new(tag::figcaption)
         .with_body(Some(elem.realize(engine, styles)?))
-        .pack()
-        .spanned(elem.span()))
+        .pack())
 };
 
 const QUOTE_RULE: ShowFn<QuoteElem> = |elem, _, styles| {
@@ -376,19 +361,11 @@ fn show_cell(tag: HtmlTag, cell: &Cell, styles: StyleChain) -> Content {
         .spanned(cell.span())
 }
 
-const SUB_RULE: ShowFn<SubElem> = |elem, _, _| {
-    Ok(HtmlElem::new(tag::sub)
-        .with_body(Some(elem.body.clone()))
-        .pack()
-        .spanned(elem.span()))
-};
+const SUB_RULE: ShowFn<SubElem> =
+    |elem, _, _| Ok(HtmlElem::new(tag::sub).with_body(Some(elem.body.clone())).pack());
 
-const SUPER_RULE: ShowFn<SuperElem> = |elem, _, _| {
-    Ok(HtmlElem::new(tag::sup)
-        .with_body(Some(elem.body.clone()))
-        .pack()
-        .spanned(elem.span()))
-};
+const SUPER_RULE: ShowFn<SuperElem> =
+    |elem, _, _| Ok(HtmlElem::new(tag::sup).with_body(Some(elem.body.clone())).pack());
 
 const UNDERLINE_RULE: ShowFn<UnderlineElem> = |elem, _, _| {
     // Note: In modern HTML, `<u>` is not the underline element, but
@@ -427,8 +404,7 @@ const RAW_RULE: ShowFn<RawElem> = |elem, _, styles| {
 
     Ok(HtmlElem::new(if elem.block.get(styles) { tag::pre } else { tag::code })
         .with_body(Some(Content::sequence(seq)))
-        .pack()
-        .spanned(elem.span()))
+        .pack())
 };
 
 const RAW_LINE_RULE: ShowFn<RawLine> = |elem, _, _| Ok(elem.body.clone());

--- a/crates/typst-layout/src/rules.rs
+++ b/crates/typst-layout/src/rules.rs
@@ -272,7 +272,7 @@ const HEADING_RULE: ShowFn<HeadingElem> = |elem, engine, styles| {
         BlockElem::new().with_body(Some(BlockBody::Content(realized)))
     };
 
-    Ok(block.pack().spanned(span))
+    Ok(block.pack())
 };
 
 const FIGURE_RULE: ShowFn<FigureElem> = |elem, _, styles| {
@@ -326,8 +326,7 @@ const FIGURE_RULE: ShowFn<FigureElem> = |elem, _, styles| {
 const FIGURE_CAPTION_RULE: ShowFn<FigureCaption> = |elem, engine, styles| {
     Ok(BlockElem::new()
         .with_body(Some(BlockBody::Content(elem.realize(engine, styles)?)))
-        .pack()
-        .spanned(elem.span()))
+        .pack())
 };
 
 const QUOTE_RULE: ShowFn<QuoteElem> = |elem, _, styles| {
@@ -550,9 +549,7 @@ const BIBLIOGRAPHY_RULE: ShowFn<BibliographyElem> = |elem, engine, styles| {
 };
 
 const TABLE_RULE: ShowFn<TableElem> = |elem, _, _| {
-    Ok(BlockElem::multi_layouter(elem.clone(), crate::grid::layout_table)
-        .pack()
-        .spanned(elem.span()))
+    Ok(BlockElem::multi_layouter(elem.clone(), crate::grid::layout_table).pack())
 };
 
 const TABLE_CELL_RULE: ShowFn<TableCell> = |elem, _, styles| {
@@ -703,27 +700,19 @@ const ALIGN_RULE: ShowFn<AlignElem> =
     |elem, _, styles| Ok(elem.body.clone().aligned(elem.alignment.get(styles)));
 
 const PAD_RULE: ShowFn<PadElem> = |elem, _, _| {
-    Ok(BlockElem::multi_layouter(elem.clone(), crate::pad::layout_pad)
-        .pack()
-        .spanned(elem.span()))
+    Ok(BlockElem::multi_layouter(elem.clone(), crate::pad::layout_pad).pack())
 };
 
 const COLUMNS_RULE: ShowFn<ColumnsElem> = |elem, _, _| {
-    Ok(BlockElem::multi_layouter(elem.clone(), crate::flow::layout_columns)
-        .pack()
-        .spanned(elem.span()))
+    Ok(BlockElem::multi_layouter(elem.clone(), crate::flow::layout_columns).pack())
 };
 
 const STACK_RULE: ShowFn<StackElem> = |elem, _, _| {
-    Ok(BlockElem::multi_layouter(elem.clone(), crate::stack::layout_stack)
-        .pack()
-        .spanned(elem.span()))
+    Ok(BlockElem::multi_layouter(elem.clone(), crate::stack::layout_stack).pack())
 };
 
 const GRID_RULE: ShowFn<GridElem> = |elem, _, _| {
-    Ok(BlockElem::multi_layouter(elem.clone(), crate::grid::layout_grid)
-        .pack()
-        .spanned(elem.span()))
+    Ok(BlockElem::multi_layouter(elem.clone(), crate::grid::layout_grid).pack())
 };
 
 const GRID_CELL_RULE: ShowFn<GridCell> = |elem, _, styles| {
@@ -753,33 +742,23 @@ fn show_cell(
 }
 
 const MOVE_RULE: ShowFn<MoveElem> = |elem, _, _| {
-    Ok(BlockElem::single_layouter(elem.clone(), crate::transforms::layout_move)
-        .pack()
-        .spanned(elem.span()))
+    Ok(BlockElem::single_layouter(elem.clone(), crate::transforms::layout_move).pack())
 };
 
 const SCALE_RULE: ShowFn<ScaleElem> = |elem, _, _| {
-    Ok(BlockElem::single_layouter(elem.clone(), crate::transforms::layout_scale)
-        .pack()
-        .spanned(elem.span()))
+    Ok(BlockElem::single_layouter(elem.clone(), crate::transforms::layout_scale).pack())
 };
 
 const ROTATE_RULE: ShowFn<RotateElem> = |elem, _, _| {
-    Ok(BlockElem::single_layouter(elem.clone(), crate::transforms::layout_rotate)
-        .pack()
-        .spanned(elem.span()))
+    Ok(BlockElem::single_layouter(elem.clone(), crate::transforms::layout_rotate).pack())
 };
 
 const SKEW_RULE: ShowFn<SkewElem> = |elem, _, _| {
-    Ok(BlockElem::single_layouter(elem.clone(), crate::transforms::layout_skew)
-        .pack()
-        .spanned(elem.span()))
+    Ok(BlockElem::single_layouter(elem.clone(), crate::transforms::layout_skew).pack())
 };
 
 const REPEAT_RULE: ShowFn<RepeatElem> = |elem, _, _| {
-    Ok(BlockElem::single_layouter(elem.clone(), crate::repeat::layout_repeat)
-        .pack()
-        .spanned(elem.span()))
+    Ok(BlockElem::single_layouter(elem.clone(), crate::repeat::layout_repeat).pack())
 };
 
 const HIDE_RULE: ShowFn<HideElem> =
@@ -801,83 +780,66 @@ const LAYOUT_RULE: ShowFn<LayoutElem> = |elem, _, _| {
             crate::flow::layout_fragment(engine, &result, locator, styles, regions)
         },
     )
-    .pack()
-    .spanned(elem.span()))
+    .pack())
 };
 
 const IMAGE_RULE: ShowFn<ImageElem> = |elem, _, styles| {
     Ok(BlockElem::single_layouter(elem.clone(), crate::image::layout_image)
         .with_width(elem.width.get(styles))
         .with_height(elem.height.get(styles))
-        .pack()
-        .spanned(elem.span()))
+        .pack())
 };
 
 const LINE_RULE: ShowFn<LineElem> = |elem, _, _| {
-    Ok(BlockElem::single_layouter(elem.clone(), crate::shapes::layout_line)
-        .pack()
-        .spanned(elem.span()))
+    Ok(BlockElem::single_layouter(elem.clone(), crate::shapes::layout_line).pack())
 };
 
 const RECT_RULE: ShowFn<RectElem> = |elem, _, styles| {
     Ok(BlockElem::single_layouter(elem.clone(), crate::shapes::layout_rect)
         .with_width(elem.width.get(styles))
         .with_height(elem.height.get(styles))
-        .pack()
-        .spanned(elem.span()))
+        .pack())
 };
 
 const SQUARE_RULE: ShowFn<SquareElem> = |elem, _, styles| {
     Ok(BlockElem::single_layouter(elem.clone(), crate::shapes::layout_square)
         .with_width(elem.width.get(styles))
         .with_height(elem.height.get(styles))
-        .pack()
-        .spanned(elem.span()))
+        .pack())
 };
 
 const ELLIPSE_RULE: ShowFn<EllipseElem> = |elem, _, styles| {
     Ok(BlockElem::single_layouter(elem.clone(), crate::shapes::layout_ellipse)
         .with_width(elem.width.get(styles))
         .with_height(elem.height.get(styles))
-        .pack()
-        .spanned(elem.span()))
+        .pack())
 };
 
 const CIRCLE_RULE: ShowFn<CircleElem> = |elem, _, styles| {
     Ok(BlockElem::single_layouter(elem.clone(), crate::shapes::layout_circle)
         .with_width(elem.width.get(styles))
         .with_height(elem.height.get(styles))
-        .pack()
-        .spanned(elem.span()))
+        .pack())
 };
 
 const POLYGON_RULE: ShowFn<PolygonElem> = |elem, _, _| {
-    Ok(BlockElem::single_layouter(elem.clone(), crate::shapes::layout_polygon)
-        .pack()
-        .spanned(elem.span()))
+    Ok(BlockElem::single_layouter(elem.clone(), crate::shapes::layout_polygon).pack())
 };
 
 const CURVE_RULE: ShowFn<CurveElem> = |elem, _, _| {
-    Ok(BlockElem::single_layouter(elem.clone(), crate::shapes::layout_curve)
-        .pack()
-        .spanned(elem.span()))
+    Ok(BlockElem::single_layouter(elem.clone(), crate::shapes::layout_curve).pack())
 };
 
 const PATH_RULE: ShowFn<PathElem> = |elem, _, _| {
-    Ok(BlockElem::single_layouter(elem.clone(), crate::shapes::layout_path)
-        .pack()
-        .spanned(elem.span()))
+    Ok(BlockElem::single_layouter(elem.clone(), crate::shapes::layout_path).pack())
 };
 
 const EQUATION_RULE: ShowFn<EquationElem> = |elem, _, styles| {
     if elem.block.get(styles) {
         Ok(BlockElem::multi_layouter(elem.clone(), crate::math::layout_equation_block)
-            .pack()
-            .spanned(elem.span()))
+            .pack())
     } else {
-        Ok(InlineElem::layouter(elem.clone(), crate::math::layout_equation_inline)
-            .pack()
-            .spanned(elem.span()))
+        Ok(InlineElem::layouter(elem.clone(), crate::math::layout_equation_inline).pack())
     }
 };
 

--- a/crates/typst-realize/src/lib.rs
+++ b/crates/typst-realize/src/lib.rs
@@ -374,7 +374,9 @@ fn visit_show_rules<'a>(
             }
 
             // Apply a built-in show rule.
-            ShowStep::Builtin(rule) => rule.apply(&output, s.engine, chained),
+            ShowStep::Builtin(rule) => rule
+                .apply(&output, s.engine, chained)
+                .map(|content| content.spanned(output.span())),
         };
 
         // Errors in show rules don't terminate compilation immediately. We just


### PR DESCRIPTION
When generating content in native show rules, it's good when that content has spans set, so that there is a source code location when there is a warning or error later, and to assist jumps between source and output. This process is currently quite manual and it's easy to forget to do it. Unfortunately, it's also rarely checked by tests as there typically isn't a warning or error.

This PR makes a small step to automate this more: The outermost element generated by a native show rule now automatically inherits the element's span if it doesn't have a span otherwise. This means we can remove quite a few `.spanned(elem.span())` calls.

Note that this only applies to the one outermost element though. Any inner generated content still needs manual spans. We can look into automating this further in the future, though we must be careful not to cause accidental slowdown if we're doing content traversals.