### PR TITLE
Bump `zip` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
  "libz-rs-sys",
@@ -1469,9 +1469,9 @@ dependencies = [
 
 [[package]]
 name = "libz-rs-sys"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "902bc563b5d65ad9bba616b490842ef0651066a1a1dc3ce1087113ffcb873c8d"
+checksum = "172a788537a2221661b480fee8dc5f96c580eb34fa88764d3205dc356c7e4221"
 dependencies = [
  "zlib-rs",
 ]
@@ -3932,13 +3932,12 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.5.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c03817464f64e23f6f37574b4fdc8cf65925b5bfd2b0f2aedf959791941f88"
+checksum = "9aed4ac33e8eb078c89e6cbb1d5c4c7703ec6d299fc3e7c3695af8f8b423468b"
 dependencies = [
  "arbitrary",
  "crc32fast",
- "crossbeam-utils",
  "flate2",
  "indexmap 2.7.1",
  "memchr",
@@ -3947,9 +3946,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b20717f0917c908dc63de2e44e97f1e6b126ca58d0e391cee86d504eb8fbd05"
+checksum = "626bd9fa9734751fc50d6060752170984d7053f5a39061f524cda68023d4db8a"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,7 @@ xmlparser = "0.13.5"
 xmlwriter = "0.1.0"
 xz2 = { version = "0.1", features = ["static"] }
 yaml-front-matter = "0.1"
-zip = { version = "2.5", default-features = false, features = ["deflate"] }
+zip = { version = "4.3", default-features = false, features = ["deflate"] }
 
 [profile.dev.package."*"]
 opt-level = 2


### PR DESCRIPTION
Fixes https://github.com/typst/typst/issues/6298

Also fixes rust-analyzer not working on this repository due to:
```
Failed to read Cargo metadata with dependencies for typst/Cargo.toml: 
cargo metadata exited with an error: Updating crates.io index 
Updating git repository https://github.com/typst/codex 
Updating git repository https://github.com/typst/typst-assets 
Updating git repository https://github.com/typst/typst-dev-assets 
Updating git repository https://github.com/LaurenzV/krilla 
error: failed to select a version for the requirement zip = "^2.5" 
version 2.5.0 is yanked version 2.6.0 is yanked 
version 2.6.1 is yanked 
location searched: crates.io index 
required by package typst-cli v0.13.1 (typst/crates/typst-cli)
```

Interestingly, this error only occurred with recent rust-analyzer versions (downgrading helped). So there might also be a rust-analyzer bug here somehow.