### PR TITLE
Restore timing scopes for native show rules

### DIFF
--- a/crates/typst-realize/src/lib.rs
+++ b/crates/typst-realize/src/lib.rs
@@ -374,9 +374,11 @@ fn visit_show_rules<'a>(
             }
 
             // Apply a built-in show rule.
-            ShowStep::Builtin(rule) => rule
-                .apply(&output, s.engine, chained)
-                .map(|content| content.spanned(output.span())),
+            ShowStep::Builtin(rule) => {
+                let _scope = typst_timing::TimingScope::new(output.elem().name());
+                rule.apply(&output, s.engine, chained)
+                    .map(|content| content.spanned(output.span()))
+            }
         };
 
         // Errors in show rules don't terminate compilation immediately. We just


### PR DESCRIPTION
There used to be separate `#[typst_timing::time(..)]` on all built-in show rules. Those got lost in https://github.com/typst/typst/pull/6569. This restores them, in a generic fashion.