### PR TITLE
Hint that deprecated items will be removed in `0.15.0`

### DIFF
--- a/crates/typst-library/src/diag.rs
+++ b/crates/typst-library/src/diag.rs
@@ -246,11 +246,11 @@ impl DeprecationSink for () {
 impl DeprecationSink for (&mut Engine<'_>, Span) {
     /// Emits the deprecation message as a warning.
     fn emit(self, message: &str, version: Option<&str>) {
-        self.0.sink.warn(
-            SourceDiagnostic::warning(self.1, message).with_hints(
-                version.map(|v| eco_format!("this will be removed in {}", v)),
-            ),
-        );
+        self.0
+            .sink
+            .warn(SourceDiagnostic::warning(self.1, message).with_hints(
+                version.map(|v| eco_format!("it will be removed in Typst {}", v)),
+            ));
     }
 }
 

--- a/crates/typst-library/src/diag.rs
+++ b/crates/typst-library/src/diag.rs
@@ -234,18 +234,23 @@ impl From<SyntaxError> for SourceDiagnostic {
 
 /// Destination for a deprecation message when accessing a deprecated value.
 pub trait DeprecationSink {
-    /// Emits the given deprecation message into this sink.
-    fn emit(self, message: &str);
+    /// Emits the given deprecation message into this sink alongside a version
+    /// in which the deprecated item is planned to be removed.
+    fn emit(self, message: &str, until: Option<&str>);
 }
 
 impl DeprecationSink for () {
-    fn emit(self, _: &str) {}
+    fn emit(self, _: &str, _: Option<&str>) {}
 }
 
 impl DeprecationSink for (&mut Engine<'_>, Span) {
     /// Emits the deprecation message as a warning.
-    fn emit(self, message: &str) {
-        self.0.sink.warn(SourceDiagnostic::warning(self.1, message));
+    fn emit(self, message: &str, version: Option<&str>) {
+        self.0.sink.warn(
+            SourceDiagnostic::warning(self.1, message).with_hints(
+                version.map(|v| eco_format!("this will be removed in {}", v)),
+            ),
+        );
     }
 }
 

--- a/crates/typst-library/src/foundations/scope.rs
+++ b/crates/typst-library/src/foundations/scope.rs
@@ -254,7 +254,7 @@ pub struct Binding {
     /// The category of the binding.
     category: Option<Category>,
     /// The deprecation information if this item is deprecated.
-    deprecation: Option<Box<DeprecationInfo>>,
+    deprecation: Option<Box<Deprecation>>,
 }
 
 /// The different kinds of slots.
@@ -284,20 +284,8 @@ impl Binding {
     }
 
     /// Marks this binding as deprecated, with the given `message`.
-    pub fn deprecated(&mut self, message: &'static str) -> &mut Self {
-        self.deprecation
-            .get_or_insert_with(|| Box::new(DeprecationInfo::new()))
-            .deprecated_message(message);
-        self
-    }
-
-    /// Set the version in which the binding is planned to be removed.
-    ///
-    /// This is ignored if [`Binding::deprecated`] isn't also set.
-    pub fn deprecated_until(&mut self, version: &'static str) -> &mut Self {
-        self.deprecation
-            .get_or_insert_with(|| Box::new(DeprecationInfo::new()))
-            .deprecated_until(version);
+    pub fn deprecated(&mut self, deprecation: Deprecation) -> &mut Self {
+        self.deprecation = Some(Box::new(deprecation));
         self
     }
 
@@ -349,7 +337,7 @@ impl Binding {
     }
 
     /// A deprecation message for the value, if any.
-    pub fn deprecation(&self) -> Option<&DeprecationInfo> {
+    pub fn deprecation(&self) -> Option<&Deprecation> {
         self.deprecation.as_deref()
     }
 
@@ -370,14 +358,14 @@ pub enum Capturer {
 
 /// Information about a deprecated binding.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub struct DeprecationInfo {
+pub struct Deprecation {
     /// A deprecation message for the definition.
     message: &'static str,
     /// A version in which the deprecated binding is planned to be removed.
     until: Option<&'static str>,
 }
 
-impl DeprecationInfo {
+impl Deprecation {
     /// Creates new deprecation info with a default message to display when
     /// emitting the deprecation warning.
     pub fn new() -> Self {
@@ -385,13 +373,13 @@ impl DeprecationInfo {
     }
 
     /// Set the message to display when emitting the deprecation warning.
-    pub fn deprecated_message(&mut self, message: &'static str) -> &mut Self {
+    pub fn with_message(mut self, message: &'static str) -> Self {
         self.message = message;
         self
     }
 
     /// Set the version in which the binding is planned to be removed.
-    pub fn deprecated_until(&mut self, version: &'static str) -> &mut Self {
+    pub fn with_until(mut self, version: &'static str) -> Self {
         self.until = Some(version);
         self
     }
@@ -407,7 +395,7 @@ impl DeprecationInfo {
     }
 }
 
-impl Default for DeprecationInfo {
+impl Default for Deprecation {
     fn default() -> Self {
         Self::new()
     }

--- a/crates/typst-library/src/foundations/symbol.rs
+++ b/crates/typst-library/src/foundations/symbol.rs
@@ -151,7 +151,7 @@ impl Symbol {
                 modifiers.best_match_in(list.variants().map(|(m, _, d)| (m, d)))
             {
                 if let Some(message) = deprecation {
-                    sink.emit(message)
+                    sink.emit(message, None)
                 }
                 return Ok(self);
             }

--- a/crates/typst-library/src/loading/cbor.rs
+++ b/crates/typst-library/src/loading/cbor.rs
@@ -33,7 +33,10 @@ pub fn cbor(
 impl cbor {
     /// Reads structured data from CBOR bytes.
     #[func(title = "Decode CBOR")]
-    #[deprecated = "`cbor.decode` is deprecated, directly pass bytes to `cbor` instead"]
+    #[deprecated(
+        message = "`cbor.decode` is deprecated, directly pass bytes to `cbor` instead",
+        until = "0.15.0"
+    )]
     pub fn decode(
         engine: &mut Engine,
         /// CBOR data.

--- a/crates/typst-library/src/loading/csv.rs
+++ b/crates/typst-library/src/loading/csv.rs
@@ -95,7 +95,10 @@ pub fn csv(
 impl csv {
     /// Reads structured data from a CSV string/bytes.
     #[func(title = "Decode CSV")]
-    #[deprecated = "`csv.decode` is deprecated, directly pass bytes to `csv` instead"]
+    #[deprecated(
+        message = "`csv.decode` is deprecated, directly pass bytes to `csv` instead",
+        until = "0.15.0"
+    )]
     pub fn decode(
         engine: &mut Engine,
         /// CSV data.

--- a/crates/typst-library/src/loading/json.rs
+++ b/crates/typst-library/src/loading/json.rs
@@ -67,7 +67,10 @@ pub fn json(
 impl json {
     /// Reads structured data from a JSON string/bytes.
     #[func(title = "Decode JSON")]
-    #[deprecated = "`json.decode` is deprecated, directly pass bytes to `json` instead"]
+    #[deprecated(
+        message = "`json.decode` is deprecated, directly pass bytes to `json` instead",
+        until = "0.15.0"
+    )]
     pub fn decode(
         engine: &mut Engine,
         /// JSON data.

--- a/crates/typst-library/src/loading/toml.rs
+++ b/crates/typst-library/src/loading/toml.rs
@@ -41,7 +41,10 @@ pub fn toml(
 impl toml {
     /// Reads structured data from a TOML string/bytes.
     #[func(title = "Decode TOML")]
-    #[deprecated = "`toml.decode` is deprecated, directly pass bytes to `toml` instead"]
+    #[deprecated(
+        message = "`toml.decode` is deprecated, directly pass bytes to `toml` instead",
+        until = "0.15.0"
+    )]
     pub fn decode(
         engine: &mut Engine,
         /// TOML data.

--- a/crates/typst-library/src/loading/xml.rs
+++ b/crates/typst-library/src/loading/xml.rs
@@ -75,7 +75,10 @@ pub fn xml(
 impl xml {
     /// Reads structured data from an XML string/bytes.
     #[func(title = "Decode XML")]
-    #[deprecated = "`xml.decode` is deprecated, directly pass bytes to `xml` instead"]
+    #[deprecated(
+        message = "`xml.decode` is deprecated, directly pass bytes to `xml` instead",
+        until = "0.15.0"
+    )]
     pub fn decode(
         engine: &mut Engine,
         /// XML data.

--- a/crates/typst-library/src/loading/yaml.rs
+++ b/crates/typst-library/src/loading/yaml.rs
@@ -54,7 +54,10 @@ pub fn yaml(
 impl yaml {
     /// Reads structured data from a YAML string/bytes.
     #[func(title = "Decode YAML")]
-    #[deprecated = "`yaml.decode` is deprecated, directly pass bytes to `yaml` instead"]
+    #[deprecated(
+        message = "`yaml.decode` is deprecated, directly pass bytes to `yaml` instead",
+        until = "0.15.0"
+    )]
     pub fn decode(
         engine: &mut Engine,
         /// YAML data.

--- a/crates/typst-library/src/symbols.rs
+++ b/crates/typst-library/src/symbols.rs
@@ -1,6 +1,6 @@
 //! Modifiable symbols.
 
-use crate::foundations::{Module, Scope, Symbol, Value};
+use crate::foundations::{Deprecation, Module, Scope, Symbol, Value};
 
 /// Hook up all `symbol` definitions.
 pub(super) fn define(global: &mut Scope) {
@@ -23,7 +23,7 @@ fn extend_scope_from_codex_module(scope: &mut Scope, module: codex::Module) {
 
         let scope_binding = scope.define(name, value);
         if let Some(message) = binding.deprecation {
-            scope_binding.deprecated(message);
+            scope_binding.deprecated(Deprecation::new().with_message(message));
         }
     }
 }

--- a/crates/typst-library/src/visualize/image/mod.rs
+++ b/crates/typst-library/src/visualize/image/mod.rs
@@ -178,7 +178,10 @@ pub struct ImageElem {
 impl ImageElem {
     /// Decode a raster or vector graphic from bytes or a string.
     #[func(title = "Decode Image")]
-    #[deprecated = "`image.decode` is deprecated, directly pass bytes to `image` instead"]
+    #[deprecated(
+        message = "`image.decode` is deprecated, directly pass bytes to `image` instead",
+        until = "0.15.0"
+    )]
     pub fn decode(
         span: Span,
         /// The data to decode as an image. Can be a string for SVGs.

--- a/crates/typst-library/src/visualize/mod.rs
+++ b/crates/typst-library/src/visualize/mod.rs
@@ -46,6 +46,7 @@ pub(super) fn define(global: &mut Scope) {
         .deprecated("the `path` function is deprecated, use `curve` instead");
     global
         .define("pattern", Type::of::<Tiling>())
-        .deprecated("the name `pattern` is deprecated, use `tiling` instead");
+        .deprecated("the name `pattern` is deprecated, use `tiling` instead")
+        .deprecated_until("0.15.0");
     global.reset_category();
 }

--- a/crates/typst-library/src/visualize/mod.rs
+++ b/crates/typst-library/src/visualize/mod.rs
@@ -24,6 +24,7 @@ pub use self::shape::*;
 pub use self::stroke::*;
 pub use self::tiling::*;
 
+use crate::foundations::Deprecation;
 use crate::foundations::{Element, Scope, Type};
 
 /// Hook up all visualize definitions.
@@ -41,12 +42,14 @@ pub(super) fn define(global: &mut Scope) {
     global.define_elem::<CircleElem>();
     global.define_elem::<PolygonElem>();
     global.define_elem::<CurveElem>();
-    global
-        .define("path", Element::of::<PathElem>())
-        .deprecated("the `path` function is deprecated, use `curve` instead");
-    global
-        .define("pattern", Type::of::<Tiling>())
-        .deprecated("the name `pattern` is deprecated, use `tiling` instead")
-        .deprecated_until("0.15.0");
+    global.define("path", Element::of::<PathElem>()).deprecated(
+        Deprecation::new()
+            .with_message("the `path` function is deprecated, use `curve` instead"),
+    );
+    global.define("pattern", Type::of::<Tiling>()).deprecated(
+        Deprecation::new()
+            .with_message("the name `pattern` is deprecated, use `tiling` instead")
+            .with_until("0.15.0"),
+    );
     global.reset_category();
 }

--- a/crates/typst-macros/src/scope.rs
+++ b/crates/typst-macros/src/scope.rs
@@ -64,17 +64,22 @@ pub fn scope(_: TokenStream, item: syn::Item) -> Result<TokenStream> {
                         Punctuated::<MetaNameValue, Token![,]>::parse_separated_nonempty,
                     )?;
 
+                    let mut deprecation =
+                        quote! { crate::foundations::Deprecation::new() };
+
                     if let Some(message) = args.iter().find_map(|pair| {
                         pair.path.is_ident("message").then_some(&pair.value)
                     }) {
-                        def = quote! { #def.deprecated(#message) }
+                        deprecation = quote! { #deprecation.with_message(#message) }
                     }
 
                     if let Some(version) = args.iter().find_map(|pair| {
                         pair.path.is_ident("until").then_some(&pair.value)
                     }) {
-                        def = quote! { #def.deprecated_until(#version) }
+                        deprecation = quote! { #deprecation.with_until(#version) }
                     }
+
+                    def = quote! { #def.deprecated(#deprecation) }
                 }
                 _ => {}
             }

--- a/docs/src/lib.rs
+++ b/docs/src/lib.rs
@@ -17,7 +17,7 @@ use serde::Deserialize;
 use serde_yaml as yaml;
 use std::sync::LazyLock;
 use typst::diag::{StrResult, bail};
-use typst::foundations::DeprecationInfo;
+use typst::foundations::Deprecation;
 use typst::foundations::{
     AutoValue, Binding, Bytes, CastInfo, Func, Module, NoneValue, ParamInfo, Repr, Scope,
     Smart, Type, Value,
@@ -382,7 +382,7 @@ fn func_page(
     parent: &str,
     func: &Func,
     path: &[&str],
-    deprecation: Option<&DeprecationInfo>,
+    deprecation: Option<&Deprecation>,
 ) -> PageModel {
     let model = func_model(resolver, func, path, false, deprecation);
     let name = func.name().unwrap();
@@ -403,7 +403,7 @@ fn func_model(
     func: &Func,
     path: &[&str],
     nested: bool,
-    deprecation: Option<&DeprecationInfo>,
+    deprecation: Option<&Deprecation>,
 ) -> FuncModel {
     let name = func.name().unwrap();
     let scope = func.scope().unwrap();
@@ -439,8 +439,8 @@ fn func_model(
         oneliner: oneliner(details),
         element: func.element().is_some(),
         contextual: func.contextual().unwrap_or(false),
-        deprecation_message: deprecation.map(DeprecationInfo::message),
-        deprecation_until: deprecation.and_then(DeprecationInfo::until),
+        deprecation_message: deprecation.map(Deprecation::message),
+        deprecation_until: deprecation.and_then(Deprecation::until),
         details: Html::markdown(resolver, details, nesting),
         example: example.map(|md| Html::markdown(resolver, md, None)),
         self_,
@@ -740,8 +740,8 @@ fn symbols_model(resolver: &dyn Resolver, group: &GroupData) -> SymbolsModel {
                     .map(|(other, _, _)| complete(other))
                     .collect(),
                 deprecation_message: deprecation_message
-                    .or_else(|| binding.deprecation().map(DeprecationInfo::message)),
-                deprecation_until: binding.deprecation().and_then(DeprecationInfo::until),
+                    .or_else(|| binding.deprecation().map(Deprecation::message)),
+                deprecation_until: binding.deprecation().and_then(Deprecation::until),
             });
         }
     }

--- a/docs/src/model.rs
+++ b/docs/src/model.rs
@@ -89,7 +89,8 @@ pub struct FuncModel {
     pub oneliner: EcoString,
     pub element: bool,
     pub contextual: bool,
-    pub deprecation: Option<&'static str>,
+    pub deprecation_message: Option<&'static str>,
+    pub deprecation_until: Option<&'static str>,
     pub details: Html,
     /// This example is only for nested function models. Others can have
     /// their example directly in their details.
@@ -165,7 +166,8 @@ pub struct SymbolModel {
     pub markup_shorthand: Option<&'static str>,
     pub math_shorthand: Option<&'static str>,
     pub math_class: Option<&'static str>,
-    pub deprecation: Option<&'static str>,
+    pub deprecation_message: Option<&'static str>,
+    pub deprecation_until: Option<&'static str>,
 }
 
 /// Shorthands listed on a category page.

--- a/tests/suite/loading/cbor.typ
+++ b/tests/suite/loading/cbor.typ
@@ -1,3 +1,4 @@
 --- cbor-decode-deprecated ---
 // Warning: 15-21 `cbor.decode` is deprecated, directly pass bytes to `cbor` instead
+// Hint: 15-21 this will be removed in 0.15.0
 #let _ = cbor.decode

--- a/tests/suite/loading/cbor.typ
+++ b/tests/suite/loading/cbor.typ
@@ -1,4 +1,4 @@
 --- cbor-decode-deprecated ---
 // Warning: 15-21 `cbor.decode` is deprecated, directly pass bytes to `cbor` instead
-// Hint: 15-21 this will be removed in 0.15.0
+// Hint: 15-21 it will be removed in Typst 0.15.0
 #let _ = cbor.decode

--- a/tests/suite/loading/csv.typ
+++ b/tests/suite/loading/csv.typ
@@ -32,4 +32,5 @@
 
 --- csv-decode-deprecated ---
 // Warning: 14-20 `csv.decode` is deprecated, directly pass bytes to `csv` instead
+// Hint: 14-20 this will be removed in 0.15.0
 #let _ = csv.decode

--- a/tests/suite/loading/csv.typ
+++ b/tests/suite/loading/csv.typ
@@ -32,5 +32,5 @@
 
 --- csv-decode-deprecated ---
 // Warning: 14-20 `csv.decode` is deprecated, directly pass bytes to `csv` instead
-// Hint: 14-20 this will be removed in 0.15.0
+// Hint: 14-20 it will be removed in Typst 0.15.0
 #let _ = csv.decode

--- a/tests/suite/loading/json.typ
+++ b/tests/suite/loading/json.typ
@@ -11,7 +11,7 @@
 
 --- json-decode-deprecated ---
 // Warning: 15-21 `json.decode` is deprecated, directly pass bytes to `json` instead
-// Hint: 15-21 this will be removed in 0.15.0
+// Hint: 15-21 it will be removed in Typst 0.15.0
 #let _ = json.decode
 
 --- issue-3363-json-large-number ---

--- a/tests/suite/loading/json.typ
+++ b/tests/suite/loading/json.typ
@@ -11,6 +11,7 @@
 
 --- json-decode-deprecated ---
 // Warning: 15-21 `json.decode` is deprecated, directly pass bytes to `json` instead
+// Hint: 15-21 this will be removed in 0.15.0
 #let _ = json.decode
 
 --- issue-3363-json-large-number ---

--- a/tests/suite/loading/toml.typ
+++ b/tests/suite/loading/toml.typ
@@ -42,4 +42,5 @@
 
 --- toml-decode-deprecated ---
 // Warning: 15-21 `toml.decode` is deprecated, directly pass bytes to `toml` instead
+// Hint: 15-21 this will be removed in 0.15.0
 #let _ = toml.decode

--- a/tests/suite/loading/toml.typ
+++ b/tests/suite/loading/toml.typ
@@ -42,5 +42,5 @@
 
 --- toml-decode-deprecated ---
 // Warning: 15-21 `toml.decode` is deprecated, directly pass bytes to `toml` instead
-// Hint: 15-21 this will be removed in 0.15.0
+// Hint: 15-21 it will be removed in Typst 0.15.0
 #let _ = toml.decode

--- a/tests/suite/loading/xml.typ
+++ b/tests/suite/loading/xml.typ
@@ -29,4 +29,5 @@
 
 --- xml-decode-deprecated ---
 // Warning: 14-20 `xml.decode` is deprecated, directly pass bytes to `xml` instead
+// Hint: 14-20 this will be removed in 0.15.0
 #let _ = xml.decode

--- a/tests/suite/loading/xml.typ
+++ b/tests/suite/loading/xml.typ
@@ -29,5 +29,5 @@
 
 --- xml-decode-deprecated ---
 // Warning: 14-20 `xml.decode` is deprecated, directly pass bytes to `xml` instead
-// Hint: 14-20 this will be removed in 0.15.0
+// Hint: 14-20 it will be removed in Typst 0.15.0
 #let _ = xml.decode

--- a/tests/suite/loading/yaml.typ
+++ b/tests/suite/loading/yaml.typ
@@ -18,5 +18,5 @@
 
 --- yaml-decode-deprecated ---
 // Warning: 15-21 `yaml.decode` is deprecated, directly pass bytes to `yaml` instead
-// Hint: 15-21 this will be removed in 0.15.0
+// Hint: 15-21 it will be removed in Typst 0.15.0
 #let _ = yaml.decode

--- a/tests/suite/loading/yaml.typ
+++ b/tests/suite/loading/yaml.typ
@@ -18,4 +18,5 @@
 
 --- yaml-decode-deprecated ---
 // Warning: 15-21 `yaml.decode` is deprecated, directly pass bytes to `yaml` instead
+// Hint: 15-21 this will be removed in 0.15.0
 #let _ = yaml.decode

--- a/tests/suite/visualize/image.typ
+++ b/tests/suite/visualize/image.typ
@@ -188,26 +188,31 @@ A #box(image("/assets/images/tiger.jpg", height: 1cm, width: 80%)) B
 --- image-decode-svg ---
 // Test parsing from svg data
 // Warning: 8-14 `image.decode` is deprecated, directly pass bytes to `image` instead
+// Hint: 8-14 this will be removed in 0.15.0
 #image.decode(`<svg xmlns="http://www.w3.org/2000/svg" height="140" width="500"><ellipse cx="200" cy="80" rx="100" ry="50" style="fill:yellow;stroke:purple;stroke-width:2" /></svg>`.text, format: "svg")
 
 --- image-decode-bad-svg ---
 // Error: 15-152 failed to parse SVG (missing root node at 1:1)
 // Warning: 8-14 `image.decode` is deprecated, directly pass bytes to `image` instead
+// Hint: 8-14 this will be removed in 0.15.0
 #image.decode(`<svg height="140" width="500"><ellipse cx="200" cy="80" rx="100" ry="50" style="fill:yellow;stroke:purple;stroke-width:2" /></svg>`.text, format: "svg")
 
 --- image-decode-detect-format ---
 // Test format auto detect
 // Warning: 8-14 `image.decode` is deprecated, directly pass bytes to `image` instead
+// Hint: 8-14 this will be removed in 0.15.0
 #image.decode(read("/assets/images/tiger.jpg", encoding: none), width: 80%)
 
 --- image-decode-specify-format ---
 // Test format manual
 // Warning: 8-14 `image.decode` is deprecated, directly pass bytes to `image` instead
+// Hint: 8-14 this will be removed in 0.15.0
 #image.decode(read("/assets/images/tiger.jpg", encoding: none), format: "jpg", width: 80%)
 
 --- image-decode-specify-wrong-format ---
 // Error: 2-91 failed to decode image (Format error decoding Png: Invalid PNG signature.)
 // Warning: 8-14 `image.decode` is deprecated, directly pass bytes to `image` instead
+// Hint: 8-14 this will be removed in 0.15.0
 #image.decode(read("/assets/images/tiger.jpg", encoding: none), format: "png", width: 80%)
 
 --- image-pixmap-empty ---

--- a/tests/suite/visualize/image.typ
+++ b/tests/suite/visualize/image.typ
@@ -188,31 +188,31 @@ A #box(image("/assets/images/tiger.jpg", height: 1cm, width: 80%)) B
 --- image-decode-svg ---
 // Test parsing from svg data
 // Warning: 8-14 `image.decode` is deprecated, directly pass bytes to `image` instead
-// Hint: 8-14 this will be removed in 0.15.0
+// Hint: 8-14 it will be removed in Typst 0.15.0
 #image.decode(`<svg xmlns="http://www.w3.org/2000/svg" height="140" width="500"><ellipse cx="200" cy="80" rx="100" ry="50" style="fill:yellow;stroke:purple;stroke-width:2" /></svg>`.text, format: "svg")
 
 --- image-decode-bad-svg ---
 // Error: 15-152 failed to parse SVG (missing root node at 1:1)
 // Warning: 8-14 `image.decode` is deprecated, directly pass bytes to `image` instead
-// Hint: 8-14 this will be removed in 0.15.0
+// Hint: 8-14 it will be removed in Typst 0.15.0
 #image.decode(`<svg height="140" width="500"><ellipse cx="200" cy="80" rx="100" ry="50" style="fill:yellow;stroke:purple;stroke-width:2" /></svg>`.text, format: "svg")
 
 --- image-decode-detect-format ---
 // Test format auto detect
 // Warning: 8-14 `image.decode` is deprecated, directly pass bytes to `image` instead
-// Hint: 8-14 this will be removed in 0.15.0
+// Hint: 8-14 it will be removed in Typst 0.15.0
 #image.decode(read("/assets/images/tiger.jpg", encoding: none), width: 80%)
 
 --- image-decode-specify-format ---
 // Test format manual
 // Warning: 8-14 `image.decode` is deprecated, directly pass bytes to `image` instead
-// Hint: 8-14 this will be removed in 0.15.0
+// Hint: 8-14 it will be removed in Typst 0.15.0
 #image.decode(read("/assets/images/tiger.jpg", encoding: none), format: "jpg", width: 80%)
 
 --- image-decode-specify-wrong-format ---
 // Error: 2-91 failed to decode image (Format error decoding Png: Invalid PNG signature.)
 // Warning: 8-14 `image.decode` is deprecated, directly pass bytes to `image` instead
-// Hint: 8-14 this will be removed in 0.15.0
+// Hint: 8-14 it will be removed in Typst 0.15.0
 #image.decode(read("/assets/images/tiger.jpg", encoding: none), format: "png", width: 80%)
 
 --- image-pixmap-empty ---

--- a/tests/suite/visualize/tiling.typ
+++ b/tests/suite/visualize/tiling.typ
@@ -161,5 +161,6 @@
 #set page(width: auto, height: auto, margin: 0pt)
 
 // Warning: 10-17 the name `pattern` is deprecated, use `tiling` instead
+// Hint: 10-17 this will be removed in 0.15.0
 #let t = pattern(size: (10pt, 10pt), line(stroke: 4pt, start: (0%, 0%), end: (100%, 100%)))
 #rect(width: 50pt, height: 50pt, fill: t)

--- a/tests/suite/visualize/tiling.typ
+++ b/tests/suite/visualize/tiling.typ
@@ -161,6 +161,6 @@
 #set page(width: auto, height: auto, margin: 0pt)
 
 // Warning: 10-17 the name `pattern` is deprecated, use `tiling` instead
-// Hint: 10-17 this will be removed in 0.15.0
+// Hint: 10-17 it will be removed in Typst 0.15.0
 #let t = pattern(size: (10pt, 10pt), line(stroke: 4pt, start: (0%, 0%), end: (100%, 100%)))
 #rect(width: 50pt, height: 50pt, fill: t)


### PR DESCRIPTION
There are some points to clear up:
- Should we name the `remove_in` field something like `until`? Rust uses `since` for some of its attributes, including the deprecation. I assume that, if we were to add something like `stable(since = "...", ...)` down the line, having `until` is more fitting. But changing it when it comes up is fine too.
- Should we care to emit good diagnostics in the macros (see TODO in the macro stuff)? So far it seems that macros kind of just assume you're familiar with them, which keeps their implementation simple, but incorrect usage may not signal any error to new contributors.