### PR TITLE
Add rust-analyzer to flake devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -127,6 +127,10 @@
           checks = self'.checks;
           inputsFrom = [ typst ];
 
+          buildInputs = with pkgs; [
+            rust-analyzer
+          ];
+
           packages = [
             # A script for quickly running tests.
             # See https://github.com/typst/typst/blob/main/tests/README.md#making-an-alias


### PR DESCRIPTION
This ensures that a system toolchain rust-analzyer doesn't blow the cargo cache in cases where it differs from flake's toolchain version. Most notably, running tests would require a rebuild on a nix system with rust-analyzer having a different version of that in the devShell.