### PR TITLE
Follow the comment on setting the `State`'s mask

### DIFF
--- a/crates/typst-render/src/lib.rs
+++ b/crates/typst-render/src/lib.rs
@@ -93,7 +93,7 @@ struct State<'a> {
     size: Size,
 }
 
-impl State<'_> {
+impl<'a> State<'a> {
     fn new(size: Size, transform: sk::Transform, pixel_per_pt: f32) -> Self {
         Self {
             size,
@@ -128,9 +128,10 @@ impl State<'_> {
     }
 
     /// Sets the current mask.
-    fn with_mask(self, mask: Option<&sk::Mask>) -> State<'_> {
-        // Ensure that we're using the parent's mask if we don't have one.
-        if mask.is_some() { State { mask, ..self } } else { State { mask: None, ..self } }
+    ///
+    /// If no mask is provided, the parent mask is used.
+    fn with_mask(self, mask: Option<&'a sk::Mask>) -> State<'a> {
+        State { mask: mask.or(self.mask), ..self }
     }
 
     /// Sets the size of the first hard frame in the hierarchy.


### PR DESCRIPTION
This does not actually change any existing behavior, as `with_mask` is not used in a way that uses it. However, it should align reality with expectations.

## Alternatives

There is a case to be made for simply removing the function, or for not changing its behavior, but simply the code. I think the new behavior (and the one written about in the code's comment) makes sense though.

## Postface

Interestingly, this PR was inspired by an AI-generated slop PR that changed the same line of code in a different manner.[^1]

[^1]: https://github.com/typst/typst/pull/6640/files#diff-756093ac5fe76dbe9e281b08197b3cec0a930f18fab8d23a57c781c21886a606R174-R175