### PR TITLE
feat: `--deps0` flag for getting a NUL-separated dependency list

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -267,6 +267,10 @@ pub struct CompileArgs {
     #[clap(long = "make-deps", value_name = "PATH")]
     pub make_deps: Option<PathBuf>,
 
+    /// File path to which a list of NUL-separated current compilation's dependencies will be written
+    #[clap(long, value_name = "PATH")]
+    pub deps0: Option<PathBuf>,
+
     /// Processing arguments.
     #[clap(flatten)]
     pub process: ProcessArgs,


### PR DESCRIPTION
This is much easier to parse than `Makefile` and doesn't need any imperfect escaping, since file paths can't contain NUL. Also, unlike  `--make-deps`, it works even when the output path is stdout, since the output paths aren't actually needed. And, since the output paths are not needed, it can generate a (partial) dependency list even when the compilation fails.

This format matches what commands like `find -print0` and `grep -Z` (or, if you like fancy rust stuff, `fd -0` and `rg -0`) generate and what commands like `xargs -0` and `sort -0` expect. This is common on Unix-like systems, and the latest POSIX standard (POSIX.1-2024) includes NUL flag in various utilities, which has already been supported by GNU and BSD coreutils/findutils (and maybe others) for a long time.

Related: [SC2011](https://www.shellcheck.net/wiki/SC2011)

My use case: I use the [`redo`](https://redo.readthedocs.io/) build system, which uses shell scripts (by default) rather than some special DSL, and dependencies are declared by a certain command invocation rather than some special syntax. This is the recipe I use for building PDF files (`default.pdf.do`):
```sh
typst compile "$2.typ" "$3" -f pdf --deps0 /dev/stdout | xargs -0 redo-ifchange
```
This task would be harder using `--make-deps`, because I would need to implement make-like parsing in shell. That could be achieved using `read`, as suggested by [`redo-ifchange(1)`](https://redo.readthedocs.io/en/latest/redo-ifchange/#tip-1), but AFAIK `read` behavior doesn't match `make` behavior perfectly, and I can't be bothered to check throughoutly how different make implementations handle escaping in dependency lists. KISS at its finest.

The `--deps0` flag can probably be renamed to something else.