### PR TITLE
Lint for iterations over hash types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,7 @@ strip = true
 [workspace.lints.clippy]
 blocks_in_conditions = "allow"
 comparison_chain = "allow"
+iter_over_hash_type = "warn"
 manual_range_contains = "allow"
 mutable_key_type = "allow"
 uninlined_format_args = "warn"

--- a/crates/typst-cli/src/watch.rs
+++ b/crates/typst-cli/src/watch.rs
@@ -139,6 +139,7 @@ impl Watcher {
     fn update(&mut self, iter: impl IntoIterator<Item = PathBuf>) -> StrResult<()> {
         // Mark all files as not "seen" so that we may unwatch them if they
         // aren't in the dependency list.
+        #[allow(clippy::iter_over_hash_type, reason = "order does not matter")]
         for seen in self.watched.values_mut() {
             *seen = false;
         }

--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -173,6 +173,7 @@ impl SystemWorld {
 
     /// Reset the compilation state in preparation of a new compilation.
     pub fn reset(&mut self) {
+        #[allow(clippy::iter_over_hash_type, reason = "order does not matter")]
         for slot in self.slots.get_mut().values_mut() {
             slot.reset();
         }


### PR DESCRIPTION
Found this nice little lint that can help avoid non-determinism due to iteration order on a hashmap being random.