### PR TITLE
Improve code snippets in Table Guide

### DIFF
--- a/docs/guides/tables.md
+++ b/docs/guides/tables.md
@@ -257,7 +257,7 @@ Let's start with an example of a horizontally striped table:
 
 #set table(
   fill: (rgb("EAF2F5"), none),
-  stroke: frame(rgb("21222C")),
+  stroke: frame(1pt + rgb("21222C")),
 )
 
 #table(
@@ -303,7 +303,7 @@ horizontal stripes instead:
 >>>
 #set table(
   fill: (_, y) => if calc.odd(y) { rgb("EAF2F5") },
-  stroke: frame(rgb("21222C")),
+  stroke: frame(1pt + rgb("21222C")),
 )
 >>>
 >>> #table(
@@ -346,7 +346,7 @@ something like this:
 >>>
 #set table(
   fill: (_, y) => (none, rgb("EAF2F5"), rgb("DDEAEF")).at(calc.rem(y, 3)),
-  stroke: frame(rgb("21222C")),
+  stroke: frame(1pt + rgb("21222C")),
 )
 >>>
 >>> #table(
@@ -671,7 +671,7 @@ one intersection highlighted.
   columns: 3,
   stroke: (x: none),
 
-  [], [*High Neuroticism*], [*Low Neuroticism*],
+  table.header[][*High Neuroticism*][*Low Neuroticism*],
 
   [*High Agreeableness*],
   table.cell(stroke: orange + 2pt)[


### PR DESCRIPTION
The snippets with the `frame` function should actually provide a `stroke` argument, not a `color`. Otherwise when the table is broken across pages, the header on the next page has no bottom line.

Possibly related to #5320; apparently when the `stroke` for a header which broken to the next page does not have a value for a field, it takes the value from the cells further down (which normally have lower precedence)?
In the context of this PR here it looks like it used the `0pt` from the `top: if y < 2 { stroke } else { 0pt }`.

| Before | After |
| - | - |
| ![Screenshot before changes](https://github.com/user-attachments/assets/104df001-99bb-45be-8885-a44502f6fec8) | ![Screenshot after changes](https://github.com/user-attachments/assets/57e4afe5-e53c-4c7f-8289-11fef0eb07e7) |
