### PR TITLE
Add 16:10 presentation format

### DIFF
--- a/crates/typst-library/src/layout/page.rs
+++ b/crates/typst-library/src/layout/page.rs
@@ -903,6 +903,7 @@ papers! {
     (NEWSPAPER_BERLINER:   315.0,    470.0, "newspaper-berliner")
     (NEWSPAPER_BROADSHEET: 381.0,    578.0, "newspaper-broadsheet")
     (PRESENTATION_16_9:    297.0, 167.0625, "presentation-16-9")
+    (PRESENTATION_16_10:   297.0,  185.625, "presentation-16-10")
     (PRESENTATION_4_3:     280.0,    210.0, "presentation-4-3")
 }
 


### PR DESCRIPTION
Allows for presentations filling 16:10 projectors and screens.

See also https://github.com/touying-typ/touying/issues/141