### PR TITLE
Remove unnecessary `comemo` dependency in `typst-syntax`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3267,7 +3267,6 @@ dependencies = [
 name = "typst-syntax"
 version = "0.13.1"
 dependencies = [
- "comemo",
  "ecow",
  "serde",
  "toml",

--- a/crates/typst-syntax/Cargo.toml
+++ b/crates/typst-syntax/Cargo.toml
@@ -15,7 +15,6 @@ readme = { workspace = true }
 [dependencies]
 typst-timing = { workspace = true }
 typst-utils = { workspace = true }
-comemo = { workspace = true }
 ecow = { workspace = true }
 serde = { workspace = true }
 toml = { workspace = true }


### PR DESCRIPTION
Was used in the past, but isn't anymore