### PR TITLE
Update guides welcome text to refer to list instead of specific guides

### DIFF
--- a/docs/guides/welcome.md
+++ b/docs/guides/welcome.md
@@ -4,8 +4,7 @@ description: Guides for Typst.
 
 # Guides
 Welcome to the Guides section! Here, you'll find helpful material for specific
-user groups or use cases. Currently, two guides are available: An introduction
-to Typst for LaTeX users, and a detailed look at page setup. Feel free to
+user groups or use cases. Please see the list below for the available guides. Feel free to
 propose other topics for guides!
 
 ## List of Guides

--- a/docs/guides/welcome.md
+++ b/docs/guides/welcome.md
@@ -4,8 +4,8 @@ description: Guides for Typst.
 
 # Guides
 Welcome to the Guides section! Here, you'll find helpful material for specific
-user groups or use cases. Please see the list below for the available guides. Feel free to
-propose other topics for guides!
+user groups or use cases. Please see the list below for the available guides.
+Feel free to propose other topics for guides!
 
 ## List of Guides
 - [Guide for LaTeX users]($guides/guide-for-latex-users)


### PR DESCRIPTION
The welcome text for the Guides section previously mentioned only two guides, omitting the table guide. To address this and make future updates easier, the text now refers readers to the list below instead of mentioning specific guide names.

This ensures the welcome message stays accurate as more guides are added.