### PR TITLE
Support for raw syntax highlighting in HTML export

### DIFF
--- a/crates/typst-html/src/css.rs
+++ b/crates/typst-html/src/css.rs
@@ -26,7 +26,6 @@ impl Properties {
     }
 
     /// Adds a new property in builder-style.
-    #[expect(unused)]
     pub fn with(mut self, property: &str, value: impl Display) -> Self {
         self.push(property, value);
         self

--- a/crates/typst-html/src/lib.rs
+++ b/crates/typst-html/src/lib.rs
@@ -16,7 +16,7 @@ mod typed;
 pub use self::document::html_document;
 pub use self::dom::*;
 pub use self::encode::html;
-pub use self::rules::register;
+pub use self::rules::{html_span_filled, register};
 
 use ecow::EcoString;
 use typst_library::Category;

--- a/crates/typst-html/src/rules.rs
+++ b/crates/typst-html/src/rules.rs
@@ -17,7 +17,7 @@ use typst_library::text::{
     HighlightElem, LinebreakElem, OverlineElem, RawElem, RawLine, SmallcapsElem,
     SpaceElem, StrikeElem, SubElem, SuperElem, UnderlineElem,
 };
-use typst_library::visualize::ImageElem;
+use typst_library::visualize::{Color, ImageElem};
 
 use crate::{FrameElem, HtmlAttrs, HtmlElem, HtmlTag, attr, css, tag};
 
@@ -426,6 +426,20 @@ const RAW_RULE: ShowFn<RawElem> = |elem, _, styles| {
         code
     })
 };
+
+/// This is used by `RawElem::synthesize` through a routine.
+///
+/// It's a temporary workaround until `TextElem::fill` is supported in HTML
+/// export.
+#[doc(hidden)]
+pub fn html_span_filled(content: Content, color: Color) -> Content {
+    let span = content.span();
+    HtmlElem::new(tag::span)
+        .with_styles(css::Properties::new().with("color", css::color(color)))
+        .with_body(Some(content))
+        .pack()
+        .spanned(span)
+}
 
 const RAW_LINE_RULE: ShowFn<RawLine> = |elem, _, _| Ok(elem.body.clone());
 

--- a/crates/typst-library/src/routines.rs
+++ b/crates/typst-library/src/routines.rs
@@ -15,6 +15,7 @@ use crate::foundations::{
 use crate::introspection::{Introspector, Locator, SplitLocator};
 use crate::layout::{Frame, Region};
 use crate::model::DocumentInfo;
+use crate::visualize::Color;
 
 /// Defines the `Routines` struct.
 macro_rules! routines {
@@ -95,6 +96,12 @@ routines! {
 
     /// Constructs the `html` module.
     fn html_module() -> Module
+
+    /// Wraps content in a span with a color.
+    ///
+    /// This is a temporary workaround until `TextElem::fill` is supported in
+    /// HTML export.
+    fn html_span_filled(content: Content, color: Color) -> Content
 }
 
 /// Defines what kind of realization we are performing.

--- a/crates/typst/src/lib.rs
+++ b/crates/typst/src/lib.rs
@@ -358,4 +358,5 @@ pub static ROUTINES: LazyLock<Routines> = LazyLock::new(|| Routines {
     realize: typst_realize::realize,
     layout_frame: typst_layout::layout_frame,
     html_module: typst_html::module,
+    html_span_filled: typst_html::html_span_filled,
 });

--- a/tests/ref/html/raw-html.html
+++ b/tests/ref/html/raw-html.html
@@ -6,6 +6,6 @@
   </head>
   <body>
     <p>This is <code><strong>*</strong><strong>inline</strong><strong>*</strong></code>.</p>
-    <pre><code>#set text(blue)<br><strong>*</strong><strong>Hello</strong><strong>*</strong> <em>_</em><em>world</em><em>_</em>!</code></pre>
+    <pre><code><span style="color: #d73a49">#</span><span style="color: #d73a49">set</span> <span style="color: #4b69c6">text</span>(blue)<br><strong>*</strong><strong>Hello</strong><strong>*</strong> <em>_</em><em>world</em><em>_</em>!</code></pre>
   </body>
 </html>


### PR DESCRIPTION
This PR adds support for syntax highlighting of raw blocks in HTML export. The "proper" way to support this would be to add support for `TextElem::fill` in HTML export. However, doing this properly is a bit tricky. Since having syntax highlighting work in HTML export is pretty useful, I've opted to implement a workaround for now.