### PR TITLE
Wrap raw blocks in `<code>` tag additionally to `<pre>` tag

### DIFF
--- a/crates/typst-html/src/rules.rs
+++ b/crates/typst-html/src/rules.rs
@@ -415,9 +415,16 @@ const RAW_RULE: ShowFn<RawElem> = |elem, _, styles| {
         seq.push(line.clone().pack());
     }
 
-    Ok(HtmlElem::new(if elem.block.get(styles) { tag::pre } else { tag::code })
+    let code = HtmlElem::new(tag::code)
         .with_body(Some(Content::sequence(seq)))
-        .pack())
+        .pack()
+        .spanned(elem.span());
+
+    Ok(if elem.block.get(styles) {
+        HtmlElem::new(tag::pre).with_body(Some(code)).pack()
+    } else {
+        code
+    })
 };
 
 const RAW_LINE_RULE: ShowFn<RawLine> = |elem, _, _| Ok(elem.body.clone());

--- a/tests/ref/html/raw-html.html
+++ b/tests/ref/html/raw-html.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body>
+    <p>This is <code><strong>*</strong><strong>inline</strong><strong>*</strong></code>.</p>
+    <pre><code>#set text(blue)<br><strong>*</strong><strong>Hello</strong><strong>*</strong> <em>_</em><em>world</em><em>_</em>!</code></pre>
+  </body>
+</html>

--- a/tests/suite/text/raw.typ
+++ b/tests/suite/text/raw.typ
@@ -487,6 +487,13 @@ test
   assert.eq(block, c.input.block, message: "in point " + c.name + ", expect " + repr(block) + ", got " + repr(c.input.block) + "")
 }
 
+--- raw-html html ---
+This is ```typ *inline*```.
+```typ
+#set text(blue)
+*Hello* _world_!
+```
+
 --- raw-line ---
 #set page(width: 200pt)
 


### PR DESCRIPTION
As recommended by https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-code-element