### PR TITLE
Ensure that whitespace is not collapsed in inline raw blocks

### DIFF
--- a/crates/typst-html/src/rules.rs
+++ b/crates/typst-html/src/rules.rs
@@ -415,16 +415,20 @@ const RAW_RULE: ShowFn<RawElem> = |elem, _, styles| {
         seq.push(line.clone().pack());
     }
 
+    let mut inline = css::Properties::new();
+    let block = elem.block.get(styles);
+    if !block {
+        // Without the `<pre>` tag, whitespace would be collapsed by default.
+        inline.push("white-space", "pre-wrap");
+    }
+
     let code = HtmlElem::new(tag::code)
+        .with_styles(inline)
         .with_body(Some(Content::sequence(seq)))
         .pack()
         .spanned(elem.span());
 
-    Ok(if elem.block.get(styles) {
-        HtmlElem::new(tag::pre).with_body(Some(code)).pack()
-    } else {
-        code
-    })
+    Ok(if block { HtmlElem::new(tag::pre).with_body(Some(code)).pack() } else { code })
 };
 
 /// This is used by `RawElem::synthesize` through a routine.

--- a/tests/ref/html/raw-html-inline-spaces.html
+++ b/tests/ref/html/raw-html-inline-spaces.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body>
+    <p>This has <code style="white-space: pre-wrap">double  spaces  inside</code>, which should be kept.</p>
+  </body>
+</html>

--- a/tests/ref/html/raw-html.html
+++ b/tests/ref/html/raw-html.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body>
-    <p>This is <code><strong>*</strong><strong>inline</strong><strong>*</strong></code>.</p>
+    <p>This is <code style="white-space: pre-wrap"><strong>*</strong><strong>inline</strong><strong>*</strong></code>.</p>
     <pre><code><span style="color: #d73a49">#</span><span style="color: #d73a49">set</span> <span style="color: #4b69c6">text</span>(blue)<br><strong>*</strong><strong>Hello</strong><strong>*</strong> <em>_</em><em>world</em><em>_</em>!</code></pre>
   </body>
 </html>

--- a/tests/suite/text/raw.typ
+++ b/tests/suite/text/raw.typ
@@ -494,6 +494,9 @@ This is ```typ *inline*```.
 *Hello* _world_!
 ```
 
+--- raw-html-inline-spaces html ---
+This has `double  spaces  inside`, which should be kept.
+
 --- raw-line ---
 #set page(width: 200pt)
 


### PR DESCRIPTION
Without this, multiple spaces in inline code blocks will be rendered as a single one in browsers.

We could potentially omit this if the raw text does not contain consecutive whitespace. Not sure whether that's worth it.