### PR TITLE
Remove use of "last" and "end" for conic gradient circle docs

### DIFF
--- a/crates/typst-library/src/visualize/gradient.rs
+++ b/crates/typst-library/src/visualize/gradient.rs
@@ -426,10 +426,10 @@ impl Gradient {
         #[named]
         #[default(Smart::Auto)]
         relative: Smart<RelativeTo>,
-        /// The center of the last circle of the gradient.
+        /// The center of the circle of the gradient.
         ///
-        /// A value of `{(50%, 50%)}` means that the end circle is
-        /// centered inside of its container.
+        /// A value of `{(50%, 50%)}` means that the circle is centered inside
+        /// of its container.
         #[named]
         #[default(Axes::splat(Ratio::new(0.5)))]
         center: Axes<Ratio>,
@@ -1083,7 +1083,7 @@ pub struct ConicGradient {
     pub stops: Vec<(Color, Ratio)>,
     /// The direction of this gradient.
     pub angle: Angle,
-    /// The center of last circle of this gradient.
+    /// The center of circle of this gradient.
     pub center: Axes<Ratio>,
     /// The color space in which to interpolate the gradient.
     pub space: ColorSpace,


### PR DESCRIPTION
These seem to have arised from a copy-paste of the docs from RadialGradient, which does have two circles defining it.