### PR TITLE
Unify and document the behaviours of `{json,yaml,toml,cbor}.encode`

### DIFF
--- a/crates/typst-library/src/foundations/bytes.rs
+++ b/crates/typst-library/src/foundations/bytes.rs
@@ -276,7 +276,7 @@ impl Serialize for Bytes {
         S: Serializer,
     {
         if serializer.is_human_readable() {
-            serializer.serialize_str(&eco_format!("{self:?}"))
+            serializer.serialize_str(&self.repr())
         } else {
             serializer.serialize_bytes(self)
         }

--- a/crates/typst-library/src/foundations/plugin.rs
+++ b/crates/typst-library/src/foundations/plugin.rs
@@ -21,7 +21,9 @@ use crate::loading::{DataSource, Load};
 /// compiled to a 32-bit shared WebAssembly library. Plugin functions may accept
 /// multiple [byte buffers]($bytes) as arguments and return a single byte
 /// buffer. They should typically be wrapped in idiomatic Typst functions that
-/// perform the necessary conversions between native Typst types and bytes.
+/// perform the necessary conversions between native Typst types and bytes by
+/// leveraging [`str`]($str/#constructor), [`bytes`]($bytes/#constructor), and
+/// [data loading functions]($reference/data-loading).
 ///
 /// For security reasons, plugins run in isolation from your system. This means
 /// that printing, reading files, or similar things are not supported.

--- a/crates/typst-library/src/foundations/repr.rs
+++ b/crates/typst-library/src/foundations/repr.rs
@@ -14,15 +14,30 @@ pub const MINUS_SIGN: &str = "\u{2212}";
 /// in monospace with syntax-highlighting. The exceptions are `{none}`,
 /// integers, floats, strings, content, and functions.
 ///
-/// **Note:** This function is for debugging purposes. Its output should not be
-/// considered stable and may change at any time!
-///
 /// # Example
 /// ```example
 /// #none vs #repr(none) \
 /// #"hello" vs #repr("hello") \
 /// #(1, 2) vs #repr((1, 2)) \
 /// #[*Hi*] vs #repr([*Hi*])
+/// ```
+///
+/// # For debugging purposes only { #debugging-only }
+///
+/// This function is for debugging purposes. Its output should not be considered
+/// stable and may change at any time.
+///
+/// To be specific, having the same `repr` does not guarantee that values are
+/// equivalent, and `repr` is not a strict inverse of [`eval`]. In the following
+/// example, for readability, the [`length`] is rounded to two significant digits
+/// and the parameter list and body of the [unamed `function`]($function/#unnamed)
+/// are omitted.
+///
+/// ```example
+/// #assert(2pt / 3 < 0.67pt)
+/// #repr(2pt / 3)
+///
+/// #repr(x => x + 1)
 /// ```
 #[func(title = "Representation")]
 pub fn repr(

--- a/crates/typst-library/src/foundations/repr.rs
+++ b/crates/typst-library/src/foundations/repr.rs
@@ -29,9 +29,9 @@ pub const MINUS_SIGN: &str = "\u{2212}";
 ///
 /// To be specific, having the same `repr` does not guarantee that values are
 /// equivalent, and `repr` is not a strict inverse of [`eval`]. In the following
-/// example, for readability, the [`length`] is rounded to two significant digits
-/// and the parameter list and body of the [unamed `function`]($function/#unnamed)
-/// are omitted.
+/// example, for readability, the [`length`] is rounded to two significant
+/// digits and the parameter list and body of the
+/// [unnamed `function`]($function/#unnamed) are omitted.
 ///
 /// ```example
 /// #assert(2pt / 3 < 0.67pt)

--- a/crates/typst-library/src/layout/ratio.rs
+++ b/crates/typst-library/src/layout/ratio.rs
@@ -35,7 +35,7 @@ use crate::foundations::{Repr, repr, ty};
 /// | [`float`]       | `{27% * 0.37037}`       | `{10%}`         |
 /// | [`fraction`]    | `{27% * 3fr}`           | `{0.81fr}`      |
 ///
-/// When ratios are displayed in the document, they are rounded to two
+/// When ratios are [displayed]($repr) in the document, they are rounded to two
 /// significant digits for readability.
 #[ty(cast)]
 #[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]

--- a/crates/typst-library/src/loading/cbor.rs
+++ b/crates/typst-library/src/loading/cbor.rs
@@ -16,9 +16,6 @@ use crate::loading::{DataSource, Load};
 /// another CBOR data type.
 ///
 /// # Conversion details { #conversion }
-/// Typst uses [ciborium](https://docs.rs/ciborium/latest/ciborium/#compatibility-with-other-implementations)
-/// to process CBOR data. The ciborium project is wire-compatible with other
-/// implementations in decoding, but not necessarily encoding.
 ///
 /// | CBOR value | Converted into Typst   |
 /// | ---------- | ---------------------- |

--- a/crates/typst-library/src/loading/cbor.rs
+++ b/crates/typst-library/src/loading/cbor.rs
@@ -28,8 +28,9 @@ use crate::loading::{DataSource, Load};
 /// | array      | [`array`]              |
 /// | map        | [`dictionary`]         |
 ///
-/// - Be aware that **CBOR integers** larger than 2<sup>63</sup>-1 or smaller than
-///   -2<sup>63</sup> will be approximated as floating-point numbers.
+/// - Be aware that **CBOR integers** larger than 2<sup>63</sup>-1 or smaller
+///   than -2<sup>63</sup> will be converted to floating point numbers, which
+///   may result in an approximative value.
 ///
 /// - **CBOR tags** are not supported, and an error will be thrown.
 ///

--- a/crates/typst-library/src/loading/cbor.rs
+++ b/crates/typst-library/src/loading/cbor.rs
@@ -9,7 +9,7 @@ use crate::loading::{DataSource, Load};
 /// Reads structured data from a CBOR file.
 ///
 /// The file must contain a valid CBOR serialization. The CBOR values will be
-/// converted into corresponding Typst values listed in the
+/// converted into corresponding Typst values as listed in the
 /// [table below](#conversion).
 ///
 /// The function returns a dictionary, an array or, depending on the CBOR file,
@@ -28,12 +28,6 @@ use crate::loading::{DataSource, Load};
 /// | array      | [`array`]              |
 /// | map        | [`dictionary`]         |
 ///
-/// - Be aware that **CBOR integers** larger than 2<sup>63</sup>-1 or smaller
-///   than -2<sup>63</sup> will be converted to floating point numbers, which
-///   may result in an approximative value.
-///
-/// - **CBOR tags** are not supported, and an error will be thrown.
-///
 /// | Typst value                           | Converted into CBOR          |
 /// | ------------------------------------- | ---------------------------- |
 /// | types that can be converted from CBOR | corresponding CBOR value     |
@@ -41,8 +35,16 @@ use crate::loading::{DataSource, Load};
 /// | [`content`]                           | a map describing the content |
 /// | other types ([`length`], etc.)        | text via [`repr`]            |
 ///
-/// Note that the **`repr`** function is [for debugging purposes only]($repr/#debugging-only),
-/// and its output is not guaranteed to be stable across typst versions.
+/// ## Notes
+///
+/// - Be aware that CBOR integers larger than 2<sup>63</sup>-1 or smaller than
+///   -2<sup>63</sup> will be converted to floating point numbers, which may
+///   result in an approximative value.
+///
+/// - CBOR tags are not supported, and an error will be thrown.
+///
+/// - The `repr` function is [for debugging purposes only]($repr/#debugging-only),
+///   and its output is not guaranteed to be stable across Typst versions.
 #[func(scope, title = "CBOR")]
 pub fn cbor(
     engine: &mut Engine,

--- a/crates/typst-library/src/loading/cbor.rs
+++ b/crates/typst-library/src/loading/cbor.rs
@@ -32,8 +32,7 @@ use crate::loading::{DataSource, Load};
 /// | map        | [`dictionary`]         |
 ///
 /// - Be aware that **CBOR integers** larger than 2<sup>63</sup>-1 or smaller than
-///   -2<sup>63</sup> will be approximated as floating-point numbers or rejected
-///   for parsing.
+///   -2<sup>63</sup> will be approximated as floating-point numbers.
 ///
 /// - **CBOR tags** are not supported, and an error will be thrown.
 ///

--- a/crates/typst-library/src/loading/json.rs
+++ b/crates/typst-library/src/loading/json.rs
@@ -57,7 +57,7 @@ use crate::loading::{DataSource, Load, Readable};
 /// In most cases, **JSON numbers** will be converted to floats or integers
 /// depending on whether they are whole numbers. However, be aware that integers
 /// larger than 2<sup>63</sup>-1 or smaller than -2<sup>63</sup> will be converted
-/// to floating point numbers, which may result in an approximative value.
+/// to floating-point numbers, which may result in an approximative value.
 ///
 /// | Typst value                           | Converted into JSON              |
 /// | ------------------------------------- | -------------------------------- |
@@ -67,8 +67,8 @@ use crate::loading::{DataSource, Load, Readable};
 /// | [`content`]                           | an object describing the content |
 /// | other types ([`length`], etc.)        | string via [`repr`]              |
 ///
-/// - **Bytes** are not encoded as JSON arrays for performance reasons. Consider
-///   using [`cbor.encode`] for binary data.
+/// - **Bytes** are not encoded as JSON arrays for performance and readability
+///   reasons. Consider using [`cbor.encode`] for binary data.
 ///
 /// - The **`repr`** function is [for debugging purposes only]($repr/#debugging-only),
 ///   and its output is not guaranteed to be stable across typst versions.

--- a/crates/typst-library/src/loading/json.rs
+++ b/crates/typst-library/src/loading/json.rs
@@ -8,15 +8,9 @@ use crate::loading::{DataSource, Load, Readable};
 
 /// Reads structured data from a JSON file.
 ///
-/// The file must contain a valid JSON value, such as object or array. JSON
-/// objects will be converted into Typst dictionaries, and JSON arrays will be
-/// converted into Typst arrays. Strings and booleans will be converted into the
-/// Typst equivalents, `null` will be converted into `{none}`, and numbers will
-/// be converted to floats or integers depending on whether they are whole
-/// numbers.
-///
-/// Be aware that integers larger than 2<sup>63</sup>-1 will be converted to
-/// floating point numbers, which may result in an approximative value.
+/// The file must contain a valid JSON value, such as object or array. The JSON
+/// values will be converted into corresponding Typst values listed in the
+/// [table below](#conversion).
 ///
 /// The function returns a dictionary, an array or, depending on the JSON file,
 /// another JSON data type.
@@ -48,6 +42,36 @@ use crate::loading::{DataSource, Load, Readable};
 /// #forecast(json("monday.json"))
 /// #forecast(json("tuesday.json"))
 /// ```
+///
+/// # Conversion details { #conversion }
+///
+/// | JSON value | Converted into Typst |
+/// | ---------- | -------------------- |
+/// | `null`     | `{none}`             |
+/// | bool       | [`bool`]             |
+/// | number     | [`float`] or [`int`] |
+/// | string     | [`str`]              |
+/// | array      | [`array`]            |
+/// | object     | [`dictionary`]       |
+///
+/// In most cases, **JSON numbers** will be converted to floats or integers
+/// depending on whether they are whole numbers. However, be aware that integers
+/// larger than 2<sup>63</sup>-1 or smaller than -2<sup>63</sup> will be converted
+/// to floating point numbers, which may result in an approximative value.
+///
+/// | Typst value                           | Converted into JSON              |
+/// | ------------------------------------- | -------------------------------- |
+/// | types that can be converted from JSON | corresponding JSON value         |
+/// | [`bytes`]                             | string via [`repr`]              |
+/// | [`symbol`]                            | string                           |
+/// | [`content`]                           | an object describing the content |
+/// | other types ([`length`], etc.)        | string via [`repr`]              |
+///
+/// - **Bytes** are not encoded as JSON arrays for performance reasons. Consider
+///   using [`cbor.encode`] for binary data.
+///
+/// - The **`repr`** function is [for debugging purposes only]($repr/#debugging-only),
+///   and its output is not guaranteed to be stable across typst versions.
 #[func(scope, title = "JSON")]
 pub fn json(
     engine: &mut Engine,

--- a/crates/typst-library/src/loading/json.rs
+++ b/crates/typst-library/src/loading/json.rs
@@ -9,7 +9,7 @@ use crate::loading::{DataSource, Load, Readable};
 /// Reads structured data from a JSON file.
 ///
 /// The file must contain a valid JSON value, such as object or array. The JSON
-/// values will be converted into corresponding Typst values listed in the
+/// values will be converted into corresponding Typst values as listed in the
 /// [table below](#conversion).
 ///
 /// The function returns a dictionary, an array or, depending on the JSON file,
@@ -54,11 +54,6 @@ use crate::loading::{DataSource, Load, Readable};
 /// | array      | [`array`]            |
 /// | object     | [`dictionary`]       |
 ///
-/// In most cases, **JSON numbers** will be converted to floats or integers
-/// depending on whether they are whole numbers. However, be aware that integers
-/// larger than 2<sup>63</sup>-1 or smaller than -2<sup>63</sup> will be converted
-/// to floating-point numbers, which may result in an approximative value.
-///
 /// | Typst value                           | Converted into JSON              |
 /// | ------------------------------------- | -------------------------------- |
 /// | types that can be converted from JSON | corresponding JSON value         |
@@ -67,11 +62,18 @@ use crate::loading::{DataSource, Load, Readable};
 /// | [`content`]                           | an object describing the content |
 /// | other types ([`length`], etc.)        | string via [`repr`]              |
 ///
-/// - **Bytes** are not encoded as JSON arrays for performance and readability
+/// ## Notes
+/// - In most cases, JSON numbers will be converted to floats or integers
+///   depending on whether they are whole numbers. However, be aware that
+///   integers larger than 2<sup>63</sup>-1 or smaller than -2<sup>63</sup> will
+///   be converted to floating-point numbers, which may result in an
+///   approximative value.
+///
+/// - Bytes are not encoded as JSON arrays for performance and readability
 ///   reasons. Consider using [`cbor.encode`] for binary data.
 ///
-/// - The **`repr`** function is [for debugging purposes only]($repr/#debugging-only),
-///   and its output is not guaranteed to be stable across typst versions.
+/// - The `repr` function is [for debugging purposes only]($repr/#debugging-only),
+///   and its output is not guaranteed to be stable across Typst versions.
 #[func(scope, title = "JSON")]
 pub fn json(
     engine: &mut Engine,

--- a/crates/typst-library/src/loading/toml.rs
+++ b/crates/typst-library/src/loading/toml.rs
@@ -9,7 +9,7 @@ use crate::loading::{DataSource, Load, Readable};
 /// Reads structured data from a TOML file.
 ///
 /// The file must contain a valid TOML table. The TOML values will be converted
-/// into corresponding Typst values listed in the [table below](#conversion).
+/// into corresponding Typst values as listed in the [table below](#conversion).
 ///
 /// The function returns a dictionary representing the TOML table.
 ///
@@ -41,10 +41,6 @@ use crate::loading::{DataSource, Load, Readable};
 /// | array      | [`array`]            |
 /// | table      | [`dictionary`]       |
 ///
-/// Be aware that **TOML integers** larger than 2<sup>63</sup>-1 or smaller than
-/// -2<sup>63</sup> cannot be represented losslessly in Typst, and an error will
-/// be thrown according to the [specification](https://toml.io/en/v1.0.0#integer).
-///
 /// | Typst value                           | Converted into TOML            |
 /// | ------------------------------------- | ------------------------------ |
 /// | types that can be converted from TOML | corresponding TOML value       |
@@ -54,11 +50,17 @@ use crate::loading::{DataSource, Load, Readable};
 /// | [`content`]                           | a table describing the content |
 /// | other types ([`length`], etc.)        | string via [`repr`]            |
 ///
-/// - **Bytes** are not encoded as TOML arrays for performance and readability
+/// ## Notes
+/// - Be aware that TOML integers larger than 2<sup>63</sup>-1 or smaller
+///   than -2<sup>63</sup> cannot be represented losslessly in Typst, and an
+///   error will be thrown according to the
+///   [specification](https://toml.io/en/v1.0.0#integer).
+///
+/// - Bytes are not encoded as TOML arrays for performance and readability
 ///   reasons. Consider using [`cbor.encode`] for binary data.
 ///
-/// - The **`repr`** function is [for debugging purposes only]($repr/#debugging-only),
-///   and its output is not guaranteed to be stable across typst versions.
+/// - The `repr` function is [for debugging purposes only]($repr/#debugging-only),
+///   and its output is not guaranteed to be stable across Typst versions.
 #[func(scope, title = "TOML")]
 pub fn toml(
     engine: &mut Engine,

--- a/crates/typst-library/src/loading/toml.rs
+++ b/crates/typst-library/src/loading/toml.rs
@@ -3,16 +3,15 @@ use typst_syntax::Spanned;
 
 use crate::diag::{At, LoadError, LoadedWithin, ReportPos, SourceResult};
 use crate::engine::Engine;
-use crate::foundations::{Str, Value, func, scope};
+use crate::foundations::{Dict, Str, func, scope};
 use crate::loading::{DataSource, Load, Readable};
 
 /// Reads structured data from a TOML file.
 ///
-/// The file must contain a valid TOML table. TOML tables will be converted into
-/// Typst dictionaries, and TOML arrays will be converted into Typst arrays.
-/// Strings, booleans and datetimes will be converted into the Typst equivalents
-/// and numbers will be converted to floats or integers depending on whether
-/// they are whole numbers.
+/// The file must contain a valid TOML table. The TOML values will be converted
+/// into corresponding Typst values listed in the [table below](#conversion).
+///
+/// The function returns a dictionary representing the TOML table.
 ///
 /// The TOML file in the example consists of a table with the keys `title`,
 /// `version`, and `authors`.
@@ -26,12 +25,46 @@ use crate::loading::{DataSource, Load, Readable};
 /// Authors: #(details.authors
 ///   .join(", ", last: " and "))
 /// ```
+///
+/// # Conversion details { #conversion }
+///
+/// First of all, TOML documents are tables. Other values must be put in a table
+/// to be encoded or decoded.
+///
+/// | TOML value | Converted into Typst |
+/// | ---------- | -------------------- |
+/// | string     | [`str`]              |
+/// | integer    | [`int`]              |
+/// | float      | [`float`]            |
+/// | boolean    | [`bool`]             |
+/// | datetime   | [`datetime`]         |
+/// | array      | [`array`]            |
+/// | table      | [`dictionary`]       |
+///
+/// Be aware that **TOML integers** larger than 2<sup>63</sup>-1 or smaller than
+/// -2<sup>63</sup> cannot be represented losslessly in Typst, and an error will
+/// be thrown according to the [spec](https://toml.io/en/v1.0.0#integer).
+///
+/// | Typst value                           | Converted into TOML            |
+/// | ------------------------------------- | ------------------------------ |
+/// | types that can be converted from TOML | corresponding TOML value       |
+/// | `{none}`                              | ignored                        |
+/// | [`bytes`]                             | string via [`repr`]            |
+/// | [`symbol`]                            | string                         |
+/// | [`content`]                           | a table describing the content |
+/// | other types ([`length`], etc.)        | string via [`repr`]            |
+///
+/// - **Bytes** are not encoded as TOML arrays for performance reasons.
+///   Consider using [`cbor.encode`] for binary data.
+///
+/// - The **`repr`** function is [for debugging purposes only]($repr/#debugging-only),
+///   and its output is not guaranteed to be stable across typst versions.
 #[func(scope, title = "TOML")]
 pub fn toml(
     engine: &mut Engine,
     /// A [path]($syntax/#paths) to a TOML file or raw TOML bytes.
     source: Spanned<DataSource>,
-) -> SourceResult<Value> {
+) -> SourceResult<Dict> {
     let loaded = source.load(engine.world)?;
     let raw = loaded.data.as_str().within(&loaded)?;
     ::toml::from_str(raw).map_err(format_toml_error).within(&loaded)
@@ -49,7 +82,7 @@ impl toml {
         engine: &mut Engine,
         /// TOML data.
         data: Spanned<Readable>,
-    ) -> SourceResult<Value> {
+    ) -> SourceResult<Dict> {
         toml(engine, data.map(Readable::into_source))
     }
 
@@ -57,7 +90,9 @@ impl toml {
     #[func(title = "Encode TOML")]
     pub fn encode(
         /// Value to be encoded.
-        value: Spanned<Value>,
+        ///
+        /// TOML documents are tables. Therefore, only dictionaries are suitable.
+        value: Spanned<Dict>,
         /// Whether to pretty-print the resulting TOML.
         #[named]
         #[default(true)]

--- a/crates/typst-library/src/loading/toml.rs
+++ b/crates/typst-library/src/loading/toml.rs
@@ -43,7 +43,7 @@ use crate::loading::{DataSource, Load, Readable};
 ///
 /// Be aware that **TOML integers** larger than 2<sup>63</sup>-1 or smaller than
 /// -2<sup>63</sup> cannot be represented losslessly in Typst, and an error will
-/// be thrown according to the [spec](https://toml.io/en/v1.0.0#integer).
+/// be thrown according to the [specification](https://toml.io/en/v1.0.0#integer).
 ///
 /// | Typst value                           | Converted into TOML            |
 /// | ------------------------------------- | ------------------------------ |
@@ -54,8 +54,8 @@ use crate::loading::{DataSource, Load, Readable};
 /// | [`content`]                           | a table describing the content |
 /// | other types ([`length`], etc.)        | string via [`repr`]            |
 ///
-/// - **Bytes** are not encoded as TOML arrays for performance reasons.
-///   Consider using [`cbor.encode`] for binary data.
+/// - **Bytes** are not encoded as TOML arrays for performance and readability
+///   reasons. Consider using [`cbor.encode`] for binary data.
 ///
 /// - The **`repr`** function is [for debugging purposes only]($repr/#debugging-only),
 ///   and its output is not guaranteed to be stable across typst versions.

--- a/crates/typst-library/src/loading/yaml.rs
+++ b/crates/typst-library/src/loading/yaml.rs
@@ -46,9 +46,10 @@ use crate::loading::{DataSource, Load, Readable};
 /// | mapping                                | [`dictionary`]       |
 ///
 /// - In most cases, **YAML numbers** will be converted to floats or integers
-///   depending on whether they are whole numbers. However, be aware that integers
-///   larger than 2<sup>63</sup>-1 or smaller than -2<sup>63</sup> will be
-///   approximated as floating-point numbers.
+///   depending on whether they are whole numbers. However, be aware that
+///   integers larger than 2<sup>63</sup>-1 or smaller than -2<sup>63</sup> will
+///   be converted to floating-point numbers, which may result in an
+///   approximative value.
 ///
 /// - **Custom YAML tags** are ignored, though the loaded value will still be present.
 ///
@@ -60,8 +61,8 @@ use crate::loading::{DataSource, Load, Readable};
 /// | [`content`]                           | a mapping describing the content |
 /// | other types ([`length`], etc.)        | string via [`repr`]              |
 ///
-/// - **Bytes** are not encoded as YAML sequences for performance reasons.
-///   Consider using [`cbor.encode`] for binary data.
+/// - **Bytes** are not encoded as YAML sequences for performance and readability
+///   reasons. Consider using [`cbor.encode`] for binary data.
 ///
 /// - The **`repr`** function is [for debugging purposes only]($repr/#debugging-only),
 ///   and its output is not guaranteed to be stable across typst versions.

--- a/crates/typst-library/src/loading/yaml.rs
+++ b/crates/typst-library/src/loading/yaml.rs
@@ -8,20 +8,15 @@ use crate::loading::{DataSource, Load, Readable};
 
 /// Reads structured data from a YAML file.
 ///
-/// The file must contain a valid YAML object or array. YAML mappings will be
-/// converted into Typst dictionaries, and YAML sequences will be converted into
-/// Typst arrays. Strings and booleans will be converted into the Typst
-/// equivalents, null-values (`null`, `~` or empty ``) will be converted into
-/// `{none}`, and numbers will be converted to floats or integers depending on
-/// whether they are whole numbers. Custom YAML tags are ignored, though the
-/// loaded value will still be present.
+/// The file must contain a valid YAML object or array. The YAML values will be
+/// converted into corresponding Typst values listed in the [table below](#conversion).
 ///
-/// Be aware that integers larger than 2<sup>63</sup>-1 will be converted to
-/// floating point numbers, which may give an approximative value.
+/// The function returns a dictionary, an array or, depending on the YAML file,
+/// another YAML data type.
 ///
 /// The YAML files in the example contain objects with authors as keys,
 /// each with a sequence of their own submapping with the keys
-/// "title" and "published"
+/// "title" and "published".
 ///
 /// # Example
 /// ```example
@@ -38,6 +33,38 @@ use crate::loading::{DataSource, Load, Readable};
 ///   yaml("scifi-authors.yaml")
 /// )
 /// ```
+///
+/// # Conversion details { #conversion }
+///
+/// | YAML value                             | Converted into Typst |
+/// | -------------------------------------- | -------------------- |
+/// | null-values (`null`, `~` or empty ` `) | `{none}`             |
+/// | boolean                                | [`bool`]             |
+/// | number                                 | [`float`] or [`int`] |
+/// | string                                 | [`str`]              |
+/// | sequence                               | [`array`]            |
+/// | mapping                                | [`dictionary`]       |
+///
+/// - In most cases, **YAML numbers** will be converted to floats or integers
+///   depending on whether they are whole numbers. However, be aware that integers
+///   larger than 2<sup>63</sup>-1 or smaller than -2<sup>63</sup> will be
+///   approximated as floating-point numbers or rejected for parsing.
+///
+/// - **Custom YAML tags** are ignored, though the loaded value will still be present.
+///
+/// | Typst value                           | Converted into YAML              |
+/// | ------------------------------------- | -------------------------------- |
+/// | types that can be converted from YAML | corresponding YAML value         |
+/// | [`bytes`]                             | string via [`repr`]              |
+/// | [`symbol`]                            | string                           |
+/// | [`content`]                           | a mapping describing the content |
+/// | other types ([`length`], etc.)        | string via [`repr`]              |
+///
+/// - **Bytes** are not encoded as YAML sequences for performance reasons.
+///   Consider using [`cbor.encode`] for binary data.
+///
+/// - The **`repr`** function is [for debugging purposes only]($repr/#debugging-only),
+///   and its output is not guaranteed to be stable across typst versions.
 #[func(scope, title = "YAML")]
 pub fn yaml(
     engine: &mut Engine,

--- a/crates/typst-library/src/loading/yaml.rs
+++ b/crates/typst-library/src/loading/yaml.rs
@@ -48,7 +48,7 @@ use crate::loading::{DataSource, Load, Readable};
 /// - In most cases, **YAML numbers** will be converted to floats or integers
 ///   depending on whether they are whole numbers. However, be aware that integers
 ///   larger than 2<sup>63</sup>-1 or smaller than -2<sup>63</sup> will be
-///   approximated as floating-point numbers or rejected for parsing.
+///   approximated as floating-point numbers.
 ///
 /// - **Custom YAML tags** are ignored, though the loaded value will still be present.
 ///

--- a/crates/typst-library/src/loading/yaml.rs
+++ b/crates/typst-library/src/loading/yaml.rs
@@ -9,7 +9,8 @@ use crate::loading::{DataSource, Load, Readable};
 /// Reads structured data from a YAML file.
 ///
 /// The file must contain a valid YAML object or array. The YAML values will be
-/// converted into corresponding Typst values listed in the [table below](#conversion).
+/// converted into corresponding Typst values as listed in the
+/// [table below](#conversion).
 ///
 /// The function returns a dictionary, an array or, depending on the YAML file,
 /// another YAML data type.
@@ -45,14 +46,6 @@ use crate::loading::{DataSource, Load, Readable};
 /// | sequence                               | [`array`]            |
 /// | mapping                                | [`dictionary`]       |
 ///
-/// - In most cases, **YAML numbers** will be converted to floats or integers
-///   depending on whether they are whole numbers. However, be aware that
-///   integers larger than 2<sup>63</sup>-1 or smaller than -2<sup>63</sup> will
-///   be converted to floating-point numbers, which may result in an
-///   approximative value.
-///
-/// - **Custom YAML tags** are ignored, though the loaded value will still be present.
-///
 /// | Typst value                           | Converted into YAML              |
 /// | ------------------------------------- | -------------------------------- |
 /// | types that can be converted from YAML | corresponding YAML value         |
@@ -61,11 +54,20 @@ use crate::loading::{DataSource, Load, Readable};
 /// | [`content`]                           | a mapping describing the content |
 /// | other types ([`length`], etc.)        | string via [`repr`]              |
 ///
-/// - **Bytes** are not encoded as YAML sequences for performance and readability
+/// ## Notes
+/// - In most cases, YAML numbers will be converted to floats or integers
+///   depending on whether they are whole numbers. However, be aware that
+///   integers larger than 2<sup>63</sup>-1 or smaller than -2<sup>63</sup> will
+///   be converted to floating-point numbers, which may result in an
+///   approximative value.
+///
+/// - Custom YAML tags are ignored, though the loaded value will still be present.
+///
+/// - Bytes are not encoded as YAML sequences for performance and readability
 ///   reasons. Consider using [`cbor.encode`] for binary data.
 ///
-/// - The **`repr`** function is [for debugging purposes only]($repr/#debugging-only),
-///   and its output is not guaranteed to be stable across typst versions.
+/// - The `repr` function is [for debugging purposes only]($repr/#debugging-only),
+///   and its output is not guaranteed to be stable across Typst versions.
 #[func(scope, title = "YAML")]
 pub fn yaml(
     engine: &mut Engine,

--- a/docs/reference/library/data-loading.md
+++ b/docs/reference/library/data-loading.md
@@ -2,3 +2,14 @@ Data loading from external files.
 
 These functions help you with loading and embedding data, for example from the
 results of an experiment.
+
+# Encoding
+Some of the functions are also capable of encoding, e.g. [`cbor.encode`]. They
+facilitate passing structured data to [plugins]($plugin).
+
+However, each data format has its own native types. Therefore, for an arbitrary
+Typst value, the encode-to-decode roundtrip might be lossy. In general, numbers,
+strings, and [arrays]($array) or [dictionaries]($dictionary) composed of them
+can be reliably converted, while other types may fall back to strings via [`repr`],
+which is [for debugging purposes only]($repr/#debugging-only). Please refer to
+the page of each data format for details.

--- a/tests/suite/loading/cbor.typ
+++ b/tests/suite/loading/cbor.typ
@@ -22,3 +22,16 @@
     message: "failed to approximately decode " + name,
   )
 }
+
+--- cbor-encode-bytes ---
+#let value = bytes("Typst")
+#test(cbor(cbor.encode(value)), value)
+
+--- cbor-encode-any ---
+#import "edge-case.typ": special-types
+#for value in special-types {
+  test(
+    cbor.encode(value),
+    cbor.encode(repr(value)),
+  )
+}

--- a/tests/suite/loading/edge-case.typ
+++ b/tests/suite/loading/edge-case.typ
@@ -1,5 +1,5 @@
 // SKIP
-// Edge cases in deserialization.
+// Edge cases in serialization and deserialization.
 // They can be imported when testing decoding functions.
 
 #let representable-integer = (
@@ -22,3 +22,21 @@
   (162, 109, 114, 101, 112, 114, 101, 115, 101, 110, 116, 97, 98, 108, 101, 162, 103, 105, 54, 52, 95, 109, 97, 120, 27, 127, 255, 255, 255, 255, 255, 255, 255, 103, 105, 54, 52, 95, 109, 105, 110, 59, 127, 255, 255, 255, 255, 255, 255, 255, 101, 108, 97, 114, 103, 101, 167, 112, 105, 54, 52, 95, 109, 97, 120, 95, 112, 108, 117, 115, 95, 111, 110, 101, 27, 128, 0, 0, 0, 0, 0, 0, 0, 113, 105, 54, 52, 95, 109, 105, 110, 95, 109, 105, 110, 117, 115, 95, 111, 110, 101, 59, 128, 0, 0, 0, 0, 0, 0, 0, 103, 117, 54, 52, 95, 109, 97, 120, 27, 255, 255, 255, 255, 255, 255, 255, 255, 112, 117, 54, 52, 95, 109, 97, 120, 95, 112, 108, 117, 115, 95, 111, 110, 101, 194, 73, 1, 0, 0, 0, 0, 0, 0, 0, 0, 104, 105, 49, 50, 56, 95, 109, 97, 120, 194, 80, 
 127, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 104, 105, 49, 50, 56, 95, 109, 105, 110, 195, 80, 127, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 104, 117, 49, 50, 56, 95, 109, 97, 120, 194, 80, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255),
 )
+
+// These special Typst types are supported by neither human-readable nor binary
+// data formats. They should fall back to strings via `repr` when encoded, but
+// the specific output can be changed.
+#let special-types = (
+  decimal("2.99792458"),
+  3.14159pt,
+  2.99em,
+  <sec:intro>,
+  panic,
+  x => x + 1,
+  regex("\p{Letter}"),
+  stroke(red + 5pt),
+  auto,
+)
+
+// These special Typst types are not supported by human-readable data formats.
+#let special-types-for-human = special-types + (bytes("Typst"),)

--- a/tests/suite/loading/json.typ
+++ b/tests/suite/loading/json.typ
@@ -38,3 +38,12 @@
     message: "failed to approximately decode " + name,
   )
 }
+
+--- json-encode-any ---
+#import "edge-case.typ": special-types-for-human
+#for value in special-types-for-human {
+  test(
+    json.encode(value),
+    json.encode(repr(value)),
+  )
+}

--- a/tests/suite/loading/toml.typ
+++ b/tests/suite/loading/toml.typ
@@ -69,3 +69,20 @@
 #import "edge-case.typ": large-integer
 // Error: 7-56 failed to parse TOML (number too small to fit in target type at 1:7)
 #toml(bytes("key = " + large-integer.i64-min-minus-one))
+
+--- toml-encode-any ---
+#import "edge-case.typ": special-types-for-human
+#for value in special-types-for-human {
+  test(
+    toml.encode((key: value)),
+    toml.encode((key: repr(value))),
+  )
+}
+
+--- toml-encode-non-table ---
+// Error: 14-15 expected dictionary, found integer
+#toml.encode(3)
+
+--- toml-decode-non-table ---
+// Error: 7-17 failed to parse TOML (expected `.`, `=` at 1:2)
+#toml(bytes("3"))

--- a/tests/suite/loading/yaml.typ
+++ b/tests/suite/loading/yaml.typ
@@ -39,3 +39,12 @@
     message: "failed to approximately decode " + name,
   )
 }
+
+--- yaml-encode-any ---
+#import "edge-case.typ": special-types-for-human
+#for value in special-types-for-human {
+  test(
+    yaml.encode(value),
+    yaml.encode(repr(value)),
+  )
+}


### PR DESCRIPTION
Unify and document the behaviours of `{json,yaml,toml,cbor}.encode`

Resolves #6738

## Update docs related to data loading and `repr`

- Add a _Conversion details_ section to each format.

- Mention that `*.encode` may fall back to `repr`, and explain common confusions.

- Fix a few copy-and-paste errors.

- Use the terms of each format.

  For instance, JSON object, YAML mapping, TOML table, CBOR map.
  (People are really good at coining names.)
  In addition, integer and floats are distinct in TOML and CBOR, but unified as _numbers_ in JSON and YAML.

- ~~Mention that `cbor.encode` uses ciborium, and other implementations may not be able to parse its result.~~

  Now reverted. [`serde_cbor`](https://crates.io/crates/serde_cbor) has been archvied for 4 years. Therefore, it's not really important nowadays.

## Code changes

- Change `serialize_str(bytes)` from `Debug::fmt` to `repr`.

  That is, _Bytes(n)_ → _bytes(n)_ for human readable formats (JSON, YAML, TOML).

- Narrow the input of `toml.decode` and the output of `toml` from `Value` to `Dict`.

  Because TOML documents can only be tables.

## References

- Initial discussions in #1935
- [serde_json 1.0.138](https://docs.rs/serde_json/1.0.138/serde_json/value/enum.Value.html)
- ~~[serde_yaml 0.8.26](https://docs.rs/serde_yaml/0.8.26/serde_yaml/enum.Value.html)~~ [serde_yaml 0.9.34](https://docs.rs/serde_yaml/0.9.34+deprecated/serde_yaml/enum.Value.html)
- [toml 0.8.19](https://docs.rs/toml/0.8.19/toml/enum.Value.html)
- [ciborium 0.2.2](https://docs.rs/ciborium/0.2.2/ciborium/enum.Value.html)

## Additional notes on decoding large integers

The behaviour is now improved in #6836. 

<details><summary>The original notes</summary>

A large integer will be approximated as a floating-point number or rejected for parsing.
It depends on how large it is, and how the deserializer is implemented.

Previous docs:
- JSON: large integers are approximated to floating point numbers
- YAML: large integers are approximated to floating point numbers
- TOML: numbers are converted to floats or integers
- CBOR: large integers are approximated to floating point numbers

This PR:

- JSON: large integers are approximated to floating point numbers
- YAML: large integers are approximated to floating point numbers or rejected for parsing
- TOML: large integers are rejected for parsing
- CBOR: large integers are approximated to floating point numbers or rejected for parsing

Actual behaviours and analyses:
- ✅ JSON: matches previous docs.
- 🙁 YAML: copied from json and sensitive to `serde_yaml` version (see below)
- ✅ TOML: the spec says _an error must be thrown_ explicitly
- 🙁 CBOR: copied from json

| Format | $2^{63} - 1$ | $2^{63}$                | $-2^{63}-1$                      | $2^{63} \times 10$               |
| ------ | ------------ | ----------------------- | -------------------------------- | -------------------------------- |
| JSON   | int          | float                   | float                            | float                            |
| YAML   | int          | float                   | Error: i128 is not a typst value | Error: u128 is not a typst value |
| TOML   | int          | Error: number too large | Error: number too small          | Error: number too large          |
| CBOR   | int          | float                   | Error: i128 is not a typst value | Error: u128 is not a typst value |

<details><summary>Test code</summary>

```typst
#assert.eq(type(json(bytes("9223372036854775807"))), int)
#assert.eq(type(json(bytes("9223372036854775808"))), float)
#assert.eq(type(json(bytes("-9223372036854775809"))), float)
#assert.eq(type(json(bytes("92233720368547758080"))), float)


#assert.eq(type(yaml(bytes("9223372036854775807"))), int)
#assert.eq(type(yaml(bytes("9223372036854775808"))), float)
// [Error] Failed to parse YAML (invalid type: integer -9223372036854775809 as i128, expected a typst value)
// #yaml(bytes("-9223372036854775809"))
// [Error] Failed to parse YAML (invalid type: integer 92233720368547758080 as u128, expected a typst value)
// #yaml(bytes("92233720368547758080"))

#assert.eq(type(toml(bytes("a = 9223372036854775807")).a), int)
// [Error] Failed to parse TOML (number too small to fit in target type at line 1 column 5)
// #toml(bytes("a = -9223372036854775809"))
// [Error] Failed to parse TOML (number too large to fit in target type at line 1 column 5)
// #toml(bytes("a = 9223372036854775808"))
// [Error] Failed to parse TOML (number too large to fit in target type at line 1 column 5)
// #toml(bytes("a = 92233720368547758080"))

#assert.eq(type(cbor(bytes((27, 127, 255, 255, 255, 255, 255, 255, 255)))), int)
#assert.eq(type(cbor(bytes((27, 128, 0, 0, 0, 0, 0, 0, 0)))), float)
// [Error] Failed to parse CBOR (Semantic(None, "invalid type: integer -9223372036854775809 as i128, expected a typst value")) 
// #cbor(bytes((59, 128, 0, 0, 0, 0, 0, 0, 0)))
// [Error] Failed to parse CBOR (Semantic(None, "invalid type: integer 92233720368547758080 as u128, expected a typst value")) 
// #cbor(bytes((194, 73, 5, 0, 0, 0, 0, 0, 0, 0, 0)))
```

</details> 

`serde_yaml` behaviour depends on version. [The following code is ok for `serde_yaml` 0.9.34](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=1d7140a79f626252475cf57d6225b517) (latest, used by hayagriva), but panics with ``invalid type: integer `-9223372036854775809` as i128, expected f64`` for `serde_yaml` 0.8.26 (~~used by typst~~).

```rust
let x: f64 = serde_yaml::from_str("-9223372036854775809").unwrap();
```

**Update:** The typst project contains two versions of `serde_yaml`: 0.9.34 is directly used by both hayagriva and typst, and 0.8.26 is used by typst via yaml-front-matter. Therefore, the above analysis might be inaccurate.

--- 

A bit related to #3157.
</details>