### PR TITLE
Move grid cell locator creation to GridLayouter

### DIFF
--- a/crates/typst-html/src/rules.rs
+++ b/crates/typst-html/src/rules.rs
@@ -5,7 +5,7 @@ use typst_library::diag::{At, bail, warning};
 use typst_library::foundations::{
     Content, NativeElement, NativeRuleMap, ShowFn, Smart, StyleChain, Target,
 };
-use typst_library::introspection::{Counter, Locator};
+use typst_library::introspection::Counter;
 use typst_library::layout::resolve::{Cell, CellGrid, Entry, table_to_cellgrid};
 use typst_library::layout::{BlockBody, BlockElem, BoxElem, OuterVAlignment, Sizing};
 use typst_library::model::{
@@ -278,9 +278,7 @@ const REF_RULE: ShowFn<RefElem> = |elem, engine, styles| elem.realize(engine, st
 const CITE_GROUP_RULE: ShowFn<CiteGroup> = |elem, engine, _| elem.realize(engine);
 
 const TABLE_RULE: ShowFn<TableElem> = |elem, engine, styles| {
-    // The locator is not used by HTML export, so we can just fabricate one.
-    let locator = Locator::root();
-    Ok(show_cellgrid(table_to_cellgrid(elem, engine, locator, styles)?, styles))
+    Ok(show_cellgrid(table_to_cellgrid(elem, engine, styles)?, styles))
 };
 
 fn show_cellgrid(grid: CellGrid, styles: StyleChain) -> Content {

--- a/crates/typst-layout/src/grid/layouter.rs
+++ b/crates/typst-layout/src/grid/layouter.rs
@@ -275,16 +275,23 @@ impl<'a> GridLayouter<'a> {
         }
     }
 
+    /// Create a [`Locator`] for use in [`layout_cell`].
     pub(super) fn cell_locator(
         &self,
         pos: Axes<usize>,
         disambiguator: usize,
     ) -> Locator<'a> {
-        let mut locator = self.locator.relayout().split().next(&pos);
+        // This key is unique for each cell position, so the split locator can
+        // be side-stepped.
+        let key = ((pos.x as u128) << 64) | (pos.y as u128);
+        let mut cell_locator = self.locator.relayout().split().next_inner(key);
+
+        // The disambiguator is used for repeated cells, e.g. in repeated headers.
         if disambiguator > 0 {
-            locator = locator.split().next_inner(disambiguator as u128);
+            cell_locator = cell_locator.split().next_inner(disambiguator as u128);
         }
-        locator
+
+        cell_locator
     }
 
     /// Determines the columns sizes and then layouts the grid row-by-row.

--- a/crates/typst-layout/src/grid/layouter.rs
+++ b/crates/typst-layout/src/grid/layouter.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
 use std::fmt::Debug;
 
+use rustc_hash::FxHashMap;
 use typst_library::diag::{SourceResult, bail};
 use typst_library::engine::Engine;
 use typst_library::foundations::{Resolve, StyleChain};
@@ -30,7 +30,7 @@ pub struct GridLayouter<'a> {
     /// The regions to layout children into.
     pub(super) regions: Regions<'a>,
     /// The locators for the each cell in the cell grid.
-    pub(super) cell_locators: HashMap<Axes<usize>, Locator<'a>>,
+    pub(super) cell_locators: FxHashMap<Axes<usize>, Locator<'a>>,
     /// The inherited styles.
     pub(super) styles: StyleChain<'a>,
     /// Resolved column sizes.
@@ -246,7 +246,7 @@ impl<'a> GridLayouter<'a> {
 
         // Prepare the locators for each cell in the cell grid.
         let mut locator = locator.split();
-        let mut cell_locators = HashMap::new();
+        let mut cell_locators = FxHashMap::default();
         for y in 0..grid.rows.len() {
             for x in 0..grid.cols.len() {
                 let Some(Entry::Cell(cell)) = grid.entry(x, y) else {

--- a/crates/typst-layout/src/grid/layouter.rs
+++ b/crates/typst-layout/src/grid/layouter.rs
@@ -29,7 +29,7 @@ pub struct GridLayouter<'a> {
     pub(super) grid: &'a CellGrid,
     /// The regions to layout children into.
     pub(super) regions: Regions<'a>,
-    /// The locator for the grid.
+    /// The locators for the each cell in the cell grid.
     pub(super) cell_locators: HashMap<Axes<usize>, Locator<'a>>,
     /// The inherited styles.
     pub(super) styles: StyleChain<'a>,

--- a/crates/typst-layout/src/grid/lines.rs
+++ b/crates/typst-layout/src/grid/lines.rs
@@ -560,17 +560,15 @@ pub fn hline_stroke_at_column(
 mod test {
     use std::num::NonZeroUsize;
     use typst_library::foundations::Content;
-    use typst_library::introspection::Locator;
     use typst_library::layout::grid::resolve::{Cell, Entry, LinePosition};
     use typst_library::layout::{Axes, Sides, Sizing};
     use typst_utils::NonZeroExt;
 
     use super::*;
 
-    fn sample_cell() -> Cell<'static> {
+    fn sample_cell() -> Cell {
         Cell {
             body: Content::default(),
-            locator: Locator::root(),
             fill: None,
             colspan: NonZeroUsize::ONE,
             rowspan: NonZeroUsize::ONE,
@@ -580,10 +578,9 @@ mod test {
         }
     }
 
-    fn cell_with_colspan_rowspan(colspan: usize, rowspan: usize) -> Cell<'static> {
+    fn cell_with_colspan_rowspan(colspan: usize, rowspan: usize) -> Cell {
         Cell {
             body: Content::default(),
-            locator: Locator::root(),
             fill: None,
             colspan: NonZeroUsize::try_from(colspan).unwrap(),
             rowspan: NonZeroUsize::try_from(rowspan).unwrap(),
@@ -593,7 +590,7 @@ mod test {
         }
     }
 
-    fn sample_grid_for_vlines(gutters: bool) -> CellGrid<'static> {
+    fn sample_grid_for_vlines(gutters: bool) -> CellGrid {
         const COLS: usize = 4;
         const ROWS: usize = 6;
         let entries = vec![
@@ -1116,7 +1113,7 @@ mod test {
         }
     }
 
-    fn sample_grid_for_hlines(gutters: bool) -> CellGrid<'static> {
+    fn sample_grid_for_hlines(gutters: bool) -> CellGrid {
         const COLS: usize = 4;
         const ROWS: usize = 9;
         let entries = vec![

--- a/crates/typst-layout/src/grid/mod.rs
+++ b/crates/typst-layout/src/grid/mod.rs
@@ -28,14 +28,10 @@ use self::rowspans::{Rowspan, UnbreakableRowGroup};
 pub fn layout_cell(
     cell: &Cell,
     engine: &mut Engine,
-    disambiguator: usize,
+    locator: Locator,
     styles: StyleChain,
     regions: Regions,
 ) -> SourceResult<Fragment> {
-    let mut locator = cell.locator.relayout();
-    if disambiguator > 0 {
-        locator = locator.split().next_inner(disambiguator as u128);
-    }
     crate::layout_fragment(engine, &cell.body, locator, styles, regions)
 }
 
@@ -48,8 +44,8 @@ pub fn layout_grid(
     styles: StyleChain,
     regions: Regions,
 ) -> SourceResult<Fragment> {
-    let grid = grid_to_cellgrid(elem, engine, locator, styles)?;
-    GridLayouter::new(&grid, regions, styles, elem.span()).layout(engine)
+    let grid = grid_to_cellgrid(elem, engine, styles)?;
+    GridLayouter::new(&grid, regions, locator, styles, elem.span()).layout(engine)
 }
 
 /// Layout the table.
@@ -61,6 +57,6 @@ pub fn layout_table(
     styles: StyleChain,
     regions: Regions,
 ) -> SourceResult<Fragment> {
-    let grid = table_to_cellgrid(elem, engine, locator, styles)?;
-    GridLayouter::new(&grid, regions, styles, elem.span()).layout(engine)
+    let grid = table_to_cellgrid(elem, engine, styles)?;
+    GridLayouter::new(&grid, regions, locator, styles, elem.span()).layout(engine)
 }

--- a/crates/typst-layout/src/grid/rowspans.rs
+++ b/crates/typst-layout/src/grid/rowspans.rs
@@ -145,7 +145,8 @@ impl GridLayouter<'_> {
         }
 
         // Push the layouted frames directly into the finished frames.
-        let fragment = layout_cell(cell, engine, disambiguator, self.styles, pod)?;
+        let locator = self.cell_locator(Axes::new(x, y), disambiguator);
+        let fragment = layout_cell(cell, engine, locator, self.styles, pod)?;
         let (current_region, current_header_row_height) = current_region_data.unzip();
 
         // Clever trick to process finished header rows:

--- a/crates/typst-layout/src/lists.rs
+++ b/crates/typst-layout/src/lists.rs
@@ -36,8 +36,6 @@ pub fn layout_list(
         .aligned(HAlignment::Start + VAlignment::Top);
 
     let mut cells = vec![];
-    let mut locator = locator.split();
-
     for item in &elem.children {
         // Text in wide lists shall always turn into paragraphs.
         let mut body = item.body.clone();
@@ -45,13 +43,10 @@ pub fn layout_list(
             body += ParbreakElem::shared();
         }
 
-        cells.push(Cell::new(Content::empty(), locator.next(&())));
-        cells.push(Cell::new(marker.clone(), locator.next(&marker.span())));
-        cells.push(Cell::new(Content::empty(), locator.next(&())));
-        cells.push(Cell::new(
-            body.set(ListElem::depth, Depth(1)),
-            locator.next(&item.body.span()),
-        ));
+        cells.push(Cell::new(Content::empty()));
+        cells.push(Cell::new(marker.clone()));
+        cells.push(Cell::new(Content::empty()));
+        cells.push(Cell::new(body.set(ListElem::depth, Depth(1))));
     }
 
     let grid = CellGrid::new(
@@ -64,7 +59,7 @@ pub fn layout_list(
         Axes::with_y(&[gutter.into()]),
         cells,
     );
-    let layouter = GridLayouter::new(&grid, regions, styles, elem.span());
+    let layouter = GridLayouter::new(&grid, regions, locator, styles, elem.span());
 
     layouter.layout(engine)
 }
@@ -88,7 +83,6 @@ pub fn layout_enum(
     });
 
     let mut cells = vec![];
-    let mut locator = locator.split();
     let mut number = elem
         .start
         .get(styles)
@@ -131,13 +125,10 @@ pub fn layout_enum(
             body += ParbreakElem::shared();
         }
 
-        cells.push(Cell::new(Content::empty(), locator.next(&())));
-        cells.push(Cell::new(resolved, locator.next(&())));
-        cells.push(Cell::new(Content::empty(), locator.next(&())));
-        cells.push(Cell::new(
-            body.set(EnumElem::parents, smallvec![number]),
-            locator.next(&item.body.span()),
-        ));
+        cells.push(Cell::new(Content::empty()));
+        cells.push(Cell::new(resolved));
+        cells.push(Cell::new(Content::empty()));
+        cells.push(Cell::new(body.set(EnumElem::parents, smallvec![number])));
         number =
             if reversed { number.saturating_sub(1) } else { number.saturating_add(1) };
     }
@@ -152,7 +143,7 @@ pub fn layout_enum(
         Axes::with_y(&[gutter.into()]),
         cells,
     );
-    let layouter = GridLayouter::new(&grid, regions, styles, elem.span());
+    let layouter = GridLayouter::new(&grid, regions, locator, styles, elem.span());
 
     layouter.layout(engine)
 }


### PR DESCRIPTION
This avoids storing `Locator`s inside the `CellGrid` and by that removes the lifetime parameter. I did this primarily to be able to store the `CellGrid` in a wrapper element in introspection tags, so it can be used in the pdf export for accessibility tags. But I think it cleans up the design overall.
Instead of using the cell body spans for initial disambiguation in the cell grid, the cell coordinates are used (which should never collide). And then the additional layouting disambiguator is used as before.
I'm not 100% sure this is correct, so maybe you can have a look at the `GridLayouter::cell_locator` function, but all tests seem to pass :)