### PR TITLE
Don't hide captured inner lifetime

### DIFF
--- a/crates/typst-library/src/visualize/image/pdf.rs
+++ b/crates/typst-library/src/visualize/image/pdf.rs
@@ -70,7 +70,7 @@ impl PdfImage {
     }
 
     /// Returns the PDF page of the image.
-    pub fn page(&self) -> &Page {
+    pub fn page(&self) -> &Page<'_> {
         &self.document().pdf().pages()[self.0.page_index]
     }
 


### PR DESCRIPTION
Same as the small `pdf-writer` PR. From what I can gather the inner lifetime could be `'static`, but since this is because it's cached, which could change, so I opted for the shortened lifetime (which is what I think rustc does here too).