### PR TITLE
Improve docs of `Cell<T>` params of `table` and `grid`

### DIFF
--- a/crates/typst-library/src/layout/grid/mod.rs
+++ b/crates/typst-library/src/layout/grid/mod.rs
@@ -100,7 +100,7 @@ use crate::visualize::{Paint, Stroke};
 /// )
 /// ```
 ///
-/// # Styling the grid
+/// # Styling the grid { #styling }
 /// The grid's appearance can be customized through different parameters. These
 /// are the most important ones:
 ///
@@ -174,9 +174,9 @@ pub struct GridElem {
 
     /// How to fill the cells.
     ///
-    /// This can be a color or a function that returns a color. The function
-    /// receives the cells' column and row indices, starting from zero. This can
-    /// be used to implement striped grids.
+    /// This can be a color or a [function that returns a color]($styling). The
+    /// function receives the cells' column and row indices, starting from zero.
+    /// This can be used to implement striped grids.
     ///
     /// ```example
     /// #grid(

--- a/crates/typst-library/src/model/table.rs
+++ b/crates/typst-library/src/model/table.rs
@@ -146,7 +146,7 @@ pub struct TableElem {
     ///
     /// This can be a color or a function that returns a color. The function
     /// receives the cells' column and row indices, starting from zero. This can
-    /// be used to implement striped tables.
+    /// be used to [implement striped tables]($guides/table-guide/#fills).
     ///
     /// ```example
     /// #table(
@@ -173,6 +173,9 @@ pub struct TableElem {
     /// The function receives the cells' column and row indices, starting from
     /// zero. If set to `{auto}`, the outer alignment is used.
     ///
+    /// The table guide has a
+    /// [dedicated section on alignment]($guides/table-guide/#alignment).
+    ///
     /// ```example
     /// #table(
     ///   columns: 3,
@@ -193,7 +196,8 @@ pub struct TableElem {
     /// [`table.hline`] and [`table.vline`] alongside your table cells.
     ///
     /// See the [grid documentation]($grid.stroke) for more information on
-    /// strokes.
+    /// strokes, or the [table guide]($guides/table-guide/#strokes) for
+    /// practical usages.
     #[fold]
     #[default(Celled::Value(Sides::splat(Some(Some(Arc::new(Stroke::default()))))))]
     pub stroke: Celled<Sides<Option<Option<Arc<Stroke>>>>>,


### PR DESCRIPTION
**(Not finished yet)**

- Add links to the table guide.
- Improve the general description about `Cell<T>` ([`$grid/#styling`](https://typst.app/docs/reference/layout/grid/#styling-the-grid)), and add links to it.
- Document arguments and returned values of functions, fields of dictionaries, and items of arrays.

Relates-to: #408
