### PR TITLE
Use `stylistic-set: 1` in favor of `ss01` in docs and tests

### DIFF
--- a/crates/typst-library/src/math/style.rs
+++ b/crates/typst-library/src/math/style.rs
@@ -91,13 +91,13 @@ pub fn cal(
 /// in Typst, however only a few math fonts currently support this.
 ///
 /// The other way is using [font features]($text.features). For example, the
-/// roundhand style might be available in a font through the `ss01` feature.
-/// To use it in Typst, you could then define your own version of `scr` like
-/// this:
+/// roundhand style might be available in a font through the
+/// _[stylistic set]($text.stylistic-set) 1_ (`ss01`) feature. To use it in
+/// Typst, you could then define your own version of `scr` like this:
 ///
 /// ```example
 /// #let scr(it) = text(
-///   features: ("ss01",),
+///   stylistic-set: 1,
 ///   $cal(it)$,
 /// )
 ///

--- a/tests/suite/math/text.typ
+++ b/tests/suite/math/text.typ
@@ -18,7 +18,7 @@ $ "hi ∅ hey" $
 $ sum_(i in NN) 1 + i $
 
 --- math-font-features-switch ---
-#let scr(it) = text(features: ("ss01",), $cal(it)$)
+#let scr(it) = text(stylistic-set: 1, $cal(it)$)
 $cal(P)_i != scr(P)_i$, $cal(bold(I))_l != bold(scr(I))_l$
 $ product.co_(B in scr(B))^(B in scr(bold(B))) cal(B)(X) $
 
@@ -29,7 +29,7 @@ $ product.co_(B in scr(B))^(B in scr(bold(B))) cal(B)(X) $
     (name: "XITS Math", covers: regex("[\u{1D49C}-\u{1D503}]")),
     "New Computer Modern Math"
   ),
-  features: ("ss01",),
+  stylistic-set: 1,
 )
 $ cal(P)_i (X) * cal(C)_1 $
 


### PR DESCRIPTION
They are equivalent, but `stylistic-set: 1` is less cryptic than `features: ("ss01",)`. (I thought `ss` means script style…)

_Stylistic Set 1_ is the “friendly name” of `ss01`.
Ref: [Registered features, p-t (OpenType 1.9.1) - Typography | Microsoft Learn](https://learn.microsoft.com/en-us/typography/opentype/spec/features_pt#tag-ss01---ss20)
