### PR TITLE
Add initial support for variable fonts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,21 +958,19 @@ dependencies = [
 
 [[package]]
 name = "hayro"
-version = "0.1.0"
-source = "git+https://github.com/LaurenzV/hayro?rev=e701f95#e701f9569157a2fe4ade68930dc9e9283782dcca"
+version = "0.2.0"
+source = "git+https://github.com/LaurenzV/hayro?rev=cbebe75#cbebe75cbd131b97349a2f78507c508c0d01390d"
 dependencies = [
  "bytemuck",
  "hayro-interpret",
  "image",
  "kurbo",
- "rustc-hash",
- "smallvec",
 ]
 
 [[package]]
 name = "hayro-font"
 version = "0.1.0"
-source = "git+https://github.com/LaurenzV/hayro?rev=e701f95#e701f9569157a2fe4ade68930dc9e9283782dcca"
+source = "git+https://github.com/LaurenzV/hayro?rev=cbebe75#cbebe75cbd131b97349a2f78507c508c0d01390d"
 dependencies = [
  "log",
  "phf",
@@ -980,8 +978,8 @@ dependencies = [
 
 [[package]]
 name = "hayro-interpret"
-version = "0.1.0"
-source = "git+https://github.com/LaurenzV/hayro?rev=e701f95#e701f9569157a2fe4ade68930dc9e9283782dcca"
+version = "0.2.0"
+source = "git+https://github.com/LaurenzV/hayro?rev=cbebe75#cbebe75cbd131b97349a2f78507c508c0d01390d"
 dependencies = [
  "bitflags 2.9.1",
  "hayro-font",
@@ -990,15 +988,17 @@ dependencies = [
  "log",
  "phf",
  "qcms",
- "skrifa",
+ "rustc-hash",
+ "siphasher",
+ "skrifa 0.32.0",
  "smallvec",
  "yoke 0.8.0",
 ]
 
 [[package]]
 name = "hayro-syntax"
-version = "0.0.1"
-source = "git+https://github.com/LaurenzV/hayro?rev=e701f95#e701f9569157a2fe4ade68930dc9e9283782dcca"
+version = "0.2.0"
+source = "git+https://github.com/LaurenzV/hayro?rev=cbebe75#cbebe75cbd131b97349a2f78507c508c0d01390d"
 dependencies = [
  "flate2",
  "kurbo",
@@ -1010,8 +1010,8 @@ dependencies = [
 
 [[package]]
 name = "hayro-write"
-version = "0.1.0"
-source = "git+https://github.com/LaurenzV/hayro?rev=e701f95#e701f9569157a2fe4ade68930dc9e9283782dcca"
+version = "0.2.0"
+source = "git+https://github.com/LaurenzV/hayro?rev=cbebe75#cbebe75cbd131b97349a2f78507c508c0d01390d"
 dependencies = [
  "flate2",
  "hayro-syntax",
@@ -1416,7 +1416,7 @@ dependencies = [
 [[package]]
 name = "krilla"
 version = "0.4.0"
-source = "git+https://github.com/LaurenzV/krilla?rev=abdf031#abdf031c9e5ba89d606f6f145fad648c75812aec"
+source = "git+https://github.com/LaurenzV/krilla?rev=e856746#e856746be51fce7709ddc746fc16e389fbfa2daf"
 dependencies = [
  "base64",
  "bumpalo",
@@ -1434,7 +1434,7 @@ dependencies = [
  "rustc-hash",
  "rustybuzz",
  "siphasher",
- "skrifa",
+ "skrifa 0.33.2",
  "smallvec",
  "subsetter",
  "tiny-skia-path",
@@ -1446,7 +1446,7 @@ dependencies = [
 [[package]]
 name = "krilla-svg"
 version = "0.1.0"
-source = "git+https://github.com/LaurenzV/krilla?rev=abdf031#abdf031c9e5ba89d606f6f145fad648c75812aec"
+source = "git+https://github.com/LaurenzV/krilla?rev=e856746#e856746be51fce7709ddc746fc16e389fbfa2daf"
 dependencies = [
  "flate2",
  "fontdb",
@@ -1895,8 +1895,7 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 [[package]]
 name = "pdf-writer"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ea27c5015ab81753fc61e49f8cde74999346605ee148bb20008ef3d3150e0dc"
+source = "git+https://github.com/typst/pdf-writer?rev=143a1c3#143a1c3543a1422a22bda40a68022d0d9ad3a40e"
 dependencies = [
  "bitflags 2.9.1",
  "itoa",
@@ -2158,6 +2157,16 @@ name = "read-fonts"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "192735ef611aac958468e670cb98432c925426f3cb71521fda202130f7388d91"
+dependencies = [
+ "bytemuck",
+ "font-types",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8250b8f09ed4b9ba9271e06f10e7b1f03e8f8e3619e2368a991ecb25efa204"
 dependencies = [
  "bytemuck",
  "font-types",
@@ -2488,7 +2497,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d632b5a73f566303dbeabd344dc3e716fd4ddc9a70d6fc8ea8e6f06617da97"
 dependencies = [
  "bytemuck",
- "read-fonts",
+ "read-fonts 0.30.1",
+]
+
+[[package]]
+name = "skrifa"
+version = "0.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78cc1f79e5624f166718224ef883095bea315801aca75b62c64f3937755a586d"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.31.3",
 ]
 
 [[package]]
@@ -2587,10 +2606,12 @@ dependencies = [
 [[package]]
 name = "subsetter"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35725d9d2d056905865f8a36146e45be43691b15fc5d973bd7f79dd438288544"
+source = "git+https://github.com/typst/subsetter?rev=02ad2a4#02ad2a43e9f1fce02a194018ec5687c107e87ce4"
 dependencies = [
+ "kurbo",
  "rustc-hash",
+ "skrifa 0.33.2",
+ "write-fonts",
 ]
 
 [[package]]
@@ -3797,6 +3818,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
  "bitflags 2.9.1",
+]
+
+[[package]]
+name = "write-fonts"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cac89848aeba9b7e1877f1e89e3f9c95adb8771f640e1ef23c605aa734748c2b"
+dependencies = [
+ "font-types",
+ "indexmap 2.7.1",
+ "kurbo",
+ "log",
+ "read-fonts 0.31.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,8 @@ fs_extra = "1.3"
 rustc-hash = "2.1"
 glidesort = "0.1.2"
 hayagriva = "0.8.1"
-hayro-syntax = { git = "https://github.com/LaurenzV/hayro", rev = "e701f95" }
-hayro = { git = "https://github.com/LaurenzV/hayro", rev = "e701f95" }
+hayro-syntax = { git = "https://github.com/LaurenzV/hayro", rev = "cbebe75" }
+hayro = { git = "https://github.com/LaurenzV/hayro", rev = "cbebe75" }
 heck = "0.5"
 hypher = "0.1.4"
 icu_properties = { version = "1.4", features = ["serde"] }
@@ -75,8 +75,8 @@ image = { version = "0.25.5", default-features = false, features = ["png", "jpeg
 indexmap = { version = "2", features = ["serde"] }
 infer = { version = "0.19.0", default-features = false }
 kamadak-exif = "0.6"
-krilla = { git = "https://github.com/LaurenzV/krilla", rev = "abdf031", default-features = false, features = ["raster-images", "comemo", "rayon", "pdf"] }
-krilla-svg = { git = "https://github.com/LaurenzV/krilla", rev = "abdf031" }
+krilla = { git = "https://github.com/LaurenzV/krilla", rev = "e856746", default-features = false, features = ["raster-images", "comemo", "rayon", "pdf"] }
+krilla-svg = { git = "https://github.com/LaurenzV/krilla", rev = "e856746" }
 kurbo = "0.11"
 libfuzzer-sys = "0.4"
 lipsum = "0.9"

--- a/crates/typst-cli/src/fonts.rs
+++ b/crates/typst-cli/src/fonts.rs
@@ -13,7 +13,8 @@ pub fn fonts(command: &FontsCommand) {
         println!("{name}");
         if command.variants {
             for info in infos {
-                let FontVariantCoverage { style, weight, stretch } = info.variant_coverage.clone();
+                let FontVariantCoverage { style, weight, stretch } =
+                    info.variant_coverage.clone();
                 println!("- Style: {style:?}, Weight: {weight:?}, Stretch: {stretch:?}");
             }
         }

--- a/crates/typst-cli/src/fonts.rs
+++ b/crates/typst-cli/src/fonts.rs
@@ -1,4 +1,4 @@
-use typst::text::FontVariant;
+use typst::text::FontVariantCoverage;
 use typst_kit::fonts::Fonts;
 
 use crate::args::FontsCommand;
@@ -13,7 +13,7 @@ pub fn fonts(command: &FontsCommand) {
         println!("{name}");
         if command.variants {
             for info in infos {
-                let FontVariant { style, weight, stretch } = info.variant;
+                let FontVariantCoverage { style, weight, stretch } = info.variant_coverage.clone();
                 println!("- Style: {style:?}, Weight: {weight:?}, Stretch: {stretch:?}");
             }
         }

--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -10,7 +10,7 @@ use rustc_hash::FxHashMap;
 use typst::diag::{FileError, FileResult};
 use typst::foundations::{Bytes, Datetime, Dict, IntoValue};
 use typst::syntax::{FileId, Lines, Source, VirtualPath};
-use typst::text::{Font, FontBook};
+use typst::text::{Font, FontBook, FontKey};
 use typst::utils::LazyHash;
 use typst::{Library, LibraryExt, World};
 use typst_kit::fonts::{FontSlot, Fonts};
@@ -220,10 +220,10 @@ impl World for SystemWorld {
         self.slot(id, |slot| slot.file(&self.root, &self.package_storage))
     }
 
-    fn font(&self, index: usize) -> Option<Font> {
+    fn font(&self, key: FontKey) -> Option<Font> {
         // comemo's validation may invoke this function with an invalid index. This is
         // impossible in typst-cli but possible if a custom tool mutates the fonts.
-        self.fonts.get(index)?.get()
+        self.fonts.get(key.index)?.get(key.instance_params)
     }
 
     fn today(&self, offset: Option<i64>) -> Option<Datetime> {

--- a/crates/typst-ide/src/utils.rs
+++ b/crates/typst-ide/src/utils.rs
@@ -78,14 +78,14 @@ pub fn plain_docs_sentence(docs: &str) -> EcoString {
 
 /// Create a short description of a font family.
 pub fn summarize_font_family(mut variants: Vec<&FontInfo>) -> EcoString {
-    variants.sort_by_key(|info| info.variant);
+    variants.sort_by_key(|info| info.variant_coverage);
 
     let mut has_italic = false;
     let mut min_weight = u16::MAX;
     let mut max_weight = 0;
     for info in &variants {
-        let weight = info.variant.weight.to_number();
-        has_italic |= info.variant.style == FontStyle::Italic;
+        let weight = info.variant_coverage.weight.to_number();
+        has_italic |= info.variant_coverage.style == FontStyle::Italic;
         min_weight = min_weight.min(weight);
         max_weight = min_weight.max(weight);
     }

--- a/crates/typst-kit/src/fonts.rs
+++ b/crates/typst-kit/src/fonts.rs
@@ -54,6 +54,7 @@ impl FontSlot {
                 let data = fs::read(
                     self.path
                         .as_ref()
+                        // TODO: Ths causes a crash if I run `cargo r -- c --ignore-system-fonts  test.typ`
                         .expect("`path` is not `None` if `font` is uninitialized"),
                 )
                 .ok()?;

--- a/crates/typst-library/src/lib.rs
+++ b/crates/typst-library/src/lib.rs
@@ -36,7 +36,7 @@ use crate::diag::FileResult;
 use crate::foundations::{Array, Binding, Bytes, Datetime, Dict, Module, Scope, Styles};
 use crate::layout::{Alignment, Dir};
 use crate::routines::Routines;
-use crate::text::{Font, FontBook};
+use crate::text::{Font, FontBook, FontKey};
 use crate::visualize::Color;
 
 /// The environment in which typesetting occurs.
@@ -74,7 +74,7 @@ pub trait World: Send + Sync {
     fn file(&self, id: FileId) -> FileResult<Bytes>;
 
     /// Try to access the font with the given index in the font book.
-    fn font(&self, index: usize) -> Option<Font>;
+    fn font(&self, key: FontKey) -> Option<Font>;
 
     /// Get the current date.
     ///
@@ -109,7 +109,7 @@ macro_rules! world_impl {
                 self.deref().file(id)
             }
 
-            fn font(&self, index: usize) -> Option<Font> {
+            fn font(&self, index: FontKey) -> Option<Font> {
                 self.deref().font(index)
             }
 

--- a/crates/typst-library/src/text/font/book.rs
+++ b/crates/typst-library/src/text/font/book.rs
@@ -8,6 +8,7 @@ use unicode_segmentation::UnicodeSegmentation;
 
 use super::exceptions::find_exception;
 use crate::text::{Font, FontStretch, FontStyle, FontVariant, FontWeight};
+use crate::text::font::variant::FontVariantCoverage;
 
 /// Metadata about a collection of fonts.
 #[derive(Debug, Default, Clone, Hash)]
@@ -155,9 +156,8 @@ impl FontBook {
                         current.family.len(),
                     )
                 }),
-                current.variant.style.distance(variant.style),
-                current.variant.stretch.distance(variant.stretch),
-                current.variant.weight.distance(variant.weight),
+                
+                current.variant_coverage.distance(&variant)
             );
 
             if best_key.is_none_or(|b| key < b) {
@@ -177,7 +177,7 @@ pub struct FontInfo {
     pub family: String,
     /// Properties that distinguish this font from other fonts in the same
     /// family.
-    pub variant: FontVariant,
+    pub variant_coverage: FontVariantCoverage,
     /// Properties of the font.
     pub flags: FontFlags,
     /// The unicode coverage of the font.
@@ -263,7 +263,7 @@ impl FontInfo {
                 .and_then(|c| c.stretch)
                 .unwrap_or_else(|| FontStretch::from_number(ttf.width().to_number()));
 
-            FontVariant { style, weight, stretch }
+            FontVariantCoverage::new(style, weight, stretch)
         };
 
         // Determine the unicode coverage.
@@ -291,7 +291,7 @@ impl FontInfo {
 
         Some(FontInfo {
             family,
-            variant,
+            variant_coverage: variant,
             flags,
             coverage: Coverage::from_vec(codepoints),
         })

--- a/crates/typst-library/src/text/font/book.rs
+++ b/crates/typst-library/src/text/font/book.rs
@@ -84,12 +84,8 @@ impl FontBook {
     ///
     /// The `family` should be all lowercase.
     pub fn select(&self, family: &str, variant: FontVariant) -> Option<FontKey> {
-        println!("searching {}, {:?}", family, variant);
         let ids = self.families.get(family)?;
-        let res = self.find_best_variant(None, variant, ids.iter().copied());
-
-        println!("res: {:?}", res);
-        res
+        self.find_best_variant(None, variant, ids.iter().copied())
     }
 
     /// Iterate over all variants of a family.

--- a/crates/typst-library/src/text/font/mod.rs
+++ b/crates/typst-library/src/text/font/mod.rs
@@ -17,7 +17,7 @@ use crate::layout::{Abs, Em, Frame};
 use crate::text::{
     BottomEdge, DEFAULT_SUBSCRIPT_METRICS, DEFAULT_SUPERSCRIPT_METRICS, TopEdge,
 };
-use smallvec::{SmallVec, smallvec};
+use smallvec::SmallVec;
 use std::cell::OnceCell;
 use std::fmt::{self, Debug, Formatter};
 use std::hash::{Hash, Hasher};

--- a/crates/typst-library/src/text/font/mod.rs
+++ b/crates/typst-library/src/text/font/mod.rs
@@ -7,7 +7,7 @@ mod exceptions;
 mod variant;
 
 pub use self::book::{Coverage, FontBook, FontFlags, FontInfo};
-pub use self::variant::{FontStretch, FontStyle, FontVariant, FontWeight};
+pub use self::variant::{FontStretch, FontStyle, FontVariant, FontVariantCoverage, FontWeight};
 
 use std::cell::OnceCell;
 use std::fmt::{self, Debug, Formatter};
@@ -200,7 +200,7 @@ impl Hash for Font {
 
 impl Debug for Font {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "Font({}, {:?})", self.info().family, self.info().variant)
+        write!(f, "Font({}, {:?})", self.info().family, self.info().variant_coverage)
     }
 }
 

--- a/crates/typst-library/src/text/mod.rs
+++ b/crates/typst-library/src/text/mod.rs
@@ -1422,11 +1422,11 @@ fn check_font_list(engine: &mut Engine, list: &Spanned<FontList>) {
                     .info(index)
                     .is_some_and(|x| x.flags.contains(FontFlags::VARIABLE))
                 {
-                    engine.sink.warn(warning!(
-                        list.span,
-                        "variable fonts are not currently supported and may render incorrectly";
-                        hint: "try installing a static version of \"{}\" instead", family.as_str()
-                    ))
+                    // engine.sink.warn(warning!(
+                    //     list.span,
+                    //     "variable fonts are not currently supported and may render incorrectly";
+                    //     hint: "try installing a static version of \"{}\" instead", family.as_str()
+                    // ))
                 }
             }
             None => engine.sink.warn(warning!(

--- a/crates/typst-library/src/visualize/image/svg.rs
+++ b/crates/typst-library/src/visualize/image/svg.rs
@@ -217,11 +217,11 @@ impl FontResolver<'_> {
         // `exclude_fonts` is actually never empty in practice. Still, we
         // prefer to fall back to the default variant rather than panicking
         // in case that changes in the future.
-        let variant = like.map(|info| info.variant).unwrap_or_default();
+        let variant = like.map(|info| info.variant_coverage.clone()).unwrap_or_default();
 
         // Select the font.
         let index =
-            self.book.select_fallback(like, variant, c.encode_utf8(&mut [0; 4]))?;
+            self.book.select_fallback(like, variant.default_variant(), c.encode_utf8(&mut [0; 4]))?;
 
         self.get_or_load(index, db)
     }
@@ -248,7 +248,7 @@ impl FontResolver<'_> {
     ) -> Option<fontdb::ID> {
         let font = self.world.font(index)?;
         let info = font.info();
-        let variant = info.variant;
+        let variant = info.variant_coverage.default_variant();
         let id = Arc::make_mut(db).push_face_info(fontdb::FaceInfo {
             id: fontdb::ID::dummy(),
             source: fontdb::Source::Binary(Arc::new(font.data().clone())),

--- a/crates/typst-pdf/src/attach.rs
+++ b/crates/typst-pdf/src/attach.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use krilla::Document;
-use krilla::embed::{AssociationKind, EmbeddedFile};
+use krilla::embed::{AssociationKind, EmbeddedFile, MimeType};
 use typst_library::diag::{SourceResult, bail};
 use typst_library::foundations::{NativeElement, StyleChain};
 use typst_library::layout::PagedDocument;
@@ -42,7 +42,8 @@ pub(crate) fn attach_files(
 
         let file = EmbeddedFile {
             path,
-            mime_type,
+            mime_type: mime_type.map(|m| MimeType::new(&m).unwrap()),
+            modification_date: None,
             description,
             association_kind,
             data: data.into(),

--- a/crates/typst-pdf/src/text.rs
+++ b/crates/typst-pdf/src/text.rs
@@ -83,7 +83,19 @@ fn build_font(typst_font: Font) -> SourceResult<krilla::text::Font> {
     let font_data: Arc<dyn AsRef<[u8]> + Send + Sync> =
         Arc::new(typst_font.data().clone());
 
-    match krilla::text::Font::new(font_data.into(), typst_font.index()) {
+    let instance_parameters = typst_font
+        .instance_parameters()
+        .coordinates()
+        .map(|i| (krilla::text::Tag::new(i.0), i.1))
+        .collect::<Vec<_>>();
+
+    println!("pdf instance parameters: {:?}", instance_parameters);
+
+    match krilla::text::Font::new_variable(
+        font_data.into(),
+        typst_font.index(),
+        &instance_parameters,
+    ) {
         None => {
             let font_str = display_font(&typst_font);
             bail!(Span::detached(), "failed to process font {font_str}");

--- a/crates/typst-pdf/src/text.rs
+++ b/crates/typst-pdf/src/text.rs
@@ -88,9 +88,7 @@ fn build_font(typst_font: Font) -> SourceResult<krilla::text::Font> {
         .coordinates()
         .map(|i| (krilla::text::Tag::new(i.0), i.1))
         .collect::<Vec<_>>();
-
-    println!("pdf instance parameters: {:?}", instance_parameters);
-
+    
     match krilla::text::Font::new_variable(
         font_data.into(),
         typst_font.index(),


### PR DESCRIPTION
This PR is still in-progress and aims to add some initial support for variable fonts. `Initial` because the aim is not to give the user full control over setting custom variation coordinates (this could be good future work, but probably makes more sense to implement in conjunction with the planned `font` object). The aim is to automatically select a correct instance based on the `wght` (font weight), `wdth` (font stretch), and `ital`/`slnt` (italic) axes, which I think should over 95%+ of the use cases.

It also adds support for embedding CFF2 fonts in PDFs by converting them to a TTF font, which is not the best approach (better would be to convert to CFF), but it should do the job. CFF2 fonts are pretty rare ([less than 1% of variable fonts](https://almanac.httparchive.org/en/2024/fonts#variable-fonts)), but based on past issues it seems like some systems do use some CFF2-based Noto fonts, so this is definitely worth fixing.

Fixes #185 (tracking support for specifying variable font axes is probably worth opening a new issue for).

Example:
```
#for (font, d_text) in (
    ("Cantarell", "I love using variable fonts!"),
    ("Noto Sans CJK SC", "我太喜欢使用可变字体了!"),
    ("Roboto", "I love using variable fonts!"),
) {
    [= #font]
    for i in range(100, 900, step: 100) {
        text(weight: i, font: font)[#d_text \ ]
    }
}
```

Result:
[test.pdf](https://github.com/user-attachments/files/21813827/test.pdf)

TODOs:

- Properly hook up the `wdth` and `slant`/`italic` axes.
- Bulk test with maany fonts to ensure it works as expected.
- Fix or find a workaround for the `pixglyph` bug that makes CFF2 fonts render as black rectangles in PNG export.
- Investigate whether the code leads to regressions in SVG rendering, where variable fonts are currently not supported.
- Add test cases
- Clean up code + documentation