### PR TITLE
Fix `repr` of `foo.with(..)`

### DIFF
--- a/crates/typst-library/src/foundations/func.rs
+++ b/crates/typst-library/src/foundations/func.rs
@@ -424,9 +424,13 @@ impl Debug for Func {
 
 impl repr::Repr for Func {
     fn repr(&self) -> EcoString {
-        match self.name() {
-            Some(name) => name.into(),
-            None => "(..) => ..".into(),
+        const DEFAULT: &str = "(..) => ..";
+        match &self.repr {
+            Repr::Native(native) => native.name.into(),
+            Repr::Element(elem) => elem.name().into(),
+            Repr::Closure(closure) => closure.name().unwrap_or(DEFAULT).into(),
+            Repr::Plugin(func) => func.name().clone(),
+            Repr::With(_) => DEFAULT.into(),
         }
     }
 }

--- a/crates/typst-library/src/foundations/plugin.rs
+++ b/crates/typst-library/src/foundations/plugin.rs
@@ -212,7 +212,7 @@ pub struct PluginFunc {
 
 impl PluginFunc {
     /// The name of the plugin function.
-    pub fn name(&self) -> &str {
+    pub fn name(&self) -> &EcoString {
         &self.name
     }
 

--- a/tests/suite/foundations/repr.typ
+++ b/tests/suite/foundations/repr.typ
@@ -35,6 +35,7 @@
 #t(f, `f`)
 #t(rect , `rect`)
 #t(() => none, `(..) => ..`)
+#t(f.with(), `(..) => ..`)
 
 // Types.
 #t(int, `int`)


### PR DESCRIPTION
Currently, the following code displays `foo`.

```typ
#let foo(a) = {}
#repr(foo.with(1))
```

This is undesirable, because the value that is being represented is not actually the function `foo`, but rather a partially applied version. I would argue that two reprs that do not contain `..` should be equal iff the underlying values are equal.

I went for `(..) => ..`. An alternative is `foo.with(..)`, which conveys more information. I prefer `(..) => ..` because it makes it clearer that it is a function.