### PR TITLE
Fix typo in doc on quotes parameter of smartquote

### DIFF
--- a/crates/typst-library/src/text/smartquote.rs
+++ b/crates/typst-library/src/text/smartquote.rs
@@ -71,7 +71,7 @@ pub struct SmartQuoteElem {
     ///     opening and closing double quotes (characters here refer to Unicode
     ///     grapheme clusters)
     ///   - [array]: an array containing the opening and closing double quotes
-    ///   - [dictionary]: an array containing the double and single quotes, each
+    ///   - [dictionary]: a dictionary containing the double and single quotes, each
     ///     specified as either `{auto}`, string, or array
     ///
     /// ```example


### PR DESCRIPTION
In the `smartquote` documentation for the [quotes](https://typst.app/docs/reference/text/smartquote/#parameters-quotes) parameter, the dictionary item currently says "an array" but it should read "a dictionary".