### PR TITLE
Add default named arg to json loader

### DIFF
--- a/tests/suite/loading/json.typ
+++ b/tests/suite/loading/json.typ
@@ -5,6 +5,10 @@
 #test(data.at(0).name, "Debby")
 #test(data.at(2).weight, 150)
 
+--- json-not-found ---
+// Error: 7-18 file not found (searched at tests/suite/loading/nope.json)
+#json("nope.json")
+
 --- json-invalid ---
 // Error: "/assets/data/bad.json" 3:14 failed to parse JSON (expected value at line 3 column 14)
 #json("/assets/data/bad.json")
@@ -19,3 +23,9 @@
 // but not overflow
 #let bignum = json("/assets/data/big-number.json")
 #bignum
+
+--- json-default ---
+// Use the default balue
+#let data_def = json("nope_default.json", default: none)
+#test(data_def, none)
+


### PR DESCRIPTION
Hello,

This allows the user to handle a possible file not found error

I can also do the same for other loader if needed
Maybe also for the `read()` call

Thanks