### PR TITLE
Fix `sub` and `super` oneliners

### DIFF
--- a/crates/typst-library/src/text/shift.rs
+++ b/crates/typst-library/src/text/shift.rs
@@ -14,11 +14,11 @@ use crate::text::{FontMetrics, ScriptMetrics, TextSize};
 /// ```
 #[elem(title = "Subscript")]
 pub struct SubElem {
-    /// Whether to create artificial subscripts by lowering and scaling down
-    /// regular glyphs.
+    /// Whether to use subscript glyphs from the font if available.
     ///
     /// Ideally, subscripts glyphs are provided by the font (using the `subs`
-    /// OpenType feature). Otherwise, Typst is able to synthesize subscripts.
+    /// OpenType feature). Otherwise, Typst is able to synthesize subscripts by
+    /// lowering and scaling down regular glyphs.
     ///
     /// When this is set to `{false}`, synthesized glyphs will be used
     /// regardless of whether the font provides dedicated subscript glyphs. When
@@ -69,11 +69,11 @@ pub struct SubElem {
 /// ```
 #[elem(title = "Superscript")]
 pub struct SuperElem {
-    /// Whether to create artificial superscripts by raising and scaling down
-    /// regular glyphs.
+    /// Whether to use superscript glyphs from the font if available.
     ///
     /// Ideally, superscripts glyphs are provided by the font (using the `sups`
-    /// OpenType feature). Otherwise, Typst is able to synthesize superscripts.
+    /// OpenType feature). Otherwise, Typst is able to synthesize superscripts
+    /// by raising and scaling down regular glyphs.
     ///
     /// When this is set to `{false}`, synthesized glyphs will be used
     /// regardless of whether the font provides dedicated superscript glyphs.


### PR DESCRIPTION
Before, the oneliners were inverted, implying setting `typographic` to `true` would _disable_ the use of font-provided glyphs. The actual behavior is opposite.