### PR TITLE
Fix Unicode mapping of hyphenation artifacts

### DIFF
--- a/crates/typst-layout/src/inline/line.rs
+++ b/crates/typst-layout/src/inline/line.rs
@@ -178,7 +178,8 @@ pub fn line<'a>(
         && pred.dash == Some(Dash::Hard)
         && let Some(base) = pred.items.last_text()
         && should_repeat_hyphen(base.lang, full)
-        && let Some(hyphen) = ShapedText::hyphen(engine, p.config.fallback, base, trim)
+        && let Some(hyphen) =
+            ShapedText::hyphen(engine, p.config.fallback, base, trim, false)
     {
         items.push(Item::Text(hyphen), START_HYPHEN_IDX);
     }
@@ -188,7 +189,8 @@ pub fn line<'a>(
     // Add a hyphen at the line end, if we ended on a soft hyphen.
     if dash == Some(Dash::Soft)
         && let Some(base) = items.last_text()
-        && let Some(hyphen) = ShapedText::hyphen(engine, p.config.fallback, base, trim)
+        && let Some(hyphen) =
+            ShapedText::hyphen(engine, p.config.fallback, base, trim, true)
     {
         items.push(Item::Text(hyphen), END_HYPHEN_IDX);
     }
@@ -659,7 +661,7 @@ fn overhang(c: char) -> f64 {
     match c {
         // Dashes.
         '–' | '—' => 0.2,
-        '-' => 0.55,
+        '-' | '\u{ad}' => 0.55,
 
         // Punctuation.
         '.' | ',' => 0.8,

--- a/crates/typst-layout/src/inline/shaping.rs
+++ b/crates/typst-layout/src/inline/shaping.rs
@@ -21,6 +21,11 @@ use unicode_script::{Script, UnicodeScript};
 use super::{Item, Range, SpanMapper, decorate};
 use crate::modifiers::FrameModifyText;
 
+const SHY: char = '\u{ad}';
+const SHY_STR: &str = "\u{ad}";
+const HYPHEN: char = '-';
+const HYPHEN_STR: &str = "-";
+
 /// The result of shaping text.
 ///
 /// This type contains owned or borrowed shaped text runs, which can be
@@ -441,11 +446,15 @@ impl<'a> ShapedText<'a> {
     }
 
     /// Creates shaped text containing a hyphen.
+    ///
+    /// If `soft` is true, the item will map to plain text as a soft hyphen.
+    /// Otherwise, it will map to a normal hyphen.
     pub fn hyphen(
         engine: &Engine,
         fallback: bool,
         base: &ShapedText<'a>,
         pos: usize,
+        soft: bool,
     ) -> Option<Self> {
         let world = engine.world;
         let book = world.book();
@@ -466,10 +475,11 @@ impl<'a> ShapedText<'a> {
             let glyph_id = ttf.glyph_index('-')?;
             let x_advance = font.to_em(ttf.glyph_hor_advance(glyph_id)?);
             let size = base.styles.resolve(TextElem::size);
+            let (c, text) = if soft { (SHY, SHY_STR) } else { (HYPHEN, HYPHEN_STR) };
 
             Some(ShapedText {
                 base: pos,
-                text: "",
+                text,
                 dir: base.dir,
                 lang: base.lang,
                 region: base.region,
@@ -484,9 +494,9 @@ impl<'a> ShapedText<'a> {
                     y_offset: Em::zero(),
                     size,
                     adjustability: Adjustability::default(),
-                    range: pos..pos,
+                    range: pos..pos + text.len(),
                     safe_to_break: true,
-                    c: '-',
+                    c,
                     is_justifiable: false,
                     script: Script::Common,
                 }]),


### PR DESCRIPTION
This fixes how hyphenation artifacts are mapped to Unicode, following up on the refactorings in #6798. Originally, they were mapped to hard hyphens. Since the switch to krilla they were mapped to empty text via `/ActualText`. Now they'll be mapped to U+AD SHY HYPHEN, in line with the PDF 1.7 spec Section 14.8.2.2.3.

PDF provides two ways for text to be mapped to Unicode text: The `/ToUnicode` glyph to text mapping and the `/ActualText` mechanism. Since the former only supports one mapping per glyph, it's not sufficient to encode the hyphen glyph to both a hard hyphen and soft hyphen depending on the circumstance. For this reason, krilla will write `/ActualText` when both appear but were mapped to different text by Typst.

Viewer support for `/ActualText` is kinda patchy, so some viewers will just ignore it, but what we're doing now is at the very least spec-compliant. It would be possible to duplicate the glyph on the font level during subsetting to make it work in even more viewers, but we decided that this is out of scope for now.

Fixes https://github.com/typst/typst/issues/1267