### PR TITLE
feat: embed SVG when output format is SVG

### DIFF
--- a/crates/typst-svg/src/image.rs
+++ b/crates/typst-svg/src/image.rs
@@ -9,12 +9,52 @@ use typst_library::layout::{Abs, Axes};
 use typst_library::visualize::{
     ExchangeFormat, Image, ImageKind, ImageScaling, PdfImage, RasterFormat,
 };
+use xmlparser::{Token, Tokenizer};
 
 use crate::SVGRenderer;
 
 impl SVGRenderer<'_> {
     /// Render an image element.
     pub(super) fn render_image(&mut self, image: &Image, size: &Axes<Abs>) {
+        if let ImageKind::Svg(svg) = image.kind() {
+            let svg_raw = std::str::from_utf8(svg.data()).unwrap();
+            let svg_tokenizer = Tokenizer::from(svg_raw);
+            for token in svg_tokenizer {
+                match token {
+                    Ok(Token::Attribute { prefix, local, value, .. }) => {
+                        let name = if prefix.as_str().is_empty() {
+                            local.as_str().to_string()
+                        } else {
+                            format!("{}:{}", prefix, local)
+                        };
+                        self.xml.write_attribute(&name, &value)
+                    }
+                    // Ok(Token::Cdata { .. }) => {}
+                    Ok(Token::Comment { text, .. }) => self.xml.write_comment(&text),
+                    Ok(Token::Declaration { .. }) => {
+                        self.xml.write_declaration();
+                    }
+                    // Ok(Token::DtdEnd { .. }) => {}
+                    // Ok(Token::DtdStart { .. }) => {}
+                    Ok(Token::ElementEnd { end, .. }) => {
+                        if matches!(end, xmlparser::ElementEnd::Close(..)) {
+                            self.xml.end_element();
+                        }
+                    }
+                    Ok(Token::ElementStart { local, .. }) => {
+                        self.xml.start_element(&local)
+                    }
+                    // Ok(Token::EmptyDtd { .. }) => {}
+                    // Ok(Token::EntityDeclaration { .. }) => {}
+                    // Ok(Token::ProcessingInstruction { .. }) => {}
+                    Ok(Token::Text { text }) => self.xml.write_text(&text),
+                    // Err(e) => eprintln!("Error: {}", e),
+                    _ => panic!("Error"),
+                }
+            }
+            return;
+        }
+
         let url = convert_image_to_base64_url(image);
         self.xml.start_element("image");
         self.xml.write_attribute("xlink:href", &url);

--- a/crates/typst-svg/src/image.rs
+++ b/crates/typst-svg/src/image.rs
@@ -31,9 +31,9 @@ impl SVGRenderer<'_> {
                     }
                     // Ok(Token::Cdata { .. }) => {}
                     Ok(Token::Comment { text, .. }) => self.xml.write_comment(&text),
-                    Ok(Token::Declaration { .. }) => {
-                        self.xml.write_declaration();
-                    }
+                    // Ok(Token::Declaration { .. }) => {
+                    //     self.xml.write_declaration();
+                    // }
                     // Ok(Token::DtdEnd { .. }) => {}
                     // Ok(Token::DtdStart { .. }) => {}
                     Ok(Token::ElementEnd { end, .. }) => {

--- a/crates/typst-svg/src/image.rs
+++ b/crates/typst-svg/src/image.rs
@@ -25,7 +25,7 @@ impl SVGRenderer<'_> {
                         let name = if prefix.as_str().is_empty() {
                             local.as_str().to_string()
                         } else {
-                            format!("{}:{}", prefix, local)
+                            format!("{prefix}:{local}")
                         };
                         self.xml.write_attribute(&name, &value)
                     }

--- a/crates/typst-svg/src/image.rs
+++ b/crates/typst-svg/src/image.rs
@@ -30,13 +30,7 @@ impl SVGRenderer<'_> {
                             };
                             self.xml.write_attribute(&name, &value)
                         }
-                        // Ok(Token::Cdata { .. }) => {}
                         Ok(Token::Comment { text, .. }) => self.xml.write_comment(&text),
-                        // Ok(Token::Declaration { .. }) => {
-                        //     self.xml.write_declaration();
-                        // }
-                        // Ok(Token::DtdEnd { .. }) => {}
-                        // Ok(Token::DtdStart { .. }) => {}
                         Ok(Token::ElementEnd { end, .. }) => {
                             if matches!(end, xmlparser::ElementEnd::Close(..)) {
                                 self.xml.end_element();
@@ -45,9 +39,6 @@ impl SVGRenderer<'_> {
                         Ok(Token::ElementStart { local, .. }) => {
                             self.xml.start_element(&local)
                         }
-                        // Ok(Token::EmptyDtd { .. }) => {}
-                        // Ok(Token::EntityDeclaration { .. }) => {}
-                        // Ok(Token::ProcessingInstruction { .. }) => {}
                         Ok(Token::Text { text }) => self.xml.write_text(&text),
                         Err(e) => {
                             eprintln!("The SVG Image have Element can't parse: {e}")

--- a/crates/typst-svg/src/image.rs
+++ b/crates/typst-svg/src/image.rs
@@ -49,7 +49,9 @@ impl SVGRenderer<'_> {
                         // Ok(Token::EntityDeclaration { .. }) => {}
                         // Ok(Token::ProcessingInstruction { .. }) => {}
                         Ok(Token::Text { text }) => self.xml.write_text(&text),
-                        Err(e) => eprintln!("The SVG Image have Element can't parse: {e}" ),
+                        Err(e) => {
+                            eprintln!("The SVG Image have Element can't parse: {e}")
+                        }
                         _ => {}
                     }
                 }

--- a/crates/typst-svg/src/image.rs
+++ b/crates/typst-svg/src/image.rs
@@ -48,8 +48,8 @@ impl SVGRenderer<'_> {
                     // Ok(Token::EntityDeclaration { .. }) => {}
                     // Ok(Token::ProcessingInstruction { .. }) => {}
                     Ok(Token::Text { text }) => self.xml.write_text(&text),
-                    // Err(e) => eprintln!("Error: {}", e),
-                    _ => panic!("Error"),
+                    Err(e) => eprintln!("Error: {}", e),
+                    _ => {},
                 }
             }
             return;


### PR DESCRIPTION
This PR aim to embed origin SVG code when output format is SVG, this keep image unchange and easy to re-edit SVG.

Closes #6812
## Example

```typst
#let svg = "<svg fill=\"#239DAD\" role=\"img\" viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\"><title>Typst</title><path d=\"M12.654 17.846c0 1.114.16 1.861.479 2.242.32.381.901.572 1.743.572.872 0 1.99-.44 3.356-1.319l.871 1.45C16.547 22.931 14.44 24 12.785 24c-1.656 0-2.964-.395-3.922-1.187-.959-.82-1.438-2.256-1.438-4.307V6.989H5.246l-.349-1.626 2.528-.791V2.418L12.654 0v4.835l5.142-.395-.48 2.857-4.662-.176v10.725Z\"/></svg>"

#image(bytes(svg))
```

typst compile test.typ --format svg

```
<svg class="typst-doc" viewBox="0 0 595.2755905511812 841.8897637795276" width="595.2755905511812pt" height="841.8897637795276pt" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:h5="http://www.w3.org/1999/xhtml">
    <path class="typst-shape" fill="#ffffff" fill-rule="nonzero" d="M 0 0 L 0 841.8898 L 595.2756 841.8898 L 595.2756 0 Z "/>
    <g>
        <g transform="translate(70.86614173228347 70.86614173228347)">
            <svg fill="#239DAD" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                <title>
                    Typst
                </title>
                <path d="M12.654 17.846c0 1.114.16 1.861.479 2.242.32.381.901.572 1.743.572.872 0 1.99-.44 3.356-1.319l.871 1.45C16.547 22.931 14.44 24 12.785 24c-1.656 0-2.964-.395-3.922-1.187-.959-.82-1.438-2.256-1.438-4.307V6.989H5.246l-.349-1.626 2.528-.791V2.418L12.654 0v4.835l5.142-.395-.48 2.857-4.662-.176v10.725Z"/>
            </svg>
        </g>
    </g>
</svg>
```

looks good now, ~~but still need adding test and other things,~~ Please leave any review suggestion.