### PR TITLE
Add hint to LrElem to mark implicit pairs

### DIFF
--- a/crates/typst-eval/src/math.rs
+++ b/crates/typst-eval/src/math.rs
@@ -68,7 +68,7 @@ impl Eval for ast::MathDelimited<'_> {
         let open = self.open().eval_display(vm)?;
         let body = self.body().eval(vm)?;
         let close = self.close().eval_display(vm)?;
-        Ok(LrElem::new(open + body + close).pack())
+        Ok(LrElem::new(open + body + close).with_explicit(false).pack())
     }
 }
 

--- a/crates/typst-eval/src/math.rs
+++ b/crates/typst-eval/src/math.rs
@@ -128,15 +128,7 @@ impl Eval for ast::MathFrac<'_> {
         let denom_expr = self.denom();
         let denom = denom_expr.eval_display(vm)?;
 
-        let num_depar =
-            matches!(num_expr, ast::Expr::Math(math) if math.was_deparenthesized());
-        let denom_depar =
-            matches!(denom_expr, ast::Expr::Math(math) if math.was_deparenthesized());
-
-        Ok(FracElem::new(num, denom)
-            .with_num_deparenthesized(num_depar)
-            .with_denom_deparenthesized(denom_depar)
-            .pack())
+        Ok(FracElem::new(num, denom).pack())
     }
 }
 

--- a/crates/typst-layout/src/math/frac.rs
+++ b/crates/typst-layout/src/math/frac.rs
@@ -1,6 +1,6 @@
 use typst_library::diag::SourceResult;
 use typst_library::foundations::{
-    Content, NativeElement, Packed, Resolve, StyleChain, SymbolElem,
+    Content, NativeElement, Packed, Resolve, SequenceElem, StyleChain, SymbolElem,
 };
 use typst_library::layout::{Abs, Em, Frame, FrameItem, Point, Size};
 use typst_library::math::{
@@ -24,24 +24,53 @@ pub fn layout_frac(
     ctx: &mut MathContext,
     styles: StyleChain,
 ) -> SourceResult<()> {
-    match elem.style.get(styles) {
-        FracStyle::Skewed => {
-            layout_skewed_frac(ctx, styles, &elem.num, &elem.denom, elem.span())
+    // Should the fraction operands be deparenthesized ?
+    let fraction_style = elem.style.get(styles);
+    let deparen = fraction_style != FracStyle::Horizontal;
+
+    // If we are deparenthesizing, do it only if the outer lr pair is implicit
+    // and is indeed a pair of parentheses.
+    let mut num = elem.num.clone();
+    if deparen
+        && let Some(lr_num) = elem.num.to_packed::<LrElem>()
+        && !lr_num.explicit.unwrap_or(true)
+        && let Some(seq_num) = lr_num.body.to_packed::<SequenceElem>()
+        && let [first_num_delim, content @ .., last_num_delim] =
+            seq_num.children.as_slice()
+        && let Some(first_num_delim_symbol) = first_num_delim.to_packed::<SymbolElem>()
+        && let Some(last_num_delim_symbol) = last_num_delim.to_packed::<SymbolElem>()
+        && first_num_delim_symbol.text == '('
+        && last_num_delim_symbol.text == ')'
+    {
+        num = SequenceElem::new(content.to_vec().clone()).pack();
+    }
+
+    let mut denom = elem.denom.clone();
+    if deparen
+        && let Some(lr_denom) = elem.denom.to_packed::<LrElem>()
+        && !lr_denom.explicit.unwrap_or(true)
+        && let Some(seq_denom) = lr_denom.body.to_packed::<SequenceElem>()
+        && let [first_denom_delim, content @ .., last_denom_delim] =
+            seq_denom.children.as_slice()
+        && let Some(first_denom_delim_symbol) =
+            first_denom_delim.to_packed::<SymbolElem>()
+        && let Some(last_denom_delim_symbol) = last_denom_delim.to_packed::<SymbolElem>()
+        && first_denom_delim_symbol.text == '('
+        && last_denom_delim_symbol.text == ')'
+    {
+        denom = SequenceElem::new(content.to_vec().clone()).pack();
+    }
+
+    match fraction_style {
+        FracStyle::Skewed => layout_skewed_frac(ctx, styles, &num, &denom, elem.span()),
+        FracStyle::Horizontal => {
+            layout_horizontal_frac(ctx, styles, &num, &denom, elem.span())
         }
-        FracStyle::Horizontal => layout_horizontal_frac(
-            ctx,
-            styles,
-            &elem.num,
-            &elem.denom,
-            elem.span(),
-            elem.num_deparenthesized.get(styles),
-            elem.denom_deparenthesized.get(styles),
-        ),
         FracStyle::Vertical => layout_vertical_frac_like(
             ctx,
             styles,
-            &elem.num,
-            std::slice::from_ref(&elem.denom),
+            &num,
+            std::slice::from_ref(&denom),
             false,
             elem.span(),
         ),
@@ -169,19 +198,7 @@ fn layout_horizontal_frac(
     num: &Content,
     denom: &Content,
     span: Span,
-    num_deparen: bool,
-    denom_deparen: bool,
 ) -> SourceResult<()> {
-    let num = if num_deparen {
-        &LrElem::new(Content::sequence(vec![
-            SymbolElem::packed('('),
-            num.clone(),
-            SymbolElem::packed(')'),
-        ]))
-        .pack()
-    } else {
-        num
-    };
     let num_frame = ctx.layout_into_fragment(num, styles)?;
     ctx.push(num_frame);
 
@@ -190,16 +207,6 @@ fn layout_horizontal_frac(
     slash.center_on_axis();
     ctx.push(slash);
 
-    let denom = if denom_deparen {
-        &LrElem::new(Content::sequence(vec![
-            SymbolElem::packed('('),
-            denom.clone(),
-            SymbolElem::packed(')'),
-        ]))
-        .pack()
-    } else {
-        denom
-    };
     let denom_frame = ctx.layout_into_fragment(denom, styles)?;
     ctx.push(denom_frame);
 

--- a/crates/typst-library/src/math/frac.rs
+++ b/crates/typst-library/src/math/frac.rs
@@ -36,20 +36,6 @@ pub struct FracElem {
     /// ```
     #[default(FracStyle::Vertical)]
     pub style: FracStyle,
-
-    /// Whether the numerator was originally surrounded by parentheses
-    /// that were stripped by the parser.
-    #[internal]
-    #[parse(None)]
-    #[default(false)]
-    pub num_deparenthesized: bool,
-
-    /// Whether the denominator was originally surrounded by parentheses
-    /// that were stripped by the parser.
-    #[internal]
-    #[parse(None)]
-    #[default(false)]
-    pub denom_deparenthesized: bool,
 }
 
 /// Fraction style

--- a/crates/typst-syntax/src/ast.rs
+++ b/crates/typst-syntax/src/ast.rs
@@ -840,16 +840,6 @@ impl<'a> Math<'a> {
     pub fn exprs(self) -> impl DoubleEndedIterator<Item = Expr<'a>> {
         self.0.children().filter_map(Expr::cast_with_space)
     }
-
-    /// Whether this `Math` node was originally parenthesized.
-    pub fn was_deparenthesized(self) -> bool {
-        let mut iter = self.0.children();
-        matches!(iter.next().map(SyntaxNode::kind), Some(SyntaxKind::LeftParen))
-            && matches!(
-                iter.next_back().map(SyntaxNode::kind),
-                Some(SyntaxKind::RightParen)
-            )
-    }
 }
 
 node! {

--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -361,14 +361,12 @@ fn math_expr_prec(p: &mut Parser, min_prec: usize, stop: SyntaxKind) {
             ast::Assoc::Right => {}
         }
 
-        if kind == SyntaxKind::MathFrac {
-            math_unparen(p, m);
-        }
-
         p.eat();
         let m2 = p.marker();
         math_expr_prec(p, prec, stop);
-        math_unparen(p, m2);
+        if kind != SyntaxKind::MathFrac {
+            math_unparen(p, m2);
+        }
 
         if p.eat_if(SyntaxKind::Underscore) || p.eat_if(SyntaxKind::Hat) {
             let m3 = p.marker();


### PR DESCRIPTION
This PR changes the deparenthesization logic of fractions:
- Previously, this would be done by two internal `num/denom_deparenthesized` boolean internal fields set at eval time using data from the AST/CST.
- With this PR: A synthesized field on LrElem indicates whether each pair was automatically built at parsing time or wheter it was explicitly built from the constructor (`explicit: bool`). Deparenthesizing is then a process that happens during layout by checking for an implicit l/r `()` outer pair on numerator and denominator.

The point of this change is to allow some deparenthesization logic to happen in user space. Previously, one could not, for example, change the horizontal fraction slash character without dropping parentheses:
```typst
#show math.frac.where(style: "horizontal"): it => it.num + "|" + it.denom

$ (a+b) / c $
// Previously this would render as : a+b|c
// Now: (a+b)|c
```
If deparenthesization is desired from extracted num/denom content then custom logic is possible in userspace (previously this would always be deparenthesized with no way of reparenthesizing).