### PR TITLE
Update nix flake and use nixfmt

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1727060013,
-        "narHash": "sha256-/fC5YlJy4IoAW9GhkJiwyzk0K/gQd9Qi4rRcoweyG9E=",
+        "lastModified": 1755993354,
+        "narHash": "sha256-FCRRAzSaL/+umLIm3RU3O/+fJ2ssaPHseI2SSFL8yZU=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "6b40cc876c929bfe1e3a24bf538ce3b5622646ba",
+        "rev": "25bd41b24426c7734278c2ff02e53258851db914",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1727245890,
-        "narHash": "sha256-B4gUhZxqdn24PqL7z7ZuvLOS84HVskhKRByWdgA4/RI=",
+        "lastModified": 1755585599,
+        "narHash": "sha256-tl/0cnsqB/Yt7DbaGMel2RLa7QG5elA8lkaOXli6VdY=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "de3acda8b67b92abeeb35ac236924afd959874ad",
+        "rev": "6ed03ef4c8ec36d193c18e06b9ecddde78fb7e42",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1726153070,
-        "narHash": "sha256-HO4zgY0ekfwO5bX0QH/3kJ/h4KvUDFZg8YpkNwIbg1U=",
+        "lastModified": 1754487366,
+        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
+        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
         "type": "github"
       },
       "original": {
@@ -56,11 +56,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1726937504,
-        "narHash": "sha256-bvGoiQBvponpZh8ClUcmJ6QnsNKw0EMrCQJARK3bI1c=",
+        "lastModified": 1756125398,
+        "narHash": "sha256-XexyKZpf46cMiO5Vbj+dWSAXOnr285GHsMch8FBoHbc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9357f4f23713673f310988025d9dc261c20e70c6",
+        "rev": "3b9f00d7a7bf68acd4c4abb9d43695afb04e03a5",
         "type": "github"
       },
       "original": {
@@ -72,14 +72,17 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1725233747,
-        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+        "lastModified": 1753579242,
+        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
       }
     },
     "root": {
@@ -95,11 +98,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1727104575,
-        "narHash": "sha256-lB/ZS0SnHyE8Z3G8DIL/QJPg6w6x5ZhgVO2pBqnz89g=",
+        "lastModified": 1755504847,
+        "narHash": "sha256-VX0B9hwhJypCGqncVVLC+SmeMVd/GAYbJZ0MiiUn2Pk=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "3d0343251fe084b335b55c17a52bb4a3527b1bd0",
+        "rev": "a905e3b21b144d77e1b304e49f3264f6f8d4db75",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -15,130 +15,157 @@
     };
   };
 
-  outputs = inputs@{ flake-parts, crane, nixpkgs, fenix, rust-manifest, self, ... }: flake-parts.lib.mkFlake { inherit inputs; } {
-    systems = import inputs.systems;
+  outputs =
+    inputs@{
+      flake-parts,
+      crane,
+      nixpkgs,
+      fenix,
+      rust-manifest,
+      self,
+      ...
+    }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = import inputs.systems;
 
-    imports = [
-      inputs.flake-parts.flakeModules.easyOverlay
-    ];
+      imports = [
+        inputs.flake-parts.flakeModules.easyOverlay
+      ];
 
-    perSystem = { self', pkgs, lib, system, ... }:
-      let
-        cargoToml = lib.importTOML ./Cargo.toml;
+      perSystem =
+        {
+          self',
+          pkgs,
+          lib,
+          system,
+          ...
+        }:
+        let
+          cargoToml = lib.importTOML ./Cargo.toml;
 
-        pname = "typst";
-        version = cargoToml.workspace.package.version;
+          pname = "typst";
+          version = cargoToml.workspace.package.version;
 
-        rust-toolchain = (fenix.packages.${system}.fromManifestFile rust-manifest).defaultToolchain;
+          rust-toolchain = (fenix.packages.${system}.fromManifestFile rust-manifest).defaultToolchain;
 
-        # Crane-based Nix flake configuration.
-        # Based on https://github.com/ipetkov/crane/blob/master/examples/trunk-workspace/flake.nix
-        craneLib = (crane.mkLib pkgs).overrideToolchain rust-toolchain;
+          # Crane-based Nix flake configuration.
+          # Based on https://github.com/ipetkov/crane/blob/master/examples/trunk-workspace/flake.nix
+          craneLib = (crane.mkLib pkgs).overrideToolchain rust-toolchain;
 
-        # Typst files to include in the derivation.
-        # Here we include Rust files, docs and tests.
-        src = lib.fileset.toSource {
-          root = ./.;
-          fileset = lib.fileset.unions [
-            ./Cargo.toml
-            ./Cargo.lock
-            ./rustfmt.toml
-            ./crates
-            ./docs
-            ./tests
-          ];
+          # Typst files to include in the derivation.
+          # Here we include Rust files, docs and tests.
+          src = lib.fileset.toSource {
+            root = ./.;
+            fileset = lib.fileset.unions [
+              ./Cargo.toml
+              ./Cargo.lock
+              ./rustfmt.toml
+              ./crates
+              ./docs
+              ./tests
+            ];
+          };
+
+          # Typst derivation's args, used within crane's derivation generation
+          # functions.
+          commonCraneArgs = {
+            inherit src pname version;
+
+            buildInputs = [
+              pkgs.openssl
+            ]
+            ++ (lib.optionals pkgs.stdenv.isDarwin [
+              pkgs.darwin.apple_sdk.frameworks.CoreServices
+              pkgs.libiconv
+            ]);
+
+            nativeBuildInputs = [
+              pkgs.pkg-config
+              pkgs.openssl.dev
+            ];
+          };
+
+          # Derivation with just the dependencies, so we don't have to keep
+          # re-building them.
+          cargoArtifacts = craneLib.buildDepsOnly commonCraneArgs;
+
+          typst = craneLib.buildPackage (
+            commonCraneArgs
+            // {
+              inherit cargoArtifacts;
+
+              nativeBuildInputs = commonCraneArgs.nativeBuildInputs ++ [
+                pkgs.installShellFiles
+              ];
+
+              postInstall = ''
+                installManPage crates/typst-cli/artifacts/*.1
+                installShellCompletion \
+                  crates/typst-cli/artifacts/typst.{bash,fish} \
+                  --zsh crates/typst-cli/artifacts/_typst
+              '';
+
+              GEN_ARTIFACTS = "artifacts";
+              TYPST_VERSION =
+                let
+                  rev = self.shortRev or "dirty";
+                  version = cargoToml.workspace.package.version;
+                in
+                "${version} (${rev})";
+
+              meta.mainProgram = "typst";
+            }
+          );
+        in
+        {
+          formatter = pkgs.nixfmt-tree;
+
+          packages = {
+            default = typst;
+            typst-dev = self'.packages.default;
+          };
+
+          overlayAttrs = builtins.removeAttrs self'.packages [ "default" ];
+
+          apps.default = {
+            type = "app";
+            program = lib.getExe typst;
+          };
+
+          checks = {
+            typst-fmt = craneLib.cargoFmt commonCraneArgs;
+            typst-clippy = craneLib.cargoClippy (
+              commonCraneArgs
+              // {
+                inherit cargoArtifacts;
+                cargoClippyExtraArgs = "--workspace -- --deny warnings";
+              }
+            );
+            typst-test = craneLib.cargoTest (
+              commonCraneArgs
+              // {
+                inherit cargoArtifacts;
+                cargoTestExtraArgs = "--workspace";
+              }
+            );
+          };
+
+          devShells.default = craneLib.devShell {
+            checks = self'.checks;
+            inputsFrom = [ typst ];
+
+            buildInputs = with pkgs; [
+              rust-analyzer
+            ];
+
+            packages = [
+              # A script for quickly running tests.
+              # See https://github.com/typst/typst/blob/main/tests/README.md#making-an-alias
+              (pkgs.writeShellScriptBin "testit" ''
+                cargo test --workspace --test tests -- "$@"
+              '')
+            ];
+          };
         };
-
-        # Typst derivation's args, used within crane's derivation generation
-        # functions.
-        commonCraneArgs = {
-          inherit src pname version;
-
-          buildInputs = [
-            pkgs.openssl
-          ] ++ (lib.optionals pkgs.stdenv.isDarwin [
-            pkgs.darwin.apple_sdk.frameworks.CoreServices
-            pkgs.libiconv
-          ]);
-
-          nativeBuildInputs = [
-            pkgs.pkg-config
-            pkgs.openssl.dev
-          ];
-        };
-
-        # Derivation with just the dependencies, so we don't have to keep
-        # re-building them.
-        cargoArtifacts = craneLib.buildDepsOnly commonCraneArgs;
-
-        typst = craneLib.buildPackage (commonCraneArgs // {
-          inherit cargoArtifacts;
-
-          nativeBuildInputs = commonCraneArgs.nativeBuildInputs ++ [
-            pkgs.installShellFiles
-          ];
-
-          postInstall = ''
-            installManPage crates/typst-cli/artifacts/*.1
-            installShellCompletion \
-              crates/typst-cli/artifacts/typst.{bash,fish} \
-              --zsh crates/typst-cli/artifacts/_typst
-          '';
-
-          GEN_ARTIFACTS = "artifacts";
-          TYPST_VERSION =
-            let
-              rev = self.shortRev or "dirty";
-              version = cargoToml.workspace.package.version;
-            in
-            "${version} (${rev})";
-
-          meta.mainProgram = "typst";
-        });
-      in
-      {
-        formatter = pkgs.nixfmt-tree;
-
-        packages = {
-          default = typst;
-          typst-dev = self'.packages.default;
-        };
-
-        overlayAttrs = builtins.removeAttrs self'.packages [ "default" ];
-
-        apps.default = {
-          type = "app";
-          program = lib.getExe typst;
-        };
-
-        checks = {
-          typst-fmt = craneLib.cargoFmt commonCraneArgs;
-          typst-clippy = craneLib.cargoClippy (commonCraneArgs // {
-            inherit cargoArtifacts;
-            cargoClippyExtraArgs = "--workspace -- --deny warnings";
-          });
-          typst-test = craneLib.cargoTest (commonCraneArgs // {
-            inherit cargoArtifacts;
-            cargoTestExtraArgs = "--workspace";
-          });
-        };
-
-        devShells.default = craneLib.devShell {
-          checks = self'.checks;
-          inputsFrom = [ typst ];
-
-          buildInputs = with pkgs; [
-            rust-analyzer
-          ];
-
-          packages = [
-            # A script for quickly running tests.
-            # See https://github.com/typst/typst/blob/main/tests/README.md#making-an-alias
-            (pkgs.writeShellScriptBin "testit" ''
-              cargo test --workspace --test tests -- "$@"
-            '')
-          ];
-        };
-      };
-  };
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -97,7 +97,7 @@
         });
       in
       {
-        formatter = pkgs.nixpkgs-fmt;
+        formatter = pkgs.nixfmt-tree;
 
         packages = {
           default = typst;


### PR DESCRIPTION
Switches to use the [official formatter](https://github.com/NixOS/nixfmt?tab=readme-ov-file#nix-fmt-experimental) and formats the `flake.nix` file with it.

I had originally only updated the `nixpkgs` input (for the `nixfmt` package), but then I got a hash mismatch in `crane` with `nix build`. So I just decided to update all the inputs instead :shrug: (there's no harm in it I guess and it has been a while since they were last updated).