### PR TITLE
Handle italic_angle in various renderers

### DIFF
--- a/crates/typst-render/src/text.rs
+++ b/crates/typst-render/src/text.rs
@@ -66,14 +66,17 @@ fn render_outline_glyph(
 
         let scale = text.size.to_f32() / text.font.units_per_em() as f32;
 
+        let italic_skew = text.font.ttf().italic_angle().to_radians().tan();
+
         let mut pixmap = None;
 
         let rule = sk::FillRule::default();
 
         // Flip vertically because font design coordinate
         // system is Y-up.
-        let ts = ts.pre_scale(scale, -scale);
-        let state_ts = state.pre_concat(sk::Transform::from_scale(scale, -scale));
+        let state_ts = state.pre_concat(sk::Transform::from_skew(italic_skew, 0.0));
+        let state_ts = state_ts.pre_concat(sk::Transform::from_scale(scale, -scale));
+        let ts = state_ts.transform;
         let paint = paint::to_sk_paint(
             &text.fill,
             state_ts,

--- a/crates/typst-svg/src/text.rs
+++ b/crates/typst-svg/src/text.rs
@@ -23,7 +23,7 @@ impl SVGRenderer<'_> {
 
         self.xml.start_element("g");
         self.xml.write_attribute("class", "typst-text");
-        self.xml.write_attribute("transform", "scale(1, -1)");
+        self.xml.write_attribute("transform", &format!("skewX({}) scale(1, -1)", text.font.ttf().italic_angle()));
 
         let mut x: f64 = 0.0;
         let mut y: f64 = 0.0;


### PR DESCRIPTION
Tested with Univers Oblique (a non-free font, so not sure how to commit tests for this. create or modify a font specifically for this testing? it's surprisingly hard to find fonts that break on this.)

Also requires this fix in pixglyph: https://github.com/typst/pixglyph/pull/3

`glyph_frame` also needs this in theory, but Univers certainly doesn't have any glyphs that would trigger the fallback so I wasn't able to get a motivating test case.