### PR TITLE
Skip labels with invalid characters in reference completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3065,6 +3065,7 @@ dependencies = [
  "typst-assets",
  "typst-dev-assets",
  "typst-eval",
+ "typst-syntax",
  "unscanny",
 ]
 

--- a/crates/typst-ide/Cargo.toml
+++ b/crates/typst-ide/Cargo.toml
@@ -15,6 +15,7 @@ readme = { workspace = true }
 [dependencies]
 typst = { workspace = true }
 typst-eval = { workspace = true }
+typst-syntax = { workspace = true }
 comemo = { workspace = true }
 ecow = { workspace = true }
 pathdiff = { workspace = true }


### PR DESCRIPTION
When completing @, skip labels that have names that we know are incompatible with the @ syntax. For example, `label("t/1")` creates a label that is impossible to use with the @t/1 syntax, so it should be skipped, for both `@` and `<` completion.

This is submitted for discussion.

- `@test,1 @test/2 @test@2` are not valid syntax (or if they are, they reference `@test`)
- `<test,1> <test/2> <test@2>` are not valid syntax

Reference completion is autocompletion after e.g `@t`, label completion after e.g `<t`.

- When using certain packages they use lots of internal label names as part of their implementation. These label names fill the label list and makes it harder for the user to find the labels and references they want to use.
- The convention for what to ignore here will influence names libraries use, they will/should use names that are hidden if their label names should not be completed or visible to the user.

New internal dependency

- typst-ide depends on typst-syntax.