### PR TITLE
Fix punctuation in HTML placeholder

### DIFF
--- a/crates/typst-cli/src/server.rs
+++ b/crates/typst-cli/src/server.rs
@@ -201,7 +201,7 @@ const PLACEHOLDER_HTML: &str = "\
   </head>
   <body>
     <main>
-      <div>Waiting for output ...</div>
+      <div>Waiting for output…</div>
       <div><code>typst watch {INPUT}</code></div>
     </main>
   </body>


### PR DESCRIPTION
This fixes a minor punctuation mistake in a placeholder text.