### PR TITLE
Document and test `Sides<T>` parameters

### DIFF
--- a/crates/typst-library/src/layout/container.rs
+++ b/crates/typst-library/src/layout/container.rs
@@ -69,19 +69,16 @@ pub struct BoxElem {
 
     /// How much to pad the box's content.
     ///
-    /// This can be:
-    /// - a single length for all sides
-    /// - a dictionary of lengths for individual sides
+    /// This can be a single length for all sides or a dictionary of lengths
+    /// for individual sides. When passing a dictionary, it can contain the
+    /// following keys in order of precedence: `top`, `right`, `bottom`, `left`
+    /// (controlling the respective cell sides), `x`, `y` (controlling vertical
+    /// and horizontal insets), and `rest` (covers all insets not styled by
+    /// other dictionary entries). All keys are optional; omitted keys will use
+    /// their previously set value, or the default value if never set.
     ///
-    /// When passing a dictionary, it can contain the following keys in order of
-    /// precedence: `top`, `right`, `bottom`, `left` (controlling the respective
-    /// cell sides), `x`, `y` (controlling vertical and horizontal insets), and
-    /// `rest` (covers all insets not styled by other dictionary entries). All
-    /// keys are optional; omitted keys will use their previously set value, or
-    /// the default value if never set.
-    ///
-    /// Here the lengths can be [relative] and ratios are relative to the box
-    /// size without outset.
+    /// [Relative lengths]($relative) are relative to the box size without
+    /// outset.
     ///
     /// _Note:_ When the box contains text, its exact size depends on the
     /// current [text edges]($text.top-edge).
@@ -94,11 +91,9 @@ pub struct BoxElem {
 
     /// How much to expand the box's size without affecting the layout.
     ///
-    /// This can be:
-    /// - a single length for all sides
-    /// - a dictionary of lengths for individual sides
-    /// Here the lengths can be [relative] and ratios are relative to the box
-    /// size without outset. See the above documentation for [inset]($box.inset)
+    /// This can be a single length for all sides or a dictionary of lengths for
+    /// individual sides. [Relative lengths]($relative) are relative to the box
+    /// size without outset. See the documentation for [inset]($box.inset) above
     /// for further details.
     ///
     /// This is useful to prevent padding from affecting line layout. For a

--- a/crates/typst-library/src/layout/container.rs
+++ b/crates/typst-library/src/layout/container.rs
@@ -69,6 +69,20 @@ pub struct BoxElem {
 
     /// How much to pad the box's content.
     ///
+    /// This can be:
+    /// - a single length for all sides
+    /// - a dictionary of lengths for individual sides
+    ///
+    /// When passing a dictionary, it can contain the following keys in order of
+    /// precedence: `top`, `right`, `bottom`, `left` (controlling the respective
+    /// cell sides), `x`, `y` (controlling vertical and horizontal insets), and
+    /// `rest` (covers all insets not styled by other dictionary entries). All
+    /// keys are optional; omitted keys will use their previously set value, or
+    /// the default value if never set.
+    ///
+    /// Here the lengths can be [relative] and ratios are relative to the box
+    /// size without outset.
+    ///
     /// _Note:_ When the box contains text, its exact size depends on the
     /// current [text edges]($text.top-edge).
     ///
@@ -79,6 +93,13 @@ pub struct BoxElem {
     pub inset: Sides<Option<Rel<Length>>>,
 
     /// How much to expand the box's size without affecting the layout.
+    ///
+    /// This can be:
+    /// - a single length for all sides
+    /// - a dictionary of lengths for individual sides
+    /// Here the lengths can be [relative] and ratios are relative to the box
+    /// size without outset. See the above documentation for [inset]($box.inset)
+    /// for further details.
     ///
     /// This is useful to prevent padding from affecting line layout. For a
     /// generalized version of the example below, see the documentation for the

--- a/crates/typst-library/src/layout/page.rs
+++ b/crates/typst-library/src/layout/page.rs
@@ -126,8 +126,10 @@ pub struct PageElem {
     ///   - `rest`: The margins on all sides except those for which the
     ///     dictionary explicitly sets a size.
     ///
-    /// The values for `left` and `right` are mutually exclusive with
-    /// the values for `inside` and `outside`.
+    /// All keys are optional; omitted keys will use their previously set value,
+    /// or the default margin if never set. In addition, the values for `left`
+    /// and `right` are mutually exclusive with the values for `inside` and
+    /// `outside`.
     ///
     /// ```example
     /// #set page(

--- a/crates/typst-library/src/visualize/shape.rs
+++ b/crates/typst-library/src/visualize/shape.rs
@@ -73,6 +73,7 @@ pub struct RectElem {
     /// the width and height divided by two. This can be:
     ///
     /// - A relative length for a uniform corner radius.
+    ///
     /// - A dictionary: With a dictionary, the stroke for each side can be set
     ///   individually. The dictionary can contain the following keys in order
     ///   of precedence:

--- a/crates/typst-library/src/visualize/shape.rs
+++ b/crates/typst-library/src/visualize/shape.rs
@@ -36,11 +36,15 @@ pub struct RectElem {
     /// How to stroke the rectangle. This can be:
     ///
     /// - `{none}` to disable stroking
+    ///
     /// - `{auto}` for a stroke of `{1pt + black}` if and only if no fill is
     ///   given.
+    ///
     /// - Any kind of [stroke]
+    ///
     /// - A dictionary describing the stroke for each side individually. The
     ///   dictionary can contain the following keys in order of precedence:
+    ///
     ///   - `top`: The top stroke.
     ///   - `right`: The right stroke.
     ///   - `bottom`: The bottom stroke.
@@ -49,6 +53,9 @@ pub struct RectElem {
     ///   - `y`: The vertical stroke.
     ///   - `rest`: The stroke on all sides except those for which the
     ///     dictionary explicitly sets a size.
+    ///
+    ///   All keys are optional; omitted keys will use their previously set
+    ///   value, or the default stroke if never set.
     ///
     /// ```example
     /// #stack(

--- a/docs/guides/tables.md
+++ b/docs/guides/tables.md
@@ -543,9 +543,9 @@ If you want more fine-grained control of where lines get placed in your table,
 you can also pass a dictionary with the keys `top`, `left`, `right`, `bottom`
 (controlling the respective cell sides), `x`, `y` (controlling vertical and
 horizontal strokes), and `rest` (covers all strokes not styled by other
-dictionary entries). All keys are optional; omitted keys will be treated as if
-their value was the default value. For example, to get a table with only
-horizontal lines, you can do this:
+dictionary entries). All keys are optional; omitted keys will use their
+previously set value, or the default value if never set. For example, to get a
+table with only horizontal lines, you can do this:
 
 ```example
 #table(

--- a/tests/suite/layout/container.typ
+++ b/tests/suite/layout/container.typ
@@ -152,6 +152,26 @@ Paragraph
 #show bibliography: none
 #bibliography("/assets/bib/works.bib")
 
+--- box-inset-ratio ---
+#let body-width = 10pt
+#context for inset in range(10).map(n => n / 10) {
+  // If there's infinite available space, then:
+  // ```
+  // measured-width = body-width + measured-width × inset.
+  // ```
+  // (not counting truncation errors)
+  let (width: measured-width) = measure(
+    box(
+      // Outset should not affect inset.
+      outset: 137pt,
+      inset: (left: 100% * inset),
+      block(width: body-width)
+    ),
+    width: auto,
+  )
+  assert.eq(measured-width, body-width / (1 - inset))
+}
+
 --- block-sticky ---
 #set page(height: 100pt)
 #lines(3)
@@ -332,23 +352,3 @@ c
   radius: 100%,
   rect(fill: gray, height: 1cm, width: 1cm),
 )
-
---- box-inset-ratio ---
-#let body-width = 10pt
-#context for inset in range(10).map(n => n / 10) {
-  // If there's infinite available space, then:
-  // ```
-  // measured-width = body-width + measured-width × inset.
-  // ```
-  // (not counting truncation errors)
-  let (width: measured-width) = measure(
-    box(
-      // Outset should not affect inset.
-      outset: 137pt,
-      inset: (left: 100% * inset),
-      block(width: body-width)
-    ),
-    width: auto,
-  )
-  assert.eq(measured-width, body-width / (1 - inset))
-}

--- a/tests/suite/layout/container.typ
+++ b/tests/suite/layout/container.typ
@@ -335,21 +335,20 @@ c
 
 --- box-inset-ratio ---
 #let body-width = 10pt
-
 #context for inset in range(10).map(n => n / 10) {
   // If there's infinite available space, then:
-  //   measured-width =  body-width + measured-width × inset.
+  // ```
+  // measured-width = body-width + measured-width × inset.
+  // ```
   // (not counting truncation errors)
-  let measured-width = measure(
-    box(inset: (left: 100% * inset), box(width: body-width)),
+  let (width: measured-width) = measure(
+    box(
+      // Outset should not affect inset.
+      outset: 137pt,
+      inset: (left: 100% * inset),
+      block(width: body-width)
+    ),
     width: auto,
-  ).width
+  )
   assert.eq(measured-width, body-width / (1 - inset))
-
-  // Moreover, outset should not affect inset.
-  let measured-width-with-outset = measure(
-    box(outset: 137pt, inset: (left: 100% * inset), box(width: body-width)),
-    width: auto,
-  ).width
-  assert.eq(measured-width-with-outset, measured-width)
 }

--- a/tests/suite/layout/container.typ
+++ b/tests/suite/layout/container.typ
@@ -332,3 +332,24 @@ c
   radius: 100%,
   rect(fill: gray, height: 1cm, width: 1cm),
 )
+
+--- box-inset-ratio ---
+#let body-width = 10pt
+
+#context for inset in range(10).map(n => n / 10) {
+  // If there's infinite available space, then:
+  //   measured-width =  body-width + measured-width × inset.
+  // (not counting truncation errors)
+  let measured-width = measure(
+    box(inset: (left: 100% * inset), box(width: body-width)),
+    width: auto,
+  ).width
+  assert.eq(measured-width, body-width / (1 - inset))
+
+  // Moreover, outset should not affect inset.
+  let measured-width-with-outset = measure(
+    box(outset: 137pt, inset: (left: 100% * inset), box(width: body-width)),
+    width: auto,
+  ).width
+  assert.eq(measured-width-with-outset, measured-width)
+}


### PR DESCRIPTION
This PR is extracted from #6764 and resolves comments on `container.rs` in that PR.

- Document that `box.inset` and `box.outset` accept **dictionaries** containing top, right, x, y, rest, etc.

- Document what will happen if `box.inset` (or `page.margin`, `rect.stroke`, `table.stroke`) receives a dictionary with some keys **omitted**.

- Document that `box.inset` and similar parameters accept **relative** length, and add a test for that.

  Previously, there isn't any test that passes a ratio to `{box,block,rect,table,…}.inset`.

  The formula in the added test comes from [the `grow` function in typst-layout](https://github.com/typst/typst/blob/main/crates/typst-layout/src/pad.rs#L61-L93).

  It is important to mention that ratios are relative to the box size. People might mistakenly think they are relative to the size of available space, as in [Inset paragraph by exactly half a page - Questions - Typst Forum](https://forum.typst.app/t/inset-paragraph-by-exactly-half-a-page/5898/2).

## Things not covered in this PR

- Add links from `{table,grid}.inset` to `box.inset`.

  #6764 will add examples on `inset`. Theses links will be added together.

- Document that `page.margin` also accepts relative lengths.

  This feature is never tested and the behaviour looks buggy (for instance, `#set page(margin: (y: 20%), height: auto)`).
  Moreover, the only use case I know might deserve a dedicated API.

  > The only use case I know is [directly setting the width of the type area, instead of the paper width](https://typst-doc-cn.github.io/clreq/#directly-setting-the-width-of-the-type-area-instead-of-the-paper-width), like `#set page(margin: (x: (100% - 42em) / 2))`.


  Therefore, it requires more discussion.
