### PR TITLE
Add a link from `math.vec` to `math.{arrow,bold}` in docs

### DIFF
--- a/crates/typst-library/src/math/matrix.rs
+++ b/crates/typst-library/src/math/matrix.rs
@@ -20,6 +20,9 @@ const DEFAULT_COL_GAP: Em = Em::new(0.5);
 /// Content in the vector's elements can be aligned with the
 /// [`align`]($math.vec.align) parameter, or the `&` symbol.
 ///
+/// This function expresses a vector as its components. For symbolic notation,
+/// use [`arrow`]($math.arrow) or [`bold`]($math.bold) instead.
+///
 /// # Example
 /// ```example
 /// $ vec(a, b, c) dot vec(1, 2, 3)

--- a/crates/typst-library/src/math/matrix.rs
+++ b/crates/typst-library/src/math/matrix.rs
@@ -20,8 +20,9 @@ const DEFAULT_COL_GAP: Em = Em::new(0.5);
 /// Content in the vector's elements can be aligned with the
 /// [`align`]($math.vec.align) parameter, or the `&` symbol.
 ///
-/// This function expresses a vector as its components. For symbolic notation,
-/// use [`arrow`]($math.arrow) or [`bold`]($math.bold) instead.
+/// This function is for typesetting vector components. To typeset a symbol that
+/// represents a vector, [`arrow`]($math.arrow) and [`bold`]($math.bold) are
+/// commonly used.
 ///
 /// # Example
 /// ```example


### PR DESCRIPTION
LaTeX `\vec` ≠ Typst `vec` surprises some people, like Sinthoras who posted [How to write a vector arrow over a variable? Equivalent of LaTeX vec function? - Questions - Typst Forum](https://forum.typst.app/t/how-to-write-a-vector-arrow-over-a-variable-equivalent-of-latex-vec-function/5854).

I didn't mention `bold(upright(v))` or `hat(n)`, because it's too obvious.
There are also people who are confused by the missing space in `arrow(AB)`, but I don't think `math.vec` is the right place to explain.