### PR TITLE
Add -e flag to winget installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Typst's CLI is available from different sources:
       - View [Typst on Repology][repology]
       - View [Typst's Snap][snap]
   - macOS: `brew install typst`
-  - Windows: `winget install --id Typst.Typst`
+  - Windows: `winget install -e --id Typst.Typst`
 
 - If you have a [Rust][rust] toolchain installed, you can install
   - the latest released Typst version with


### PR DESCRIPTION
The `-e` (`--exact`) flag keeps winget from installing another package that was fuzzily matched. This is not *necessary* here, as the provided `--id` should match only Typst and at the moment, `winget search typst` only returns Typst itself and tinymist anyway, but it is another level of security, which I personally think should be recommended to users when installing.