### PR TITLE
Raise an error when mutating method is accessed outside of a call expression

### DIFF
--- a/tests/suite/scripting/field.typ
+++ b/tests/suite/scripting/field.typ
@@ -74,3 +74,7 @@
   // Hint: 3-4 try creating a new stroke with the updated field value instead
   s.thickness = 5pt
 }
+
+--- field-mutable-cannot-access ---
+// Error: 8-12 cannot access mutating fields on array
+#array.push


### PR DESCRIPTION
Currently, Typst allows you to access mutating methods as fields on types which leads to inconsistent behavior. For instance, the following code works without errors

```typ
#let arr = (1, 2, 3)
#let push = array.push
#push(arr, 4)
#arr
```

However, since `arr` is cloned when passed to the `push` and due to the COW semantics of Arc, the array `arr` remains unmodified.

This PR adds an error that is raised when a mutating method is accessed on a type outside of a call expression.