### PR TITLE
More useful `Debug` impls for `Tag` and `Location`

### DIFF
--- a/crates/typst-library/src/introspection/location.rs
+++ b/crates/typst-library/src/introspection/location.rs
@@ -95,7 +95,13 @@ impl Location {
 
 impl Debug for Location {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "Location({})", self.0)
+        if f.alternate() {
+            write!(f, "Location({})", self.0)
+        } else {
+            // Print a shorter version by default to make it more readable.
+            let truncated = self.0 as u16;
+            write!(f, "Location({truncated})")
+        }
     }
 }
 

--- a/crates/typst-library/src/introspection/tag.rs
+++ b/crates/typst-library/src/introspection/tag.rs
@@ -35,9 +35,10 @@ impl Tag {
 
 impl Debug for Tag {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let loc = self.location();
         match self {
-            Tag::Start(elem) => write!(f, "Start({:?})", elem.elem().name()),
-            Tag::End(..) => f.pad("End"),
+            Tag::Start(elem) => write!(f, "Start({:?}, {loc:?})", elem.elem().name()),
+            Tag::End(..) => f.pad("End({loc:?})"),
         }
     }
 }


### PR DESCRIPTION
The current `Debug` impl for `Location` is very noisy because the number is 128 bit. For readability purposes, truncating it to 16 bit is better and the location probably is still low enough for debugging.

The current `Debug` impl for `Tag` is pretty useless since it does not print the location. It now does.