### PR TITLE
Fix potential crash in `Debug` impl of `Property`

### DIFF
--- a/crates/typst-library/src/foundations/styles.rs
+++ b/crates/typst-library/src/foundations/styles.rs
@@ -317,7 +317,7 @@ impl Debug for Property {
             f,
             "Set({}.{}: ",
             self.elem.name(),
-            self.elem.field_name(self.id).unwrap()
+            self.elem.field_name(self.id).unwrap_or("internal")
         )?;
         self.value.fmt(f)?;
         write!(f, ")")


### PR DESCRIPTION
The current `Debug` impl can panic for internal fields. We don't have name metadata for them currently, but printing "internal" is still better than crashing.