### PR TITLE
Fix `Debug` impl for end tags

### DIFF
--- a/crates/typst-library/src/introspection/tag.rs
+++ b/crates/typst-library/src/introspection/tag.rs
@@ -38,7 +38,7 @@ impl Debug for Tag {
         let loc = self.location();
         match self {
             Tag::Start(elem) => write!(f, "Start({:?}, {loc:?})", elem.elem().name()),
-            Tag::End(..) => f.pad("End({loc:?})"),
+            Tag::End(..) => write!(f, "End({loc:?})"),
         }
     }
 }


### PR DESCRIPTION
Small oversight in #6901 — we don't want a literal `{loc:?}`