### PR TITLE
Expand tags even a bit more around groupings

### DIFF
--- a/crates/typst-ide/src/jump.rs
+++ b/crates/typst-ide/src/jump.rs
@@ -417,7 +417,7 @@ mod tests {
     fn test_footnote_links() {
         let s = "#footnote[Hi]";
         test_click(s, point(10.0, 10.0), pos(1, 10.0, 31.58).map(Jump::Position));
-        test_click(s, point(19.0, 33.0), pos(1, 10.0, 10.0).map(Jump::Position));
+        test_click(s, point(19.0, 33.0), pos(1, 10.0, 16.58).map(Jump::Position));
     }
 
     #[test]

--- a/tests/ref/html/link-html-here.html
+++ b/tests/ref/html/link-html-here.html
@@ -5,6 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body>
-    <p id="loc-1"><a href="#loc-1">Go</a></p>
+    <p><a id="loc-1" href="#loc-1">Go</a></p>
   </body>
 </html>

--- a/tests/ref/html/link-html-id-attach.html
+++ b/tests/ref/html/link-html-id-attach.html
@@ -14,8 +14,9 @@
       <li><a href="#t6">Go</a></li>
       <li><a href="#t7">Go</a></li>
       <li><a href="#t8">Go</a></li>
+      <li><a href="#t9">Go</a></li>
     </ul>
-    <p id="t1">Hi</p>
+    <p><span id="t1">Hi</span></p>
     <p><span id="t2">Hi</span> there</p>
     <p>See <span id="t4">it</span></p>
     <p>See <span id="t5">it</span> here</p>
@@ -25,5 +26,6 @@
     <span id="t7"></span>
     <p>See</p>
     <span id="t8"></span>
+    <p><strong id="t9">Strong</strong></p>
   </body>
 </html>

--- a/tests/ref/html/link-html-nested-empty.html
+++ b/tests/ref/html/link-html-nested-empty.html
@@ -5,8 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body>
-    <span id="a"></span><span id="b"></span>
-    <p>Hi</p>
+    <p><span id="a"></span><span id="b"></span>Hi</p>
     <p><a href="#a">A</a> <a href="#b">B</a> <a href="#a">C</a></p>
   </body>
 </html>

--- a/tests/src/custom.rs
+++ b/tests/src/custom.rs
@@ -38,8 +38,12 @@ pub fn check(test: &Test, world: &TestWorld, doc: Option<&PagedDocument>) -> Str
             test_eq!(sink, info.title.as_deref(), Some("Alternative"));
         }
         "tags-grouping" | "tags-textual" => {
-            if let Err(message) = check_balanced(doc.unwrap()) {
-                sink.push_str(message);
+            if let Some(doc) = doc {
+                if let Err(message) = check_balanced(doc) {
+                    sink.push_str(message);
+                }
+            } else {
+                sink.push_str("missing document");
             }
         }
         _ => {}

--- a/tests/suite/introspection/tags.typ
+++ b/tests/suite/introspection/tags.typ
@@ -75,7 +75,7 @@
 // When there's only a link, it will surround the paragraph.
 #case(
   link("A")[A],
-  "<a><p></p></a>"
+  "<p><a></a></p>"
 )
 
 --- tags-textual ---

--- a/tests/suite/model/link.typ
+++ b/tests/suite/model/link.typ
@@ -70,7 +70,7 @@ Text <hey>
 // Tests how IDs and, if necessary, spans, are added to the DOM to support
 // links.
 
-#for i in range(1, 9) {
+#for i in range(1, 10) {
   list.item(link(label("t" + str(i)), [Go]))
 }
 
@@ -97,6 +97,8 @@ See #[] <t7>
 
 // Nothing 2
 See #metadata(none) <t8>
+
+*Strong* <t9>
 
 --- link-html-label-disambiguation html ---
 // Tests automatic ID generation for labelled elements.


### PR DESCRIPTION
Follow-up to https://github.com/typst/typst/pull/6881 that goes even a little further. In the original PR, leading tags that were closed within a grouping are merged into the grouping, and the same for trailing tags. What wasn't merged into the grouping are leading tags that are closed by trailing tags. As a result, `#link("A")[A]` (just the link becomes the whole paragraph) resulted in the tag nesting `link > p`. With this PR, such tag pairings are also included in the grouping, resulting in the nesting `p > link`. This also makes auto-ID generation in HTML export a bit nicer.