### PR TITLE
Make `select_where!` usable outside of typst-library

### DIFF
--- a/crates/typst-library/src/foundations/mod.rs
+++ b/crates/typst-library/src/foundations/mod.rs
@@ -74,6 +74,7 @@ use typst_syntax::SyntaxMode;
 pub use {
     ecow::{eco_format, eco_vec},
     indexmap::IndexMap,
+    smallvec::SmallVec,
 };
 
 use comemo::TrackedMut;

--- a/crates/typst-library/src/foundations/selector.rs
+++ b/crates/typst-library/src/foundations/selector.rs
@@ -18,7 +18,7 @@ use crate::introspection::{Introspector, Locatable, Location, Unqueriable};
 macro_rules! __select_where {
     ($ty:ty $(, $field:ident => $value:expr)* $(,)?) => {{
         #[allow(unused_mut)]
-        let mut fields = ::smallvec::SmallVec::new();
+        let mut fields = $crate::foundations::SmallVec::new();
         $(
             fields.push((
                 <$ty>::$field.index(),


### PR DESCRIPTION
This fixes a problem where `select_where!` couldn't be used in crates that do not directly depend on `smallvec`.