### PR TITLE
Consistently ignore styles for tags

### DIFF
--- a/crates/typst-layout/src/flow/collect.rs
+++ b/crates/typst-layout/src/flow/collect.rs
@@ -113,8 +113,8 @@ impl<'a> Collector<'a, '_, '_> {
         let (start, end) = self.children.split_prefix_suffix(|(c, _)| c.is::<TagElem>());
         let inner = &self.children[start..end];
 
-        // Compute the shared styles, ignoring tags.
-        let styles = StyleChain::trunk(inner.iter().map(|&(_, s)| s)).unwrap_or_default();
+        // Compute the shared styles.
+        let styles = StyleChain::trunk_from_pairs(inner).unwrap_or_default();
 
         // Layout the lines.
         let lines = crate::inline::layout_inline(

--- a/crates/typst-layout/src/pages/run.rs
+++ b/crates/typst-layout/src/pages/run.rs
@@ -6,7 +6,7 @@ use typst_library::foundations::{
     Content, NativeElement, Resolve, Smart, StyleChain, Styles,
 };
 use typst_library::introspection::{
-    Counter, CounterDisplayElem, CounterKey, Introspector, Locator, LocatorLink, TagElem,
+    Counter, CounterDisplayElem, CounterKey, Introspector, Locator, LocatorLink,
 };
 use typst_library::layout::{
     Abs, AlignElem, Alignment, Axes, Binding, ColumnsElem, Dir, Frame, HAlignment,
@@ -249,8 +249,7 @@ fn layout_page_run_impl(
 ///     constructor styles are not liftable.
 fn determine_page_styles(children: &[Pair], initial: StyleChain) -> Styles {
     // Determine the shared styles (excluding tags).
-    let tagless = children.iter().filter(|(c, _)| !c.is::<TagElem>()).map(|&(_, s)| s);
-    let base = StyleChain::trunk(tagless).unwrap_or(initial).to_map();
+    let base = StyleChain::trunk_from_pairs(children).unwrap_or(initial).to_map();
 
     // Determine the initial styles that are also shared by everything. We can't
     // use `StyleChain::trunk` because it currently doesn't deal with partially

--- a/crates/typst-library/src/foundations/styles.rs
+++ b/crates/typst-library/src/foundations/styles.rs
@@ -16,6 +16,7 @@ use crate::foundations::{
     Content, Context, Element, Field, Func, NativeElement, OneOrMultiple, Packed,
     RefableProperty, Repr, Selector, SettableProperty, Target, cast, ty,
 };
+use crate::introspection::TagElem;
 
 /// A list of style properties.
 #[ty(cast)]
@@ -702,6 +703,13 @@ impl<'a> StyleChain<'a> {
         }
 
         Some(trunk)
+    }
+
+    /// Determines the shared trunk of a list of elements.
+    ///
+    /// This will ignore styles for tags (conceptually, they just don't exist).
+    pub fn trunk_from_pairs(iter: &[(&Content, Self)]) -> Option<Self> {
+        Self::trunk(iter.iter().filter(|(c, _)| !c.is::<TagElem>()).map(|&(_, s)| s))
     }
 }
 

--- a/crates/typst-realize/src/lib.rs
+++ b/crates/typst-realize/src/lib.rs
@@ -1386,7 +1386,7 @@ fn select_span(children: &[Pair]) -> Span {
 /// Turn realized content with styles back into owned content and a trunk style
 /// chain.
 fn repack<'a>(buf: &[Pair<'a>]) -> (Content, StyleChain<'a>) {
-    let trunk = StyleChain::trunk(buf.iter().map(|&(_, s)| s)).unwrap_or_default();
+    let trunk = StyleChain::trunk_from_pairs(buf).unwrap_or_default();
     let depth = trunk.links().count();
 
     let mut seq = Vec::with_capacity(buf.len());


### PR DESCRIPTION
This ensures that style chains associated with tags never make it into shared trunk styles for groupings. Fixes a problem that https://github.com/typst/typst/pull/6909 exhibits in combination with #6619.