### PR TITLE
Add `default` argument to `array.join`

### DIFF
--- a/crates/typst-library/src/foundations/array.rs
+++ b/crates/typst-library/src/foundations/array.rs
@@ -701,8 +701,18 @@ impl Array {
         /// An alternative separator between the last two items.
         #[named]
         last: Option<Value>,
+        /// What to return if the array is empty.
+        #[named]
+        default: Option<Value>,
     ) -> StrResult<Value> {
         let len = self.0.len();
+
+        if let Some(result) = default
+            && len == 0
+        {
+            return Ok(result);
+        }
+
         let separator = separator.unwrap_or(Value::None);
 
         let mut last = last;

--- a/tests/src/world.rs
+++ b/tests/src/world.rs
@@ -266,6 +266,6 @@ fn lines(
     (1..=count)
         .map(|n| numbering.apply(engine, context, &[n]))
         .collect::<SourceResult<Array>>()?
-        .join(Some('\n'.into_value()), None)
+        .join(Some('\n'.into_value()), None, None)
         .at(span)
 }

--- a/tests/suite/foundations/array.typ
+++ b/tests/suite/foundations/array.typ
@@ -300,6 +300,11 @@
 #test(("a", "b", "c").join(), "abc")
 #test("(" + ("a", "b", "c").join(", ") + ")", "(a, b, c)")
 
+--- array-join-default ---
+#test(().join(default: "EMPTY", ", "), "EMPTY")
+#test(("hello",).join(default: "EMPTY", ", "), "hello")
+#test(("hello", "world").join(default: "EMPTY", ", "), "hello, world")
+
 --- array-join-bad-values ---
 // Error: 2-22 cannot join boolean with boolean
 #(true, false).join()


### PR DESCRIPTION
Closes https://github.com/typst/typst/issues/6891.

One open question is what to do when no default is provided and the array is empty. For now, I chose to return `none` (i.e., no change in behavior). `array.sum` and `array.product` raise an error in this case, so we might want to align with that.