### PR TITLE
Use Title Case for Doc Pages

### DIFF
--- a/crates/typst-library/src/layout/grid/mod.rs
+++ b/crates/typst-library/src/layout/grid/mod.rs
@@ -106,7 +106,7 @@ use crate::visualize::{Paint, Stroke};
 ///
 /// # Styling the grid { #styling }
 /// The grid and table elements work similarly. For a hands-on explanation,
-/// refer to the [table guide]($guides/table-guide/#fills); for a quick overview,
+/// refer to the [Table Guide]($guides/table-guide/#fills); for a quick overview,
 /// continue reading.
 ///
 /// The grid's appearance can be customized through different parameters. These

--- a/crates/typst-library/src/layout/page.rs
+++ b/crates/typst-library/src/layout/page.rs
@@ -204,7 +204,7 @@ pub struct PageElem {
     #[ghost]
     pub fill: Smart<Option<Paint>>,
 
-    /// How to number the pages. You can refer to the page setup guide for
+    /// How to number the pages. You can refer to the Page Setup Guide for
     /// [customizing page numbers]($guides/page-setup-guide/#page-numbers).
     ///
     /// Accepts a [numbering pattern or function]($numbering) taking one or two

--- a/crates/typst-library/src/model/table.rs
+++ b/crates/typst-library/src/model/table.rs
@@ -18,7 +18,7 @@ use crate::visualize::{Paint, Stroke};
 /// Tables are used to arrange content in cells. Cells can contain arbitrary
 /// content, including multiple paragraphs and are specified in row-major order.
 /// For a hands-on explanation of all the ways you can use and customize tables
-/// in Typst, check out the [table guide]($guides/table-guide).
+/// in Typst, check out the [Table Guide]($guides/table-guide).
 ///
 /// Because tables are just grids with different defaults for some cell
 /// properties (notably `stroke` and `inset`), refer to the [grid
@@ -188,7 +188,7 @@ pub struct TableElem {
     /// - use a function that maps a cell's X/Y position (both starting from
     ///   zero) to its alignment
     ///
-    /// See the [table guide]($guides/table-guide/#alignment) for details.
+    /// See the [Table Guide]($guides/table-guide/#alignment) for details.
     ///
     /// ```example
     /// #table(
@@ -208,7 +208,7 @@ pub struct TableElem {
     /// - a function that maps a cell's position to its fill
     ///
     /// Most notably, arrays and functions are useful for creating striped
-    /// tables. See the [table guide]($guides/table-guide/#fills) for more
+    /// tables. See the [Table Guide]($guides/table-guide/#fills) for more
     /// details.
     ///
     /// ```example
@@ -247,7 +247,7 @@ pub struct TableElem {
     /// - use an array of strokes corresponding to each column
     /// - use a function that maps a cell's position to its stroke
     ///
-    /// See the [table guide]($guides/table-guide/#strokes) for more details.
+    /// See the [Table Guide]($guides/table-guide/#strokes) for more details.
     #[fold]
     #[default(Celled::Value(Sides::splat(Some(Some(Arc::new(Stroke::default()))))))]
     pub stroke: Celled<Sides<Option<Option<Arc<Stroke>>>>>,

--- a/docs/changelog/0.11.0.md
+++ b/docs/changelog/0.11.0.md
@@ -7,7 +7,7 @@ description: Changes in Typst 0.11.0
 
 ## Tables
 - Tables are now _much_ more flexible, read the new
-  [table guide]($guides/table-guide) to get started
+  [Table Guide]($guides/table-guide) to get started
 - Added [`table.cell`] element for per-cell configuration
 - Cells can now span multiple [columns]($table.cell.colspan) or
   [rows]($table.cell.rowspan)

--- a/docs/changelog/0.12.0.md
+++ b/docs/changelog/0.12.0.md
@@ -33,7 +33,7 @@ description: Changes in Typst 0.12.0
 - Added support for multi-column floating placement and figures via
   [`place.scope`] and [`figure.scope`].  Two-column documents should now prefer
   `{set page(columns: 2)}` over `{show: column.with(2)}` (see the
-  [page setup guide]($guides/page-setup-guide/#columns)).
+  [Page Setup Guide]($guides/page-setup-guide/#columns)).
 - Added support for automatic [line numbering]($par.line) (often used in
   academic papers)
 - Added [`par.spacing`] property for configuring paragraph spacing. This should

--- a/docs/changelog/0.4.0.md
+++ b/docs/changelog/0.4.0.md
@@ -13,7 +13,7 @@ description: Changes in Typst 0.4.0
 - The `{"chicago-notes"}` [citation style]($cite.style) is now available
 
 ## Documentation
-- Added a [Guide for LaTeX users]($guides/guide-for-latex-users)
+- Added a [Guide for LaTeX Users]($guides/guide-for-latex-users)
 - Now shows default values for optional arguments
 - Added richer outlines in "On this Page"
 - Added initial support for search keywords: "Table of Contents" will now find

--- a/docs/changelog/0.8.0.md
+++ b/docs/changelog/0.8.0.md
@@ -96,7 +96,7 @@ description: Changes in Typst 0.8.0
 - Fixed crash when field wasn't present and `--one` is passed to `typst query`
 
 ## Miscellaneous Improvements
-- Added [page setup guide]($guides/page-setup-guide)
+- Added [Page Setup Guide]($guides/page-setup-guide)
 - Added [`figure.caption`]($figure.caption) function that can be used for
   simpler figure customization (**Breaking change** because `it.caption` now
   renders the full caption with supplement in figure show rules and manual

--- a/docs/changelog/0.9.0.md
+++ b/docs/changelog/0.9.0.md
@@ -169,7 +169,7 @@ description: Changes in Typst 0.9.0
   displayed in math mode.
 - Added support for specifying a default value instead of failing for `remove`
   function in [array]($array.remove) and [dictionary]($dictionary.remove)
-- Simplified page setup guide examples
+- Simplified Page Setup Guide examples
 - Switched the documentation from using the word "hashtag" to the word "hash"
   where appropriate
 - Added support for [`array.zip`]($array.zip) without any further arguments

--- a/docs/guides/guide-for-latex-users.md
+++ b/docs/guides/guide-for-latex-users.md
@@ -4,7 +4,7 @@ description: |
   similarities between Typst and LaTeX so you can get started quickly.
 ---
 
-# Guide for LaTeX users { # }
+# Guide for LaTeX Users { # }
 This page is a good starting point if you have used LaTeX before and want to try
 out Typst. We will explore the main differences between these two systems from a
 user perspective. Although Typst is not built upon LaTeX and has a different

--- a/docs/guides/page-setup.md
+++ b/docs/guides/page-setup.md
@@ -4,7 +4,7 @@ description: |
   Typst. Learn how to create appealing and clear layouts and get there quickly.
 ---
 
-# Page setup guide
+# Page Setup Guide
 Your page setup is a big part of the first impression your document gives. Line
 lengths, margins, and columns influence
 [appearance](https://practicaltypography.com/page-margins.html) and

--- a/docs/guides/tables.md
+++ b/docs/guides/tables.md
@@ -4,7 +4,7 @@ description: |
   explains all you need to know about tables in Typst.
 ---
 
-# Table guide
+# Table Guide
 Tables are a great way to present data to your readers in an easily readable,
 compact, and organized manner. They are not only used for numerical values, but
 also survey responses, task planning, schedules, and more. Because of this wide

--- a/docs/guides/welcome.md
+++ b/docs/guides/welcome.md
@@ -8,6 +8,6 @@ user groups or use cases. Please see the list below for the available guides.
 Feel free to propose other topics for guides!
 
 ## List of Guides
-- [Guide for LaTeX users]($guides/guide-for-latex-users)
-- [Page setup guide]($guides/page-setup-guide)
-- [Table guide]($guides/table-guide)
+- [Guide for LaTeX Users]($guides/guide-for-latex-users)
+- [Page Setup Guide]($guides/page-setup-guide)
+- [Table Guide]($guides/table-guide)


### PR DESCRIPTION
Fixes https://github.com/typst/typst/issues/6934.

I also changed all references to the pages in question to use title case as well.