### PR TITLE
Eliminate unnecessary `usize` usages from `typst-syntax`

### DIFF
--- a/crates/typst-syntax/src/ast.rs
+++ b/crates/typst-syntax/src/ast.rs
@@ -1068,7 +1068,7 @@ node! {
 
 impl<'a> MathRoot<'a> {
     /// The index of the root.
-    pub fn index(self) -> Option<usize> {
+    pub fn index(self) -> Option<u8> {
         match self.0.children().next().map(|node| node.text().as_str()) {
             Some("∜") => Some(4),
             Some("∛") => Some(3),

--- a/crates/typst-syntax/src/ast.rs
+++ b/crates/typst-syntax/src/ast.rs
@@ -1531,7 +1531,7 @@ impl UnOp {
     }
 
     /// The precedence of this operator.
-    pub fn precedence(self) -> usize {
+    pub fn precedence(self) -> u8 {
         match self {
             Self::Pos | Self::Neg => 7,
             Self::Not => 4,
@@ -1651,7 +1651,7 @@ impl BinOp {
     }
 
     /// The precedence of this operator.
-    pub fn precedence(self) -> usize {
+    pub fn precedence(self) -> u8 {
         match self {
             Self::Mul => 6,
             Self::Div => 6,

--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -647,7 +647,7 @@ fn code_expr(p: &mut Parser) {
 }
 
 /// Parses a code expression with at least the given precedence.
-fn code_expr_prec(p: &mut Parser, atomic: bool, min_prec: usize) {
+fn code_expr_prec(p: &mut Parser, atomic: bool, min_prec: u8) {
     let m = p.marker();
     if !atomic && p.at_set(set::UNARY_OP) {
         let op = ast::UnOp::from_kind(p.current()).unwrap();


### PR DESCRIPTION
This follows the spirit of #6026: `usize` should only be used for ~~indices and lengths~~ things bounded by memory.

This PR is separated into disjoint commits to make reviewing easier.

Notes:
- For the precedences, I just went with the smallest type that fits all the values we use, so `u8`. There's also a case to be made for `u16`, but I think if there's ever a need for it, it can just be changed again then.
- For `MathRoot`, I think it's safe to say that we won't have syntax for roots with index greater than 255 in the future, so `u8` is the best choice.
- ~~For the other two, I just went with `u64` for obvious reasons. I'm actually not perfectly sure about these: They're not explicitly indices or lengths, but I don't know if it might not still be impossible for them to exceed `usize::MAX`... If so, then those two commits should of course be dropped.~~ Edit (see https://github.com/typst/typst/pull/6942#pullrequestreview-3250067497): These are justified in their use of `usize`.

I checked all occurrences of `usize` in `typst-syntax` and everything besides what I changed here is justified (indices, ranges, and lengths).