### PR TITLE
Add an example that number every 5th `par.line`

### DIFF
--- a/crates/typst-library/src/model/par.rs
+++ b/crates/typst-library/src/model/par.rs
@@ -459,6 +459,15 @@ pub struct ParLine {
     /// Violets are blue. \
     /// Typst is there for you.
     /// ```
+    ///
+    /// ```example
+    /// >>> #set page(width: 200pt, margin: (left: 3em))
+    /// #set par.line(
+    ///   numbering: i => if calc.rem(i, 5) == 0 or i == 1 { i },
+    /// )
+    ///
+    /// #lorem(60)
+    /// ```
     #[ghost]
     pub numbering: Option<Numbering>,
 


### PR DESCRIPTION
Proposed [on the forum](https://forum.typst.app/t/how-to-number-every-5th-line/1295/3) by Mc-Zen in October 2024.

<img width="469" height="561" alt="图片" src="https://github.com/user-attachments/assets/743fca22-7944-49fa-9ce8-0d3a26a049aa" />
