### PR TITLE
Cargo.lock: update stacker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2535,9 +2535,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stacker"
-version = "0.1.17"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799c883d55abdb5e98af1a7b3f23b9b6de8ecada0ecac058672d7635eb48ca7b"
+checksum = "cddb07e32ddb770749da91081d8d0ac3a16f1a569a18b20348cd371f5dead06b"
 dependencies = [
  "cc",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ shell-escape = "0.1.5"
 sigpipe = "0.1"
 siphasher = "1"
 smallvec = { version = "1.11.1", features = ["union", "const_generics", "const_new"] }
-stacker = "0.1.15"
+stacker = "0.1.19"
 syn = { version = "2", features = ["full", "extra-traits"] }
 syntect = { version = "5", default-features = false, features = ["parsing", "regex-fancy", "plist-load", "yaml-load"] }
 tar = "0.4"


### PR DESCRIPTION
Using stacker < 0.1.19 panics when building anything but trivial code with /proc hidden (as can happen in some CI, but can be reproduced with e.g. bwrap)

```
$ bwrap --dev-bind /dev /dev --ro-bind /usr /usr \
        --ro-bind /lib /lib --ro-bind /lib64 /lib64  \
        --ro-bind $PWD $PWD \
        ./target/release/typst compile - - <<<'#list[a][b]'

thread 'main' panicked at ~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/stacker-0.1.17/src/lib.rs:412:13:
assertion `left == right` failed
  left: 2
 right: 0
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Bumping stacker brings in improved error handling[1], which fixes the issue (arguably guessing stack size does not work but that does not seem to be a big problem)

Link: https://github.com/rust-lang/stacker/commit/5eed05f39c2c71cb9153a94e27826535ed6d545b [1]


-----------------------

This is a bit far fetched but panic isn't great ergonomics and it took me a few minutes to understand what was going on here (I'll just have /proc available from now on :p)
I'm not sure how the Cargo.lock update policy is, I just ran `cargo update stacker` for this as 0.1.19 has been out since Feb and it doesn't look like it wouldn't get updated quickly otherwise.
(note it doesn't seem to impact the rust-version, which is much newer for Typst than stacker -- the window-sys version rollback seems to be something gone wrong in #5808 as only 0.52.0 and 0.59.0 are available; but I'm not on windows to check)

Thanks for Typst!