### PR TITLE
Fix a typo in the plugin doc

### DIFF
--- a/crates/typst-library/src/foundations/plugin.rs
+++ b/crates/typst-library/src/foundations/plugin.rs
@@ -48,7 +48,7 @@ use crate::loading::{DataSource, Load};
 /// ```
 ///
 /// # Purity
-/// Plugin functions **must be pure:** A plugin function call most not have any
+/// Plugin functions **must be pure:** A plugin function call must not have any
 /// observable side effects on future plugin calls and given the same arguments,
 /// it must always return the same value.
 ///


### PR DESCRIPTION
_most_ → _must_.

Resolves https://github.com/typst/webapp-issues/issues/729