### PR TITLE
Introduce internal `DirectLinkElem` as a temporary workaround

### DIFF
--- a/crates/typst-html/src/rules.rs
+++ b/crates/typst-html/src/rules.rs
@@ -12,10 +12,10 @@ use typst_library::layout::{
     BlockBody, BlockElem, BoxElem, HElem, OuterVAlignment, Sizing,
 };
 use typst_library::model::{
-    Attribution, CiteElem, CiteGroup, Destination, EmphElem, EnumElem, FigureCaption,
-    FigureElem, FootnoteElem, FootnoteEntry, HeadingElem, LinkElem, LinkTarget, ListElem,
-    OutlineElem, OutlineEntry, OutlineNode, ParElem, ParbreakElem, QuoteElem, RefElem,
-    StrongElem, TableCell, TableElem, TermsElem, TitleElem,
+    Attribution, CiteElem, CiteGroup, Destination, DirectLinkElem, EmphElem, EnumElem,
+    FigureCaption, FigureElem, FootnoteElem, FootnoteEntry, HeadingElem, LinkElem,
+    LinkTarget, ListElem, OutlineElem, OutlineEntry, OutlineNode, ParElem, ParbreakElem,
+    QuoteElem, RefElem, StrongElem, TableCell, TableElem, TermsElem, TitleElem,
 };
 use typst_library::text::{
     HighlightElem, LinebreakElem, OverlineElem, RawElem, RawLine, SmallcapsElem,
@@ -39,6 +39,7 @@ pub fn register(rules: &mut NativeRuleMap) {
     rules.register(Html, ENUM_RULE);
     rules.register(Html, TERMS_RULE);
     rules.register(Html, LINK_RULE);
+    rules.register(Html, DIRECT_LINK_RULE);
     rules.register(Html, TITLE_RULE);
     rules.register(Html, HEADING_RULE);
     rules.register(Html, FIGURE_RULE);
@@ -179,6 +180,14 @@ const LINK_RULE: ShowFn<LinkElem> = |elem, engine, _| {
         .with_optional_attr(attr::href, href)
         .with_body(Some(elem.body.clone()))
         .pack())
+};
+
+const DIRECT_LINK_RULE: ShowFn<DirectLinkElem> = |elem, _, _| {
+    Ok(LinkElem::new(
+        LinkTarget::Dest(Destination::Location(elem.loc)),
+        elem.body.clone(),
+    )
+    .pack())
 };
 
 const TITLE_RULE: ShowFn<TitleElem> = |elem, _, styles| {

--- a/crates/typst-layout/src/rules.rs
+++ b/crates/typst-layout/src/rules.rs
@@ -18,10 +18,11 @@ use typst_library::layout::{
 };
 use typst_library::math::EquationElem;
 use typst_library::model::{
-    Attribution, BibliographyElem, CiteElem, CiteGroup, CslSource, Destination, EmphElem,
-    EnumElem, FigureCaption, FigureElem, FootnoteElem, FootnoteEntry, HeadingElem,
-    LinkElem, ListElem, OutlineElem, OutlineEntry, ParElem, ParbreakElem, QuoteElem,
-    RefElem, StrongElem, TableCell, TableElem, TermsElem, TitleElem, Works,
+    Attribution, BibliographyElem, CiteElem, CiteGroup, CslSource, Destination,
+    DirectLinkElem, EmphElem, EnumElem, FigureCaption, FigureElem, FootnoteElem,
+    FootnoteEntry, HeadingElem, LinkElem, ListElem, OutlineElem, OutlineEntry, ParElem,
+    ParbreakElem, QuoteElem, RefElem, StrongElem, TableCell, TableElem, TermsElem,
+    TitleElem, Works,
 };
 use typst_library::pdf::AttachElem;
 use typst_library::text::{
@@ -47,6 +48,7 @@ pub fn register(rules: &mut NativeRuleMap) {
     rules.register(Paged, ENUM_RULE);
     rules.register(Paged, TERMS_RULE);
     rules.register(Paged, LINK_RULE);
+    rules.register(Paged, DIRECT_LINK_RULE);
     rules.register(Paged, TITLE_RULE);
     rules.register(Paged, HEADING_RULE);
     rules.register(Paged, FIGURE_RULE);
@@ -216,6 +218,9 @@ const LINK_RULE: ShowFn<LinkElem> = |elem, engine, _| {
     let dest = elem.dest.resolve(engine.introspector).at(elem.span())?;
     Ok(body.linked(dest))
 };
+
+const DIRECT_LINK_RULE: ShowFn<DirectLinkElem> =
+    |elem, _, _| Ok(elem.body.clone().linked(Destination::Location(elem.loc)));
 
 const TITLE_RULE: ShowFn<TitleElem> = |elem, _, styles| {
     Ok(BlockElem::new()

--- a/crates/typst-library/src/model/bibliography.rs
+++ b/crates/typst-library/src/model/bibliography.rs
@@ -36,7 +36,8 @@ use crate::layout::{
 };
 use crate::loading::{DataSource, Load, LoadSource, Loaded, format_yaml_error};
 use crate::model::{
-    CitationForm, CiteGroup, Destination, FootnoteElem, HeadingElem, LinkElem, Url,
+    CitationForm, CiteGroup, Destination, DirectLinkElem, FootnoteElem, HeadingElem,
+    LinkElem, Url,
 };
 use crate::routines::Routines;
 use crate::text::{
@@ -835,8 +836,7 @@ impl<'a> Generator<'a> {
                     let mut content =
                         renderer.display_elem_child(elem, &mut None, false)?;
                     if let Some(location) = first_occurrences.get(item.key.as_str()) {
-                        let dest = Destination::Location(*location);
-                        content = content.linked(dest);
+                        content = DirectLinkElem::new(*location, content).pack();
                     }
                     StrResult::Ok(content)
                 })
@@ -971,8 +971,7 @@ impl ElemRenderer<'_> {
         if let Some(hayagriva::ElemMeta::Entry(i)) = elem.meta
             && let Some(location) = (self.link)(i)
         {
-            let dest = Destination::Location(location);
-            content = content.linked(dest);
+            content = DirectLinkElem::new(location, content).pack();
         }
 
         Ok(content)

--- a/crates/typst-library/src/model/reference.rs
+++ b/crates/typst-library/src/model/reference.rs
@@ -5,13 +5,12 @@ use crate::diag::{At, Hint, SourceResult, bail};
 use crate::engine::Engine;
 use crate::foundations::{
     Cast, Content, Context, Func, IntoValue, Label, NativeElement, Packed, Repr, Smart,
-    StyleChain, Synthesize, TargetElem, cast, elem,
+    StyleChain, Synthesize, cast, elem,
 };
 use crate::introspection::{Counter, CounterKey, Locatable};
 use crate::math::EquationElem;
 use crate::model::{
-    BibliographyElem, CiteElem, Destination, Figurable, FootnoteElem, LinkElem,
-    LinkTarget, Numbering,
+    BibliographyElem, CiteElem, DirectLinkElem, Figurable, FootnoteElem, Numbering,
 };
 use crate::text::TextElem;
 
@@ -347,14 +346,7 @@ fn realize_reference(
         content = supplement + TextElem::packed("\u{a0}") + content;
     }
 
-    Ok(if styles.get(TargetElem::target).is_html() {
-        LinkElem::new(LinkTarget::Dest(Destination::Location(loc)), content).pack()
-    } else {
-        // TODO: We should probably also use `LinkElem` in the paged target, but
-        // it's a bit breaking and it becomes hard to style links without
-        // affecting references, so this change should be well-considered.
-        content.linked(Destination::Location(loc))
-    })
+    Ok(DirectLinkElem::new(loc, content).pack())
 }
 
 /// Turn a reference into a citation.


### PR DESCRIPTION
This is a temporary hack that introduces an element which can be used to create links across HTML and paged export that do not react to `show link` rules. This is the current behaviour of `ref`, `cite`, `footnote`, etc. and means that these are not adversely affected by `show link: underline` rules in paged export.

In the future, we'll want to migrate everything to normal links (see https://github.com/typst/typst/issues/5614), but to do that, I'd first like to have a simpler way to style only URL links. https://github.com/typst/typst/pull/6903 was an attempt at that, but it has some problems. Another option would be a synthesized field `kind` on `link` that could be used, e.g. `show link.where(kind: "url"): underline`. However, I decided to not rush the design on that after all, so for now we've got this temporary hack that maintains the status quo while unblocking progress on HTML export.