### PR TITLE
Revise DOM for footnotes in HTML

### DIFF
--- a/crates/typst-html/src/rules.rs
+++ b/crates/typst-html/src/rules.rs
@@ -331,11 +331,10 @@ const FOOTNOTE_CONTAINER_RULE: ShowFn<FootnoteContainer> = |_, engine, _| {
         let loc = note.location().unwrap();
         let span = note.span();
         HtmlElem::new(tag::li)
-            .with_body(Some(
-                FootnoteEntry::new(note).pack().spanned(span).located(loc.variant(1)),
-            ))
+            .with_body(Some(FootnoteEntry::new(note).pack().spanned(span)))
             .with_parent(loc)
             .pack()
+            .located(loc.variant(1))
             .spanned(span)
     });
 
@@ -348,36 +347,27 @@ const FOOTNOTE_CONTAINER_RULE: ShowFn<FootnoteContainer> = |_, engine, _| {
         .pack();
 
     // The user may want to style the whole footnote element so we wrap it in an
-    // additional selectable container. `aside` has the right semantics as a
-    // container for auxiliary page content. There is no ARIA role for
-    // footnotes, so we use a class instead. (There is `doc-endnotes`, but has
-    // footnotes and endnotes have somewhat different semantics.)
-    Ok(HtmlElem::new(tag::aside)
-        .with_attr(attr::class, "footnotes")
+    // additional selectable container. This is also how it's done in the ARIA
+    // spec (although there, the section also contains an additional heading).
+    Ok(HtmlElem::new(tag::section)
+        .with_attr(attr::role, "doc-endnotes")
         .with_body(Some(list))
         .pack())
 };
 
 const FOOTNOTE_ENTRY_RULE: ShowFn<FootnoteEntry> = |elem, engine, styles| {
-    let span = elem.span();
-    let (dest, num, body) = elem.realize(engine, styles)?;
-    let sup = SuperElem::new(num).pack().spanned(span);
+    let (prefix, body) = elem.realize(engine, styles)?;
 
-    // We create a link back to the first footnote reference.
-    let link = LinkElem::new(dest.into(), sup)
-        .pack()
-        .spanned(span)
-        .styled(HtmlElem::role.set(Some("doc-backlink".into())));
+    // The prefix is a link back to the first footnote reference, so
+    // `doc-backlink` is the appropriate ARIA role.
+    let backlink = prefix.styled(HtmlElem::role.set(Some("doc-backlink".into())));
 
-    // We want to use the Digital Publishing ARIA role `doc-footnote` and the
-    // fallback role `note` for each individual footnote. Because the enclosing
-    // `li`, as a child of an `ol`, must have the implicit `listitem` role, we
-    // need an additional container. We chose a `div` instead of a `span` to
-    // allow for block-level content in the footnote.
-    Ok(HtmlElem::new(tag::div)
-        .with_attr(attr::role, "doc-footnote note")
-        .with_body(Some(link + body))
-        .pack())
+    // We do not use the ARIA role `doc-footnote` because it "is only for
+    // representing individual notes that occur within the body of a work" (see
+    // <https://www.w3.org/TR/dpub-aria-1.1/#doc-footnote>). Our footnotes more
+    // appropriately modelled as ARIA endnotes. This is also in line with how
+    // Pandoc handles footnotes.
+    Ok(backlink + body)
 };
 
 const OUTLINE_RULE: ShowFn<OutlineElem> = |elem, engine, styles| {

--- a/crates/typst-layout/src/rules.rs
+++ b/crates/typst-layout/src/rules.rs
@@ -387,13 +387,11 @@ const FOOTNOTE_RULE: ShowFn<FootnoteElem> = |elem, engine, styles| {
 };
 
 const FOOTNOTE_ENTRY_RULE: ShowFn<FootnoteEntry> = |elem, engine, styles| {
-    let span = elem.span();
     let number_gap = Em::new(0.05);
-    let (dest, num, body) = elem.realize(engine, styles)?;
-    let sup = SuperElem::new(num).pack().spanned(span).linked(dest);
+    let (prefix, body) = elem.realize(engine, styles)?;
     Ok(Content::sequence([
         HElem::new(elem.indent.get(styles).into()).pack(),
-        sup,
+        prefix,
         HElem::new(number_gap.into()).with_weak(true).pack(),
         body,
     ]))

--- a/crates/typst-library/src/model/footnote.rs
+++ b/crates/typst-library/src/model/footnote.rs
@@ -11,8 +11,8 @@ use crate::foundations::{
 };
 use crate::introspection::{Count, Counter, CounterUpdate, Locatable, Location};
 use crate::layout::{Abs, Em, Length, Ratio};
-use crate::model::{Destination, Numbering, NumberingPattern, ParElem};
-use crate::text::{TextElem, TextSize};
+use crate::model::{Destination, DirectLinkElem, Numbering, NumberingPattern, ParElem};
+use crate::text::{SuperElem, TextElem, TextSize};
 use crate::visualize::{LineElem, Stroke};
 
 /// A footnote.
@@ -280,7 +280,8 @@ impl Packed<FootnoteEntry> {
         &self,
         engine: &mut Engine,
         styles: StyleChain,
-    ) -> SourceResult<(Destination, Content, Content)> {
+    ) -> SourceResult<(Content, Content)> {
+        let span = self.span();
         let default = StyleChain::default();
         let numbering = self.note.numbering.get_ref(default);
         let counter = Counter::of(FootnoteElem::ELEM);
@@ -292,8 +293,11 @@ impl Packed<FootnoteEntry> {
         };
 
         let num = counter.display_at_loc(engine, loc, styles, numbering)?;
+        let sup = SuperElem::new(num).pack().spanned(span);
+        let prefix = DirectLinkElem::new(loc, sup).pack().spanned(span);
         let body = self.note.body_content().unwrap().clone();
-        Ok((Destination::Location(loc), num, body))
+
+        Ok((prefix, body))
     }
 }
 

--- a/tests/ref/html/footnote-basic.html
+++ b/tests/ref/html/footnote-basic.html
@@ -6,12 +6,10 @@
   </head>
   <body>
     <p><a id="loc-1" href="#loc-2" role="doc-noteref"><sup>1</sup></a></p>
-    <aside class="footnotes">
+    <section role="doc-endnotes">
       <ol style="list-style-type: none">
-        <li>
-          <div id="loc-2" role="doc-footnote note"><a href="#loc-1" role="doc-backlink"><sup>1</sup></a>Hi</div>
-        </li>
+        <li id="loc-2"><a href="#loc-1" role="doc-backlink"><sup>1</sup></a>Hi</li>
       </ol>
-    </aside>
+    </section>
   </body>
 </html>

--- a/tests/ref/html/footnote-container-set-rule-html.html
+++ b/tests/ref/html/footnote-container-set-rule-html.html
@@ -6,12 +6,10 @@
   </head>
   <body>
     <p>An [A]<a id="loc-1" href="#loc-2" role="doc-noteref"><sup>1</sup></a></p>
-    <aside class="footnotes">
+    <section role="doc-endnotes">
       <ol style="list-style-type: none">
-        <li>
-          <div id="loc-2" role="doc-footnote note"><a href="#loc-1" role="doc-backlink"><sup>1</sup></a>A [B]</div>
-        </li>
+        <li id="loc-2"><a href="#loc-1" role="doc-backlink"><sup>1</sup></a>A [B]</li>
       </ol>
-    </aside>
+    </section>
   </body>
 </html>

--- a/tests/ref/html/footnote-container-show-set-rule-html.html
+++ b/tests/ref/html/footnote-container-show-set-rule-html.html
@@ -6,12 +6,10 @@
   </head>
   <body>
     <p>An [A]<a id="loc-1" href="#loc-2" role="doc-noteref"><sup>1</sup></a></p>
-    <aside class="footnotes">
+    <section role="doc-endnotes">
       <ol style="list-style-type: none">
-        <li>
-          <div id="loc-2" role="doc-footnote note"><a href="#loc-1" role="doc-backlink"><sup>1</sup></a>A “B”</div>
-        </li>
+        <li id="loc-2"><a href="#loc-1" role="doc-backlink"><sup>1</sup></a>A “B”</li>
       </ol>
-    </aside>
+    </section>
   </body>
 </html>

--- a/tests/ref/html/footnote-entry-html.html
+++ b/tests/ref/html/footnote-entry-html.html
@@ -6,14 +6,12 @@
   </head>
   <body>
     <p>A<a href="#loc-2" role="doc-noteref"><sup>1</sup></a> B<a href="#loc-3" role="doc-noteref"><sup>2</sup></a> C<a id="loc-1" href="#loc-4" role="doc-noteref"><sup>3</sup></a></p>
-    <aside class="footnotes">
+    <section role="doc-endnotes">
       <ol style="list-style-type: none">
-        <li><span id="loc-2">The A is replaced!</span></li>
-        <li><span id="loc-3"></span></li>
-        <li>
-          <div id="loc-4" role="doc-footnote note"><a href="#loc-1" role="doc-backlink"><sup>3</sup></a><em>C</em></div>
-        </li>
+        <li id="loc-2">The A is replaced!</li>
+        <li id="loc-3"></li>
+        <li id="loc-4"><a href="#loc-1" role="doc-backlink"><sup>3</sup></a><em>C</em></li>
       </ol>
-    </aside>
+    </section>
   </body>
 </html>

--- a/tests/ref/html/footnote-nested.html
+++ b/tests/ref/html/footnote-nested.html
@@ -6,27 +6,15 @@
   </head>
   <body>
     <p>First<br>Second<a id="loc-1" href="#loc-4" role="doc-noteref"><sup>1</sup></a> Third<a id="loc-2" href="#loc-9" role="doc-noteref"><sup>4</sup></a><br>Fourth<a id="loc-3" href="#loc-12" role="doc-noteref"><sup>6</sup></a></p>
-    <aside class="footnotes">
+    <section role="doc-endnotes">
       <ol style="list-style-type: none">
-        <li>
-          <div id="loc-4" role="doc-footnote note"><a href="#loc-1" role="doc-backlink"><sup>1</sup></a>A,<a id="loc-5" href="#loc-6" role="doc-noteref"><sup>2</sup></a></div>
-        </li>
-        <li>
-          <div id="loc-6" role="doc-footnote note"><a href="#loc-5" role="doc-backlink"><sup>2</sup></a>B,<a id="loc-7" href="#loc-8" role="doc-noteref"><sup>3</sup></a></div>
-        </li>
-        <li>
-          <div id="loc-8" role="doc-footnote note"><a href="#loc-7" role="doc-backlink"><sup>3</sup></a>C</div>
-        </li>
-        <li>
-          <div id="loc-9" role="doc-footnote note"><a href="#loc-2" role="doc-backlink"><sup>4</sup></a>D,<a id="loc-10" href="#loc-11" role="doc-noteref"><sup>5</sup></a></div>
-        </li>
-        <li>
-          <div id="loc-11" role="doc-footnote note"><a href="#loc-10" role="doc-backlink"><sup>5</sup></a>E</div>
-        </li>
-        <li>
-          <div id="loc-12" role="doc-footnote note"><a href="#loc-3" role="doc-backlink"><sup>6</sup></a>F</div>
-        </li>
+        <li id="loc-4"><a href="#loc-1" role="doc-backlink"><sup>1</sup></a>A,<a id="loc-5" href="#loc-6" role="doc-noteref"><sup>2</sup></a></li>
+        <li id="loc-6"><a href="#loc-5" role="doc-backlink"><sup>2</sup></a>B,<a id="loc-7" href="#loc-8" role="doc-noteref"><sup>3</sup></a></li>
+        <li id="loc-8"><a href="#loc-7" role="doc-backlink"><sup>3</sup></a>C</li>
+        <li id="loc-9"><a href="#loc-2" role="doc-backlink"><sup>4</sup></a>D,<a id="loc-10" href="#loc-11" role="doc-noteref"><sup>5</sup></a></li>
+        <li id="loc-11"><a href="#loc-10" role="doc-backlink"><sup>5</sup></a>E</li>
+        <li id="loc-12"><a href="#loc-3" role="doc-backlink"><sup>6</sup></a>F</li>
       </ol>
-    </aside>
+    </section>
   </body>
 </html>

--- a/tests/ref/html/footnote-space-collapsing.html
+++ b/tests/ref/html/footnote-space-collapsing.html
@@ -6,15 +6,11 @@
   </head>
   <body>
     <p>A<a id="loc-1" href="#loc-3" role="doc-noteref"><sup>1</sup></a><br>A<a id="loc-2" href="#loc-4" role="doc-noteref"><sup>2</sup></a></p>
-    <aside class="footnotes">
+    <section role="doc-endnotes">
       <ol style="list-style-type: none">
-        <li>
-          <div id="loc-3" role="doc-footnote note"><a href="#loc-1" role="doc-backlink"><sup>1</sup></a>A</div>
-        </li>
-        <li>
-          <div id="loc-4" role="doc-footnote note"><a href="#loc-2" role="doc-backlink"><sup>2</sup></a>A</div>
-        </li>
+        <li id="loc-3"><a href="#loc-1" role="doc-backlink"><sup>1</sup></a>A</li>
+        <li id="loc-4"><a href="#loc-2" role="doc-backlink"><sup>2</sup></a>A</li>
       </ol>
-    </aside>
+    </section>
   </body>
 </html>


### PR DESCRIPTION
While `doc-footnote` seems like the right role at first, the semantics of `doc-endnotes` are a bit better match for what we're doing and using it means a cleaner DOM structure (one div less per footnote, better placement of `id` attributes) that is more in line with the outline and the bibliography (which are structurally similar). The updated DOM is also in line with what pandoc does.