### PR TITLE
Remove outdated `set_location` call on citations

### DIFF
--- a/crates/typst-library/src/model/reference.rs
+++ b/crates/typst-library/src/model/reference.rs
@@ -362,10 +362,6 @@ fn to_citation(
         },
     ));
 
-    if let Some(loc) = reference.location() {
-        elem.set_location(loc);
-    }
-
     elem.synthesize(engine, styles)?;
 
     Ok(elem)


### PR DESCRIPTION
I'm not even entirely sure what the purpose of this was (it was added years ago). I think it was something related to backlinks and saving one layout iteration, but it shouldn't have any sensible effect anymore, it does not affect any tests, and it is conceptually very wrong as locations are supposed to be unique IDs. Having different types of elements with the same location breaks various assumptions.