### PR TITLE
Add warning when glyph is not found

### DIFF
--- a/crates/typst-layout/src/inline/line.rs
+++ b/crates/typst-layout/src/inline/line.rs
@@ -124,7 +124,7 @@ pub enum Dash {
 
 /// Create a line which spans the given range.
 pub fn line<'a>(
-    engine: &Engine,
+    engine: &mut Engine,
     p: &'a Preparation,
     range: Range,
     breakpoint: Breakpoint,
@@ -200,7 +200,7 @@ pub fn line<'a>(
 /// to keep non-text items after the trim (e.g. tags).
 fn collect_items<'a>(
     items: &mut Items<'a>,
-    engine: &Engine,
+    engine: &mut Engine,
     p: &'a Preparation,
     range: Range,
     trim: &Trim,
@@ -278,7 +278,7 @@ where
 /// Collects / reshapes all items for the given `subrange` with continuous
 /// direction.
 fn collect_range<'a>(
-    engine: &Engine,
+    engine: &mut Engine,
     p: &'a Preparation,
     range: Range,
     trim: &Trim,
@@ -312,7 +312,7 @@ fn collect_range<'a>(
 
         let mut item: ItemEntry = if split {
             // When the item is split in half, reshape it.
-            let reshaped = shaped.reshape(engine, sliced);
+            let reshaped = shaped.reshape(engine, sliced, &p.spans);
             Item::Text(reshaped).into()
         } else {
             // When the item is fully contained, just keep it.

--- a/crates/typst-layout/src/inline/linebreak.rs
+++ b/crates/typst-layout/src/inline/linebreak.rs
@@ -140,7 +140,7 @@ impl Trim {
 
 /// Breaks the text into lines.
 pub fn linebreak<'a>(
-    engine: &Engine,
+    engine: &mut Engine,
     p: &'a Preparation<'a>,
     width: Abs,
 ) -> Vec<Line<'a>> {
@@ -155,7 +155,7 @@ pub fn linebreak<'a>(
 /// very unbalanced line, but is fast and simple.
 #[typst_macros::time]
 fn linebreak_simple<'a>(
-    engine: &Engine,
+    engine: &mut Engine,
     p: &'a Preparation<'a>,
     width: Abs,
 ) -> Vec<Line<'a>> {
@@ -215,7 +215,7 @@ fn linebreak_simple<'a>(
 /// the layout determined for the last breakpoint at the end of text.
 #[typst_macros::time]
 fn linebreak_optimized<'a>(
-    engine: &Engine,
+    engine: &mut Engine,
     p: &'a Preparation<'a>,
     width: Abs,
 ) -> Vec<Line<'a>> {
@@ -234,7 +234,7 @@ fn linebreak_optimized<'a>(
 /// bound on the cost. This allows us to skip many parts of the search space.
 #[typst_macros::time]
 fn linebreak_optimized_bounded<'a>(
-    engine: &Engine,
+    engine: &mut Engine,
     p: &'a Preparation<'a>,
     width: Abs,
     metrics: &CostMetrics,
@@ -372,7 +372,7 @@ fn linebreak_optimized_bounded<'a>(
 /// linebreaking. We can use it to heavily prune the search space.
 #[typst_macros::time]
 fn linebreak_optimized_approximate(
-    engine: &Engine,
+    engine: &mut Engine,
     p: &Preparation,
     width: Abs,
     metrics: &CostMetrics,

--- a/crates/typst-layout/src/inline/prepare.rs
+++ b/crates/typst-layout/src/inline/prepare.rs
@@ -90,7 +90,7 @@ pub fn prepare<'a>(
 
         match segment {
             Segment::Text(_, styles) => {
-                shape_range(&mut items, engine, text, &bidi, range, styles);
+                shape_range(&mut items, engine, text, &bidi, range, styles, &spans);
             }
             Segment::Item(item) => items.push((range, item)),
         }


### PR DESCRIPTION
I was about to ask how hard is it to implement https://github.com/typst/typst/issues/5137, but then I looked inside, and there is a clear place where compiler knows that font family is not found and there is even access to `engine` to collect the warning. So it's really easy.

However, `engine` is under a shared reference and I don't know how to get span for the warned text/glyph. So I changed `engine` to be a mutable reference as well as I added missing spans to the function body. I only then realized that `Preparation` has the needed spans inside, so the change reduced a little.

I still don't know how to get accurate spans, like in the `ShapedText::build`. But offset 0 works not that bad for a simple example:

```typ
No warnings here.

#emoji.axe

#set text(fallback: false)
No warnings here either.

textテキストтекст
```

The warning text can be so many things, so I have no idea what to print. Also being able to check for `--font-path` and `--ignore-system-fonts` flags can improve hint precision. Also can't add native hints in `warning!`.

Anyway, looks like it's pretty much ready, other than engine/span/message issues. I mean, it _works_, which is nice to see.
