### PR TITLE
Add French translations

### DIFF
--- a/crates/typst-library/translations/fr.txt
+++ b/crates/typst-library/translations/fr.txt
@@ -7,5 +7,5 @@ outline = Table des matières
 raw = Liste
 page = page
 footnote = Note
-# email =
-# telephone =
+email = E-mail
+telephone = Téléphone


### PR DESCRIPTION
This adds some French translations.

The actual French word for "email" would be "courriel" or "mél" but I don't think anyone uses those words in the real world.

Also, depending on where those translations are used, it might be better to use "Adresse mail" ("E-mail address") and "Numéro de téléphone" ("Phone number").