### PR TITLE
Improve example rendering of parameters and nested functions

### DIFF
--- a/crates/typst-library/src/foundations/str.rs
+++ b/crates/typst-library/src/foundations/str.rs
@@ -424,15 +424,15 @@ impl Str {
     ///   capturing, not the whole match! This is empty unless the `pattern` was
     ///   a regex with capturing groups.
     ///
-    /// ```example
-    /// #assert.eq("Is there a".match("for this?"), none)
-    /// #"The time of my life.".match(regex("[mit]+e"))
-    /// ```
-    ///
-    /// ```example
+    /// ```example:"Basic usage"
     /// #let pat = regex("not (a|an) (apple|cat)")
     /// #"I'm a doctor, not an apple.".match(pat) \
     /// #"I am not a cat!".match(pat)
+    /// ```
+    ///
+    /// ```example:"Shape of the returned dictionary"
+    /// #assert.eq("Is there a".match("for this?"), none)
+    /// #"The time of my life.".match(regex("[mit]+e"))
     /// ```
     #[func]
     pub fn match_(

--- a/crates/typst-library/src/layout/grid/mod.rs
+++ b/crates/typst-library/src/layout/grid/mod.rs
@@ -291,7 +291,7 @@ pub struct GridElem {
     ///
     /// See the [styling section](#styling) above for more details.
     ///
-    /// ```example
+    /// ```example:"Passing a function to set a stroke based on position"
     /// #set page(width: 420pt)
     /// #set text(number-type: "old-style")
     /// #show grid.cell.where(y: 0): set text(size: 1.3em)
@@ -325,7 +325,7 @@ pub struct GridElem {
     /// )
     /// ```
     ///
-    /// ```example
+    /// ```example:"Folding the stroke dictionary"
     /// #set page(height: 13em, width: 26em)
     ///
     /// #let cv(..jobs) = grid(
@@ -335,7 +335,7 @@ pub struct GridElem {
     ///     (right: (
     ///       paint: luma(180),
     ///       thickness: 1.5pt,
-    ///       dash: "dotted"
+    ///       dash: "dotted",
     ///     ))
     ///   },
     ///   grid.header(grid.cell(colspan: 2)[

--- a/crates/typst-library/src/layout/transform.rs
+++ b/crates/typst-library/src/layout/transform.rs
@@ -53,7 +53,6 @@ pub struct RotateElem {
     /// ```example
     /// #rotate(-1.571rad)[Space!]
     /// ```
-    ///
     #[positional]
     pub angle: Angle,
 
@@ -192,7 +191,6 @@ pub struct SkewElem {
     /// ```example
     /// #skew(ax: 30deg)[Skewed]
     /// ```
-    ///
     #[default(Angle::zero())]
     pub ax: Angle,
 
@@ -201,7 +199,6 @@ pub struct SkewElem {
     /// ```example
     /// #skew(ay: 30deg)[Skewed]
     /// ```
-    ///
     #[default(Angle::zero())]
     pub ay: Angle,
 

--- a/crates/typst-library/src/math/matrix.rs
+++ b/crates/typst-library/src/math/matrix.rs
@@ -133,13 +133,13 @@ pub struct MatElem {
     ///   - `stroke`: How to [stroke]($stroke) the line. If set to `{auto}`,
     ///     takes on a thickness of 0.05 em and square line caps.
     ///
-    /// ```example
+    /// ```example:"Basic usage"
     /// $ mat(1, 0, 1; 0, 1, 2; augment: #2) $
     /// // Equivalent to:
     /// $ mat(1, 0, 1; 0, 1, 2; augment: #(-1)) $
     /// ```
     ///
-    /// ```example
+    /// ```example:"Customizing the augmentation line"
     /// $ mat(0, 0, 0; 1, 1, 1; augment: #(hline: 1, stroke: 2pt + green)) $
     /// ```
     #[fold]

--- a/crates/typst-library/src/model/figure.rs
+++ b/crates/typst-library/src/model/figure.rs
@@ -184,7 +184,7 @@ pub struct FigureElem {
     /// or [`{image}`](image), you will need to manually specify the figure's
     /// supplement.
     ///
-    /// ```example
+    /// ```example:"Customizing the figure kind"
     /// #figure(
     ///   circle(radius: 10pt),
     ///   caption: [A curious atom.],
@@ -201,7 +201,7 @@ pub struct FigureElem {
     /// - For [images]($image): `{counter(figure.where(kind: image))}`
     /// - For a custom kind: `{counter(figure.where(kind: kind))}`
     ///
-    /// ```example
+    /// ```example:"Modifying the figure counter for specific kinds"
     /// #figure(
     ///   table(columns: 2, $n$, $1$),
     ///   caption: [The first table.],

--- a/crates/typst-library/src/text/mod.rs
+++ b/crates/typst-library/src/text/mod.rs
@@ -404,7 +404,7 @@ pub struct TextElem {
     ///   language.
     /// - And all other things which are language-aware.
     ///
-    /// ```example
+    /// ```example:"Setting the text language to German"
     /// #set text(lang: "de")
     /// #outline()
     ///

--- a/crates/typst-library/src/text/raw.rs
+++ b/crates/typst-library/src/text/raw.rs
@@ -141,7 +141,7 @@ pub struct RawElem {
     /// You can also use raw blocks creatively to create custom syntaxes for
     /// your automations.
     ///
-    /// ````example
+    /// ````example:"Implementing a DSL using raw and show rules"
     /// // Parse numbers in raw blocks with the
     /// // `mydsl` tag and sum them up.
     /// #show raw.where(lang: "mydsl"): it => {

--- a/docs/src/model.rs
+++ b/docs/src/model.rs
@@ -92,10 +92,7 @@ pub struct FuncModel {
     pub contextual: bool,
     pub deprecation_message: Option<&'static str>,
     pub deprecation_until: Option<&'static str>,
-    pub details: Html,
-    /// This example is only for nested function models. Others can have
-    /// their example directly in their details.
-    pub example: Option<Html>,
+    pub details: Vec<DetailsContent>,
     #[serde(rename = "self")]
     pub self_: bool,
     pub params: Vec<ParamModel>,
@@ -107,8 +104,7 @@ pub struct FuncModel {
 #[derive(Debug, Serialize)]
 pub struct ParamModel {
     pub name: &'static str,
-    pub details: Html,
-    pub example: Option<Html>,
+    pub details: Vec<DetailsContent>,
     pub types: Vec<&'static str>,
     pub strings: Vec<StrParam>,
     pub default: Option<Html>,
@@ -117,6 +113,18 @@ pub struct ParamModel {
     pub required: bool,
     pub variadic: bool,
     pub settable: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(tag = "kind", content = "content")]
+pub enum DetailsContent {
+    Html(Html),
+    /// An example with an optional title.
+    Example {
+        body: Html,
+        title: Option<EcoString>,
+    },
 }
 
 /// A specific string that can be passed as an argument.


### PR DESCRIPTION
This PR changes the presentation of examples for nested functions and parameters.

Previously, this was the behavior:

- Examples for nested functions got pulled below the summary
- Examples for parameters were collapsed at the end of its docs, below the default

Furthermore, the first instance of three backticks started the example, and all of the markup below was pulled into the collapsible widget or below the summary.

Now, examples appear in reading order. They terminate after their code fence ends, normal text can be below them. They are always in collapsible drawers, but for a nested function, the first example is expanded by default. Furthermore, examples can now be disambiguated with titles by using the `:"Example title"` syntax in the code fence tag.

This PR introduces some example titles.

**Parameter with multiple examples:**

<img width="801" height="553" alt="Parameter with multiple examples" src="https://github.com/user-attachments/assets/483aab5f-285a-4d8d-bf87-1640b5e3364c" />

**Nested function with multiple examples**
<img width="824" height="1120" alt="Nested function with multiple examples" src="https://github.com/user-attachments/assets/3dddc3d6-c29f-4098-8c07-1822ddccb5ea" />

Fixes #6922