### PR TITLE
Change tutorial to accomodate `title`

### DIFF
--- a/docs/guides/accessibility.md
+++ b/docs/guides/accessibility.md
@@ -184,7 +184,7 @@ Like the image function, the figure function has a [`alt` attribute]($figure.alt
 ```typ
 #figure(
   alt: "Star with a blue outline",
-  curve.with(
+  curve(
     stroke: blue,
     curve.move((25pt, 0pt)),
     curve.line((10pt, 50pt)),

--- a/docs/guides/accessibility.md
+++ b/docs/guides/accessibility.md
@@ -119,7 +119,7 @@ How can we improve the chart? First, make sure that no information is solely com
 <img src="chart-good.png" alt="The same bar chart with the original colors. This time, black outlines around each segment are added. Additionally, each segment has a unique pattern." width="958" height="637" style="box-shadow: 0 4px 12px rgb(89 85 101 / 20%); width: 500px; max-width: 50%; height: auto; display: block; margin: 24px auto; border-radius: 6px">
 </div>
 
-This could be further improved by choosing colors that are differentiable to people afflicted by common colorblindness types. There are tools on the web to [simulate the color perception of various color blindnesses][color-blind-simulator]. The Typst web app can simulate color blindness in the preview so you can check how your document performs without exporting it. You can find the options for this in the "View" menu. You could also iterate on the design by choosing two-tone patterns, aligning them to the bars, or changing font use.
+This could be further improved by choosing colors that are differentiable to people afflicted by common colorblindness types. There are tools on the web to [simulate the color perception of various color blindnesses][color-blind-simulator]. You could also iterate on the design by choosing two-tone patterns, aligning them to the bars, or changing font use.
 
 Also consider the color contrast between background and foreground. For example, when you are using light gray text for footnotes, they could become hard to read. Another situation that often leads to low contrast is superimposing text on an image.
 

--- a/docs/tutorial/3-advanced.md
+++ b/docs/tutorial/3-advanced.md
@@ -225,7 +225,7 @@ another show-set rule that selects the title to set the block spacing:
 
 With this show-set rule, we overrode the spacing below the title. We have used
 the `em` unit: It allows us to express lengths as multiples of the font size.
-Here, we used it to space the title and the author list exactly 1.2× of the font
+Here, we used it to space the title and the author list exactly 1.2× the font
 size apart. Now, let's add the abstract. Remember that the conference wants the
 abstract to be set ragged and centered.
 
@@ -281,10 +281,34 @@ affect the remainder of the document even though it was specified after the
 first set rule because content blocks _scope_ styling. Anything set within a
 content block will only affect the content within that block.
 
-Another tweak could be to save the paper title in a variable, so that we do not
-have to type it twice, for header and title. Content saved in a variable can
-then be used later in the document, just by referencing the variable with its
-name. We define a new variable with the `{let}` keyword:
+Another tweak could be to remove the duplication between the header and the title
+element's argument. Since they only share the title, it would be convenient to
+store it in a place designed to hold metadata about the document. We would then
+need a way to retrieve the title in both places. The `document` element can help
+us with the former: By using it in a set rule, we can store document metadata
+like title, description, and keywords.
+
+```typ
+#set document(title: [A Fluid Dynamic Model for Glacier Flow])
+```
+
+When exporting a PDF, the title set here will appear in the title bar of your
+PDF reader. Your operating system will also use this title to make the file
+retrievable with search. Last but not least, it contributes to making your
+document more accessible and is required if you choose to comply with PDF/UA,
+a PDF standard focused on accessibility.
+
+Now, we need a way to retrieve the value we set in the main title and the
+header. Because the `title` function is designed to work together with the
+`document` element, calling it with no arguments will just print the title. For
+the header, we will need to be more explicit: Because Typst has no way of
+knowing that you want to insert the title there, we will need to tell it to do
+so manually.
+
+Using _context,_ we can retrieve the contents of any values we have set on
+elements before. When we use the `{context}` keyword, we can access any
+property of any element, including the document element's title property. The
+syntax would then look like this:
 
 ```example:single
 #set document(title: [
@@ -299,6 +323,8 @@ name. We define a new variable with the `{let}` keyword:
 >>> margin: auto,
   header: align(
     right + horizon,
+    // Retrieve the document
+    // element's title property.
     context document.title,
   ),
 <<<   ...
@@ -338,24 +364,46 @@ name. We define a new variable with the `{let}` keyword:
 >>> #lorem(600)
 ```
 
-After we assigned the content to the `doc-title` variable, we can use it in
-functions and also within markup (prefixed by `#`, like functions). This way, if
-we decide on another title, we can easily change it in one place.
+First, notice how we called the title function with empty, round
+parentheses. Because no argument was passed, it defaulted to what we set for the
+document element above. The distinction between empty round and empty square
+brackets is important: While empty round brackets show that you are passing
+nothing, empty square brackets mean that you are passing one argument: an empty
+content block. If called that way, the title would have no visible content.
 
-Also notice that we changed the call to the `title` function from square
-brackets to round parentheses. That's because we no longer pass content, but use
-a variable, which is accessible in code mode. Another way to write this is to
-use the hashtag to enter code mode: ```[#title[#doc-title]]```. Because that's
-more verbose, the standard style is just to use round parentheses.
+Next, take a look at the header. Instead of the title in square parentheses, we
+used the context keyword to access the document title. This inserted exactly
+what we set above. The role of context is not limited to accessing properties:
+With it, you can check if some elements are present in the document, measure the
+physical dimensions of others, and more. Using context, you can build powerful
+templates that react to the preferences of the end-user.
 
 <div class="info-box">
 
-Why did we not call the variable `title`?
+<details>
+<summary>
+Why is the context keyword required to access element properties?
+</summary>
 
-Variables and functions share a _namespace._ That means that Typst's built-in
-function are just variables which are already defined in all your files. You can
-define variables with the same name (e.g. `title`), but that means that calling
-`#title[]` would not work anymore.
+Normally, when we access a variable, we know exactly what its value is going to
+be:
+
+- The variable could be a constant built into Typst, like `[#sym.pi]`
+- The variable could be defined by an argument
+- The variable could be defined or overwritten in the current scope
+
+However, sometimes, that's not enough. In this chapter of the tutorial, we have
+inserted a page header with the title. Even though we pass only one content
+block for the header, we may want different pages to have different headers. For
+example, we may want to print the chapter name or use the page number. When we
+use context, we can write a single context block that tells Typst to take a look
+at where it's inserted, look for the last heading, the current page number, or
+anything else, and go from there. That means that the same context block,
+inserted on different pages, can produce different output.
+
+For more information, read up on context [in its docs]($context) after
+completing this tutorial.
+</details>
 </div>
 
 ## Adding columns and headings { #columns-and-headings }
@@ -384,10 +432,10 @@ content in its container:
 ```
 
 If we hadn't used `{place}` here, the square would be in its own line, but here
-it overlaps the few lines of text following it. Likewise, that text acts like as
-if there was no square. To change this behavior, we can pass the argument
-`{float: true}` to ensure that the space taken up by the placed item at the top
-or bottom of the page is not occupied by any other content.
+it overlaps the few lines of text following it. Likewise, that text acts as if
+there was no square. To change this behavior, we can pass the argument `{float:
+true}` to ensure that the space taken up by the placed item at the top or bottom
+of the page is not occupied by any other content.
 
 ```example:single
 >>> #set document(title: [
@@ -642,10 +690,11 @@ the conference! The finished paper looks like this:
 
 ## Review
 You have now learned how to create titles, headers, and footers, how to use
-functions, set show rules, and scopes to locally override styles, how to create
-more complex layouts with the [`grid`] function and how to write show rules for
-individual functions, and the whole document. You also learned how to use the
-[`where` selector]($styling/#show-rules) to filter the headings by their level.
+functions, show-set rules, and scopes to locally override styles, how to create
+more complex layouts with the [`grid`] function, how to access element
+properties with context, and how to write show rules for individual functions,
+and the whole document. You also learned how to use the [`where`
+selector]($styling/#show-rules) to filter the headings by their level.
 
 The paper was a great success! You've met a lot of like-minded researchers at
 the conference and are planning a project which you hope to publish at the same

--- a/docs/tutorial/3-advanced.md
+++ b/docs/tutorial/3-advanced.md
@@ -54,8 +54,8 @@ Let's start by writing some set rules for the document.
 >>> margin: auto,
   paper: "us-letter",
   header: align(right)[
-    A fluid dynamic model for
-    glacier flow
+    A Fluid Dynamic Model for
+    Glacier Flow
   ],
   numbering: "1",
 )
@@ -85,31 +85,82 @@ surrounded by parentheses. And we could even have provided a completely custom
 function here to format things to our liking.
 
 ## Creating a title and abstract { #title-and-abstract }
-Now, let's add a title and an abstract. We'll start with the title. We center
-align it and increase its font weight by enclosing it in `[*stars*]`.
+Now, let's add a title and an abstract. We'll start with the title. Typst comes
+with a [`title`] function. Let's start by providing our title as an argument:
 
 ```example
 >>> #set page(width: 300pt, margin: 30pt)
 >>> #set text(font: "Libertinus Serif", 11pt)
-#align(center, text(17pt)[
-  *A fluid dynamic model
-  for glacier flow*
-])
+#title[
+  A Fluid Dynamic Model
+  for Glacier Flow
+]
 ```
 
-This looks right. We used the `text` function to override the previous text
-set rule locally, increasing the size to 17pt for the function's argument. Let's
-also add the author list: Since we are writing this paper together with our
-supervisor, we'll add our own and their name.
+You can see that the title is already boldfaced and has some space around it.
+However, it is left-aligned and not exactly 17pt large. Hence, we need to adjust
+its appearance. The title function does not come with any arguments for
+font or text size we could set. Instead, these properties are defined on the
+`text` and `align` functions.
+
+<div class="info-box">
+
+What is the difference between what the `title` function inserted and the
+headings we produced with equals signs?
+
+Headings, even first-level headings, can appear multiple times in your document
+whereas a title only appears once, usually at the beginning. Differentiating
+between the two helps Typst to make your document accessible for users of
+Assistive Technologies such as screen readers.
+</div>
+
+When we want to customize the arguments of some element function inside of other
+elements, we can use show-set rules. First, we use show to select which function
+we want to customize – which function should show its elements differently. We
+call this a _selector._ Then, type a double colon. Finally, write your set rule
+that applies to elements matching the selector. Summarized, the syntax looks
+like this:
+
+```typ
+#show thing-you-customize: set thing-you-set(/* ... */)
+```
+
+Let's recall: We want to center-align the title and make it 17pt large. Hence,
+we need two set show rules:
+
+- One with the **selector `title`** and the **set rule `{text(size: 17pt)}`**
+- One with the **selector `title`** and the **set rule `{align(center)}`**
+
+Hence, our example now looks like this:
+
+```example
+>>> #set page(width: 300pt, margin: 30pt)
+>>> #set text(font: "Libertinus Serif", 11pt)
+#show title: set text(
+  size: 17pt,
+)
+#show title: set align(center)
+#title[
+  A Fluid Dynamic Model
+  for Glacier Flow
+]
+```
+
+This looks right. Let's also add the author list: Since we are writing this
+paper together with our supervisor, we'll add our own and their name.
 
 ```example
 >>> #set page(width: 300pt, margin: 30pt)
 >>> #set text(font: "Libertinus Serif", 11pt)
 >>>
->>> #align(center, text(17pt)[
->>>   *A fluid dynamic model
->>>   for glacier flow*
->>> ])
+>>> #show title: set text(
+>>>   size: 17pt,
+>>> )
+>>> #show title: set align(center)
+>>> #title[
+>>>   A Fluid Dynamic Model
+>>>   for Glacier Flow
+>>> ]
 #grid(
   columns: (1fr, 1fr),
   align(center)[
@@ -137,26 +188,71 @@ column. The grid takes an arbitrary number of content arguments specifying the
 cells. Rows are added automatically, but they can also be manually sized with
 the `rows` argument.
 
-Now, let's add the abstract. Remember that the conference wants the abstract to
-be set ragged and centered.
+Looking at the authors and the title, they are a bit too close together. You can
+address this by using another show-set rule to insert some space below the
+title. The title, the grid, paragraphs, and all other elements that Typst
+arranges from the top to the bottom of the page are called blocks. Each block is
+controlled by the [`block`] function. It controls behaviors like their distance
+and whether a block can contain a page break. That means that we can write
+another show-set rule that selects the title to set the block spacing:
+
+```example
+>>> #set page(width: 300pt, margin: 30pt)
+>>> #set text(font: "Libertinus Serif", 11pt)
+>>>
+#show title: set text(
+  size: 17pt,
+)
+#show title: set align(center)
+#show title: set block(below: 1.2em)
+#title[
+  A Fluid Dynamic Model
+  for Glacier Flow
+]
+#grid(
+<<<   // ...
+>>>   columns: (1fr, 1fr),
+>>>   align(center)[
+>>>     Therese Tungsten \
+>>>     Artos Institute \
+>>>     #link("mailto:tung@artos.edu")
+>>>   ],
+>>>   align(center)[
+>>>     Dr. John Doe \
+>>>     Artos Institute \
+>>>     #link("mailto:doe@artos.edu")
+>>>   ]
+)
+```
+
+With this show-set rule, we inserted additional spacing below the title. We have
+used the `em` unit: It allows us to express lengths as multiples of the font
+size. Here, we used it to add 1.2x of the font size as spacing. Now, let's add
+the abstract. Remember that the conference wants the abstract to be set ragged
+and centered.
 
 ```example:0,0,612,317.5
 >>> #set page(
 >>>   "us-letter",
 >>>   margin: auto,
 >>>   header: align(right + horizon)[
->>>     A fluid dynamic model for
->>>     glacier flow
+>>>     A Fluid Dynamic Model for
+>>>     Glacier Flow
 >>>   ],
 >>>   numbering: "1",
 >>> )
 >>> #set par(justify: true)
 >>> #set text(font: "Libertinus Serif", 11pt)
 >>>
->>> #align(center, text(17pt)[
->>>   *A fluid dynamic model
->>>   for glacier flow*
->>> ])
+>>> #show title: set text(
+>>>   size: 17pt,
+>>> )
+>>> #show title: set align(center)
+>>> #show title: set block(below: 1.2em)
+>>> #title[
+>>>   A Fluid Dynamic Model
+>>>   for Glacier Flow
+>>> ]
 >>>
 >>> #grid(
 >>>   columns: (1fr, 1fr),
@@ -189,13 +285,14 @@ first set rule because content blocks _scope_ styling. Anything set within a
 content block will only affect the content within that block.
 
 Another tweak could be to save the paper title in a variable, so that we do not
-have to type it twice, for header and title. We can do that with the `{let}`
-keyword:
+have to type it twice, for header and title. Content saved in a variable can
+then be used later in the document, just by referencing the variable with its
+name. We define a new variable with the `{let}` keyword:
 
 ```example:single
-#let title = [
-  A fluid dynamic model
-  for glacier flow
+#let doc-title = [
+  A Fluid Dynamic Model
+  for Glacier Flow
 ]
 
 <<< ...
@@ -205,7 +302,7 @@ keyword:
 >>> margin: auto,
   header: align(
     right + horizon,
-    title
+    doc-title,
   ),
 <<<   ...
 >>> numbering: "1",
@@ -213,9 +310,12 @@ keyword:
 >>> #set par(justify: true)
 >>> #set text(font: "Libertinus Serif", 11pt)
 
-#align(center, text(17pt)[
-  *#title*
-])
+>>> #show title: set text(
+>>>   size: 17pt,
+>>> )
+>>> #show title: set align(center)
+>>> #show title: set block(below: 1.2em)
+#title(doc-title)
 
 <<< ...
 
@@ -242,9 +342,25 @@ keyword:
 >>> #lorem(600)
 ```
 
-After we bound the content to the `title` variable, we can use it in functions
-and also within markup (prefixed by `#`, like functions). This way, if we decide
-on another title, we can easily change it in one place.
+After we bound the content to the `doc-title` variable, we can use it in
+functions and also within markup (prefixed by `#`, like functions). This way, if
+we decide on another title, we can easily change it in one place.
+
+Also notice that we changed the call to the `title` function from square
+brackets to round parentheses. That's because we no longer pass content, but use
+a variable, which is accessible in code mode. Another way to write this is to
+use the hashtag to enter code mode: ```[#title[#doc-title]]```. Because that's
+more verbose, the standard style is just to use round parentheses.
+
+<div class="info-box">
+
+Why did we not call the variable `title`?
+
+Variables and functions share a _namespace._ That means that Typst's built-in
+function are just variables which are already defined in all your files. You can
+define variables with the same name (e.g. `title`), but that means that calling
+`#title[]` would not work anymore.
+</div>
 
 ## Adding columns and headings { #columns-and-headings }
 The paper above unfortunately looks like a wall of lead. To fix that, let's add
@@ -278,9 +394,9 @@ if there was no square. To change this behavior, we can pass the argument
 or bottom of the page is not occupied by any other content.
 
 ```example:single
->>> #let title = [
->>>   A fluid dynamic model
->>>   for glacier flow
+>>> #let doc-title = [
+>>>   A Fluid Dynamic Model
+>>>   for Glacier Flow
 >>> ]
 >>>
 #set page(
@@ -288,7 +404,7 @@ or bottom of the page is not occupied by any other content.
   paper: "us-letter",
   header: align(
     right + horizon,
-    title
+    doc-title
   ),
   numbering: "1",
   columns: 2,
@@ -302,11 +418,12 @@ or bottom of the page is not occupied by any other content.
   scope: "parent",
   clearance: 2em,
 )[
->>> #text(
->>>   17pt,
->>>   weight: "bold",
->>>   title,
+>>> #show title: set text(
+>>>   size: 17pt,
 >>> )
+>>> #show title: set align(center)
+>>> #show title: set block(below: 1.2em)
+>>> #title(doc-title)
 >>>
 >>> #grid(
 >>>   columns: (1fr, 1fr),
@@ -346,9 +463,9 @@ centered and use small capitals. Because the `heading` function does not offer
 a way to set any of that, we need to write our own heading show rule.
 
 ```example:50,250,265,270
->>> #let title = [
->>>   A fluid dynamic model
->>>   for glacier flow
+>>> #let doc-title = [
+>>>   A Fluid Dynamic Model
+>>>   for Glacier Flow
 >>> ]
 >>>
 >>> #set page(
@@ -356,7 +473,7 @@ a way to set any of that, we need to write our own heading show rule.
 >>>   margin: auto,
 >>>   header: align(
 >>>     right + horizon,
->>>     title
+>>>     doc-title
 >>>   ),
 >>>   numbering: "1",
 >>>   columns: 2,
@@ -376,11 +493,12 @@ a way to set any of that, we need to write our own heading show rule.
 >>>   scope: "parent",
 >>>   clearance: 2em,
 >>> )[
->>>   #text(
->>>     17pt,
->>>     weight: "bold",
->>>     title,
+>>>   #show title: set text(
+>>>     size: 17pt,
 >>>   )
+>>>   #show title: set align(center)
+>>>   #show title: set block(below: 1.2em)
+>>>   #title(doc-title)
 >>>
 >>>   #grid(
 >>>     columns: (1fr, 1fr),
@@ -427,9 +545,9 @@ elements) that allows us to filter them by their level. We can use it to
 differentiate between section and subsection headings:
 
 ```example:50,250,265,245
->>> #let title = [
->>>   A fluid dynamic model
->>>   for glacier flow
+>>> #let doc-title = [
+>>>   A Fluid Dynamic Model
+>>>   for Glacier Flow
 >>> ]
 >>>
 >>> #set page(
@@ -437,7 +555,7 @@ differentiate between section and subsection headings:
 >>>   margin: auto,
 >>>   header: align(
 >>>     right + horizon,
->>>     title
+>>>     doc-title
 >>>   ),
 >>>   numbering: "1",
 >>>   columns: 2,
@@ -468,11 +586,12 @@ differentiate between section and subsection headings:
 >>>   scope: "parent",
 >>>   clearance: 2em,
 >>> )[
->>>   #text(
->>>     17pt,
->>>     weight: "bold",
->>>     title,
+>>>   #show title: set text(
+>>>     size: 17pt,
 >>>   )
+>>>   #show title: set align(center)
+>>>   #show title: set block(below: 1.2em)
+>>>   #title(doc-title)
 >>>
 >>>   #grid(
 >>>     columns: (1fr, 1fr),
@@ -529,10 +648,10 @@ the conference! The finished paper looks like this:
 >
 
 ## Review
-You have now learned how to create headers and footers, how to use functions and
-scopes to locally override styles, how to create more complex layouts with the
-[`grid`] function and how to write show rules for individual functions, and the
-whole document. You also learned how to use the
+You have now learned how to create titles, headers, and footers, how to use
+functions, set show rules, and scopes to locally override styles, how to create
+more complex layouts with the [`grid`] function and how to write show rules for
+individual functions, and the whole document. You also learned how to use the
 [`where` selector]($styling/#show-rules) to filter the headings by their level.
 
 The paper was a great success! You've met a lot of like-minded researchers at

--- a/docs/tutorial/3-advanced.md
+++ b/docs/tutorial/3-advanced.md
@@ -116,9 +116,9 @@ Assistive Technology such as screen readers.
 
 When we want to customize the properties of some element inside of another kind
 of element, we can use show-set rules. First, we use `show` to select which
-element we want to customize. We call this a _selector._ Then, we type a double
-colon. Next, we write the set rule that should apply to elements matching the
-selector. Summarized, the syntax looks like this:
+element we want to customize. We call this a _selector._ Then, we type a colon.
+Next, we write the set rule that should apply to elements matching the selector.
+Summarized, the syntax looks like this:
 
 ```typ
 #show your-selector: set some-element(/* ... */)
@@ -130,7 +130,7 @@ we need two show-set rules:
 - One with the selector `title` and the rule `{set text(size: 17pt)}`
 - One with the selector `title` and the rule `{set align(center)}`
 
-Hence, our example now looks like this:
+Our example now looks like this:
 
 ```example
 >>> #set page(width: 300pt, margin: 30pt)

--- a/docs/tutorial/3-advanced.md
+++ b/docs/tutorial/3-advanced.md
@@ -117,7 +117,7 @@ Assistive Technology such as screen readers.
 When we want to customize the properties of some element inside of another kind
 of element, we can use show-set rules. First, we use `show` to select which
 element we want to customize. We call this a _selector._ Then, we type a double
-colon. Next, we write the set rule that applies to elements matching the
+colon. Next, we write the set rule that should apply to elements matching the
 selector. Summarized, the syntax looks like this:
 
 ```typ
@@ -187,12 +187,12 @@ cells. Rows are added automatically, but they can also be manually sized with
 the `rows` argument.
 
 Looking at the authors and the title, they are a bit too close together. You can
-address this by using another show-set rule to insert some space below the
+address this by using another show-set rule to configure the space below the
 title. The title, the grid, paragraphs, and all other elements that Typst
-arranges from the top to the bottom of the page are called blocks. Each block is
-controlled by the [`block`] function. It controls behaviors like their distance
-and whether a block can contain a page break. That means that we can write
-another show-set rule that selects the title to set the block spacing:
+arranges from the top to the bottom of the page are called _blocks._ Each block
+is controlled by the [`block`] function. It controls behaviors like their
+distance and whether a block can contain a page break. That means that we can
+write another show-set rule that selects the title to set the block spacing:
 
 ```example
 >>> #set page(width: 300pt, margin: 30pt)
@@ -281,8 +281,8 @@ affect the remainder of the document even though it was specified after the
 first set rule because content blocks _scope_ styling. Anything set within a
 content block will only affect the content within that block.
 
-Another tweak could be to remove the duplication between the header and the title
-element's argument. Since they only share the title, it would be convenient to
+Another tweak could be to remove the duplication between the header and the
+title element's argument. Since they share the title, it would be convenient to
 store it in a place designed to hold metadata about the document. We would then
 need a way to retrieve the title in both places. The `document` element can help
 us with the former: By using it in a set rule, we can store document metadata
@@ -295,20 +295,20 @@ like title, description, and keywords.
 When exporting a PDF, the title set here will appear in the title bar of your
 PDF reader. Your operating system will also use this title to make the file
 retrievable with search. Last but not least, it contributes to making your
-document more accessible and is required if you choose to comply with PDF/UA,
-a PDF standard focused on accessibility.
+document more accessible and is required if you choose to comply with PDF/UA, a
+PDF standard focused on accessibility.
 
 Now, we need a way to retrieve the value we set in the main title and the
 header. Because the `title` function is designed to work together with the
 `document` element, calling it with no arguments will just print the title. For
 the header, we will need to be more explicit: Because Typst has no way of
-knowing that you want to insert the title there, we will need to tell it to do
-so manually.
+knowing that we want to insert the title there, we will need to tell it to do so
+manually.
 
 Using _context,_ we can retrieve the contents of any values we have set on
-elements before. When we use the `{context}` keyword, we can access any
-property of any element, including the document element's title property. The
-syntax would then look like this:
+elements before. When we use the `{context}` keyword, we can access any property
+of any element, including the document element's title property. Its use looks
+like this:
 
 ```example:single
 #set document(title: [
@@ -393,12 +393,12 @@ be:
 - The variable could be defined or overwritten in the current scope
 
 However, sometimes, that's not enough. In this chapter of the tutorial, we have
-inserted a page header with the title. Even though we pass only one content
-block for the header, we may want different pages to have different headers. For
-example, we may want to print the chapter name or use the page number. When we
-use context, we can write a single context block that tells Typst to take a look
-at where it's inserted, look for the last heading, the current page number, or
-anything else, and go from there. That means that the same context block,
+inserted a page header with the title. Even though we pass only one piece of
+content for the header, we may want different pages to have different headers.
+For example, we may want to print the chapter name or use the page number. When
+we use context, we can write a single context block that tells Typst to take a
+look at where it's inserted, look for the last heading, the current page number,
+or anything else, and go from there. That means that the same context block,
 inserted on different pages, can produce different output.
 
 For more information, read up on context [in its docs]($context) after
@@ -433,9 +433,9 @@ content in its container:
 
 If we hadn't used `{place}` here, the square would be in its own line, but here
 it overlaps the few lines of text following it. Likewise, that text acts as if
-there was no square. To change this behavior, we can pass the argument `{float:
-true}` to ensure that the space taken up by the placed item at the top or bottom
-of the page is not occupied by any other content.
+there was no square. To change this behavior, we can pass the argument
+`{float: true}` to ensure that the space taken up by the placed item at the top
+or bottom of the page is not occupied by any other content.
 
 ```example:single
 >>> #set document(title: [

--- a/docs/tutorial/3-advanced.md
+++ b/docs/tutorial/3-advanced.md
@@ -110,36 +110,34 @@ headings we produced with equals signs?
 
 Headings, even first-level headings, can appear multiple times in your document
 whereas a title only appears once, usually at the beginning. Differentiating
-between the two helps Typst to make your document accessible for users of
-Assistive Technologies such as screen readers.
+between the two helps Typst make your document accessible for users of
+Assistive Technology such as screen readers.
 </div>
 
-When we want to customize the arguments of some element function inside of other
-elements, we can use show-set rules. First, we use show to select which function
-we want to customize – which function should show its elements differently. We
-call this a _selector._ Then, type a double colon. Finally, write your set rule
-that applies to elements matching the selector. Summarized, the syntax looks
-like this:
+When we want to customize the properties of some element inside of another kind
+of element, we can use show-set rules. First, we use `show` to select which
+element we want to customize. We call this a _selector._ Then, we type a double
+colon. Next, we write the set rule that applies to elements matching the
+selector. Summarized, the syntax looks like this:
 
 ```typ
-#show thing-you-customize: set thing-you-set(/* ... */)
+#show your-selector: set some-element(/* ... */)
 ```
 
 Let's recall: We want to center-align the title and make it 17pt large. Hence,
-we need two set show rules:
+we need two show-set rules:
 
-- One with the **selector `title`** and the **set rule `{text(size: 17pt)}`**
-- One with the **selector `title`** and the **set rule `{align(center)}`**
+- One with the selector `title` and the rule `{set text(size: 17pt)}`
+- One with the selector `title` and the rule `{set align(center)}`
 
 Hence, our example now looks like this:
 
 ```example
 >>> #set page(width: 300pt, margin: 30pt)
 >>> #set text(font: "Libertinus Serif", 11pt)
-#show title: set text(
-  size: 17pt,
-)
+#show title: set text(size: 17pt)
 #show title: set align(center)
+
 #title[
   A Fluid Dynamic Model
   for Glacier Flow
@@ -153,14 +151,14 @@ paper together with our supervisor, we'll add our own and their name.
 >>> #set page(width: 300pt, margin: 30pt)
 >>> #set text(font: "Libertinus Serif", 11pt)
 >>>
->>> #show title: set text(
->>>   size: 17pt,
->>> )
+>>> #show title: set text(size: 17pt)
 >>> #show title: set align(center)
+>>>
 >>> #title[
 >>>   A Fluid Dynamic Model
 >>>   for Glacier Flow
 >>> ]
+
 #grid(
   columns: (1fr, 1fr),
   align(center)[
@@ -200,15 +198,15 @@ another show-set rule that selects the title to set the block spacing:
 >>> #set page(width: 300pt, margin: 30pt)
 >>> #set text(font: "Libertinus Serif", 11pt)
 >>>
-#show title: set text(
-  size: 17pt,
-)
+#show title: set text(size: 17pt)
 #show title: set align(center)
 #show title: set block(below: 1.2em)
+
 #title[
   A Fluid Dynamic Model
   for Glacier Flow
 ]
+
 #grid(
 <<<   // ...
 >>>   columns: (1fr, 1fr),
@@ -225,11 +223,11 @@ another show-set rule that selects the title to set the block spacing:
 )
 ```
 
-With this show-set rule, we inserted additional spacing below the title. We have
-used the `em` unit: It allows us to express lengths as multiples of the font
-size. Here, we used it to add 1.2x of the font size as spacing. Now, let's add
-the abstract. Remember that the conference wants the abstract to be set ragged
-and centered.
+With this show-set rule, we overrode the spacing below the title. We have used
+the `em` unit: It allows us to express lengths as multiples of the font size.
+Here, we used it to space the title and the author list exactly 1.2× of the font
+size apart. Now, let's add the abstract. Remember that the conference wants the
+abstract to be set ragged and centered.
 
 ```example:0,0,612,317.5
 >>> #set page(
@@ -244,11 +242,10 @@ and centered.
 >>> #set par(justify: true)
 >>> #set text(font: "Libertinus Serif", 11pt)
 >>>
->>> #show title: set text(
->>>   size: 17pt,
->>> )
+>>> #show title: set text(size: 17pt)
 >>> #show title: set align(center)
 >>> #show title: set block(below: 1.2em)
+>>>
 >>> #title[
 >>>   A Fluid Dynamic Model
 >>>   for Glacier Flow
@@ -290,10 +287,10 @@ then be used later in the document, just by referencing the variable with its
 name. We define a new variable with the `{let}` keyword:
 
 ```example:single
-#let doc-title = [
+#set document(title: [
   A Fluid Dynamic Model
   for Glacier Flow
-]
+])
 
 <<< ...
 
@@ -302,7 +299,7 @@ name. We define a new variable with the `{let}` keyword:
 >>> margin: auto,
   header: align(
     right + horizon,
-    doc-title,
+    context document.title,
   ),
 <<<   ...
 >>> numbering: "1",
@@ -310,12 +307,11 @@ name. We define a new variable with the `{let}` keyword:
 >>> #set par(justify: true)
 >>> #set text(font: "Libertinus Serif", 11pt)
 
->>> #show title: set text(
->>>   size: 17pt,
->>> )
+>>> #show title: set text(size: 17pt)
+>>>
 >>> #show title: set align(center)
 >>> #show title: set block(below: 1.2em)
-#title(doc-title)
+#title()
 
 <<< ...
 
@@ -342,7 +338,7 @@ name. We define a new variable with the `{let}` keyword:
 >>> #lorem(600)
 ```
 
-After we bound the content to the `doc-title` variable, we can use it in
+After we assigned the content to the `doc-title` variable, we can use it in
 functions and also within markup (prefixed by `#`, like functions). This way, if
 we decide on another title, we can easily change it in one place.
 
@@ -394,17 +390,17 @@ if there was no square. To change this behavior, we can pass the argument
 or bottom of the page is not occupied by any other content.
 
 ```example:single
->>> #let doc-title = [
+>>> #set document(title: [
 >>>   A Fluid Dynamic Model
 >>>   for Glacier Flow
->>> ]
+>>> ])
 >>>
 #set page(
 >>> margin: auto,
   paper: "us-letter",
   header: align(
     right + horizon,
-    doc-title
+    context document.title,
   ),
   numbering: "1",
   columns: 2,
@@ -418,12 +414,11 @@ or bottom of the page is not occupied by any other content.
   scope: "parent",
   clearance: 2em,
 )[
->>> #show title: set text(
->>>   size: 17pt,
->>> )
+>>> #show title: set text(size: 17pt)
 >>> #show title: set align(center)
 >>> #show title: set block(below: 1.2em)
->>> #title(doc-title)
+>>>
+>>> #title()
 >>>
 >>> #grid(
 >>>   columns: (1fr, 1fr),
@@ -463,17 +458,17 @@ centered and use small capitals. Because the `heading` function does not offer
 a way to set any of that, we need to write our own heading show rule.
 
 ```example:50,250,265,270
->>> #let doc-title = [
+>>> #set document(title: [
 >>>   A Fluid Dynamic Model
 >>>   for Glacier Flow
->>> ]
+>>> ])
 >>>
 >>> #set page(
 >>>   "us-letter",
 >>>   margin: auto,
 >>>   header: align(
 >>>     right + horizon,
->>>     doc-title
+>>>     context document.title,
 >>>   ),
 >>>   numbering: "1",
 >>>   columns: 2,
@@ -493,12 +488,11 @@ a way to set any of that, we need to write our own heading show rule.
 >>>   scope: "parent",
 >>>   clearance: 2em,
 >>> )[
->>>   #show title: set text(
->>>     size: 17pt,
->>>   )
+>>>   #show title: set text(size: 17pt)
 >>>   #show title: set align(center)
 >>>   #show title: set block(below: 1.2em)
->>>   #title(doc-title)
+>>>
+>>>   #title()
 >>>
 >>>   #grid(
 >>>     columns: (1fr, 1fr),
@@ -545,17 +539,17 @@ elements) that allows us to filter them by their level. We can use it to
 differentiate between section and subsection headings:
 
 ```example:50,250,265,245
->>> #let doc-title = [
+>>> #set document(title: [
 >>>   A Fluid Dynamic Model
 >>>   for Glacier Flow
->>> ]
+>>> ])
 >>>
 >>> #set page(
 >>>   "us-letter",
 >>>   margin: auto,
 >>>   header: align(
 >>>     right + horizon,
->>>     doc-title
+>>>     context document.title,
 >>>   ),
 >>>   numbering: "1",
 >>>   columns: 2,
@@ -586,12 +580,11 @@ differentiate between section and subsection headings:
 >>>   scope: "parent",
 >>>   clearance: 2em,
 >>> )[
->>>   #show title: set text(
->>>     size: 17pt,
->>>   )
+>>>   #show title: set text(size: 17pt)
 >>>   #show title: set align(center)
 >>>   #show title: set block(below: 1.2em)
->>>   #title(doc-title)
+>>>
+>>>   #title()
 >>>
 >>>   #grid(
 >>>     columns: (1fr, 1fr),

--- a/docs/tutorial/3-advanced.md
+++ b/docs/tutorial/3-advanced.md
@@ -578,17 +578,17 @@ rule:
 ```
 
 This looks great! We used show rules that apply to all headings. In the final
-smallcaps show rule, we pass the complete heading into the `smallcaps` function
-as the first argument. As we will see in the next example, you could also provide
-a custom rule, completely overriding the default heading.
+show rule, we applied the `smallcaps` function to the complete heading. As we
+will see in the next example, we can also provide a custom rule to completely
+override the default look of headings.
 
 The only remaining problem is that all headings look the same now. The
 "Motivation" and "Problem Statement" subsections ought to be italic run-in
 headers, but right now, they look indistinguishable from the section headings.
 We can fix that by using a `where` selector on our show rule: This is a
 [method]($scripting/#methods) we can call on headings (and other elements) that
-allows us to filter them by their level. We can use it to differentiate between
-section and subsection headings:
+allows us to filter them by their properties. We can use it to differentiate
+between section and subsection headings:
 
 ```example:50,250,265,245
 >>> #set document(title: [
@@ -610,10 +610,7 @@ section and subsection headings:
 >>> #set text(font: "Libertinus Serif", 11pt)
 >>>
 #show heading.where(level: 1): set align(center)
-#show heading.where(level: 1): set text(
-  size: 13pt,
-  weight: "regular",
-)
+#show heading.where(level: 1): set text(size: 13pt, weight: "regular")
 #show heading.where(level: 1): smallcaps
 
 #show heading.where(level: 2): set text(
@@ -665,21 +662,23 @@ section and subsection headings:
 ```
 
 In this example, we first scope our previous rules to first-level headings by
-using `.where(level: 1)` to make the selector more specific. Then, we add a
+using `{.where(level: 1)}` to make the selector more specific. Then, we add a
 show-set rule for the second heading level. Finally, we need a show rule with a
 custom function: Headings enclose their contents with a block by default. This
 has the effect that the heading gets its own line. However, we want it to run
 into the text, so we need to provide our own show rule to get rid of this block.
-We provide the rule a function that receives the heading as a parameter called
-`it`. As seen with the smallcaps show rule, that parameter can be used as
-content and will just print the whole default heading. When we want to build our
-own heading instead, we can use its fields like `body`, `numbers`, and `level`
-from which we can compose a custom look. Here, we are just printing the body of
-the heading with a trailing dot to remove the block. Note that this heading
-will no longer react to set rules for heading numberings and similar because we
-did not explicitly use `it.numbering` in the show rule. If you are writing show
+
+We provide the rule with a function that takes the heading as a parameter.
+This parameter is conventionally called `it`, but can have another name. The
+parameter can be used as content and will just display the whole default
+heading. Alternatively, when we want to build our own heading instead, we can
+use its fields like `body`, `numbering`, and `level` to compose a custom look.
+Here, we are just printing the body of the heading with a trailing dot and leave
+out the block that the built-in show rule produces. Note that this heading will
+no longer react to set rules for heading numbering and similar because we did
+not explicitly use `it.numbering` in the show rule. If you are writing show
 rules like this and want the document to remain customizable, you will need to
-add these fields.
+take these fields into account.
 
 This looks great! We wrote show rules that selectively apply to the first and
 second level headings. We used a `where` selector to filter the headings by

--- a/docs/tutorial/4-template.md
+++ b/docs/tutorial/4-template.md
@@ -12,6 +12,127 @@ you created in the previous chapter and turn it into a reusable template. In
 this chapter you will learn how to create a template that you and your team can
 use with just one show rule. Let's get started!
 
+## Reusing data with variables { #variables }
+In the past chapters, most of the content of the document was entered by hand.
+In the third chapter, we used the `document` element and context to cut down on
+repetition and only enter the title once. But in practice, there may be many
+more things that occur multiple times in your document. There are multiple good
+reasons to just define these repeated values once:
+
+1. It makes changing them later easier
+2. It allows you to quickly find all instances where you used something
+3. It makes it easy to be consistent throughout
+4. For long or hard-to-enter repeated segments, a shorter variable name is often
+   more convenient to type
+
+If you were using a conventional word processor, you might resort to using a
+placeholder value that you can later search for. In Typst, however, you can
+instead use variables to safely store content and reuse it across your whole
+document through a variable name.
+
+The technique of using context to reproduce an element's property we have
+learned earlier is not always the most appropriate for this: Typst's built-in
+elements focus on semantic properties like the title and description of a
+document, or things that directly relate to typesetting, like the text size.
+
+For our example, we want to take a look at Typst's pronunciation. One of the
+best ways to transcribe pronunciation is the International Phonetic Alphabet
+(IPA). But because it uses characters not found on common keyboards, typing IPA
+repeatedly can become cumbersome. So let's instead define a variable that we can
+reference multiple times.
+
+```typ
+#let ipa = [taɪpst]
+```
+
+Here, we use a new keyword, `{let}`, to indicate a variable definition. Then,
+we put the name of our variable, in this case, `ipa`. Finally, we type an equals
+sign and the value of our variable. It is enclosed in square brackets because
+it is content, mirroring how you would call a function accepting content. In
+other words, this syntax mirrors the phrase _"Let the variable `ipa` have the
+value `{[taɪpst]}`."_
+
+Now, we can use the variable everywhere in our document:
+
+```example
+#let ipa = [taɪpst]
+
+The canonical way to
+pronounce Typst is #ipa.
+
+#table(
+  columns: (1fr, 1fr),
+  [Name], [Typst],
+  [Pronunciation], ipa,
+)
+```
+
+In the example, you can see that the variable can be used both in markup
+(prefixed with a `#`) and in a function call (by just typing its name). Of
+course, we can change the value of the variable and all its occurrences will
+automatically change with it. Let's make it a bit more clear what is IPA and
+what is normal prose by rendering it in italics. We are also using slashes
+which, by convention, often enclose IPA.
+
+```example
+#let ipa = text(
+  style: "italic",
+<<< )[/taɪpst/]
+>>> box[/taɪpst/])
+
+The canonical way to
+pronounce Typst is #ipa.
+
+#table(
+  columns: (1fr, 1fr),
+  [Name], [Typst],
+  [Pronunciation], ipa,
+)
+```
+
+Here, we called the text function and assigned its _return value_ to the
+variable. When you call a function, it processes its arguments and then yields
+another value (often content). So far in this tutorial, we called most
+functions directly in markup, like this: `[#text(fill: red)[CRIMSON!]]`. This
+call to the text function returns the red text as a return value. Because we
+placed it in markup, its return value just immediately got inserted into the
+content we wrote. With variables, we can instead store it to use it later or
+compose it with other values.
+
+Variables are not limited to storing content: they can store any data type Typst
+knows about. Throughout this tutorial, you made use of many data types when you
+passed them to Typst's built-in functions. Here is an example assigning each of
+them to a variable:
+
+```typ
+// Content with markup inside
+#let blind-text = [_Lorem ipsum_ dolor sit amet]
+
+// Unformatted strings
+#let funny-font = "MS Comic Sans"
+
+// Absolute lengths (see also pt, in, ...)
+#let mile = 160934cm
+
+// Lengths relative to the font size
+#let double-space = 2em
+
+// Fractions
+#let progress = 80%
+
+// Integer numbers
+#let answer = 42
+
+// Booleans
+#let truth = false
+
+// Horizontal and vertical alignment
+#let focus = center
+```
+
+In this chapter of the tutorial, you will leverage variables and your own
+functions to build templates that can be reused across multiple documents.
+
 ## A toy template { #toy-template }
 In Typst, templates are functions in which you can wrap your whole document. To
 learn how to do that, let's first review how to write your very own functions.
@@ -23,9 +144,17 @@ They can do anything you want them to, so why not go a bit crazy?
 You are #amazed[beautiful]!
 ```
 
-This function takes a single argument, `term`, and returns a content block with
-the `term` surrounded by sparkles. We also put the whole thing in a box so that
-the term we are amazed by cannot be separated from its sparkles by a line break.
+Comparing this against the previous section, you may have noticed that this
+looks a lot like a variable definition using `{let}`. This instinct is correct,
+functions are just another data type. Here, we are defining the variable
+`amazed`, assigning it a function that takes a single argument, `term`, and
+returns content with the `term` surrounded by sparkles. We also put the whole
+thing in a [`box`] so that the term we are amazed by cannot be separated from
+its sparkles by a line break. The special syntax makes the function definition
+shorter and more readable, but you can also use the regular variable definition
+syntax (see [the scripting reference]($scripting/#bindings) for details). After
+its definition, we are able to call the function just like all built-in
+functions.
 
 Many functions that come with Typst have optional named parameters. Our
 functions can also have them. Let's add a parameter to our function that lets us

--- a/docs/tutorial/4-template.md
+++ b/docs/tutorial/4-template.md
@@ -117,7 +117,7 @@ them to a variable:
 // Lengths relative to the font size
 #let double-space = 2em
 
-// Fractions
+// Ratios
 #let progress = 80%
 
 // Integer numbers

--- a/docs/tutorial/4-template.md
+++ b/docs/tutorial/4-template.md
@@ -233,7 +233,6 @@ The resulting template function looks like this:
 
 ```typ
 #let conf(
-  doc-title: none,
   authors: (),
   abstract: [],
   doc,
@@ -248,7 +247,7 @@ The resulting template function looks like this:
     scope: "parent",
     clearance: 2em,
     {
-      title(doc-title)
+      title()
 
       let count = authors.len()
       let ncols = calc.min(count, 3)
@@ -292,7 +291,6 @@ call.
 
 ```example:single
 >>> #let conf(
->>>   doc-title: none,
 >>>   authors: (),
 >>>   abstract: [],
 >>>   doc,
@@ -302,7 +300,7 @@ call.
 >>>     margin: auto,
 >>>     header: align(
 >>>       right + horizon,
->>>       doc-title
+>>>       context document.title,
 >>>     ),
 >>>     numbering: "1",
 >>>     columns: 2,
@@ -336,7 +334,7 @@ call.
 >>>     scope: "parent",
 >>>     clearance: 2em,
 >>>     {
->>>       title(doc-title)
+>>>       title()
 >>>
 >>>       let count = authors.len()
 >>>       let ncols = calc.min(count, 3)
@@ -360,11 +358,13 @@ call.
 >>>   doc
 >>> }
 <<< #import "conf.typ": conf
+
+#set document(title: [
+  A Fluid Dynamic Model for
+  Glacier Flow
+])
+
 #show: conf.with(
-  doc-title: [
-    A Fluid Dynamic Model for
-    Glacier Flow
-  ],
   authors: (
     (
       name: "Theresa Tungsten",

--- a/docs/tutorial/4-template.md
+++ b/docs/tutorial/4-template.md
@@ -240,22 +240,25 @@ previous chapter.
 
   // Heading show rules.
 <<<   ...
->>> show heading.where(
->>>   level: 1
->>> ): it => block(width: 100%)[
->>>   #set align(center)
->>>   #set text(13pt, weight: "regular")
->>>   #smallcaps(it.body)
->>> ]
+>>> show heading.where(level: 1): set align(
+>>>   center
+>>> )
+>>> show heading.where(level: 1): set text(
+>>>   size: 13pt,
+>>>   weight: "regular",
+>>> )
+>>> show heading.where(level: 1): smallcaps
 >>>
->>> show heading.where(
->>>   level: 2
->>> ): it => text(
+>>> show heading.where(level: 2): set text(
 >>>   size: 11pt,
 >>>   weight: "regular",
 >>>   style: "italic",
->>>   it.body + [.],
 >>> )
+>>> show heading.where(
+>>>   level: 2
+>>> ): it => {
+>>>   it.body + [.]
+>>> }
 
   doc
 }
@@ -440,13 +443,25 @@ call.
 >>>   show title: set align(center)
 >>>   show title: set block(below: 1.2em)
 >>>
+>>>   show heading.where(level: 1): set align(
+>>>     center
+>>>   )
+>>>   show heading.where(level: 1): set text(
+>>>     size: 13pt,
+>>>     weight: "regular",
+>>>   )
+>>>   show heading.where(level: 1): smallcaps
+>>>
+>>>   show heading.where(level: 2): set text(
+>>>     size: 11pt,
+>>>     weight: "regular",
+>>>     style: "italic",
+>>>   )
 >>>   show heading.where(
->>>     level: 1
->>>   ): it => block(width: 100%)[
->>>     #set align(center)
->>>     #set text(13pt, weight: "regular")
->>>     #smallcaps(it.body)
->>>   ]
+>>>     level: 2
+>>>   ): it => {
+>>>     it.body + [.]
+>>>   }
 >>>
 >>>   show heading.where(
 >>>     level: 2

--- a/docs/tutorial/4-template.md
+++ b/docs/tutorial/4-template.md
@@ -240,13 +240,8 @@ previous chapter.
 
   // Heading show rules.
 <<<   ...
->>> show heading.where(level: 1): set align(
->>>   center
->>> )
->>> show heading.where(level: 1): set text(
->>>   size: 13pt,
->>>   weight: "regular",
->>> )
+>>> show heading.where(level: 1): set align(center)
+>>> show heading.where(level: 1): set text(size: 13pt, weight: "regular")
 >>> show heading.where(level: 1): smallcaps
 >>>
 >>> show heading.where(level: 2): set text(
@@ -443,13 +438,8 @@ call.
 >>>   show title: set align(center)
 >>>   show title: set block(below: 1.2em)
 >>>
->>>   show heading.where(level: 1): set align(
->>>     center
->>>   )
->>>   show heading.where(level: 1): set text(
->>>     size: 13pt,
->>>     weight: "regular",
->>>   )
+>>>   show heading.where(level: 1): set align(center)
+>>>   show heading.where(level: 1): set text(size: 13pt, weight: "regular")
 >>>   show heading.where(level: 1): smallcaps
 >>>
 >>>   show heading.where(level: 2): set text(

--- a/docs/tutorial/4-template.md
+++ b/docs/tutorial/4-template.md
@@ -52,7 +52,7 @@ it is content, mirroring how you would call a function accepting content. In
 other words, this syntax mirrors the phrase _"Let the variable `ipa` have the
 value `{[taɪpst]}`."_
 
-Now, we can use the variable everywhere in our document:
+Now, we can use the variable in our document:
 
 ```example
 #let ipa = [taɪpst]
@@ -70,9 +70,9 @@ pronounce Typst is #ipa.
 In the example, you can see that the variable can be used both in markup
 (prefixed with a `#`) and in a function call (by just typing its name). Of
 course, we can change the value of the variable and all its occurrences will
-automatically change with it. Let's make it a bit more clear what is IPA and
-what is normal prose by rendering it in italics. We are also using slashes
-which, by convention, often enclose IPA.
+automatically change with it. Let's make it a bit clearer what is IPA and what
+is normal prose by rendering IPA in italics. We are also using slashes which, by
+convention, often enclose IPA.
 
 ```example
 #let ipa = text(
@@ -145,16 +145,16 @@ You are #amazed[beautiful]!
 ```
 
 Comparing this against the previous section, you may have noticed that this
-looks a lot like a variable definition using `{let}`. This instinct is correct,
-functions are just another data type. Here, we are defining the variable
+looks a lot like a variable definition using `{let}`. This instinct is correct:
+Functions are just another data type. Here, we are defining the variable
 `amazed`, assigning it a function that takes a single argument, `term`, and
 returns content with the `term` surrounded by sparkles. We also put the whole
 thing in a [`box`] so that the term we are amazed by cannot be separated from
-its sparkles by a line break. The special syntax makes the function definition
-shorter and more readable, but you can also use the regular variable definition
-syntax (see [the scripting reference]($scripting/#bindings) for details). After
-its definition, we are able to call the function just like all built-in
-functions.
+its sparkles by a line break. The special function definition syntax makes the
+definition shorter and more readable, but you can also use the regular variable
+definition syntax (see [the scripting reference]($scripting/#bindings) for
+details). After its definition, we are able to call the function just like all
+built-in functions.
 
 Many functions that come with Typst have optional named parameters. Our
 functions can also have them. Let's add a parameter to our function that lets us

--- a/docs/tutorial/4-template.md
+++ b/docs/tutorial/4-template.md
@@ -179,8 +179,8 @@ to work like this:
 ```typ
 #show: doc => conf(
   title: [
-    A fluid dynamic model for
-    glacier flow
+    A Fluid Dynamic Model for
+    Glacier Flow
   ],
   authors: (
     (
@@ -233,7 +233,7 @@ The resulting template function looks like this:
 
 ```typ
 #let conf(
-  title: none,
+  doc-title: none,
   authors: (),
   abstract: [],
   doc,
@@ -248,11 +248,7 @@ The resulting template function looks like this:
     scope: "parent",
     clearance: 2em,
     {
-      text(
-        17pt,
-        weight: "bold",
-        title,
-      )
+      title(doc-title)
 
       let count = authors.len()
       let ncols = calc.min(count, 3)
@@ -296,7 +292,7 @@ call.
 
 ```example:single
 >>> #let conf(
->>>   title: none,
+>>>   doc-title: none,
 >>>   authors: (),
 >>>   abstract: [],
 >>>   doc,
@@ -306,13 +302,16 @@ call.
 >>>     margin: auto,
 >>>     header: align(
 >>>       right + horizon,
->>>       title
+>>>       doc-title
 >>>     ),
 >>>     numbering: "1",
 >>>     columns: 2,
 >>>   )
 >>>   set par(justify: true)
 >>>   set text(font: "Libertinus Serif", 11pt)
+>>>   show title: set text(size: 17pt)
+>>>   show title: set align(center)
+>>>   show title: set block(below: 1.2em)
 >>>
 >>>   show heading.where(
 >>>     level: 1
@@ -337,11 +336,7 @@ call.
 >>>     scope: "parent",
 >>>     clearance: 2em,
 >>>     {
->>>       text(
->>>         17pt,
->>>         weight: "bold",
->>>         title,
->>>       )
+>>>       title(doc-title)
 >>>
 >>>       let count = authors.len()
 >>>       let ncols = calc.min(count, 3)
@@ -366,9 +361,9 @@ call.
 >>> }
 <<< #import "conf.typ": conf
 #show: conf.with(
-  title: [
-    A fluid dynamic model for
-    glacier flow
+  doc-title: [
+    A Fluid Dynamic Model for
+    Glacier Flow
   ],
   authors: (
     (


### PR DESCRIPTION
After the introduction of the title element, using the text function to create a title manually is bad practice. I updated the tutorial accordingly.

To make the goal of the tutorial possible, I added an explanation of set show rules. Furthermore, I mentioned the `block` function. Finally, I changed the document title to title case.