### PR TITLE
Implement a pre-compile hook for typst compile and watch

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -314,6 +314,10 @@ pub struct CompileArgs {
     /// apart from file names and line numbers.
     #[arg(long = "timings", value_name = "OUTPUT_JSON")]
     pub timings: Option<Option<PathBuf>>,
+
+    /// Runs the provided command before compiling.
+    #[arg(long = "pre-compile-script", value_name = "PRE_COMPILE_SCRIPT")]
+    pub pre_compile_script: Option<PathBuf>,
 }
 
 /// Arguments for the construction of a world. Shared by compile, watch, and


### PR DESCRIPTION
This allows the user to automatically execute a script or other command before compilation starts. While it would be trivial do do this manually with `./script && typst compile` it becomes extremely useful with `typst watch`.

The script is executed immediately before compilation starts and incleded in the typst compilation time output. If the exit status is non-zero compilation will still run to allow the user to get a partial document, however a warning is printed.

In order to avoid the case where the script triggers watched files in `typst watch` mode all watchers are paused during execution. Without this infinite compilation loops were observed.

Part-Of: #6859