### PR TITLE
Add `--deps` and `--deps-format` flags for emitting a dependency list

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -273,10 +273,20 @@ pub struct CompileArgs {
     #[arg(long = "ppi", default_value_t = 144.0)]
     pub ppi: f32,
 
-    /// File path to which a Makefile with the current compilation's
-    /// dependencies will be written.
-    #[clap(long = "make-deps", value_name = "PATH")]
-    pub make_deps: Option<PathBuf>,
+    /// File path to which a list of current compilation's dependencies will be written
+    #[clap(
+        long,
+        value_name = "PATH",
+        value_parser = output_value_parser(),
+        value_hint = ValueHint::FilePath,
+    )]
+    pub deps: Option<Output>,
+
+    /// File format to use for dependencies
+    ///
+    /// Note that JSON disallows non-Unicode paths, and Make disallows even more than that.
+    #[clap(long, default_value_t)]
+    pub deps_format: DepsFormat,
 
     /// Processing arguments.
     #[clap(flatten)]
@@ -467,6 +477,16 @@ pub enum OutputFormat {
 }
 
 display_possible_values!(OutputFormat);
+
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, ValueEnum)]
+pub enum DepsFormat {
+    #[default]
+    Zero,
+    Json,
+    Make,
+}
+
+display_possible_values!(DepsFormat);
 
 /// The target to compile for.
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, ValueEnum)]

--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -1,4 +1,5 @@
 use std::fmt::{self, Display, Formatter};
+use std::io::Write;
 use std::num::NonZeroUsize;
 use std::ops::RangeInclusive;
 use std::path::PathBuf;
@@ -273,7 +274,8 @@ pub struct CompileArgs {
     #[arg(long = "ppi", default_value_t = 144.0)]
     pub ppi: f32,
 
-    /// File path to which a list of current compilation's dependencies will be written
+    /// File path to which a list of current compilation's dependencies will be
+    /// written. Use `-` to write to stdout.
     #[clap(
         long,
         value_name = "PATH",
@@ -282,9 +284,7 @@ pub struct CompileArgs {
     )]
     pub deps: Option<Output>,
 
-    /// File format to use for dependencies
-    ///
-    /// Note that JSON disallows non-Unicode paths, and Make disallows even more than that.
+    /// File format to use for dependencies.
     #[clap(long, default_value_t)]
     pub deps_format: DepsFormat,
 
@@ -458,11 +458,52 @@ pub enum Output {
     Path(PathBuf),
 }
 
+impl Output {
+    /// Write data to the output.
+    pub fn write(&self, buffer: &[u8]) -> std::io::Result<()> {
+        match self {
+            Output::Stdout => std::io::stdout().write_all(buffer),
+            Output::Path(path) => std::fs::write(path, buffer),
+        }
+    }
+
+    /// Open the output for writing.
+    pub fn open(&self) -> std::io::Result<OpenOutput<'_>> {
+        match self {
+            Self::Stdout => Ok(OpenOutput::Stdout(std::io::stdout().lock())),
+            Self::Path(path) => std::fs::File::create(path).map(OpenOutput::File),
+        }
+    }
+}
+
 impl Display for Output {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Output::Stdout => f.pad("stdout"),
             Output::Path(path) => path.display().fmt(f),
+        }
+    }
+}
+
+/// A step-by-step writable version of [`Output`].
+#[derive(Debug)]
+pub enum OpenOutput<'a> {
+    Stdout(std::io::StdoutLock<'a>),
+    File(std::fs::File),
+}
+
+impl Write for OpenOutput<'_> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self {
+            OpenOutput::Stdout(v) => v.write(buf),
+            OpenOutput::File(v) => v.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            OpenOutput::Stdout(v) => v.flush(),
+            OpenOutput::File(v) => v.flush(),
         }
     }
 }
@@ -478,11 +519,15 @@ pub enum OutputFormat {
 
 display_possible_values!(OutputFormat);
 
+/// Which format to use for a generated dependency file.
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, ValueEnum)]
 pub enum DepsFormat {
+    /// Encodes as JSON, failing for non-Unicode paths.
     #[default]
-    Zero,
     Json,
+    /// Separates paths with NULL bytes and can express all paths.
+    Zero,
+    /// Emits in Make format, omitting inexpressible paths.
     Make,
 }
 

--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -274,6 +274,11 @@ pub struct CompileArgs {
     #[arg(long = "ppi", default_value_t = 144.0)]
     pub ppi: f32,
 
+    /// File path to which a Makefile with the current compilation's
+    /// dependencies will be written.
+    #[clap(long = "make-deps", value_name = "PATH", hide = true)]
+    pub make_deps: Option<PathBuf>,
+
     /// File path to which a list of current compilation's dependencies will be
     /// written. Use `-` to write to stdout.
     #[clap(

--- a/crates/typst-cli/src/deps.rs
+++ b/crates/typst-cli/src/deps.rs
@@ -1,0 +1,150 @@
+use std::ffi::OsString;
+use std::io::{self, Write};
+
+use crate::args::{DepsFormat, Output};
+use crate::world::SystemWorld;
+
+/// Writes dependencies in the given format.
+pub fn write_deps(
+    world: &mut SystemWorld,
+    dest: &Output,
+    format: DepsFormat,
+    outputs: Option<&[Output]>,
+) -> io::Result<()> {
+    match format {
+        DepsFormat::Json => write_deps_json(world, dest)?,
+        DepsFormat::Zero => write_deps_zero(world, dest)?,
+        DepsFormat::Make => {
+            if let Some(outputs) = outputs {
+                write_deps_make(world, dest, outputs)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Writes dependencies in JSON format.
+fn write_deps_json(world: &mut SystemWorld, dest: &Output) -> io::Result<()> {
+    use serde::ser::{SerializeSeq, Serializer};
+
+    let dest = dest.open()?;
+    let mut serializer = serde_json::Serializer::new(dest);
+    let mut seq = serializer.serialize_seq(None)?;
+
+    for dep in relative_dependencies(world)? {
+        let string = dep.as_os_str().to_str().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("{dep:?} is not valid utf-8"),
+            )
+        })?;
+        seq.serialize_element(string)?;
+    }
+
+    seq.end()?;
+    Ok(())
+}
+
+/// Writes dependencies in the Zero / Text0 format.
+fn write_deps_zero(world: &mut SystemWorld, dest: &Output) -> io::Result<()> {
+    let mut dest = dest.open()?;
+    for dep in relative_dependencies(world)? {
+        dest.write_all(dep.as_encoded_bytes())?;
+        dest.write_all(b"\0")?;
+    }
+    Ok(())
+}
+
+/// Writes dependencies in the Make format.
+fn write_deps_make(
+    world: &mut SystemWorld,
+    dest: &Output,
+    outputs: &[Output],
+) -> io::Result<()> {
+    let mut dest = dest.open()?;
+    for (i, output) in outputs.iter().enumerate() {
+        let path = match output {
+            Output::Path(path) => path.as_os_str(),
+            Output::Stdout => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "make dependencies contain the output path, \
+                     but the output was stdout",
+                ));
+            }
+        };
+
+        // Silently skip paths that aren't valid Unicode so we still
+        // produce a rule that will work for the other paths that can be
+        // processed.
+        let Some(string) = path.to_str() else { continue };
+        if i != 0 {
+            dest.write_all(b" ")?;
+        }
+        dest.write_all(munge(string).as_bytes())?;
+    }
+    dest.write_all(b":")?;
+
+    for dep in relative_dependencies(world)? {
+        // See above.
+        let Some(string) = dep.to_str() else { continue };
+        dest.write_all(b" ")?;
+        dest.write_all(munge(string).as_bytes())?;
+    }
+    dest.write_all(b"\n")?;
+
+    Ok(())
+}
+
+// Based on `munge` in libcpp/mkdeps.cc from the GCC source code. This isn't
+// perfect as some special characters can't be escaped.
+fn munge(s: &str) -> String {
+    let mut res = String::with_capacity(s.len());
+    let mut slashes = 0;
+    for c in s.chars() {
+        match c {
+            '\\' => slashes += 1,
+            '$' => {
+                res.push('$');
+                slashes = 0;
+            }
+            ':' => {
+                res.push('\\');
+                slashes = 0;
+            }
+            ' ' | '\t' => {
+                // `munge`'s source contains a comment here that says: "A
+                // space or tab preceded by 2N+1 backslashes represents N
+                // backslashes followed by space..."
+                for _ in 0..slashes + 1 {
+                    res.push('\\');
+                }
+                slashes = 0;
+            }
+            '#' => {
+                res.push('\\');
+                slashes = 0;
+            }
+            _ => slashes = 0,
+        };
+        res.push(c);
+    }
+    res
+}
+
+/// Extracts the current compilation's dependencies as paths relative to the
+/// current directory.
+fn relative_dependencies(
+    world: &mut SystemWorld,
+) -> io::Result<impl Iterator<Item = OsString>> {
+    let root = world.root().to_owned();
+    let current_dir = std::env::current_dir()?;
+    let relative_root =
+        pathdiff::diff_paths(&root, &current_dir).unwrap_or_else(|| root.clone());
+    Ok(world.dependencies().map(move |dependency| {
+        dependency
+            .strip_prefix(&root)
+            .map_or_else(|_| dependency.clone(), |x| relative_root.join(x))
+            .into_os_string()
+    }))
+}

--- a/crates/typst-cli/src/main.rs
+++ b/crates/typst-cli/src/main.rs
@@ -1,6 +1,7 @@
 mod args;
 mod compile;
 mod completions;
+mod deps;
 mod download;
 mod fonts;
 mod greet;


### PR DESCRIPTION
This PR replaces `--make-deps` with two new flags:
- `--deps` — where to write the list of dependencies
- `--deps-format` — one of `zero`, `json`, `make`:
  - `make`: Makefile format, matches the behavior of `--make-deps`
    ```Makefile
    main.pdf: lib.typ /home/tau/.cache/typst/packages/preview/physica/0.9.6/physica.typ /home/tau/.cache/typst/packages/preview/physica/0.9.6/typst.toml main.typ image.png
    ```
  - `json`: JSON array of strings, each string being a (relative) path to a dependency
    ```json
    ["lib.typ","/home/tau/.cache/typst/packages/preview/physica/0.9.6/physica.typ","/home/tau/.cache/typst/packages/preview/physica/0.9.6/typst.toml","main.typ","image.png"]
    ```
  - `zero`: sequence of strings delimited by a NUL byte
    ```
    lib.typ␀/home/tau/.cache/typst/packages/preview/physica/0.9.6/physica.typ␀/home/tau/.cache/typst/packages/preview/physica/0.9.6/typst.toml␀main.typ␀image.png␀
    ```
    
Comparison of formats:

Name | Human-readable (-2..=+2) | Machine-readable (-2..=+2) | Allowed dependency paths 
---- | ------------------------ | -------------------------- | ------------------------
Makefile       | `+1` | `-1` (largely unstandardized, essentially defined by an implementation — in fact, `--make-deps` was implemented by rewriting a part of GCC in Rust, and the GCC code says something like "well GNU Make does this; note that this still breaks sometimes") | Valid Unicode without certain characters like `$`
JSON           | `0` (can be improved to `+1` by using "pretty" option) | `+1` (standard is short and concise, easy to implement in any language, used by most utilities, but still requires stuff like escape processing) | Valid Unicode
Zero/Null/text0 | `-0.5` (needs `bat -A` or similar) | `+2` (doesn't require any sort of escape parsing, can be parsed without copying) | Anything without NUL (which AFAIK is forbidden on all existing systems)

Scale used:
- (-2, +2) is Protobuf and similar (cannot be read by a human, close to a memory dump for a machine)
- (0, 0) is something like XML (still can be read by a layperson and is well-defined, but is quite verbose and requires effort from both)
- (+2, -2) is a free-form natural language description (the native tongue for humans, absolutely unreadable for machines, and even complicated NLP stuff is still imperfect)

Unresolved questions:
- [ ] What should be the default `--deps-format`? Currently it's `zero`, because it's the only lossless one, but I admit it's not the most common format. Maybe use JSON as the middle ground?
- [ ] Should JSON be minified?
- [ ] What should be the name of the NUL-delimited format? It's too simple to have a standard (the only possible disagreement is whether the file should include a trailing NUL, but I haven't yet seen a tool not including one), so there's no standard name. I chose `zero`, because `null` can be confused for "lack of value", and `text0` is a bit longer and includes combines letters and digits, which a part of my brain doesn't like for some reason.

(continuation of #6648)