### PR TITLE
Fix check for PDF figures containing only marked content

### DIFF
--- a/crates/typst-pdf/src/tags/context/figure.rs
+++ b/crates/typst-pdf/src/tags/context/figure.rs
@@ -103,7 +103,7 @@ pub fn build_figure(
             }
             _ => (),
         }
-    } else if group.nodes().iter().any(|n| matches!(n, TagNode::Group(_))) {
+    } else if !group.nodes().iter().any(|n| matches!(n, TagNode::Group(_))) {
         // The figure contains only marked content.
         figure_ctx.tag_kind = FigureTagKind::Figure;
     }

--- a/tests/ref/pdftags/figure-tags-listing.yml
+++ b/tests/ref/pdftags/figure-tags-listing.yml
@@ -1,0 +1,29 @@
+- Tag: Div
+  /Placement: Block
+  /K:
+    - Tag: Code
+      /Placement: Block
+      /K:
+        - Tag: P
+          /K:
+            - Content: page=0 mcid=0
+            - Content: page=0 mcid=1
+            - Content: page=0 mcid=2
+            - Content: page=0 mcid=3
+            - Content: page=0 mcid=4
+            - Content: page=0 mcid=5
+            - Content: page=0 mcid=6
+        - Tag: P
+          /K:
+            - Content: page=0 mcid=7
+            - Content: page=0 mcid=8
+            - Content: page=0 mcid=9
+            - Content: page=0 mcid=10
+            - Content: page=0 mcid=11
+            - Content: page=0 mcid=12
+            - Content: page=0 mcid=13
+            - Content: page=0 mcid=14
+            - Content: page=0 mcid=15
+        - Tag: P
+          /K:
+            - Content: page=0 mcid=16

--- a/tests/ref/pdftags/figure-tags-only-marked-content.yml
+++ b/tests/ref/pdftags/figure-tags-only-marked-content.yml
@@ -1,0 +1,2 @@
+- Tag: Figure
+  /Placement: Block

--- a/tests/suite/pdftags/figure.typ
+++ b/tests/suite/pdftags/figure.typ
@@ -61,3 +61,24 @@ Ein Paragraph.
 
 #set text(lang: "en", region: "uk")
 #figure(image(alt: "A tiger", "/assets/images/tiger.jpg"))
+
+--- figure-tags-listing pdftags ---
+#figure[
+  ```rs
+  fn main() {
+      println!("Hello Typst!");
+  }
+  ```
+]
+
+--- figure-tags-only-marked-content-missing-alt pdftags ---
+// Error: 2-3:2 PDF/UA-1 error: missing alt text
+// Hint: 2-3:2 make sure your images and equations have alt text
+#figure[
+  #rect(fill: red)
+]
+
+--- figure-tags-only-marked-content pdftags nopdfua ---
+#figure[
+  #rect(fill: red)
+]


### PR DESCRIPTION
Fixes an inverted condition when checking if a Typst figure contains only marked content. If a Typst figure contains only marked content a PDF `Figure` tag should be used. If not (because there is a nested tag structure) a `Div` tag will be used instead.

This bug caused figures containing structured content (such as listings) to emit a `PDF/UA-1` error complaining about missing alt text, and vice versa would not generate an error for figures containing only marked content that didn't have a alt text.