### PR TITLE
Add missing elements to introspector that were filtered out

### DIFF
--- a/crates/typst-layout/src/grid/mod.rs
+++ b/crates/typst-layout/src/grid/mod.rs
@@ -57,7 +57,7 @@ pub fn layout_cell(
     if let Some((elem, loc, key)) = tags
         && let Some((first, remainder)) = frames.split_first_mut()
     {
-        let flags = TagFlags { locatable: false, tagged: true, labelled: false };
+        let flags = TagFlags { introspectable: false, tagged: true };
         first.prepend(Point::zero(), FrameItem::Tag(Tag::Start(elem, flags)));
         first.push(Point::zero(), FrameItem::Tag(Tag::End(loc, key, flags)));
 

--- a/crates/typst-layout/src/inline/line.rs
+++ b/crates/typst-layout/src/inline/line.rs
@@ -643,7 +643,7 @@ fn add_par_line_marker(
     // line's general baseline. However, the line number will still need to
     // manually adjust its own 'y' position based on its own baseline.
     let pos = Point::with_y(top);
-    let flags = TagFlags { locatable: false, tagged: true, labelled: false };
+    let flags = TagFlags { introspectable: false, tagged: false };
     output.push(pos, FrameItem::Tag(Tag::Start(marker.pack(), flags)));
     output.push(pos, FrameItem::Tag(Tag::End(loc, key, flags)));
 }

--- a/crates/typst-library/src/introspection/introspector.rs
+++ b/crates/typst-library/src/introspection/introspector.rs
@@ -423,7 +423,7 @@ impl IntrospectorBuilder {
     ) {
         match tag {
             Tag::Start(elem, flags) => {
-                if flags.locatable || flags.labelled {
+                if flags.introspectable {
                     let loc = elem.location().unwrap();
                     if self.seen.insert(loc) {
                         sink.push((elem.clone(), position));
@@ -431,7 +431,7 @@ impl IntrospectorBuilder {
                 }
             }
             Tag::End(loc, key, flags) => {
-                if flags.locatable || flags.labelled {
+                if flags.introspectable {
                     self.keys.insert(*key, *loc);
                 }
             }

--- a/crates/typst-library/src/introspection/tag.rs
+++ b/crates/typst-library/src/introspection/tag.rs
@@ -45,17 +45,18 @@ impl Debug for Tag {
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct TagFlags {
-    /// Whether the element is [`Locatable`](super::Locatable).
-    pub locatable: bool,
+    /// Whether the element will be inserted into the
+    /// [`Introspector`](super::Introspector).
+    /// Either because it is [`Locatable`](super::Locatable), has been labelled,
+    /// or a location has been manually set.
+    pub introspectable: bool,
     /// Whether the element is [`Tagged`](super::Tagged).
     pub tagged: bool,
-    /// Whether the element has a [`Label`](crate::foundations::Label).
-    pub labelled: bool,
 }
 
 impl TagFlags {
     pub fn any(&self) -> bool {
-        self.locatable || self.tagged || self.labelled
+        self.introspectable || self.tagged
     }
 }
 

--- a/crates/typst-realize/src/lib.rs
+++ b/crates/typst-realize/src/lib.rs
@@ -534,9 +534,10 @@ fn prepare(
     // when it stems from a query.
     let key = typst_utils::hash128(&elem);
     let flags = TagFlags {
-        locatable: elem.can::<dyn Locatable>(),
+        introspectable: elem.can::<dyn Locatable>()
+            || elem.label().is_some()
+            || elem.location().is_some(),
         tagged: elem.can::<dyn Tagged>(),
-        labelled: elem.label().is_some(),
     };
     if elem.location().is_none() && flags.any() {
         let loc = locator.next_location(engine.introspector, key);


### PR DESCRIPTION
Fixes #7015. The commit 77076ce22 introduced `TagFlags` that are used to filter which elements are added to the introspector and which are handled in tagged PDF generation. This wouldn't add elements to the introspector that aren't `Locatable` or haven't been labelled. So in case of the bibliography the `DirectLinkElem` which isn't locatable wasn't inserted into the introspector, and thus when getting the position to link to, `(0, 0)` was returned.

Now any element that has a manually assigned location will also be marked as `introspectable` and inserted into the introspector.