### PR TITLE
Invert `disable_pdf_tags` into `tagged` in `PdfOptions`

### DIFF
--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -66,7 +66,7 @@ pub struct CompileConfig {
     /// A list of standards the PDF should conform to.
     pub pdf_standards: PdfStandards,
     /// Whether to write PDF (accessibility) tags.
-    pub disable_pdf_tags: bool,
+    pub tagged: bool,
     /// A destination to write a list of dependencies to.
     pub deps: Option<Output>,
     /// The format to use for dependencies.
@@ -185,7 +185,7 @@ impl CompileConfig {
             output_format,
             pages,
             pdf_standards,
-            disable_pdf_tags: args.no_pdf_tags,
+            tagged: !args.no_pdf_tags,
             creation_timestamp: args.world.creation_timestamp,
             ppi: args.ppi,
             diagnostic_format: args.process.diagnostic_format,
@@ -336,7 +336,7 @@ fn export_pdf(document: &PagedDocument, config: &CompileConfig) -> SourceResult<
         timestamp,
         page_ranges: config.pages.clone(),
         standards: config.pdf_standards.clone(),
-        disable_tags: config.disable_pdf_tags,
+        tagged: config.tagged,
     };
     let buffer = typst_pdf::pdf(document, &options)?;
     config

--- a/crates/typst-pdf/src/convert.rs
+++ b/crates/typst-pdf/src/convert.rs
@@ -91,7 +91,7 @@ fn setup<'a>(
         xmp_metadata: true,
         cmyk_profile: None,
         configuration: options.standards.config,
-        enable_tagging: !options.disable_tags,
+        enable_tagging: options.tagged,
         render_svg_glyph_fn: render_svg_glyph,
     };
 

--- a/crates/typst-pdf/src/lib.rs
+++ b/crates/typst-pdf/src/lib.rs
@@ -39,7 +39,7 @@ pub fn pdf_tags(document: &PagedDocument, options: &PdfOptions) -> SourceResult<
 }
 
 /// Settings for PDF export.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct PdfOptions<'a> {
     /// If not `Smart::Auto`, shall be a string that uniquely and stably
     /// identifies the document. It should not change between compilations of
@@ -65,7 +65,7 @@ pub struct PdfOptions<'a> {
     /// document is written to provide a baseline of accessibility. In some
     /// circumstances, for example when trying to reduce the size of a document,
     /// it can be desirable to disable tagged PDF.
-    pub disable_tags: bool,
+    pub tagged: bool,
 }
 
 impl PdfOptions<'_> {
@@ -73,6 +73,18 @@ impl PdfOptions<'_> {
     /// PDF/UA-2.
     pub(crate) fn is_pdf_ua(&self) -> bool {
         self.standards.config.validator() == Validator::UA1
+    }
+}
+
+impl Default for PdfOptions<'_> {
+    fn default() -> Self {
+        Self {
+            ident: Smart::Auto,
+            timestamp: None,
+            page_ranges: None,
+            standards: PdfStandards::default(),
+            tagged: true,
+        }
     }
 }
 

--- a/crates/typst-pdf/src/tags/mod.rs
+++ b/crates/typst-pdf/src/tags/mod.rs
@@ -32,7 +32,7 @@ mod tree;
 mod util;
 
 pub fn init(document: &PagedDocument, options: &PdfOptions) -> SourceResult<Tags> {
-    let tree = if !options.disable_tags {
+    let tree = if options.tagged {
         tree::build(document, options)?
     } else {
         Tree::empty(document, options)
@@ -170,10 +170,10 @@ pub fn tiling<T>(
 }
 
 /// Whether tag generation is currently disabled. Either because it has been
-/// disabled by the user using the [`PdfOptions::disable_tags`] flag, or we're
-/// inside a tiling.
+/// disabled by the user using the [`PdfOptions::tagged`] flag, or we're inside
+/// a tiling.
 pub fn disabled(gc: &GlobalContext) -> bool {
-    gc.options.disable_tags || gc.tags.in_tiling
+    !gc.options.tagged || gc.tags.in_tiling
 }
 
 /// Add all annotations that were found in the page frame.


### PR DESCRIPTION
The positive condition is just a bit simpler generally in my opinion. The CLI is an exception because `true` is the default, so `false` needs an inverted flag to be enabled.