### PR TITLE
Disallow empty URLs

### DIFF
--- a/crates/typst-library/src/model/link.rs
+++ b/crates/typst-library/src/model/link.rs
@@ -308,6 +308,8 @@ impl Url {
         let url = url.into();
         if url.len() > 8000 {
             bail!("URL is too long")
+        } else if url.is_empty() {
+            bail!("URL must not be empty")
         }
         Ok(Self(url))
     }

--- a/tests/suite/model/link.typ
+++ b/tests/suite/model/link.typ
@@ -189,8 +189,12 @@ Text <hey>
 // Error: 2-20 label `<hey>` occurs multiple times in the document
 #link(<hey>)[Nope.]
 
+--- link-empty-url ---
+// Error: 7-9 URL must not be empty
+#link("")[Empty]
+
 --- link-empty-block ---
-#link("", block(height: 10pt, width: 100%))
+#link("https://example.com", block(height: 10pt, width: 100%))
 
 --- issue-758-link-repeat ---
 #let url = "https://typst.org/"


### PR DESCRIPTION
In addition to URLs that are too long, this commit disallows empty URLs in links. This addresses two PDF/UA-1 validation issues found by veraPDF on the old test `link-empty-block`: Clause 7.18.1 (test 2) and Clause 7.18.5 (test 2). Both stipulate that a non-empty contents key must be present on annotations. Because we set the `Contents` key to the URL, empty URLs fail this test. But they don't make sense anyways, so we just forbid them here.