### PR TITLE
Avoid release action from updating prerelease status

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,3 +86,4 @@ jobs:
         allowUpdates: true
         omitNameDuringUpdate: true
         omitBodyDuringUpdate: true
+        omitPrereleaseDuringUpdate: true


### PR DESCRIPTION
The action changes the status of the GitHub release from prerelease to latest when updating artifacts, which has to be undone manually.