### PR TITLE
Add optional non-root user to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,11 @@ RUN --mount=type=cache,target=/root/.cargo/git/db \
 FROM alpine:latest
 ARG CREATED
 ARG REVISION
+
+# Create a non-root user that can be activated with `--user typst`
+RUN addgroup -g 1000 typst && \
+    adduser -D -u 1000 -G typst typst
+
 LABEL org.opencontainers.image.authors="The Typst Project Developers <hello@typst.app>"
 LABEL org.opencontainers.image.created=${CREATED}
 LABEL org.opencontainers.image.description="A markup-based typesetting system"


### PR DESCRIPTION
This PR adds a non-root user to the Dockerfile but does not enable it by default.

Many organizations, like [OWASP](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-2-set-a-user), [NIST](https://nvlpubs.nist.gov/nistpubs/specialpublications/nist.sp.800-190.pdf), and the [CNCF](https://www.cncf.io/blog/2023/12/15/best-practices-for-securing-kubernetes-deployments/) recommend to run Docker images as unprivileged users. This is a defense-in-depth measure that adds an additional security layer protecting against attacks that use a vulnerability in the image and a container runtime exploit to gain root privileges on the host machine.

However, using the `USER` directive to change to a non-root user breaks downstream consumers of the image. For example, this would not work anymore if we activated a non-root user by default:

```Dockerfile
FROM typst:latest
RUN apk add additional-tool  # FAILS - permission denied
```

This is why many industry containers do not change to another user. Instead, many images, like NodeJS and Gradle, instead create a new user that then can be activated when running the container using the `--user` flag. Since we do not want to break dependents, we will handle this similarly.

We assigned the user and the group ID 1000, which match the default first user ID on many Linux systems. This is intended to make it possible to read from mounted volumes containing files created on the host. Advanced users may need to change the IDs or create their own users to accomodate their permission scenarios.

The exploit chain against which running as a non-root user protects looks like this:

1. The attacker exploits Typst or Alpine Linux to gain process privileges
2. The attacker exploits and escapes the container runtime through a vulnerability like [CVE-2019-5736](https://nvd.nist.gov/vuln/detail/cve-2019-5736), [CVE-2022-0492](https://nvd.nist.gov/vuln/detail/cve-2022-0492), or [CVE-2024-21626](https://nvd.nist.gov/vuln/detail/cve-2024-21626)
3. The attacker is now root on the whole server

With the user enabled, the runtime exploit can be harder and the attacker needs an additional privilege escalation to become root on the host.