### PR TITLE
Switch docker metadata action into semver mode

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -110,6 +110,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
 
       - name: Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@v3.0.0


### PR DESCRIPTION
Fixes https://github.com/typst/typst/issues/5864 by switching the metadata action into semver mode.

Aside from not tagging prereleases as latest, this also means that the docker tags won't have a leading `v` anymore, which is more typical (e.g. `ghcr.io/typst/typst:0.14.0` instead of `ghcr.io/typst/typst:v0.14.0`).

I also noticed that I consistently got semver prerelease versions wrong: I spelled it `0.13.0-rc1` instead of `0.13.0-rc.1` across Git and Cargo.toml. I'll use the correct syntax going forward.
