### PR TITLE
Fix unused function warning in release builds

### DIFF
--- a/crates/typst-pdf/src/tags/groups.rs
+++ b/crates/typst-pdf/src/tags/groups.rs
@@ -55,10 +55,6 @@ impl Groups {
         self.list.get_mut(id)
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &Group> {
-        self.list.iter()
-    }
-
     /// See [`util::propagate_lang`].
     pub fn propagate_lang(&mut self, id: GroupId, lang: Locale) -> Option<Locale> {
         // TODO: walk up to the first parent that has a language.

--- a/crates/typst-pdf/src/tags/tree/build.rs
+++ b/crates/typst-pdf/src/tags/tree/build.rs
@@ -200,7 +200,7 @@ pub fn build(document: &PagedDocument, options: &PdfOptions) -> SourceResult<Tre
     }
 
     #[cfg(debug_assertions)]
-    for group in tree.groups.iter().skip(1) {
+    for group in tree.groups.list.iter().skip(1) {
         assert_ne!(group.parent, GroupId::INVALID);
     }
 

--- a/crates/typst-pdf/src/tags/util/idvec.rs
+++ b/crates/typst-pdf/src/tags/util/idvec.rs
@@ -34,13 +34,12 @@ impl<T> IdVec<T> {
         &mut self.inner[id.idx()]
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &T> {
+    #[allow(unused)]
+    pub fn iter(&self) -> std::slice::Iter<'_, T> {
         self.inner.iter()
     }
 
-    pub fn iter_mut(
-        &mut self,
-    ) -> impl ExactSizeIterator<Item = &mut T> + DoubleEndedIterator {
+    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, T> {
         self.inner.iter_mut()
     }
 


### PR DESCRIPTION
The `iter` method is only used when `debug_assertions` are enabled.