### PR TITLE
Fix panic in krilla when `surface.pop()` isn't executed

### DIFF
--- a/crates/typst-pdf/src/convert.rs
+++ b/crates/typst-pdf/src/convert.rs
@@ -385,13 +385,13 @@ pub(crate) fn handle_group(
             surface.push_clip_path(clip_path, &krilla::paint::FillRule::NonZero);
         }
 
-        handle_frame(fc, &group.frame, None, surface, gc)?;
+        let res = handle_frame(fc, &group.frame, None, surface, gc);
 
         if clip_path.is_some() {
             surface.pop();
         }
 
-        Ok(())
+        res
     })?;
 
     fc.pop();

--- a/crates/typst-pdf/src/text.rs
+++ b/crates/typst-pdf/src/text.rs
@@ -9,6 +9,7 @@ use typst_library::layout::Size;
 use typst_library::text::{Font, Glyph, TextItem};
 use typst_library::visualize::FillRule;
 use typst_syntax::Span;
+use typst_utils::defer;
 
 use crate::convert::{FrameContext, GlobalContext};
 use crate::util::{AbsExt, TransformExt, display_font};
@@ -47,6 +48,7 @@ pub(crate) fn handle_text(
     let glyphs: &[PdfGlyph] = TransparentWrapper::wrap_slice(t.glyphs.as_slice());
 
     surface.push_transform(&fc.state().transform().to_krilla());
+    let mut surface = defer(surface, |s| s.pop());
     surface.set_fill(Some(fill));
     surface.set_stroke(stroke);
     surface.draw_glyphs(
@@ -57,8 +59,6 @@ pub(crate) fn handle_text(
         size.to_f32(),
         false,
     );
-
-    surface.pop();
 
     Ok(())
 }

--- a/tests/suite/pdftags/link.typ
+++ b/tests/suite/pdftags/link.typ
@@ -47,15 +47,6 @@ A random location <somewhere>
 #show bibliography: none
 #bibliography("/assets/bib/works.bib")
 
---- link-tags-place-within-artifact pdftags ---
-// Error: 2:4-4:4 PDF/UA-1 error: PDF artifacts may not contain links
-// Hint: 2:4-4:4 references, citations, and footnotes are also considered links in PDF
-#pdf.artifact[
-  #link("tel:123")[
-    #place(float: true, top + left, rect(fill: red))
-  ]
-]
-
 --- link-tags-with-parbreak-error pdftags ---
 // Error: 7-69 PDF/UA-1 error: invalid document structure, this element's PDF tag would be split up
 // Hint: 7-69 this is probably caused by paragraph grouping

--- a/tests/suite/pdftags/logical-children.typ
+++ b/tests/suite/pdftags/logical-children.typ
@@ -1,0 +1,32 @@
+--- logical-children-tags-place-within-artifact pdftags ---
+// Error: 2:4-4:4 PDF/UA-1 error: PDF artifacts may not contain links
+// Hint: 2:4-4:4 references, citations, and footnotes are also considered links in PDF
+#pdf.artifact[
+  #link("tel:123")[
+    #place(float: true, top + left, rect(fill: red))
+  ]
+]
+
+--- logical-children-tags-link-within-place-within-artifact pdftags ---
+// Error: 3:6-5:6 PDF/UA-1 error: PDF artifacts may not contain links
+// Hint: 3:6-5:6 references, citations, and footnotes are also considered links in PDF
+#pdf.artifact[
+  #place(float: true, top + left)[
+    #link("tel:123")[
+      #rect(fill: red)
+    ]
+  ]
+]
+
+--- logical-children-tags-footnote-in-tiling pdftags ---
+// Error: PDF/UA-1 error: PDF artifacts may not contain links
+// Hint: a link was used within a tiling
+// Hint: references, citations, and footnotes are also considered links in PDF
+#rect(width: 90pt, height: 90pt, fill: tiling(size: (30pt, 30pt))[
+  #footnote[hi]
+])
+
+--- logical-children-tags-place-in-tiling pdftags ---
+#rect(width: 90pt, height: 90pt, fill: tiling(size: (30pt, 30pt))[
+  #place(float: true, top + right)[hi]
+])


### PR DESCRIPTION
This fixes a few cases where krilla would panic because `surface.pop` wasn't called when the function bailed in between the `push` and `pop` calls.

As a side note, I finally wrapped my head around how to implement a generalized mechanism to defer cleanup code, and I quite like this aproach. I think it could be come in handy in other scenarios :)