### PR TITLE
Update German translations

### DIFF
--- a/crates/typst-library/translations/de.txt
+++ b/crates/typst-library/translations/de.txt
@@ -1,11 +1,11 @@
 figure = Abbildung
 table = Tabelle
 equation = Gleichung
-bibliography = Bibliographie
+bibliography = Bibliografie
 heading = Abschnitt
 outline = Inhaltsverzeichnis
 raw = Listing
 page = Seite
 footnote = Fußnote
-email = Email
+email = E-Mail
 telephone = Telefon


### PR DESCRIPTION
- Email is a material (vitreous enamel in English)
- Bibliographie is the old spelling and we should use the new spelling for consistency (otherwise Telefon would have to be Telephon)