### PR TITLE
Streamline docs for typed HTML API

### DIFF
--- a/crates/typst-html/src/typed.rs
+++ b/crates/typst-html/src/typed.rs
@@ -57,7 +57,7 @@ fn create_func_data(
             title
         },
         docs: element.docs,
-        keywords: &[],
+        keywords: &["typed-html"],
         contextual: false,
         scope: LazyLock::new(&|| Scope::new()),
         params: LazyLock::new(bump.alloc(move || create_param_info(element))),

--- a/docs/reference/groups.yml
+++ b/docs/reference/groups.yml
@@ -231,3 +231,31 @@
     For example, `#emoji.face` produces the 😀 emoji. If you frequently use
     certain emojis, you can also import them from the `emoji` module (`[#import
     emoji: face]`) to use them without the `emoji.` prefix.
+
+- name: typed
+  title: Typed HTML
+  category: html
+  path: ["html"]
+  details: |
+    A typed layer over raw HTML elements.
+
+    The `html` module provides a typed layer over the raw [`html.elem`] function
+    that allows you to conveniently create HTML elements. HTML attributes are
+    exposed as function parameters that accept Typst types and automatically
+    take care of converting those into the appropriate HTML.
+
+    Some parameters are common to all typed HTML functions. These are listed at
+    the bottom in the [Global Attributes](#global-attributes) section instead of
+    explicitly on each element for readability.
+
+    # Example
+    ```typ
+    #html.video(
+      controls: true,
+      width: 1280,
+      height: 720,
+      src: "sunrise.mp4",
+    )[
+      Your browser does not support the video tag.
+    ]
+    ```

--- a/docs/src/lib.rs
+++ b/docs/src/lib.rs
@@ -46,6 +46,12 @@ static GROUPS: LazyLock<Vec<GroupData>> = LazyLock::new(|| {
                 .map(|(k, _)| k.clone())
                 .collect();
         }
+        if group.name == "typed" {
+            group.filter = typst_assets::html::ELEMS
+                .iter()
+                .map(|elem| elem.name.into())
+                .collect();
+        }
     }
     groups
 });
@@ -286,15 +292,14 @@ fn category_page(resolver: &dyn Resolver, category: Category) -> PageModel {
         shorthands = Some(ShorthandsModel { markup, math });
     }
 
-    let mut skip = FxHashSet::default();
-    if category == Category::Math {
-        skip = GROUPS
-            .iter()
-            .filter(|g| g.category == category)
-            .flat_map(|g| &g.filter)
-            .map(|s| s.as_str())
-            .collect();
+    let mut skip: FxHashSet<&str> = GROUPS
+        .iter()
+        .filter(|g| g.category == category)
+        .flat_map(|g| &g.filter)
+        .map(|s| s.as_str())
+        .collect();
 
+    if category == Category::Math {
         // Already documented in the text category.
         skip.insert("text");
     }
@@ -467,6 +472,11 @@ fn func_model(
     }) else {
         panic!("function lacks any details")
     };
+
+    let mut params = params.to_vec();
+    if func.keywords().contains(&"typed-html") {
+        params.retain(|param| !is_global_html_attr(param.name));
+    }
 
     FuncModel {
         path: path.iter().copied().map(Into::into).collect(),
@@ -735,6 +745,35 @@ fn group_page(
         children: outline_items,
     });
 
+    let global_attributes = if group.name == "typed" {
+        let div = group.module().scope().get("div").unwrap();
+        let func = div.read().clone().cast::<Func>().unwrap();
+        func.params()
+            .unwrap()
+            .iter()
+            .filter(|param| is_global_html_attr(param.name))
+            .map(|info| param_model(resolver, info))
+            .collect()
+    } else {
+        vec![]
+    };
+
+    if !global_attributes.is_empty() {
+        let id = "global-attributes";
+        outline.push(OutlineItem {
+            id: id.into(),
+            name: "Global Attributes".into(),
+            children: global_attributes
+                .iter()
+                .map(|param| OutlineItem {
+                    id: eco_format!("{id}-{}", urlify(param.name)),
+                    name: param.name.into(),
+                    children: vec![],
+                })
+                .collect(),
+        });
+    }
+
     let model = PageModel {
         route: eco_format!("{parent}{}/", group.name),
         title: group.title.clone(),
@@ -746,6 +785,7 @@ fn group_page(
             title: group.title.clone(),
             details,
             functions,
+            global_attributes,
         }),
         children: vec![],
     };
@@ -758,6 +798,15 @@ fn group_page(
     };
 
     (model, item)
+}
+
+/// Whether the given `name` is one of a global HTML attribute (shared by all
+/// elements).
+fn is_global_html_attr(name: &str) -> bool {
+    use typst_assets::html as data;
+    data::ATTRS[..data::ATTRS_GLOBAL]
+        .iter()
+        .any(|global| global.name == name)
 }
 
 /// Create a page for a type.

--- a/docs/src/model.rs
+++ b/docs/src/model.rs
@@ -140,6 +140,7 @@ pub struct GroupModel {
     pub title: EcoString,
     pub details: Html,
     pub functions: Vec<FuncModel>,
+    pub global_attributes: Vec<ParamModel>,
 }
 
 /// Details about a type.


### PR DESCRIPTION
Makes the HTML typed docs more useful and less noisy by
- rendering all functions on one page
- rendering global attributes only once in a separate list

The typed HTML docs will also be excluded from the search.