### PR TITLE
Fix an inconsistent doc link

### DIFF
--- a/crates/typst-library/src/pdf/accessibility.rs
+++ b/crates/typst-library/src/pdf/accessibility.rs
@@ -28,7 +28,7 @@ use crate::model::{TableCell, TableElem};
 /// artifact, you may need to use this function multiple times.
 ///
 /// If you are unsure what constitutes an artifact, check the [Accessibility
-/// Guide]($guides/accessibility#artifacts).
+/// Guide]($guides/accessibility/#artifacts).
 ///
 /// In the future, this function may be moved out of the `pdf` module, making it
 /// possible to hide content in HTML export from AT.


### PR DESCRIPTION
Previously, all links with anchors have trailing slashes, e.g., `$guides/tables/#fills`.
However, #6905 introduced a `$guides/accessibility#artifacts`, which might be okay for the official website, but it causes problems for a downstream unofficial project.
This PR adds the missing trailing slash.

```bash
$ rg '\(\$guides/.+#.+\)' --only-matching --no-filename | sort | uniq -c
      1 ($guides/accessibility#artifacts)
      2 ($guides/accessibility/#basics)
      6 ($guides/accessibility/#textual-representations)
      2 ($guides/page-setup/#columns)
      1 ($guides/page-setup/#columns))
      1 ($guides/page-setup/#page-numbers)
      1 ($guides/tables/#alignment)
      2 ($guides/tables/#fills)
      1 ($guides/tables/#strokes)
```
