### PR TITLE
Add example to `frac` for changing inline vs block style

### DIFF
--- a/crates/typst-library/src/math/frac.rs
+++ b/crates/typst-library/src/math/frac.rs
@@ -53,6 +53,14 @@ pub struct FracElem {
     /// #set math.frac(style: "horizontal")
     /// $ (a + b) / b $
     /// ```
+    ///
+    /// ```example:"Different styles in inline vs block equations"
+    /// // This changes the style for inline equations only.
+    /// #show math.equation.where(block: false): set math.frac(style: "horizontal")
+    ///
+    /// This $(x-y)/z = 3$ is inline math, and this is block math:
+    /// $ (x-y)/z = 3 $
+    /// ```
     #[default(FracStyle::Vertical)]
     pub style: FracStyle,
 


### PR DESCRIPTION
A common desire of users is to have "horizontal" fractions in inline math and "vertical" fractions in block math. This PR adds an example which shows how to achieve that. (Meant to be included in 0.14)