### PR TITLE
Fix error in math argument parsing when dots aren't followed by anything

### DIFF
--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -531,8 +531,22 @@ fn math_arg<'s>(p: &mut Parser<'s>, seen: &mut FxHashSet<&'s str>) -> bool {
         if let Some(spread) = p.lexer.maybe_math_spread_arg(start) {
             p.token.node = spread;
             p.eat();
-            math_expr(p);
-            p.wrap(m, SyntaxKind::Spread);
+            let m_arg = p.marker();
+            // TODO: Refactor to combine with the other call to `math_exprs`.
+            let count =
+                math_exprs(p, syntax_set!(End, Dollar, Comma, Semicolon, RightParen));
+            if count == 0 {
+                let dots = vec![
+                    SyntaxNode::leaf(SyntaxKind::MathText, "."),
+                    SyntaxNode::leaf(SyntaxKind::MathText, "."),
+                ];
+                p[m] = SyntaxNode::inner(SyntaxKind::Math, dots);
+            } else {
+                if count > 1 {
+                    p.wrap(m_arg, SyntaxKind::Math);
+                }
+                p.wrap(m, SyntaxKind::Spread);
+            }
             return true;
         }
     }

--- a/tests/suite/math/call.typ
+++ b/tests/suite/math/call.typ
@@ -80,7 +80,7 @@ $args(..(a + b))$
 
 --- math-call-spread-multiple-exprs ---
 #let args(..body) = body
-// Error: 10 expected comma or semicolon
+// Error: 7-14 cannot spread content
 $args(..a + b)$
 
 --- math-call-spread-unexpected-dots ---
@@ -94,11 +94,8 @@ $func(...)$
 
 --- math-call-spread-empty ---
 // Test that a spread operator followed by nothing generates two dots.
-// TODO: This currently errors in parsing, but it should change to the given repr.
 #let args(..body) = body
-// Error: 17-18 unclosed delimiter
-// Error: 21 expected comma or semicolon
-// Error: 25 expected comma or semicolon
+#test-repr($args(..)$.body.text, "arguments(sequence([.], [.]))")
 #test-repr($args(.., ..; .. , ..)$.body.text, "arguments(\n  (sequence([.], [.]), sequence([.], [.])),\n  (sequence([.], [.]), sequence([.], [.])),\n)")
 
 --- math-call-named-spread-override ---


### PR DESCRIPTION
RE: https://github.com/typst/typst/pull/7036#discussion_r2411185246

This is a bug fix for an error in the math parser when using two dots not followed by anything, e.g. `$func(..)$`.

I chose to avoid refactoring the entire `math_arg` function to make the change easier to review and hopefully get in for 0.14, but I left a TODO comment for myself for later.