### PR TITLE
Fix the encoding of the placeholder HTML for `typst watch`

### DIFF
--- a/crates/typst-cli/src/server.rs
+++ b/crates/typst-cli/src/server.rs
@@ -184,7 +184,8 @@ const PLACEHOLDER_HTML: &str = "\
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset='utf-8'>
+    <meta charset=\"utf-8\">
+    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
     <title>Waiting for {INPUT}</title>
     <style>
       body {


### PR DESCRIPTION
When running `typst watch` for the html target, a placeholder html will show up if a new error occurs.
However, this placeholder html contains the non-ascii character `…`, but does not specify `<meta charset='utf-8'>`.
As a result, some browsers will guess the encoding, which could be wrong.
This PR fixes it.

Example: Firefox on my computer interprets it as [windows-1252/latin1](https://r12a.github.io/app-encodings/):

<img width="400" alt="图片" src="https://github.com/user-attachments/assets/98fa2b2a-177d-42f0-98b7-00223fad21b5" />
<img width="300" alt="图片" src="https://github.com/user-attachments/assets/2ffc101b-ea90-437d-97af-f6d63cc4b293" />

> Waiting for outputâ€¦

> 此页面处于怪异模式，排版布局可能会受到影响。若需要标准模式，请使用“`<!DOCTYPE html>`”。
> Translate: This page is in a strange mode, and the layout may be affected. If you need the standard mode, please use "`<!" DOCTYPE html>`".

> 该文档未声明字符编码，因此编码是凭内容猜测出来的。字符编码需使用 `<meta>` 标签或字节顺序标记（BOM），或是在 Content-Type HTTP 头中进行声明。
> Translate: This document does not state the character encoding, so the encoding is guessed based on the content. The character encoding needs to use the `<meta>` tag or the byte order tag (BOM), or be declared in the Content-Type HTTP header.
