### PR TITLE
Document nested raw blocks syntax

### DIFF
--- a/crates/typst-library/src/text/raw.rs
+++ b/crates/typst-library/src/text/raw.rs
@@ -67,8 +67,11 @@ use crate::visualize::Color;
 ///
 /// # Syntax
 /// This function also has dedicated syntax. You can enclose text in 1 or 3+
-/// backticks (`` ` ``) to make it raw. Two backticks produce empty raw text.
-/// This works both in markup and code.
+/// backticks (`` ` ``) to make it raw. Two backticks is equivalent to 2
+/// separate empty raw elements (putting them together in markup mode will
+/// produce an error). Using 4+ backticks makes it possible to write 3+
+/// backticks inside of it (i.e., nested code blocks). This works both in markup
+/// and code.
 ///
 /// When you use three or more backticks, you can additionally specify a
 /// language tag for syntax highlighting directly after the opening backticks.


### PR DESCRIPTION
I wanted to quote the docs for someone about 4 backticks, but it actually says nothing about why would you even need more than 3 of them.

Since https://github.com/typst/typst/pull/7070 is not done (and no new features can be added now), the mention of nested code blocks is rather useless, as everything is still colored with one single color. However, that's only for unsupported/no languages. For Typst, it can use different colors/styles:

`````typ
````typ
= Code block
```rs
println!("Hey there")
```
````
`````

<img height="100" alt="image" src="https://github.com/user-attachments/assets/50679078-60ab-411f-a27f-df2267680610" />

And with #7070 it would be even more colorful and useful.

A weird thing about docs was the 2 backticks. It claims that

`````typ
````
`````

produced empty raw text? Well, not technically. Furthermore, it won't produce anything in markup mode as it will throw an error and document won't even compile. In code mode it will produce **two** "empty raw texts." In markup you must add space or text between them to remove the error. But in any case, it just two pairs of backticks squished together, two separate raw elements with no text specified. This needs to be clarified. But it's hard to do so with few words, especially since there are "two" backticks and "two" pairs of raw elements. Which two is two, and which two is another two? Very confusing.

I also wanted to do something like "for N backticks (where N > 3) you can use (N - 1) consecutive backticks inside of it." But I think someone won't like this, and CommonMark only has example that describes this: https://spec.commonmark.org/0.31.2/#example-125.
