### PR TITLE
feat(ws): define message types (step 1 for #86)

### DIFF
--- a/ws_messages.md
+++ b/ws_messages.md
@@ -1,0 +1,7 @@
+# WebSocket Message Types (Step 1 for issue #86)
+
+- **source_patch** → sends small text changes from editor to compiler  
+- **viewport** → tells compiler which pages are visible on screen  
+- **request_render** → asks compiler to render specific pages first  
+
+This starts the base structure for “Compile Typst as you write.”


### PR DESCRIPTION
# What
Defines initial WebSocket message types needed for progressive canvas compilation:
- `source_patch` — sends small edits from editor to compiler  
- `viewport` — tells compiler which pages are visible  
- `request_render` — asks compiler to render specific pages first

# Why
This is Step 1 for issue #86 ("Compile Typst as you write").  
It begins the communication structure between editor and compiler.

#Checklist
- [x] Branch created  
- [x] Message types defined  
- [ ] Handlers and tests (next step)
