### PR TITLE
Fix wrong PR numbers in changelog

### DIFF
--- a/docs/changelog/0.14.0.md
+++ b/docs/changelog/0.14.0.md
@@ -135,7 +135,7 @@ _Thanks to [@mkorje](https://github.com/mkorje) for his work on math!_
   - Fixed a bug where [headers]($table.header) and footers could accidentally expand to contain non-header cells [#5919]
 - Added [`title`] element for displaying the document title [#5618]
 - Added [`figure.alt`] property for setting an alternative description for a figure [#6619]
-- [Link]($link) hit boxes for text are now vertically a bit larger to avoid issues with automatic link detection in PDF viewers [#6281]
+- [Link]($link) hit boxes for text are now vertically a bit larger to avoid issues with automatic link detection in PDF viewers [#6252]
 - The [`link`] function will now produce an error when passed an empty string as a URL [#7049] **(Minor breaking change)**
 - The value of the [`number`]($enum.item.number) argument of `enum.item` now takes `{auto}` instead of `{none}` for automatic numbering [#6609] **(Minor breaking change)**
 - Improved spacing of nested tight lists [#6242]
@@ -269,7 +269,7 @@ _Thanks to [@mkorje](https://github.com/mkorje) for his work on math!_
   - Fixed tooltip for scoped functions (e.g. `calc.round`) [#6234]
   - Fixed tooltip and details for figure references [#6580]
   - Expression tooltips now use `×` instead of `x` to indicate a repeated value [#6163]
-- Fixed jump from click (jumping to the source panel with a click in the preview) in presence of transformations and clipping [#6102]
+- Fixed jump from click (jumping to the source panel with a click in the preview) in presence of transformations and clipping [#6037]
 
 ## Symbols
 - Added many new symbols and variants; many more than could be listed here. View [the dedicated changelog](https://github.com/typst/codex/blob/v0.2.0/CHANGELOG.md#version-020-october-7-2025) for a full listing.
@@ -288,4 +288,4 @@ _Thanks to [@mkorje](https://github.com/mkorje) for his work on math!_
 - The `PdfOptions` struct has a new `tagged` field, which defaults to `{true}` [#6619] [#7046]
 - Fixed a potential panic in `World::font` implementations. Downstream `World` implementations might need to apply [the same fix](https://github.com/typst/typst/pull/6117). [#6117]
 - Increased minimum supported Rust version to 1.88 [#6637]
-- The Docker container now has the optional non-root user `typst`
+- The Docker container now has the optional non-root user `typst` [#7058]


### PR DESCRIPTION
These were just the ones I noticed, hopefully the new PR numbers are correct.

There might be more incorrect ones but checking all PR number again might not be worth it? It is also in some cases a bit difficult to tell if a PR number is correct because it refers to a large PR (e.g. related to HTML support) which might have included that change as side-effect.