### PR TITLE
Change `styling context` to `style context` in the context docs

### DIFF
--- a/docs/reference/language/context.md
+++ b/docs/reference/language/context.md
@@ -229,5 +229,6 @@ could call it directly at the top level of a module, the whole module and its
 exports could change over the course of multiple compiler iterations, which
 would not be desirable.
 
-[^1]: Currently, all show rules provide styling context, but only show rules on
-      [locatable]($location/#locatable) elements provide a location context.
+[^1]: Currently, all show rules provide [style context](#style-context), but
+      only show rules on [locatable]($location/#locatable) elements provide a
+      [location context](#location-context).


### PR DESCRIPTION
I sent this page to someone, and that person thought _styling context_ = _context_ and didn't realize that the _styling context_ in the footnote refers to the _style context_ of the main text.
This might be obvious to native English speakers, but most English speakers are not native…
