### PR TITLE
Document version type comparison

### DIFF
--- a/crates/typst-library/src/foundations/version.rs
+++ b/crates/typst-library/src/foundations/version.rs
@@ -65,7 +65,7 @@ impl Version {
     ///
     /// It can have any number of components (even zero).
     ///
-    /// ```example
+    /// ```example:"Constructing versions"
     /// #version() \
     /// #version(1) \
     /// #version(1, 2, 3, 4) \
@@ -76,7 +76,7 @@ impl Version {
     /// As a practical use case, this allows comparing the current version
     /// ([`{sys.version}`]($version)) to a specific one.
     ///
-    /// ```example
+    /// ```example:"Comparing with the current version"
     /// Current version: #sys.version \
     /// #(sys.version >= version(0, 14, 0)) \
     /// #(version(3, 2, 0) > version(4, 1, 0))


### PR DESCRIPTION
Mentioned in https://forum.typst.app/t/typst-0-14-just-entered-its-final-testing-period-your-help-is-wanted/6363/6?u=andrew.

The comment is not supposed to be rendered. Not sure if examples should be named. Will they be open by default? Do you toggle it with extra parameter?

There is also https://typst.app/universe/package/backtrack, which I feel like from a practical standpoint would be nice to mention. But since `version` type was added a long time ago, maybe it doesn't really make sense for someone to create a new package, that will support super old Typst versions.