### PR TITLE
Document the OpenType contextual alternates (`calt`) feature

### DIFF
--- a/crates/typst-library/src/text/mod.rs
+++ b/crates/typst-library/src/text/mod.rs
@@ -644,8 +644,8 @@ pub struct TextElem {
     /// A fine ligature.
     /// ```
     ///
-    /// Note that some programming fonts exploit other OpenType font features
-    /// to implement “ligatures,” including the contextual alternates (`calt`)
+    /// Note that some programming fonts use other OpenType font features to
+    /// implement "ligatures," including the contextual alternates (`calt`)
     /// feature, which is also enabled by default. Use the general
     /// [`features`]($text.features) parameter to control such features.
     #[default(true)]


### PR DESCRIPTION
Also document how to disable features that are enabled by default.

Resolves #6963

(The font _Cascadia Code_ was just added in https://github.com/typst/typst-dev-assets/pull/13.)
