### PR TITLE
Improve documentation for `state.update`

### DIFF
--- a/crates/typst-library/src/introspection/state.rs
+++ b/crates/typst-library/src/introspection/state.rs
@@ -353,29 +353,35 @@ impl State {
 
     /// Updates the value of the state.
     ///
-    /// Returns an _invisible_ piece of content that doesn't affect document
-    /// layout (similar to [`metadata`]). The update will be in effect at the
-    /// position where the returned content is inserted into the document. If
-    /// you don't put the output into the document, nothing will happen! This
-    /// would be the case, for example, if you write
-    /// `{let _ = state("key").update(7)}`. Updates only happen if they are
-    /// associated with a location in the document. That is, only state updates
-    /// that are _in the document_ update the said state.
+    /// Returns an invisible piece of [content] that must be inserted into the
+    /// document to take effect. This invisible content tells Typst that the
+    /// specified update should take place wherever the content is inserted into
+    /// the document.
     ///
-    /// Here is another way of looking at it. State is a part of your document,
-    /// it runs like a thread embedded in the document content. The value of a
-    /// state is the result of all state updates that happened in the document
-    /// up until that point. That’s why `state.update` returns an invisible
-    /// sliver of content that you need to return and include in the document —
-    /// a state update that is not "placed" in the document does not happen, and
-    /// "when" it happens is determined by where you place it. For example, only
-    /// figures that are placed into the document increase the value of the
-    /// figure counter. That’s also why you need context to read state, you need
-    /// to use the current document position to know where on the state’s
-    /// “thread” you are.
+    /// State is a part of your document and runs like a thread embedded in the
+    /// document content. The value of a state is the result of all state
+    /// updates that happened in the document up until that point.
+    ///
+    /// That's why `state.update` returns an invisible sliver of content that
+    /// you need to return and include in the document — a state update that is
+    /// not "placed" in the document does not happen, and "when" it happens is
+    /// determined by where you place it. That's also why you need [context] to
+    /// read state: You need to use the current document position to know where
+    /// on the state's "thread" you are.
+    ///
+    /// Storing a state update in a variable (e.g.
+    /// `{let my-update = state("key").update(c => c * 2)}`) will have no effect
+    /// by itself. Only once you insert the variable `[#my-update]` somewhere
+    /// into the document content, the update will take effect — at the position
+    /// where it was inserted. You can also use `[#my-update]` multiple times at
+    /// different positions. Then, the update will take effect multiple times as
+    /// well.
     ///
     /// In contrast to [`get`]($state.get), [`at`]($state.at), and
-    /// [`final`]($state.final), this function does not require [context].
+    /// [`final`]($state.final), this function does not require [context]. This
+    /// is because, to create the state update, we do not need to know where in
+    /// the document we are. We only need this information to resolve the
+    /// state's value.
     #[func]
     pub fn update(
         self,


### PR DESCRIPTION
This addresses some points from https://forum.typst.app/t/why-doesnt-state-behave-like-the-documentation-says/6499.
