### PR TITLE
Improve documentation for hide

### DIFF
--- a/crates/typst-library/src/layout/hide.rs
+++ b/crates/typst-library/src/layout/hide.rs
@@ -4,7 +4,7 @@ use crate::introspection::Tagged;
 /// Hides content without affecting layout.
 ///
 /// The `hide` function allows you to hide content while the layout still "sees"
-/// it. This is useful to create blank space that is exactly as large as some
+/// it. This is useful for creating blank space that is exactly as large as some
 /// content.
 ///
 /// # Example
@@ -14,10 +14,10 @@ use crate::introspection::Tagged;
 /// ```
 ///
 /// # Redaction
-/// This function may also be useful to redact content as its arguments are
+/// This function may also be useful for redacting content as its arguments are
 /// neither present visually nor accessible to Assistive Technology. That said,
 /// there can be _some_ traces of the hidden content (such as a bookmarked
-/// heading in the PDF document outline).
+/// heading in the PDF's Document Outline).
 ///
 /// Note that, depending on the circumstances, it may be possible for content to
 /// be reverse engineered based on its size in the layout. We thus do not


### PR DESCRIPTION
Current [docs for `hide`](https://typst.app/docs/reference/layout/hide) are not clear enough, IMO. This change explicitly states that nothing will be included in the output PDF, when passed to `hide`. Nothing "invisible" etc. Same for HTML and other formats.

[Apparently](https://discord.com/channels/1054443721975922748/1399326777540608041/1430486372816523326), it might not be the case for HTML and SVG...