### PR TITLE
Add outputs to JSON dependency file

### DIFF
--- a/crates/typst-cli/src/deps.rs
+++ b/crates/typst-cli/src/deps.rs
@@ -42,7 +42,7 @@ fn write_deps_json(
 
     let inputs = relative_dependencies(world)?
         .map(|dep| to_string(dep, "input"))
-        .collect::<Result<Vec<_>, _>>()?;
+        .collect::<Result<_, _>>()?;
 
     let outputs = outputs
         .map(|outputs| {
@@ -55,7 +55,7 @@ fn write_deps_json(
                         Output::Stdout => None,
                     }
                 })
-                .collect::<Result<Vec<_>, _>>()
+                .collect::<Result<_, _>>()
         })
         .transpose()?;
 


### PR DESCRIPTION
Fixes #7194

I've generated some examples with their corresponding dependency files in all supported formats (for comparison) and the JSON is shown before (as in 0.14) and after (as in this PR). Practically all of these results seem fine, except maybe one, see first bullet in the discussion below.

---

**demo.typ**

```typ
#image("monkey.svg")
```

- Make: `demo.pdf: monkey.svg demo.typ`
- zero: `monkey.svg\0demo.typ\0`
- JSON before: `{"inputs":["monkey.svg","demo.typ"]`
- JSON after: `{"inputs":["monkey.svg","demo.typ"],"outputs":["demo.pdf"]}`

---

**lorem.typ** with SVG pages output (`typst compile lorem.typ lorem{p}.svg`)

```typ
#lorem(1000)
```

- Make: `lorem1.svg lorem2.svg: lorem.typ`
- zero: `lorem.typ\0`
- JSON before: `{"inputs":["lorem.typ"]}`
- JSON after: `{"inputs":["lorem.typ"],"outputs":["lorem1.svg","lorem2.svg"]}`

---

**lorem.typ** with PDF output to stdoutt (`typst compile lorem.typ -`)

```typ
#lorem(1000)
```

- Make: *no* dep file created, `error: failed to create dependency file (make dependencies contain the output path, but the output was stdout)`
- zero: `lorem.typ\0`
- JSON before: `{"inputs":["lorem.typ"]}`
- JSON after: `{"inputs":["lorem.typ"],"outputs":[]}`

---

**error.typ**

```typ
#thereisnosuchthing
```

- Make: *no* dep file created
- zero: `error.typ\0`
- JSON before: `{"inputs":["error.typ"]}`
- JSON after: `{"inputs":["error.typ"],"outputs":null}`

---

Discussion of the results:

- With the `zero` and `json` formats, the dependency file is always written, which is good. Some build systems can make use of this information to decide which dependencies need to be added to the dependency graph. (I've written one such build system, StepUp, but there are certainly others.)

- Including the outputs in the JSON has some use cases, in which I'm particularly interested, hence this PR. For some discussion on why (not) to include it, see #7194. I think it is generally useful for custom scripts that run typst and want to perform some operation on all its output files, without (i) removing old files first or (ii) reimplementing the logic of Typst. For build tools that construct there dependency graph on the fly, which is how StepUp works, this is also the safest future-proof way to determine which outputs Typst has written.

- When running some experiments with this feature, it turned out to be more convenient to have an empty list of `outputs` when there are none, e.g. when writing to stdout or when there is an error. That way, scripts consuming the JSON file don't need to implement a conditional to process the `outputs` field. (Such scripts can still check the exitcode of Typst if they want to handle failed compilations.) This also simplifies the code in typst-cli a tiny bit.

---

Outdated discussion (other PR merged)

- I believe, if no Make dependency file can be written, an empty file could be breaking one of Make's assumptions, see https://github.com/typst/typst/issues/5886#issuecomment-3423311187 Instead of an empty file, it seems better not to write it all. In any case, this is an unrelated issue and can be dealt with in a separate PR.
    - Issue: #7232 
    - PR: #7246