### PR TITLE
Fix panic in PDF backend due to ambiguous logical parent

### DIFF
--- a/crates/typst-pdf/src/tags/tree/mod.rs
+++ b/crates/typst-pdf/src/tags/tree/mod.rs
@@ -385,10 +385,16 @@ fn close_group(tree: &mut Tree, surface: &mut Surface, id: GroupId) -> GroupId {
         GroupKind::LogicalParent(elem) => {
             let loc = elem.location().unwrap();
             // Insert logical children when closing the logical parent, so they
-            // are at the end of the group.
-            if let Some(children) = tree.logical_children.get(&loc) {
+            // are at the end of the group. In some cases there might be
+            // multiple parent groups with the same location, only insert the
+            // children for the first parent group.
+            if let Some(located) = tree.groups.by_loc(&loc)
+                && located.id == id
+                && let Some(children) = tree.logical_children.get(&loc)
+            {
                 tree.groups.push_groups(id, children);
             }
+
             tree.groups.push_group(direct_parent, id);
         }
         GroupKind::LogicalChild(inherit, logical_parent) => {

--- a/tests/ref/pdftags/query-tags-ambiguous-parent-footnote.yml
+++ b/tests/ref/pdftags/query-tags-ambiguous-parent-footnote.yml
@@ -1,0 +1,37 @@
+- Tag: P
+  /K:
+    - Tag: Lbl
+      /K:
+        - Tag: Link
+          /K:
+            - Annotation: page=0 index=0
+            - Tag: Span
+              /BaselineShift:   3.500
+              /LineHeight:   6.000
+              /K:
+                - Content: page=0 mcid=0
+    - Tag: Note
+      /K:
+        - Tag: Lbl
+          /K:
+            - Tag: Link
+              /K:
+                - Annotation: page=0 index=2
+                - Tag: Span
+                  /BaselineShift:   2.975
+                  /LineHeight:   5.100
+                  /K:
+                    - Content: page=0 mcid=2
+        - Content: page=0 mcid=3
+- Tag: P
+  /K:
+    - Tag: Lbl
+      /K:
+        - Tag: Link
+          /K:
+            - Annotation: page=0 index=1
+            - Tag: Span
+              /BaselineShift:   3.500
+              /LineHeight:   6.000
+              /K:
+                - Content: page=0 mcid=1

--- a/tests/ref/pdftags/query-tags-ambiguous-parent-place.yml
+++ b/tests/ref/pdftags/query-tags-ambiguous-parent-place.yml
@@ -1,0 +1,4 @@
+- Tag: Span
+  /Placement: Block
+  /K:
+    - Content: page=0 mcid=0

--- a/tests/suite/pdftags/query.typ
+++ b/tests/suite/pdftags/query.typ
@@ -10,16 +10,26 @@
 
 #context query(<figure>).at(0)
 
---- query-tags-ambiguous-parent-place pdftags ---
+--- query-tags-ambiguous-parent-place-error pdftags ---
 // Error: 2-43 PDF/UA-1 error: ambiguous logical parent
 // Hint: 2-43 please report this as a bug
 #place(float: true, top + left)[something] <placed>
 
 #context query(<placed>).join()
 
---- query-tags-ambiguous-parent-footnote pdftags ---
+--- query-tags-ambiguous-parent-place pdftags nopdfua ---
+#place(float: true, top + left)[something] <placed>
+
+#context query(<placed>).join()
+
+--- query-tags-ambiguous-parent-footnote-error pdftags ---
 // Error: 1:2-1:21 PDF/UA-1 error: ambiguous logical parent
 // Hint: 1:2-1:21 please report this as a bug
+#footnote[something] <note>
+
+#context query(<note>).join()
+
+--- query-tags-ambiguous-parent-footnote pdftags nopdfua ---
 #footnote[something] <note>
 
 #context query(<note>).join()


### PR DESCRIPTION
This fixes a panic where the logical child of a `place` or `footnote` had multiple parents, and would be included more than once in the tag tree.