### PR TITLE
Remove now redundant InternalGridCell

### DIFF
--- a/crates/typst-pdf/src/tags/resolve.rs
+++ b/crates/typst-pdf/src/tags/resolve.rs
@@ -278,9 +278,6 @@ fn build_group_tag(rs: &mut Resolver, group: &Group) -> Option<TagKind> {
         GroupKind::TableCell(_, tag, _) => rs.tags.take(*tag),
         GroupKind::Grid(_, _) => Tag::Div.into(),
         GroupKind::GridCell(_, _) => Tag::Div.into(),
-        GroupKind::InternalGridCell(_) => {
-            unreachable!("should be swapped out in `close_group`")
-        }
         GroupKind::List(_, numbering, _) => Tag::L(*numbering).into(),
         GroupKind::ListItemLabel(_) => Tag::Lbl.into(),
         GroupKind::ListItemBody(_) => Tag::LBody.into(),

--- a/crates/typst-pdf/src/tags/tree/build.rs
+++ b/crates/typst-pdf/src/tags/tree/build.rs
@@ -43,9 +43,7 @@ use typst_syntax::Span;
 use crate::PdfOptions;
 use crate::tags::GroupId;
 use crate::tags::context::{Ctx, FigureCtx, GridCtx, ListCtx, OutlineCtx, TableCtx};
-use crate::tags::groups::{
-    BreakOpportunity, BreakPriority, GroupKind, Groups, InternalGridCellKind,
-};
+use crate::tags::groups::{BreakOpportunity, BreakPriority, GroupKind, Groups};
 use crate::tags::tree::text::TextAttr;
 use crate::tags::tree::{Break, TraversalStates, Tree, Unfinished};
 use crate::tags::util::{ArtifactKindExt, PropertyValCopied};
@@ -412,8 +410,7 @@ fn progress_tree_start(tree: &mut TreeBuilder, elem: &Content) -> GroupId {
         // semantic meaning in the tag tree, which doesn't use page breaks for
         // it's semantic structure.
         let kind = if cell.is_repeated.val() {
-            let artifact = InternalGridCellKind::Artifact(ArtifactType::Other);
-            GroupKind::InternalGridCell(artifact)
+            GroupKind::Artifact(ArtifactType::Other)
         } else {
             let tag = tree.groups.tags.push(Tag::TD);
             GroupKind::TableCell(cell.clone(), tag, None)
@@ -430,14 +427,13 @@ fn progress_tree_start(tree: &mut TreeBuilder, elem: &Content) -> GroupId {
         let kind = if !matches!(tree.parent_kind(), GroupKind::Grid(..)) {
             // If there is no grid parent, this means a grid layouter is used
             // internally.
-            GroupKind::InternalGridCell(InternalGridCellKind::Transparent)
+            GroupKind::Transparent
         } else if cell.is_repeated.val() {
             // Only repeated grid headers and footer cells are laid out multiple
             // times. Mark duplicate headers as artifacts, since they have no
             // semantic meaning in the tag tree, which doesn't use page breaks
             // for it's semantic structure.
-            let artifact = InternalGridCellKind::Artifact(ArtifactType::Other);
-            GroupKind::InternalGridCell(artifact)
+            GroupKind::Artifact(ArtifactType::Other)
         } else {
             GroupKind::GridCell(cell.clone(), None)
         };

--- a/crates/typst-pdf/src/tags/tree/mod.rs
+++ b/crates/typst-pdf/src/tags/tree/mod.rs
@@ -465,11 +465,6 @@ fn close_group(tree: &mut Tree, surface: &mut Surface, id: GroupId) -> GroupId {
                 tree.groups.push_group(direct_parent, id);
             }
         }
-        GroupKind::InternalGridCell(internal) => {
-            // Replace with the actual group kind.
-            tree.groups.get_mut(id).kind = internal.to_kind();
-            tree.groups.push_group(direct_parent, id);
-        }
         GroupKind::List(..) => {
             tree.groups.push_group(direct_parent, id);
         }


### PR DESCRIPTION
#7198 changed how logical children inside broken table/grid cells are generated, making this variant redundant.