### PR TITLE
Properly document the default value of `array.join`'s `default` parameter

### DIFF
--- a/crates/typst-library/src/foundations/array.rs
+++ b/crates/typst-library/src/foundations/array.rs
@@ -720,7 +720,7 @@ impl Array {
         last: Option<Value>,
         /// What to return if the array is empty.
         #[named]
-        #[default(None)]
+        #[default]
         default: Option<Value>,
     ) -> StrResult<Value> {
         let len = self.0.len();


### PR DESCRIPTION
I just now realized that the default value for `array.join`'s `default` parameter isn't documented properly. This is due to me copying the way the `default` parameter is implemented for other `array` methods when adding `default` for `array.join`, without realizing that the situation here is different because we don't panic on an empty array when no `default` is provided.

The proposed change should ensure this is properly documented as `none` by default.

This begs the question of whether the current behavior is best. I can think of three possible ways to handle no `default` being provided when the array is empty:

1. Use `none` and document it properly (what this PR implements).
2. Throw an error.
3. Use `auto`, which determines a smart default based on the value of `separator`:
    - If `separator` is a string, use `""`.
    - Otherwise, use `none`.

Option 1. is consistent with all previous Typst versions. Option 2. is a breaking change relative to all previous Typst versions because an error may be emitted when the array is empty, which was not the case before. On the other hand, option 3. is mostly backward compatible with all previous Typst versions, given that `""` behaves like `none` when cast to content.

This means we can fix the documentation for now, and later decide to implement option 2. or option 3. without causing a breaking change that would not happen if we rushed it now.

TL;DR: This fixes a documentation issue and highlights a possible future improvement, with no rush to implement it now.