### PR TITLE
Move equation `Eval` impl to `math.rs`

### DIFF
--- a/crates/typst-eval/src/markup.rs
+++ b/crates/typst-eval/src/markup.rs
@@ -2,7 +2,6 @@ use typst_library::diag::{At, SourceResult, warning};
 use typst_library::foundations::{
     Content, Label, NativeElement, Repr, Smart, Symbol, Unlabellable, Value,
 };
-use typst_library::math::EquationElem;
 use typst_library::model::{
     EmphElem, EnumItem, HeadingElem, LinkElem, ListItem, ParbreakElem, RefElem,
     StrongElem, Supplement, TermItem, Url,
@@ -264,15 +263,5 @@ impl Eval for ast::TermItem<'_> {
         let term = self.term().eval(vm)?;
         let description = self.description().eval(vm)?;
         Ok(TermItem::new(term, description).pack())
-    }
-}
-
-impl Eval for ast::Equation<'_> {
-    type Output = Content;
-
-    fn eval(self, vm: &mut Vm) -> SourceResult<Self::Output> {
-        let body = self.body().eval(vm)?;
-        let block = self.block();
-        Ok(EquationElem::new(body).with_block(block).pack())
     }
 }

--- a/crates/typst-eval/src/math.rs
+++ b/crates/typst-eval/src/math.rs
@@ -2,15 +2,26 @@ use ecow::eco_format;
 use typst_library::diag::{At, SourceResult};
 use typst_library::foundations::{Content, NativeElement, Symbol, SymbolElem, Value};
 use typst_library::math::{
-    AlignPointElem, AttachElem, FracElem, LrElem, PrimesElem, RootElem,
+    AlignPointElem, AttachElem, EquationElem, FracElem, LrElem, PrimesElem, RootElem,
 };
 use typst_library::text::TextElem;
 use typst_syntax::ast::{self, AstNode, MathTextKind};
 
 use crate::{Eval, Vm};
 
+impl Eval for ast::Equation<'_> {
+    type Output = Content;
+
+    fn eval(self, vm: &mut Vm) -> SourceResult<Self::Output> {
+        let body = self.body().eval(vm)?;
+        let block = self.block();
+        Ok(EquationElem::new(body).with_block(block).pack())
+    }
+}
+
 impl Eval for ast::Math<'_> {
     type Output = Content;
+
     fn eval(self, vm: &mut Vm) -> SourceResult<Self::Output> {
         Ok(Content::sequence(
             self.exprs()


### PR DESCRIPTION
I've wanted to do this for a while, but it was always part of a larger commit/change, and I realized I can just factor it out as its own PR.
