### PR TITLE
Disable optimization for dev build to have correct stack trace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ yaml-front-matter = "0.1"
 zip = { version = "5", default-features = false, features = ["deflate"] }
 
 [profile.dev.package."*"]
-opt-level = 2
+opt-level = 0  # We need to disable optimization to have correct stack trace.
 
 [profile.release]
 lto = "thin"


### PR DESCRIPTION
Hi, I'd like to make this change to aid debugging. For example, this is the stack trace when debugging https://github.com/typst/typst/issues/7257 at commit 17a7890b2. 

After this patch, on a macOS M4 Air machine, `cargo build` takes 50.692s (down from 2min2.51s), and `cargo testit` takes 5.840s (increased from 2.053s). I think overall it's a win for developer experience.

## After this patch: stack trace with correct line numbers

For example:
* Stack frame 2 `./crates/typst-pdf/src/tags/tree/build.rs:181:5` does point to this line correctly:
  ```rust
  assert!(tree.stack.is_empty(), "tags weren't properly closed");
  ```
* Stack frame 3 `./crates/typst-pdf/src/tags/mod.rs:28:9` does print to this line correctly:
  ```rust
  tree::build(document, options)?
  ```
```
$ RUST_BACKTRACE=1 target/debug/typst compile test.typ

thread 'main' panicked at crates/typst-pdf/src/tags/tree/build.rs:181:5:
tags weren't properly closed
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:697:5
   1: core::panicking::panic_fmt
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/panicking.rs:75:14
   2: typst_pdf::tags::tree::build::build
             at ./crates/typst-pdf/src/tags/tree/build.rs:181:5
   3: typst_pdf::tags::init
             at ./crates/typst-pdf/src/tags/mod.rs:28:9
   4: typst_pdf::convert::setup
             at ./crates/typst-pdf/src/convert.rs:102:16
   5: typst_pdf::convert::convert
             at ./crates/typst-pdf/src/convert.rs:44:34
   6: typst_pdf::pdf
             at ./crates/typst-pdf/src/lib.rs:32:5
   7: typst::compile::export_pdf
             at ./crates/typst-cli/src/compile.rs:377:18
   8: typst::compile::export_paged
             at ./crates/typst-cli/src/compile.rs:341:13
   9: typst::compile::compile_and_export::{{closure}}
             at ./crates/typst-cli/src/compile.rs:313:53
  10: core::result::Result<T,E>::and_then
             at /Users/leedehai/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/result.rs:1415:22
  11: typst::compile::compile_and_export
             at ./crates/typst-cli/src/compile.rs:313:33
  12: typst::compile::compile_once
             at ./crates/typst-cli/src/compile.rs:248:43
  13: typst::compile::compile::{{closure}}
             at ./crates/typst-cli/src/compile.rs:43:38
  14: typst::timings::Timer::record
             at ./crates/typst-cli/src/timings.rs:48:23
  15: typst::compile::compile
             at ./crates/typst-cli/src/compile.rs:43:11
  16: typst::dispatch
             at ./crates/typst-cli/src/main.rs:76:38
  17: typst::main
             at ./crates/typst-cli/src/main.rs:58:15
  18: core::ops::function::FnOnce::call_once
             at /Users/leedehai/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:253:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

## Before this patch: stack trace with wrong line numbers
```
$ RUST_BACKTRACE=1 target/debug/typst compile test.typ

thread 'main' panicked at crates/typst-pdf/src/tags/tree/build.rs:174:5:
tags weren't properly closed
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:697:5
   1: core::panicking::panic_fmt
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/panicking.rs:75:14
   2: typst_pdf::tags::tree::build::build
             at ./crates/typst-pdf/src/tags/tree/build.rs:174:5
   3: typst_pdf::tags::init
             at ./crates/typst-pdf/src/tags/mod.rs:36:9
   4: typst_pdf::convert::setup
             at ./crates/typst-pdf/src/convert.rs:102:16
   5: typst_pdf::convert::convert
             at ./crates/typst-pdf/src/convert.rs:44:34
   6: typst_pdf::pdf
             at ./crates/typst-pdf/src/lib.rs:32:5
   7: typst::compile::export_pdf
             at ./crates/typst-cli/src/compile.rs:377:18
   8: typst::compile::export_paged
             at ./crates/typst-cli/src/compile.rs:341:13
   9: typst::compile::compile_and_export::{{closure}}
             at ./crates/typst-cli/src/compile.rs:313:53
  10: core::result::Result<T,E>::and_then
             at /Users/leedehai/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/result.rs:1415:22
  11: typst::compile::compile_and_export
             at ./crates/typst-cli/src/compile.rs:313:33
  12: typst::compile::compile_once
             at ./crates/typst-cli/src/compile.rs:248:43
  13: typst::compile::compile::{{closure}}
             at ./crates/typst-cli/src/compile.rs:43:38
  14: typst::timings::Timer::record
             at ./crates/typst-cli/src/timings.rs:48:23
  15: typst::compile::compile
             at ./crates/typst-cli/src/compile.rs:43:11
  16: typst::dispatch
             at ./crates/typst-cli/src/main.rs:76:38
  17: typst::main
             at ./crates/typst-cli/src/main.rs:58:15
  18: core::ops::function::FnOnce::call_once
             at /Users/leedehai/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:253:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

