### PR TITLE
Add missing Typst 0.14 changelog entry

### DIFF
--- a/docs/changelog/0.14.0.md
+++ b/docs/changelog/0.14.0.md
@@ -285,6 +285,9 @@ _Thanks to [@mkorje](https://github.com/mkorje) for his work on math!_
 - The `--make-deps` CLI flag in favor of `--deps` with `--deps-format make` [#7022]
 - Various symbols, see the [deprecation section in the dedicated changelog](https://github.com/typst/codex/blob/v0.2.0/CHANGELOG.md#deprecated) for a full listing
 
+## Removals
+- Removed compatibility behavior of type/str comparisons (e.g. `{int == "integer"}`), which was temporarily introduced in Typst 0.8 and deprecated in Typst 0.13 **(Breaking change)**
+
 ## Development
 - The `Default` impl for `Library` had to be removed for crate splitting and trait coherence reasons, but you can get a drop-in replacement via `use typst::LibraryExt` [#6576]
 - The `PdfOptions` struct has a new `tagged` field, which defaults to `{true}` [#6619] [#7046]


### PR DESCRIPTION
I don't like to update the changelog after the fact, but since this was a breaking change, it's rather important to mention.

For context: I missed this change because it never landed in main, only in the 0.13 branch, so I didn't see the commit when going through the main branch's history.