### PR TITLE
Update link on selector page to point to element functions

### DIFF
--- a/crates/typst-library/src/foundations/selector.rs
+++ b/crates/typst-library/src/foundations/selector.rs
@@ -38,7 +38,7 @@ pub use crate::__select_where as select_where;
 /// A filter for selecting elements within the document.
 ///
 /// To construct a selector you can:
-/// - use an [element function]
+/// - use an [element function]($function/#element-functions)
 /// - filter for an element function with [specific fields]($function.where)
 /// - use a [string]($str) or [regular expression]($regex)
 /// - use a [`{<label>}`]($label)


### PR DESCRIPTION
Currently the selector docs page of the website mentions element functions, but points to the functions page and not the element functions sub-heading. However, other pages that refer to element functions do point to the element functions section of the function page. This PR updates the link on the selector docs page to point to the element functions sub-section of the functions page.