### PR TITLE
Rename `global_attributes` to camelCase when serializing as `docs.json`

### DIFF
--- a/docs/src/model.rs
+++ b/docs/src/model.rs
@@ -135,7 +135,7 @@ pub struct StrParam {
 
 /// Details about a group of functions.
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")] 
+#[serde(rename_all = "camelCase")]
 pub struct GroupModel {
     pub name: EcoString,
     pub title: EcoString,


### PR DESCRIPTION
Resolves #7297

I'm not sure if this is appropriate (for example, you may have to change the closed-source part), but it's too simple.
To resolve the problem quickly, I'm submitting this PR.