### PR TITLE
Mention `SOURCE_DATE_EPOCH` in docs for `today`

### DIFF
--- a/crates/typst-library/src/foundations/datetime.rs
+++ b/crates/typst-library/src/foundations/datetime.rs
@@ -309,7 +309,13 @@ impl Datetime {
         })
     }
 
-    /// Returns the current date. Can be overridden by setting the `SOURCE_DATE_EPOCH` environment variable.
+    /// Returns the current date.
+    ///
+    /// In the CLI, this can be overridden with the `--creation-timestamp`
+    /// argument or by setting the
+    /// [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/specs/source-date-epoch/)
+    /// environment variable. In both cases, the value should be given as a UNIX
+    /// timestamp.
     ///
     /// ```example
     /// Today's date is


### PR DESCRIPTION
#3809 doesn't have any documentation yet.