### PR TITLE
Improve regex text extraction example

### DIFF
--- a/crates/typst-library/src/foundations/str.rs
+++ b/crates/typst-library/src/foundations/str.rs
@@ -994,8 +994,17 @@ impl Regex {
         /// backslash, you would need to write `{regex("\\\\")}`.
         ///
         /// If you need many escape sequences, you can also create a raw element
-        /// and extract its text to use it for your regular expressions:
-        /// ```{regex(`\d+\.\d+\.\d+`.text)}```.
+        /// and extract its text to use it for your regular expressions.
+        ///
+        /// ```example
+        /// #show regex("\\\\"): set text(red)
+        ///
+        /// The following sentence contains a backslash: C:\\Users\\Alice\\file.txt
+        ///
+        /// #show regex(`\d+\.\d+\.\d+`.text): set text(blue)
+        ///
+        /// The latest version of the software is 1.2.3, which includes several important bug fixes.
+        /// ```
         regex: Spanned<Str>,
     ) -> SourceResult<Regex> {
         Self::new(&regex.v).at(regex.span)


### PR DESCRIPTION
This pull request fixes the broken example in the [`/reference/foundations/regex/#constructor-regex`](https://typst.app/docs/reference/foundations/regex/#constructor-regex) documentation. Previously, the code was presented as block content even though it doesn't work on its own, and there was an inconsistency with a period at the end.

Since Typst's `regex` is difficult to demonstrate in isolation, I've added simple examples using the show rule with both an escape sequence and a raw element to make things clearer.