### PR TITLE
Allow creator string to be overridden

### DIFF
--- a/crates/typst-library/src/model/document.rs
+++ b/crates/typst-library/src/model/document.rs
@@ -50,6 +50,12 @@ pub struct DocumentElem {
     #[ghost]
     pub keywords: OneOrMultiple<EcoString>,
 
+    /// The custom creator metadata for this document.
+    /// If this is `{auto}` (default), Typst uses `Typst <version>`.
+    /// Otherwise, the chosen string is embedded as the creator metadata.
+    #[ghost]
+    pub creator: Smart<Option<EcoString>>,
+
     /// The document's creation date.
     ///
     /// If this is `{auto}` (default), Typst uses the current date and time.
@@ -102,6 +108,8 @@ pub struct DocumentInfo {
     pub author: Vec<EcoString>,
     /// The document's description.
     pub description: Option<EcoString>,
+    /// Custom creator metadata for this document.
+    pub creator: Smart<Option<EcoString>>,
     /// The document's keywords.
     pub keywords: Vec<EcoString>,
     /// The document's creation date.
@@ -140,6 +148,9 @@ impl DocumentInfo {
         }
         if styles.has(DocumentElem::date) {
             self.date = chain.get(DocumentElem::date);
+        }
+        if styles.has(DocumentElem::creator) {
+            self.creator = chain.get_cloned(DocumentElem::creator);
         }
     }
 


### PR DESCRIPTION
Allows e.g. augmenting the existing string with additional information (I am calling embedded-Typst from a Rust app and may wish to add additional metadata to assist with debugging).

```
#set document(creator: "MyRustTool v1.3 w/ Typst")
Hello world
```

<img width="929" height="374" alt="image" src="https://github.com/user-attachments/assets/eba0e5f0-0f8f-471d-92e1-ff9dddaaafe5" />


Provides feature parity with:

```
\usepackage[pdftex,
            pdfcreator={my custom text here}]{hyperref}
```

I note there was some previous discussion about the availability of this; my view is (quite strongly) that there is no good reason to _take away_ this control from the user by deliberately not exposing the option, but I would be happy with something in the documentation which explained why suppressing the creator string is not at all a security measure or something that reliably obfuscates what it is that has generated the document. It's no different to web servers forcing a specific `Server` header on responses, IMO. The general consensus there is that even if removing the `Server` header doesn't prevent fingerprinting the web-server, it should still be possible to modify or suppress it.