### PR TITLE
Add `location` flag to the `typst query` cli command

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -151,6 +151,10 @@ pub struct QueryCommand {
     #[clap(long = "field")]
     pub field: Option<String>,
 
+    /// Adds location information to the retrieved elements.
+    #[clap(long = "location", default_value = "false")]
+    pub location: bool,
+
     /// Expects and retrieves exactly one element.
     #[clap(long = "one", default_value = "false")]
     pub one: bool,


### PR DESCRIPTION
# Description
Implements #7008 by adding a new flag to the `typst query` command: `location`

## Why a new flag?

Adding a "location" field to the matching element value would have the following effects:
- **Potentially destructive**
  An element or metadata that already defines a "location" key would be overwritten
- **Incompatible with `--field`**
  `--field` may return scalar values, arrays, whatever really. We cannot simply attach a "location" key to these values as they are not dicts.

Solution: Wrapping the match inside a dict of structure
```json
{
  "match": <matched element or field>,
  "location": <location information>
}
```
Drawback: Breaking change, not backward compatible

Countermeasure: Add an optional `--location` flag that enables the above specified format, allowing users to opt-in into the format if they require the additional information. By default, the location information is not provided, resembling already established output format.

## Examples
**Complete "outline" element**:
`typst query <testfile> outline --pretty --location`
```json
[
  {
    "match": {
      "func": "outline",
      "title": {
        "func": "text",
        "text": "Inhaltsverzeichnis"
      },
      "target": "heading",
      "depth": null,
      "indent": "auto"
    },
    "location": {
      "page": 1,
      "x": "70.87pt",
      "y": "156.88pt"
    }
  }
]
```

**Single "title" field of "outline" element**:
`typst query <testfile> outline --pretty --location --field title`
```json
[
  {
    "match": {
      "func": "text",
      "text": "Inhaltsverzeichnis"
    },
    "location": {
      "page": 1,
      "x": "70.87pt",
      "y": "156.88pt"
    }
  }
]
```