### PR TITLE
Syntax highlighting with tree-sitter 🌳

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,31 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy 0.8.27",
+]
 
 [[package]]
 name = "aho-corasick"
@@ -16,6 +37,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -83,6 +110,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +152,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,6 +173,12 @@ name = "az"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -202,10 +252,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "by_address"
@@ -408,7 +470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -500,6 +562,131 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e15d04a0ce86cb36ead88ad68cf693ffd6cda47052b9e0ac114bc47fd9cd23c4"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c6e3969a7ce267259ce244b7867c5d3bc9e65b0a87e81039588dfdeaede9f34"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c22032c4cb42558371cf516bb47f26cdad1819d3475c133e93c49f50ebf304e"
+dependencies = [
+ "bumpalo",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli",
+ "hashbrown 0.14.5",
+ "log",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c904bc71c61b27fc57827f4a1379f29de64fe95653b620a3db77d59655eee0b8"
+dependencies = [
+ "cranelift-codegen-shared",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40180f5497572f644ce88c255480981ae2ec1d7bb4d8e0c0136a13b87a2f2ceb"
+
+[[package]]
+name = "cranelift-control"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d132c6d0bd8a489563472afc171759da0707804a65ece7ceb15a8c6d7dd5ef"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d0d9618275474fbf679dd018ac6e009acbd6ae6850f6a67be33fb3b00b323"
+dependencies = [
+ "cranelift-bitset",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fac41e16729107393174b0c9e3730fb072866100e1e64e80a1a963b2e484d57"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca20d576e5070044d0a72a9effc2deacf4d6aa650403189d8ea50126483944d"
+
+[[package]]
+name = "cranelift-native"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dee82f3f1f2c4cba9177f1cc5e350fe98764379bcd29340caa7b01f85076c7"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,6 +736,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "csv"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,6 +773,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,6 +802,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "directories-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,8 +838,19 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.0",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -653,6 +890,15 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "enum-ordinalize"
@@ -708,6 +954,12 @@ checksum = "ad9cdb4b747e485a12abb0e6566612956c7a1bafa3bdb8d682c5b6d403589e48"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fancy-regex"
@@ -784,6 +1036,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "font-types"
@@ -863,12 +1121,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "fxprof-processed-profile"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27d12c0aed7f1e24276a241aadc4cb8ea9f83000f34bc062b7cc2d51e3b0fabd"
+dependencies = [
+ "bitflags 2.9.1",
+ "debugid",
+ "fxhash",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getopts"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -905,6 +1195,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+dependencies = [
+ "fallible-iterator",
+ "indexmap 2.7.1",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "glidesort"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,9 +1229,22 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "foldhash",
+ "serde",
+]
 
 [[package]]
 name = "hayagriva"
@@ -946,7 +1260,7 @@ dependencies = [
  "roman-numerals-rs",
  "serde",
  "serde_yaml 0.9.34+deprecated",
- "thiserror",
+ "thiserror 2.0.16",
  "unic-langid",
  "unicode-segmentation",
  "unscanny",
@@ -1001,7 +1315,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c673304cec6e0dfd3b4f71fccecd45646899aa70279b62d3f933842abc4ac5"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "hayro-interpret",
  "image",
  "kurbo 0.12.0",
@@ -1249,6 +1563,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f739ee737260d955e330bc83fdeaaf1631f7fb7ed218761d3c04bb13bb7d79df"
 
 [[package]]
+name = "id-arena"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
+
+[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1382,10 +1702,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+
+[[package]]
+name = "ittapi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b996fe614c41395cdaedf3cf408a9534851090959d90d54a535f675550b64b1"
+dependencies = [
+ "anyhow",
+ "ittapi-sys",
+ "log",
+]
+
+[[package]]
+name = "ittapi-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5385394064fa2c886205dba02598013ce83d3e92d33dbdc0c52fe0e7bf4fc"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "jobserver"
@@ -1441,7 +1790,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "199be5f63da6e19b71051fd5276258a8e55449ac48e2e7492c68238f38ca9f3b"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bumpalo",
  "comemo",
  "flate2",
@@ -1503,10 +1852,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.169"
+name = "leb128"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.177"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libdeflate-sys"
@@ -1575,6 +1936,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "lipsum"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1627,10 +1994,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix 1.1.2",
+]
 
 [[package]]
 name = "memmap2"
@@ -1769,6 +2154,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.2",
+ "indexmap 2.7.1",
+ "memchr",
 ]
 
 [[package]]
@@ -1993,6 +2390,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
 name = "pixglyph"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2013,7 +2416,7 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "indexmap 2.7.1",
  "quick-xml 0.32.0",
  "serde",
@@ -2063,7 +2466,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -2100,6 +2503,18 @@ dependencies = [
  "getopts",
  "memchr",
  "unicase",
+]
+
+[[package]]
+name = "pulley-interpreter"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62d95f8575df49a2708398182f49a888cf9dc30210fb1fd2df87c889edcee75d"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "sptr",
+ "wasmtime-math",
 ]
 
 [[package]]
@@ -2223,13 +2638,38 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.15",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror",
+ "thiserror 2.0.16",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc06e6b318142614e4a48bc725abbf08ff166694835c43c9dae5a9009704639a"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.15.2",
+ "log",
+ "rustc-hash",
+ "smallvec",
 ]
 
 [[package]]
@@ -2316,6 +2756,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2330,7 +2776,20 @@ dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.59.0",
 ]
 
@@ -2427,6 +2886,9 @@ name = "semver"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
@@ -2454,6 +2916,7 @@ version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
+ "indexmap 2.7.1",
  "itoa",
  "memchr",
  "ryu",
@@ -2492,6 +2955,17 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2566,12 +3040,21 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "sptr"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
 name = "stable_deref_trait"
@@ -2591,6 +3074,12 @@ dependencies = [
  "psm",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "strict-num"
@@ -2688,7 +3177,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.16",
  "walkdir",
  "yaml-rust",
 ]
@@ -2711,6 +3200,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
+
+[[package]]
 name = "tempfile"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2720,7 +3215,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
  "windows-sys 0.59.0",
 ]
 
@@ -2739,7 +3234,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
 dependencies = [
- "rustix",
+ "rustix 0.38.44",
  "windows-sys 0.59.0",
 ]
 
@@ -2751,11 +3246,31 @@ checksum = "a38c90d48152c236a3ab59271da4f4ae63d678c5d7ad6b7714d7cb9760be5e4b"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.16",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2909,6 +3424,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "trait-variant"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78f873475d258561b06f1c595d93308a7ed124d9977cb26b148c2084a4a3cc87"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+ "wasmtime-c-api-impl",
+]
+
+[[package]]
+name = "tree-sitter-highlight"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc5f880ad8d8f94e88cb81c3557024cf1a8b75e3b504c50481ed4f5a6006ff3"
+dependencies = [
+ "regex",
+ "streaming-iterator",
+ "thiserror 2.0.16",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8"
+
+[[package]]
 name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2933,6 +3523,12 @@ name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "typst"
@@ -2989,6 +3585,8 @@ dependencies = [
  "tempfile",
  "tiny_http",
  "toml",
+ "tree-sitter",
+ "tree-sitter-highlight",
  "typst",
  "typst-eval",
  "typst-html",
@@ -3207,6 +3805,8 @@ dependencies = [
  "syntect",
  "time",
  "toml",
+ "tree-sitter",
+ "tree-sitter-highlight",
  "ttf-parser",
  "two-face",
  "typed-arena",
@@ -3223,6 +3823,7 @@ dependencies = [
  "usvg",
  "utf8_iter",
  "wasmi",
+ "wasmtime",
  "xmlwriter",
 ]
 
@@ -3298,7 +3899,7 @@ dependencies = [
 name = "typst-svg"
 version = "0.14.0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "comemo",
  "ecow",
  "flate2",
@@ -3503,6 +4104,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3520,7 +4133,7 @@ version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "flate2",
  "log",
  "native-tls",
@@ -3548,7 +4161,7 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ac8e0e3e4696253dc06167990b3fe9a2668ab66270adf949a464db4088cb354"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "data-url",
  "flate2",
  "fontdb",
@@ -3586,6 +4199,16 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "vcpkg"
@@ -3683,6 +4306,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.221.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc8444fe4920de80a4fe5ab564fff2ae58b6b73166b89751f8c6c93509da32e5"
+dependencies = [
+ "leb128",
+ "wasmparser 0.221.3",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.240.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d642d8c5ecc083aafe9ceb32809276a304547a3a6eeecceb5d8152598bc71f"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.240.0",
+]
+
+[[package]]
 name = "wasmi"
 version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3692,7 +4335,7 @@ dependencies = [
  "wasmi_collections",
  "wasmi_core",
  "wasmi_ir",
- "wasmparser",
+ "wasmparser 0.228.0",
 ]
 
 [[package]]
@@ -3721,11 +4364,344 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
+version = "0.221.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d06bfa36ab3ac2be0dee563380147a5b81ba10dd8885d7fbbc9eb574be67d185"
+dependencies = [
+ "bitflags 2.9.1",
+ "hashbrown 0.15.2",
+ "indexmap 2.7.1",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
 version = "0.228.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4abf1132c1fdf747d56bbc1bb52152400c70f336870f968b85e89ea422198ae3"
 dependencies = [
  "bitflags 2.9.1",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.240.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b722dcf61e0ea47440b53ff83ccb5df8efec57a69d150e4f24882e4eba7e24a4"
+dependencies = [
+ "bitflags 2.9.1",
+ "indexmap 2.7.1",
+ "semver",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.221.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7343c42a97f2926c7819ff81b64012092ae954c5d83ddd30c9fcdefd97d0b283"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.221.3",
+]
+
+[[package]]
+name = "wasmtime"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11976a250672556d1c4c04c6d5d7656ac9192ac9edc42a4587d6c21460010e69"
+dependencies = [
+ "addr2line",
+ "anyhow",
+ "async-trait",
+ "bitflags 2.9.1",
+ "bumpalo",
+ "cc",
+ "cfg-if",
+ "encoding_rs",
+ "fxprof-processed-profile",
+ "gimli",
+ "hashbrown 0.14.5",
+ "indexmap 2.7.1",
+ "ittapi",
+ "libc",
+ "log",
+ "mach2",
+ "memfd",
+ "object",
+ "once_cell",
+ "paste",
+ "postcard",
+ "psm",
+ "pulley-interpreter",
+ "rayon",
+ "rustix 0.38.44",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "smallvec",
+ "sptr",
+ "target-lexicon",
+ "trait-variant",
+ "wasm-encoder 0.221.3",
+ "wasmparser 0.221.3",
+ "wasmtime-asm-macros",
+ "wasmtime-cache",
+ "wasmtime-component-macro",
+ "wasmtime-component-util",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
+ "wasmtime-fiber",
+ "wasmtime-jit-debug",
+ "wasmtime-jit-icache-coherence",
+ "wasmtime-math",
+ "wasmtime-slab",
+ "wasmtime-versioned-export-macros",
+ "wasmtime-winch",
+ "wat",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasmtime-asm-macros"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f178b0d125201fbe9f75beaf849bd3e511891f9e45ba216a5b620802ccf64f2"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-c-api-impl"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea30cef3608f2de5797c7bbb94c1ba4f3676d9a7f81ae86ced1b512e2766ed0c"
+dependencies = [
+ "anyhow",
+ "log",
+ "tracing",
+ "wasmtime",
+ "wasmtime-c-api-macros",
+]
+
+[[package]]
+name = "wasmtime-c-api-macros"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022a79ebe1124d5d384d82463d7e61c6b4dd857d81f15cb8078974eeb86db65b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "wasmtime-cache"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1161c8f62880deea07358bc40cceddc019f1c81d46007bc390710b2fe24ffc"
+dependencies = [
+ "anyhow",
+ "base64 0.21.7",
+ "directories-next",
+ "log",
+ "postcard",
+ "rustix 0.38.44",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "toml",
+ "windows-sys 0.59.0",
+ "zstd",
+]
+
+[[package]]
+name = "wasmtime-component-macro"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d74de6592ed945d0a602f71243982a304d5d02f1e501b638addf57f42d57dfaf"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasmtime-component-util",
+ "wasmtime-wit-bindgen",
+ "wit-parser",
+]
+
+[[package]]
+name = "wasmtime-component-util"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707dc7b3c112ab5a366b30cfe2fb5b2f8e6a0f682f16df96a5ec582bfe6f056e"
+
+[[package]]
+name = "wasmtime-cranelift"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "366be722674d4bf153290fbcbc4d7d16895cc82fb3e869f8d550ff768f9e9e87"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli",
+ "itertools",
+ "log",
+ "object",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 1.0.69",
+ "wasmparser 0.221.3",
+ "wasmtime-environ",
+ "wasmtime-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdadc1af7097347aa276a4f008929810f726b5b46946971c660b6d421e9994ad"
+dependencies = [
+ "anyhow",
+ "cpp_demangle",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli",
+ "indexmap 2.7.1",
+ "log",
+ "object",
+ "postcard",
+ "rustc-demangle",
+ "semver",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder 0.221.3",
+ "wasmparser 0.221.3",
+ "wasmprinter",
+ "wasmtime-component-util",
+]
+
+[[package]]
+name = "wasmtime-fiber"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccba90d4119f081bca91190485650730a617be1fff5228f8c4757ce133d21117"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if",
+ "rustix 0.38.44",
+ "wasmtime-asm-macros",
+ "wasmtime-versioned-export-macros",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasmtime-jit-debug"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e7b61488a5ee00c35c8c22de707c36c0aecacf419a3be803a6a2ba5e860f56a"
+dependencies = [
+ "object",
+ "rustix 0.38.44",
+ "wasmtime-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-jit-icache-coherence"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec5e8552e01692e6c2e5293171704fed8abdec79d1a6995a0870ab190e5747d1"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasmtime-math"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29210ec2aa25e00f4d54605cedaf080f39ec01a872c5bd520ad04c67af1dde17"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmtime-slab"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb5821a96fa04ac14bc7b158bb3d5cd7729a053db5a74dad396cd513a5e5ccf"
+
+[[package]]
+name = "wasmtime-versioned-export-macros"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ff86db216dc0240462de40c8290887a613dddf9685508eb39479037ba97b5b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasmtime-winch"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdbabfb8f20502d5e1d81092b9ead3682ae59988487aafcd7567387b7a43cf8f"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "gimli",
+ "object",
+ "target-lexicon",
+ "wasmparser 0.221.3",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
+ "winch-codegen",
+]
+
+[[package]]
+name = "wasmtime-wit-bindgen"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8358319c2dd1e4db79e3c1c5d3a5af84956615343f9f89f4e4996a36816e06e6"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.7.1",
+ "wit-parser",
+]
+
+[[package]]
+name = "wast"
+version = "240.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0efe1c93db4ac562b9733e3dca19ed7fc878dba29aef22245acf84f13da4a19"
+dependencies = [
+ "bumpalo",
+ "leb128fmt",
+ "memchr",
+ "unicode-width 0.2.2",
+ "wasm-encoder 0.240.0",
+]
+
+[[package]]
+name = "wat"
+version = "1.240.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec9b6eab7ecd4d639d78515e9ea491c9bacf494aa5eda10823bd35992cf8c1e"
+dependencies = [
+ "wast",
 ]
 
 [[package]]
@@ -3745,12 +4721,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winch-codegen"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f849ef2c5f46cb0a20af4b4487aaa239846e52e2c03f13fa3c784684552859c"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "gimli",
+ "regalloc2",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 1.0.69",
+ "wasmparser 0.221.3",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
 ]
 
 [[package]]
@@ -3863,6 +4879,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-parser"
+version = "0.221.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "896112579ed56b4a538b07a3d16e562d101ff6265c46b515ce0c701eef16b2ac"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.7.1",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.221.3",
+]
+
+[[package]]
 name = "write-fonts"
 version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3903,8 +4937,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e105d177a3871454f754b33bb0ee637ecaaac997446375fd3e5d43a2ed00c909"
 dependencies = [
  "libc",
- "linux-raw-sys",
- "rustix",
+ "linux-raw-sys 0.4.15",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -4008,7 +5042,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive 0.8.27",
 ]
 
 [[package]]
@@ -4016,6 +5059,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4119,6 +5173,34 @@ dependencies = [
  "log",
  "once_cell",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,9 @@ xmlwriter = "0.1.0"
 xz2 = { version = "0.1", features = ["static"] }
 yaml-front-matter = "0.1"
 zip = { version = "5", default-features = false, features = ["deflate"] }
+tree-sitter = { version = "0.25.10", features = ["wasm"] }
+tree-sitter-highlight = "0.25.10"
+wasmtime = "29.0.1"
 
 [profile.dev.package."*"]
 opt-level = 2

--- a/crates/typst-cli/Cargo.toml
+++ b/crates/typst-cli/Cargo.toml
@@ -57,6 +57,8 @@ toml = { workspace = true }
 ureq = { workspace = true }
 xz2 = { workspace = true, optional = true }
 zip = { workspace = true, optional = true }
+tree-sitter = { workspace = true }
+tree-sitter-highlight = { workspace = true }
 
 [build-dependencies]
 chrono = { workspace = true }

--- a/crates/typst-library/Cargo.toml
+++ b/crates/typst-library/Cargo.toml
@@ -71,6 +71,9 @@ usvg = { workspace = true }
 utf8_iter = { workspace = true }
 wasmi = { workspace = true }
 xmlwriter = { workspace = true }
+tree-sitter = { workspace = true }
+tree-sitter-highlight = { workspace = true }
+wasmtime = { workspace = true }
 
 [dev-dependencies]
 typst-dev-assets = { workspace = true }

--- a/crates/typst-library/src/lib.rs
+++ b/crates/typst-library/src/lib.rs
@@ -76,6 +76,19 @@ pub trait World: Send + Sync {
     /// Try to access the font with the given index in the font book.
     fn font(&self, index: usize) -> Option<Font>;
 
+    /// Try to get the tree-sitter language for the given name
+    fn tree_sitter_language(
+        &self,
+        name: String,
+        aliases: Vec<String>,
+        wasm: &[u8],
+    ) -> Option<tree_sitter::Language> {
+        let _ = name;
+        let _ = aliases;
+        let _ = wasm;
+        None
+    }
+
     /// Get the current date.
     ///
     /// If no offset is specified, the local date should be chosen. Otherwise,
@@ -111,6 +124,15 @@ macro_rules! world_impl {
 
             fn font(&self, index: usize) -> Option<Font> {
                 self.deref().font(index)
+            }
+
+            fn tree_sitter_language(
+                &self,
+                name: String,
+                aliases: Vec<String>,
+                wasm: &[u8],
+            ) -> Option<tree_sitter::Language> {
+                self.deref().tree_sitter_language(name, aliases, wasm)
             }
 
             fn today(&self, offset: Option<i64>) -> Option<Datetime> {

--- a/crates/typst-library/src/text/mod.rs
+++ b/crates/typst-library/src/text/mod.rs
@@ -1,5 +1,7 @@
 //! Text handling.
 
+pub mod tree_sitter;
+
 mod case;
 mod deco;
 mod font;

--- a/crates/typst-library/src/text/tree_sitter.rs
+++ b/crates/typst-library/src/text/tree_sitter.rs
@@ -1,0 +1,732 @@
+use std::{collections::BTreeMap, sync::Arc};
+
+use bitflags::bitflags;
+use comemo::Tracked;
+use ecow::{EcoString, EcoVec, eco_vec};
+use std::hash::Hash;
+use syntect::highlighting::FontStyle;
+use typst_syntax::{Span, Spanned};
+use typst_utils::ManuallyHash;
+
+use crate::{
+    World,
+    diag::{LoadedWithin, SourceDiagnostic, SourceResult},
+    foundations::{Derived, Dict, FromValue, IntoValue, OneOrMultiple, Packed, Reflect},
+    loading::{DataSource, Load as _},
+    visualize::Color,
+};
+
+#[derive(Clone)]
+pub struct TreeSitterHighlightConfiguration {
+    /// These names can also refer to this highlight configuration
+    aliases: Box<[EcoString]>,
+    /// Contains the actual highlight configuration, which tells us how to
+    /// do syntax highlighting for the particular language
+    config: Arc<ManuallyHash<tree_sitter_highlight::HighlightConfiguration>>,
+}
+
+impl TreeSitterHighlightConfiguration {
+    /// Load syntaxes from sources.
+    pub(crate) fn load(
+        world: Tracked<dyn World + '_>,
+        syntaxes: Spanned<OneOrMultiple<TreeSitterSyntax>>,
+    ) -> SourceResult<
+        Derived<OneOrMultiple<TreeSitterSyntax>, Vec<TreeSitterHighlightConfiguration>>,
+    > {
+        let configurations = syntaxes
+            .v
+            .0
+            .iter()
+            .map(|syntax| syntax.load(world, syntaxes.span))
+            .collect::<SourceResult<_>>()?;
+
+        Ok(Derived::new(syntaxes.v, configurations))
+    }
+
+    /// If the language string matches this language configuration
+    pub(crate) fn matches(&self, name: &str) -> bool {
+        self.config.language_name == name
+            || self.aliases.iter().any(|alias| alias == name)
+    }
+}
+
+impl PartialEq for TreeSitterHighlightConfiguration {
+    fn eq(&self, other: &Self) -> bool {
+        self.config.language == other.config.language
+    }
+}
+
+impl std::hash::Hash for TreeSitterHighlightConfiguration {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.config.language.hash(state);
+    }
+}
+
+impl std::fmt::Debug for TreeSitterHighlightConfiguration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("HighlightConfiguration")
+            .field(&self.config.language_name)
+            .finish()
+    }
+}
+
+/// WASM Engine is shared across all threads
+static ENGINE: std::sync::OnceLock<wasmtime::Engine> = std::sync::OnceLock::new();
+
+thread_local! {
+    /// Each thread has its own tree-sitter parser with its own WASM store
+    /// That is necessary since when we add new languages to the tree-sitter parser,
+    /// we first have to take the WasmStore out, add the language, then add it back in.
+    ///
+    /// If multiple threads are using the same WasmStore, that approach would cause problems -
+    /// as the WasmStore would be missing sometimes, so syntax highlighting would randomly fail
+    pub(crate) static PARSER: std::cell::RefCell<tree_sitter::Parser>  = {
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_wasm_store(tree_sitter::WasmStore::new(ENGINE.get_or_init(Default::default)).unwrap()).unwrap();
+        std::cell::RefCell::new(parser)
+    };
+}
+
+/// Map from names of languages, to parsers of those languages.
+/// Multiple names can point to the same language.
+#[derive(Default)]
+pub struct Languages(
+    std::collections::HashMap<String, usize>,
+    Vec<tree_sitter::Language>,
+);
+
+impl Languages {
+    pub fn get(&self, language: &str) -> Option<tree_sitter::Language> {
+        self.0.get(language).map(|lang| &self.1[*lang]).cloned()
+    }
+
+    pub fn insert(
+        &mut self,
+        name: String,
+        aliases: Box<[String]>,
+        language_wasm: &[u8],
+    ) -> tree_sitter::Language {
+        let language = PARSER.with(|parser| {
+            let mut parser = parser.borrow_mut();
+            let mut store = parser
+                .take_wasm_store()
+                .expect("set once during initialization and always re-set after");
+            let language = store.load_language(&name, language_wasm).unwrap();
+            parser.set_wasm_store(store).expect("succeded during initialization");
+            language
+        });
+
+        let index = self.1.len();
+        self.1.push(language.clone());
+        self.0.insert(name, index);
+        for alias in aliases {
+            self.0.insert(alias, index);
+        }
+        language
+    }
+}
+
+bitflags! {
+    /// Attributes of syntax-highlighted text
+    #[derive(Default, Copy, Clone, Debug, PartialEq, Hash)]
+    pub struct FontAttributes: u8 {
+        const BOLD   = 0b00000001;
+        const ITALIC = 0b00000010;
+    }
+}
+
+impl From<FontAttributes> for FontStyle {
+    fn from(attrs: FontAttributes) -> Self {
+        let mut font_style = FontStyle::empty();
+        if attrs.contains(FontAttributes::BOLD) {
+            font_style.insert(FontStyle::BOLD);
+        }
+        if attrs.contains(FontAttributes::ITALIC) {
+            font_style.insert(FontStyle::ITALIC);
+        }
+        font_style
+    }
+}
+
+/// Style of text highlighted by tree-sitter
+#[derive(std::hash::Hash, Clone, Debug, PartialEq, Copy, Default)]
+pub struct TreeSitterStyle {
+    foreground: Option<Color>,
+    background: Option<Color>,
+    underline: Option<Color>,
+    attributes: FontAttributes,
+}
+
+impl Reflect for TreeSitterStyle {
+    fn input() -> crate::foundations::CastInfo {
+        Dict::input() + Color::input()
+    }
+
+    fn output() -> crate::foundations::CastInfo {
+        Dict::output() + Color::output()
+    }
+
+    fn castable(value: &crate::foundations::Value) -> bool {
+        Dict::castable(value) || Color::castable(value)
+    }
+}
+
+impl IntoValue for TreeSitterStyle {
+    fn into_value(self) -> crate::foundations::Value {
+        crate::foundations::dict! {
+            "background" => self.background,
+            "foreground" => self.foreground,
+            "bold" => self.attributes.contains(FontAttributes::BOLD),
+            "underline" => self.underline,
+            "italic" => self.attributes.contains(FontAttributes::ITALIC),
+        }
+        .into_value()
+    }
+}
+
+impl FromValue for TreeSitterStyle {
+    fn from_value(
+        value: crate::foundations::Value,
+    ) -> crate::diag::HintedStrResult<Self> {
+        if Color::castable(&value) {
+            let foreground = value.cast().expect("just checked that it's castable");
+            return Ok(Self {
+                foreground,
+                background: None,
+                underline: None,
+                attributes: FontAttributes::default(),
+            });
+        }
+
+        let mut dict = value.cast::<Dict>()?;
+        let mut attributes = FontAttributes::default();
+
+        if let Ok(bold) = dict.take("bold")
+            && bold.cast()?
+        {
+            attributes.insert(FontAttributes::BOLD);
+        }
+        if let Ok(italic) = dict.take("italic")
+            && italic.cast()?
+        {
+            attributes.insert(FontAttributes::ITALIC);
+        }
+
+        Ok(Self {
+            foreground: dict.take("foreground").unwrap_or_default().cast()?,
+            background: dict.take("background").unwrap_or_default().cast()?,
+            underline: dict.take("underline").unwrap_or_default().cast()?,
+            attributes,
+        })
+    }
+}
+
+impl TreeSitterStyle {
+    fn into_syntect_style(
+        self,
+        default_foreground: syntect::highlighting::Color,
+    ) -> syntect::highlighting::Style {
+        let foreground = self.foreground.map_or(default_foreground, |bg| {
+            let fg = bg.to_rgb();
+            syntect::highlighting::Color {
+                r: (fg.red * 255.0).round() as u8,
+                g: (fg.green * 255.0).round() as u8,
+                b: (fg.blue * 255.0).round() as u8,
+                a: (fg.alpha * 255.0).round() as u8,
+            }
+        });
+        let background = self.background.map_or(
+            syntect::highlighting::Color { r: 0, g: 0, b: 0, a: 0 },
+            |bg| {
+                let bg = bg.to_rgb();
+                syntect::highlighting::Color {
+                    r: (bg.red * 255.0).round() as u8,
+                    g: (bg.green * 255.0).round() as u8,
+                    b: (bg.blue * 255.0).round() as u8,
+                    a: (bg.alpha * 255.0).round() as u8,
+                }
+            },
+        );
+        syntect::highlighting::Style {
+            foreground,
+            background,
+            font_style: self.attributes.into(),
+        }
+    }
+}
+
+/// The syntax highlighting theme to use
+#[derive(std::hash::Hash, Clone, Debug, PartialEq)]
+pub struct TreeSitterTheme(BTreeMap<EcoString, TreeSitterStyle>);
+
+impl Reflect for TreeSitterTheme {
+    fn input() -> crate::foundations::CastInfo {
+        Dict::input()
+    }
+
+    fn output() -> crate::foundations::CastInfo {
+        Dict::output()
+    }
+
+    fn castable(value: &crate::foundations::Value) -> bool {
+        Dict::castable(value)
+    }
+}
+
+impl IntoValue for TreeSitterTheme {
+    fn into_value(self) -> crate::foundations::Value {
+        let mut dict = Dict::new();
+
+        for (key, value) in self.0 {
+            dict.insert(key.into(), value.into_value());
+        }
+
+        dict.into_value()
+    }
+}
+
+impl FromValue for TreeSitterTheme {
+    fn from_value(
+        value: crate::foundations::Value,
+    ) -> crate::diag::HintedStrResult<Self> {
+        let mut map = BTreeMap::new();
+
+        for (scope, highlight) in value.cast::<Dict>()? {
+            map.insert(scope.into(), highlight.cast()?);
+        }
+
+        Ok(Self(map))
+    }
+}
+
+#[derive(Clone, PartialEq, std::hash::Hash, Debug)]
+pub struct TreeSitterSyntax {
+    /// The tree-sitter grammar in `.wasm` format
+    grammar: DataSource,
+    /// Name of the tree-sitter grammar
+    name: EcoString,
+    /// Any aliases of the language
+    aliases: Vec<EcoString>,
+    /// `highlights.scm` query for syntax highlighting
+    highlights_query: Option<DataSource>,
+    /// `injections.scm` query for injecting nested grammars
+    injections_query: Option<DataSource>,
+    /// `locals.scm` query
+    locals_query: Option<DataSource>,
+}
+
+impl TreeSitterSyntax {
+    /// Load syntax from source
+    fn load(
+        &self,
+        world: Tracked<dyn World + '_>,
+        span: Span,
+    ) -> SourceResult<TreeSitterHighlightConfiguration> {
+        let mut errors = EcoVec::new();
+        let grammar = Spanned::new(&self.grammar, span).load(world)?;
+
+        let name = self.name.to_string();
+
+        let highlights_query = match self
+            .highlights_query
+            .as_ref()
+            .map(|query| Spanned::new(query, span).load(world))
+        {
+            Some(Ok(query)) => Some(query),
+            Some(Err(errs)) => {
+                errors.extend(errs);
+                None
+            }
+            None => None,
+        };
+        let injections_query = match self
+            .injections_query
+            .as_ref()
+            .map(|query| Spanned::new(query, span).load(world))
+        {
+            Some(Ok(query)) => Some(query),
+            Some(Err(errs)) => {
+                errors.extend(errs);
+                None
+            }
+            None => None,
+        };
+        let locals_query = match self
+            .locals_query
+            .as_ref()
+            .map(|query| Spanned::new(query, span).load(world))
+        {
+            Some(Ok(query)) => Some(query),
+            Some(Err(errs)) => {
+                errors.extend(errs);
+                None
+            }
+            None => None,
+        };
+
+        let Some(language) = world.tree_sitter_language(
+            name.clone(),
+            self.aliases.iter().map(Into::into).collect(),
+            &grammar.data,
+        ) else {
+            return Err(eco_vec!(SourceDiagnostic::warning(
+                span,
+                format!("failed to load tree-sitter grammar for `{name}`")
+            )));
+        };
+
+        let highlights_query =
+            match highlights_query.as_ref().map(|q| q.data.as_str().within(q)) {
+                Some(Ok(query)) => query,
+                Some(Err(errs)) => {
+                    errors.extend(errs);
+                    ""
+                }
+                None => "",
+            };
+        let injections_query =
+            match injections_query.as_ref().map(|q| q.data.as_str().within(q)) {
+                Some(Ok(query)) => query,
+                Some(Err(errs)) => {
+                    errors.extend(errs);
+                    ""
+                }
+                None => "",
+            };
+        let locals_query = match locals_query.as_ref().map(|q| q.data.as_str().within(q))
+        {
+            Some(Ok(query)) => query,
+            Some(Err(errs)) => {
+                errors.extend(errs);
+                ""
+            }
+            None => "",
+        };
+
+        let lang_hash = typst_utils::hash128(&language);
+        let mut highlight_configuration =
+            match tree_sitter_highlight::HighlightConfiguration::new(
+                language.clone(),
+                &name,
+                highlights_query,
+                injections_query,
+                locals_query,
+            ) {
+                Ok(conf) => conf,
+                Err(error) => {
+                    errors.push(crate::diag::SourceDiagnostic::warning(
+                        span,
+                        format!(
+                            "failed to parse tree-sitter {} `{name}`: {error}",
+                            "query for language",
+                        ),
+                    ));
+                    return Err(errors);
+                }
+            };
+
+        if !errors.is_empty() {
+            return Err(errors);
+        }
+
+        highlight_configuration.configure(SCOPES);
+
+        let highlight_configuration = TreeSitterHighlightConfiguration {
+            aliases: self.aliases.iter().map(Into::into).collect(),
+            config: std::sync::Arc::new(typst_utils::ManuallyHash::new(
+                highlight_configuration,
+                lang_hash,
+            )),
+        };
+
+        if !errors.is_empty() {
+            return Err(errors);
+        }
+
+        Ok(highlight_configuration)
+    }
+}
+
+impl Reflect for TreeSitterSyntax {
+    fn input() -> crate::foundations::CastInfo {
+        Dict::input()
+    }
+
+    fn output() -> crate::foundations::CastInfo {
+        Dict::output()
+    }
+
+    fn castable(value: &crate::foundations::Value) -> bool {
+        Dict::castable(value)
+    }
+}
+
+impl IntoValue for TreeSitterSyntax {
+    fn into_value(self) -> crate::foundations::Value {
+        crate::foundations::dict! {
+            "grammar" => self.grammar,
+            "name" => self.name,
+            "aliases" => self.aliases,
+            "highlights-query" => self.highlights_query,
+            "injections-query" => self.injections_query,
+            "locals-query" => self.locals_query
+        }
+        .into_value()
+    }
+}
+
+impl FromValue for TreeSitterSyntax {
+    fn from_value(
+        value: crate::foundations::Value,
+    ) -> crate::diag::HintedStrResult<Self> {
+        let mut dict = value.cast::<Dict>()?;
+
+        Ok(Self {
+            name: dict.take("name")?.cast()?,
+            aliases: dict
+                .take("aliases")
+                .unwrap_or_else(|_| {
+                    crate::foundations::Value::Array(crate::foundations::Array::default())
+                })
+                .cast()?,
+            grammar: dict.take("grammar")?.cast()?,
+            highlights_query: dict.take("highlights-query").unwrap_or_default().cast()?,
+            injections_query: dict.take("injections-query").unwrap_or_default().cast()?,
+            locals_query: dict.take("locals-query").unwrap_or_default().cast()?,
+        })
+    }
+}
+
+/// Highlight `lines` of text using the tree-sitter `syntax` with the
+/// color `theme`
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn highlight(
+    all_configs: &[TreeSitterHighlightConfiguration],
+    routines: &crate::routines::Routines,
+    target: crate::foundations::Target,
+    lines: EcoVec<(EcoString, Span)>,
+    seq: &mut Vec<Packed<super::RawLine>>,
+    foreground: syntect::highlighting::Color,
+    count: i64,
+    syntax: &TreeSitterHighlightConfiguration,
+    theme: &TreeSitterTheme,
+) {
+    let parser = PARSER.take();
+    let mut highlighter = tree_sitter_highlight::Highlighter::new();
+    highlighter.parser = parser;
+
+    // Whole text of the code block
+    let text = lines.iter().map(|(s, _)| s.clone()).collect::<Vec<_>>().join("\n");
+
+    let mut current_highlight = None;
+
+    // Text of the code block, broken up into individual
+    // string slices associated with their style
+    let mut pieces = Vec::new();
+
+    for event in highlighter
+        .highlight(&syntax.config, text.as_bytes(), None, |lang| {
+            all_configs
+                .iter()
+                .find(|config| config.matches(lang))
+                .map(|it| &**it.config)
+        })
+        .unwrap()
+    {
+        match event.unwrap() {
+            tree_sitter_highlight::HighlightEvent::Source { start, end } => {
+                pieces.push((&text[start..end], current_highlight));
+            }
+            tree_sitter_highlight::HighlightEvent::HighlightStart(highlight) => {
+                let scope = SCOPES[highlight.0];
+
+                // For a string like "foo.bar.baz", we want to check if "foo.bar.baz" is a valid
+                // key. If not, check "foo.bar". If not, check "foo"
+
+                let mut current_scope = Vec::new();
+
+                // List of all the scopes we'll check at the end
+                let mut all_scopes = Vec::new();
+
+                for part in scope.split(".") {
+                    current_scope.push(part);
+                    all_scopes.push(current_scope.join("."));
+                }
+
+                let color = all_scopes
+                    .into_iter()
+                    .rev()
+                    .find_map(|scope| theme.0.get(&*scope))
+                    .copied()
+                    .unwrap_or_default();
+
+                current_highlight = Some(color);
+            }
+            tree_sitter_highlight::HighlightEvent::HighlightEnd => {
+                current_highlight = None;
+            }
+        }
+    }
+
+    let mut chars = Vec::new();
+
+    for (piece, style) in pieces {
+        for char in piece.chars() {
+            chars.push((style, char));
+        }
+    }
+
+    let mut highlighted_lines = Vec::new();
+    let mut current_line = Vec::new();
+    for (style, char) in chars {
+        if char == '\n' {
+            highlighted_lines.push(current_line.clone());
+            current_line.clear();
+        } else {
+            current_line.push((style, char));
+        }
+    }
+    if !current_line.is_empty() {
+        highlighted_lines.push(current_line);
+    }
+
+    for ((i, line), (line_string, line_span)) in
+        highlighted_lines.into_iter().enumerate().zip(lines)
+    {
+        let mut line_content = Vec::new();
+        let mut span_offset = 0;
+        for (style, piece) in line {
+            let piece = piece.to_string();
+            line_content.push(crate::text::styled(
+                routines,
+                target,
+                &piece,
+                foreground,
+                // If its `None`, then it is a whitespace character
+                style.unwrap_or_default().into_syntect_style(foreground),
+                line_span,
+                span_offset,
+            ));
+            span_offset += piece.len();
+        }
+
+        seq.push(
+            Packed::new(super::RawLine::new(
+                i as i64 + 1,
+                count,
+                line_string,
+                crate::foundations::Content::sequence(line_content),
+            ))
+            .spanned(line_span),
+        );
+    }
+    PARSER.set(highlighter.parser);
+}
+
+/// Supports all the same scopes as Helix.
+/// Taken from <https://docs.helix-editor.com/themes.html#syntax-highlighting>
+///
+/// By using Helix's scopes, we are leveraging the hundreds of available
+/// language configurations + the hundreds of available themes.
+///
+/// Neovim nor Zed, nor any other source come close to the amount of
+/// languages/themes Helix supports and how easy it is to turn a Helix
+/// theme to be supported by Typst - as all Helix themes are just static .toml files
+pub const SCOPES: &[&str] = &[
+    "attribute",
+    "type",
+    "type.builtin",
+    "type.parameter",
+    "type.enum",
+    "type.enum.variant",
+    "constructor",
+    "constant",
+    "constant.builtin",
+    "constant.builtin.boolean",
+    "constant.character",
+    "constant.character.escape",
+    "constant.numeric",
+    "constant.numeric.integer",
+    "constant.numeric.float",
+    "string",
+    "string.regexp",
+    "string.special",
+    "string.special.path",
+    "string.special.url",
+    "string.special.symbol",
+    "comment",
+    "comment.line",
+    "comment.line.documentation",
+    "comment.block",
+    "comment.block.documentation",
+    "comment.unused",
+    "variable",
+    "variable.builtin",
+    "variable.parameter",
+    "variable.other",
+    "variable.other.member",
+    "variable.other.member.private",
+    "label",
+    "punctuation",
+    "punctuation.delimiter",
+    "punctuation.bracket",
+    "punctuation.special",
+    "keyword",
+    "keyword.control",
+    "keyword.control.conditional",
+    "keyword.control.repeat",
+    "keyword.control.import",
+    "keyword.control.return",
+    "keyword.control.exception",
+    "keyword.operator",
+    "keyword.directive",
+    "keyword.function",
+    "keyword.storage",
+    "keyword.storage.type",
+    "keyword.storage.modifier",
+    "operator",
+    "function",
+    "function.builtin",
+    "function.method",
+    "function.method.private",
+    "function.macro",
+    "function.special",
+    "tag",
+    "tag.builtin",
+    "namespace",
+    "special",
+    "markup",
+    "markup.heading",
+    "markup.heading.marker",
+    "markup.heading.h1",
+    "markup.heading.h2",
+    "markup.heading.h3",
+    "markup.heading.h4",
+    "markup.heading.h5",
+    "markup.heading.h6",
+    "markup.list",
+    "markup.list.unnumbered",
+    "markup.list.numbered",
+    "markup.list.checked",
+    "markup.list.unchecked",
+    "markup.bold",
+    "markup.italic",
+    "markup.strikethrough",
+    "markup.link",
+    "markup.link.url",
+    "markup.link.label",
+    "markup.link.text",
+    "markup.quote",
+    "markup.raw",
+    "markup.raw.inline",
+    "markup.raw.block",
+    "diff",
+    "diff.plus",
+    "diff.plus.gutter",
+    "diff.minus",
+    "diff.minus.gutter",
+    "diff.delta",
+    "diff.delta.moved",
+    "diff.delta.conflict",
+    "diff.delta.gutter",
+];

--- a/flake.nix
+++ b/flake.nix
@@ -147,6 +147,7 @@
             inputsFrom = [ typst ];
 
             buildInputs = [
+              pkgs.cmake
               rust-toolchain.rust-analyzer
               rust-toolchain.rust-src
             ];


### PR DESCRIPTION
Typst uses [`syntect`](https://github.com/trishume/syntect) for syntax highlighting. This PR additionally adds support for syntax highlighting with tree-sitter. Tree-sitter has several advantages over the current approach:

- Far more customizable and integrated with the typst ecosystem. Users can create themes for tree-sitter directly inside of Typst, without having to learn a separate `.tmTheme` XML format. Users can publish themes and grammars on the Typst Universe.
- **Much** better syntax highlighting, as you'll see below. One example: if a variable is a parameter to the function, tree-sitter can highlight it differently.
- Better language support. languages like HTML or Svelte that can contain many sub-languages (CSS, JS). Tree-sitter deals with these injected languages flawlessly

| `syntect` (current) | `tree-sitter` (This PR) |
|:-------:|:------:|
| <img width="1196" height="1225" alt="image" src="https://github.com/user-attachments/assets/9b1b066d-29d2-4868-9381-38c94938dd10" /> | <img width="1213" height="1221" alt="image" src="https://github.com/user-attachments/assets/3e2d9558-e508-4147-a806-551c900a6239" /> |

The code for the above preview is here:

<details>

<summary>

Code

</summary>

`````rust
#let catppuccin_mocha = (
  "rainbow.0": rgb("#f38ba8"),
  "rainbow.1": rgb("#fab387"),
  "rainbow.2": rgb("#f9e2af"),
  "rainbow.3": rgb("#a6e3a1"),
  "rainbow.4": rgb("#74c7ec"),
  "rainbow.5": rgb("#b4befe"),
  "attribute": rgb("#f9e2af"),
  "comment": (
    foreground: rgb("#9399b2"),
    italic: true,
  ),
  "constant": rgb("#fab387"),
  "constant.character": rgb("#94e2d5"),
  "constant.character.escape": rgb("#f5c2e7"),
  "constructor": rgb("#74c7ec"),
  "diagnostic.error": (
    underline: rgb("#f38ba8"),
  ),
  "diagnostic.hint": (
    underline: rgb("#94e2d5"),
  ),
  "diagnostic.info": (
    underline: rgb("#89dceb"),
  ),
  "diagnostic.warning": (
    underline: rgb("#f9e2af"),
  ),
  "diff.delta": rgb("#89b4fa"),
  "diff.minus": rgb("#f38ba8"),
  "diff.plus": rgb("#a6e3a1"),
  "error": rgb("#f38ba8"),
  "function": rgb("#89b4fa"),
  "function.macro": rgb("#f5e0dc"),
  "hint": rgb("#94e2d5"),
  "info": rgb("#89dceb"),
  "keyword": rgb("#cba6f7"),
  "keyword.control.conditional": (
    foreground: rgb("#cba6f7"),
    italic: true,
  ),
  "label": rgb("#74c7ec"),
  "markup.bold": (
    foreground: rgb("#f38ba8"),
    bold: true,
  ),
  "markup.heading.1": rgb("#f38ba8"),
  "markup.heading.2": rgb("#fab387"),
  "markup.heading.3": rgb("#f9e2af"),
  "markup.heading.4": rgb("#a6e3a1"),
  "markup.heading.5": rgb("#74c7ec"),
  "markup.heading.6": rgb("#b4befe"),
  "markup.italic": (
    foreground: rgb("#f38ba8"),
    italic: true,
  ),
  "markup.link.label": rgb("#74c7ec"),
  "markup.link.text": rgb("#b4befe"),
  "markup.link.url": (
    foreground: rgb("#89b4fa"),
    italic: true,
  ),
  "markup.list": rgb("#94e2d5"),
  "markup.list.checked": rgb("#a6e3a1"),
  "markup.list.unchecked": rgb("#9399b2"),
  "markup.quote": rgb("#f5c2e7"),
  "markup.raw": rgb("#a6e3a1"),
  "namespace": (
    foreground: rgb("#f9e2af"),
    italic: true,
  ),
  "operator": rgb("#89dceb"),
  "punctuation": rgb("#9399b2"),
  "punctuation.special": rgb("#89dceb"),
  "special": rgb("#89b4fa"),
  "string": rgb("#a6e3a1"),
  "string.regexp": rgb("#f5c2e7"),
  "string.special": rgb("#89b4fa"),
  "string.special.symbol": rgb("#f38ba8"),
  "tag": rgb("#89b4fa"),
  "type": rgb("#f9e2af"),
  "type.enum.variant": rgb("#94e2d5"),
  "ui.background": (
    foreground: rgb("#cdd6f4"),
    background: rgb("#1e1e2e"),
  ),
  "ui.bufferline": (
    foreground: rgb("#a6adc8"),
    background: rgb("#181825"),
  ),
  "ui.bufferline.active": (
    foreground: rgb("#cba6f7"),
    background: rgb("#1e1e2e"),
    underline: rgb("#cba6f7"),
  ),
  "ui.bufferline.background": (
    background: rgb("#11111b"),
  ),
  "ui.cursor": (
    foreground: rgb("#1e1e2e"),
    background: rgb("#b5a6a8"),
  ),
  "ui.cursor.insert": (
    foreground: rgb("#1e1e2e"),
    background: rgb("#7ea87f"),
  ),
  "ui.cursor.match": (
    foreground: rgb("#fab387"),
    bold: true,
  ),
  "ui.cursor.normal": (
    foreground: rgb("#1e1e2e"),
    background: rgb("#b5a6a8"),
  ),
  "ui.cursor.primary": (
    foreground: rgb("#1e1e2e"),
    background: rgb("#f5e0dc"),
  ),
  "ui.cursor.primary.insert": (
    foreground: rgb("#1e1e2e"),
    background: rgb("#a6e3a1"),
  ),
  "ui.cursor.primary.normal": (
    foreground: rgb("#1e1e2e"),
    background: rgb("#f5e0dc"),
  ),
  "ui.cursor.primary.select": (
    foreground: rgb("#1e1e2e"),
    background: rgb("#b4befe"),
  ),
  "ui.cursor.select": (
    foreground: rgb("#1e1e2e"),
    background: rgb("#878ec0"),
  ),
  "ui.cursorline.primary": (
    background: rgb("#2a2b3c"),
  ),
  "ui.help": (
    foreground: rgb("#9399b2"),
    background: rgb("#313244"),
  ),
  "ui.highlight": (
    background: rgb("#45475a"),
    bold: true,
  ),
  "ui.linenr": rgb("#45475a"),
  "ui.linenr.selected": rgb("#b4befe"),
  "ui.menu": (
    foreground: rgb("#9399b2"),
    background: rgb("#313244"),
  ),
  "ui.menu.selected": (
    foreground: rgb("#cdd6f4"),
    background: rgb("#45475a"),
    bold: true,
  ),
  "ui.popup": (
    foreground: rgb("#cdd6f4"),
    background: rgb("#313244"),
  ),
  "ui.selection": (
    background: rgb("#45475a"),
  ),
  "ui.statusline": (
    foreground: rgb("#bac2de"),
    background: rgb("#181825"),
  ),
  "ui.statusline.inactive": (
    foreground: rgb("#585b70"),
    background: rgb("#181825"),
  ),
  "ui.statusline.insert": (
    foreground: rgb("#1e1e2e"),
    background: rgb("#a6e3a1"),
    bold: true,
  ),
  "ui.statusline.normal": (
    foreground: rgb("#1e1e2e"),
    background: rgb("#f5e0dc"),
    bold: true,
  ),
  "ui.statusline.select": (
    foreground: rgb("#1e1e2e"),
    background: rgb("#b4befe"),
    bold: true,
  ),
  "ui.text": rgb("#cdd6f4"),
  "ui.text.directory": rgb("#89b4fa"),
  "ui.text.focus": (
    foreground: rgb("#cdd6f4"),
    background: rgb("#313244"),
    bold: true,
  ),
  "ui.text.inactive": rgb("#7f849c"),
  "ui.virtual": rgb("#6c7086"),
  "ui.virtual.indent-guide": rgb("#313244"),
  "ui.virtual.inlay-hint": (
    foreground: rgb("#45475a"),
    background: rgb("#181825"),
  ),
  "ui.virtual.jump-label": (
    foreground: rgb("#f5e0dc"),
    bold: true,
  ),
  "ui.virtual.ruler": (
    background: rgb("#313244"),
  ),
  "ui.window": rgb("#11111b"),
  "variable": rgb("#cdd6f4"),
  "variable.builtin": rgb("#f38ba8"),
  "variable.other.member": rgb("#94e2d5"),
  "variable.parameter": (
    foreground: rgb("#eba0ac"),
    italic: true,
  ),
  "warning": rgb("#f9e2af"),
)

#set raw(
  tree-sitter-syntaxes: (
    grammar: "rust/tree-sitter-rust.wasm",
    name: "rust",
    // aliases: ("rs",),
    highlights-query: "rust/highlights.scm",
    injections-query: "rust/injections.scm",
    locals-query: "rust/locals.scm",
  ),
  tree-sitter-theme: catppuccin_mocha,
)

#set text(rgb("#dddddd"))
#set page(fill: rgb("#131313"))

```rust
impl<T: Clone> ConvertVec for T {
    #[inline]
    default fn to_vec<A: Allocator>(s: &[Self], alloc: A) -> Vec<Self, A> {
        struct DropGuard<'a, T, A: Allocator> {
            vec: &'a mut Vec<T, A>,
            num_init: usize,
        }
        impl<'a, T, A: Allocator> Drop for DropGuard<'a, T, A> {
            #[inline]
            fn drop(&mut self) {
                // SAFETY:
                // items were marked initialized in the loop below
                unsafe {
                    self.vec.set_len(self.num_init);
                }
            }
        }
        let mut vec = Vec::with_capacity_in(s.len(), alloc);
        let mut guard = DropGuard { vec: &mut vec, num_init: 0 };
        let slots = guard.vec.spare_capacity_mut();
        // .take(slots.len()) is necessary for LLVM to remove bounds checks
        // and has better codegen than zip.
        for (i, b) in s.iter().enumerate().take(slots.len()) {
            guard.num_init = i;
            slots[i].write(b.clone());
        }
        core::mem::forget(guard);
        // SAFETY:
        // the vec was allocated and initialized above to at least this length.
        unsafe {
            vec.set_len(s.len());
        }
        vec
    }
}
```
`````

The `tree-sitter-rust.wasm` file is compiled with `tree-sitter build --wasm` against https://github.com/tree-sitter/tree-sitter-rust/tree/261b20226c04ef601adbdf185a800512a5f66291

The query files `*.scm` were obtained from https://github.com/helix-editor/helix/tree/a79292b630ae4a0e6e37814ad21411ab50926c73/runtime/queries/rust

</details>

# How it works

`raw` now accepts 2 new keys:
- `tree-sitter-syntaxes` to specify tree-sitter syntaxes to load. It is a dictionary (or list of dictionaries) with these keys:
    - `grammar`: Either `bytes` or path to a `.wasm` file containing the compiled tree-sitter grammar
    - `name`: A string specifying name of the grammar
    - `aliases`: An array of strings that also reference this grammar. This will be used in code blocks, ````` ```rs ````` and ````` ```rust ````` can both load the `rust` language
    - `highlights-query`: Either `bytes` or path to a `highlights.scm` query file that defines which tree-sitter nodes will be syntax highlighted
    - `injections-query`: Either `bytes` or path to a `injections.scm` query file that defines which language injections. This is useful when there are nested languages, for example in HTML you can have nested CSS and JS.
    - `locals-query`: Either `bytes` or path to a `locals.scm` file that defines which locals to keep track of. Also used in syntax highlighting, this allows for example tracking which identifiers come from the arguments of a function and color them differently
 - `tree-sitter-theme` Is a Dictionary of dictionaries, where each one specifies how to highlight a particular tree-sitter node:
     - `foreground` is Color
     - `background` is Color
     - `underline` is Color
     - `bold` is a boolean
     - `italic` is a boolean

# How to obtain tree-sitter themes and grammar configs 

The Helix editor provides the largest collection of themes and grammar configs.

This PR is fully compatible with all of the hundreds of languages *and* themes supported by Helix.
Helix Editor stores its themes in the `.toml` format, and I have written a tiny script that gives you a Typst `#let <theme> = ...`
code that you can put into your project.

When you copy this script as `helix-themes.rs`, run this command:

```rust
cargo +nightly -Zscript helix-theme.rs catppuccin_mocha
```

This fetches the [`catppuccin_mocha.toml`](https://github.com/helix-editor/helix/blob/master/runtime/themes/catppuccin_mocha.toml) theme from the Helix repository
and converts it into something that Typst understands.

<details>

<summary>

</summary>

`````rust
---
package.edition = "2024"

[dependencies]
serde = { version = "1.0", features = ["derive"] }
toml = "0.9"
bitflags = "2.10"
syntect = "5.3"
ureq = "3.1"
anstream = "0.6"
---

use serde::{Deserialize, Deserializer};
use std::collections::HashMap;
use std::fmt::Write;
use toml::{map::Map, Value};

fn merge_themes(parent_theme_toml: Value, theme_toml: Value) -> Value {
    let parent_palette = parent_theme_toml.get("palette");
    let palette = theme_toml.get("palette");

    // handle the table separately since it needs a `merge_depth` of 2
    // this would conflict with the rest of the theme merge strategy
    let palette_values = match (parent_palette, palette) {
        (Some(parent_palette), Some(palette)) => {
            merge_toml_values(parent_palette.clone(), palette.clone(), 2)
        }
        (Some(parent_palette), None) => parent_palette.clone(),
        (None, Some(palette)) => palette.clone(),
        (None, None) => Map::new().into(),
    };

    // add the palette correctly as nested table
    let mut palette = Map::new();
    palette.insert(String::from("palette"), palette_values);

    // merge the theme into the parent theme
    let theme = merge_toml_values(parent_theme_toml, theme_toml, 1);
    // merge the before specially handled palette into the theme
    merge_toml_values(theme, palette.into(), 1)
}

pub fn merge_toml_values(left: toml::Value, right: toml::Value, merge_depth: usize) -> toml::Value {
    use toml::Value;

    fn get_name(v: &Value) -> Option<&str> {
        v.get("name").and_then(Value::as_str)
    }

    match (left, right) {
        (Value::Array(mut left_items), Value::Array(right_items)) => {
            if merge_depth > 0 {
                left_items.reserve(right_items.len());
                for rvalue in right_items {
                    let lvalue = get_name(&rvalue)
                        .and_then(|rname| {
                            left_items.iter().position(|v| get_name(v) == Some(rname))
                        })
                        .map(|lpos| left_items.remove(lpos));
                    let mvalue = match lvalue {
                        Some(lvalue) => merge_toml_values(lvalue, rvalue, merge_depth - 1),
                        None => rvalue,
                    };
                    left_items.push(mvalue);
                }
                Value::Array(left_items)
            } else {
                Value::Array(right_items)
            }
        }
        (Value::Table(mut left_map), Value::Table(right_map)) => {
            if merge_depth > 0 {
                for (rname, rvalue) in right_map {
                    match left_map.remove(&rname) {
                        Some(lvalue) => {
                            let merged_value = merge_toml_values(lvalue, rvalue, merge_depth - 1);
                            left_map.insert(rname, merged_value);
                        }
                        None => {
                            left_map.insert(rname, rvalue);
                        }
                    }
                }
                Value::Table(left_map)
            } else {
                Value::Table(right_map)
            }
        }
        // Catch everything else we didn't handle, and use the right value
        (_, value) => value,
    }
}

fn load_theme(theme_name: &str) -> Value {
    let theme_toml = load_theme_toml(theme_name);

    if let Some(parent_theme_name) = theme_toml.get("inherits") {
        let parent_theme_name = parent_theme_name.as_str().unwrap();
        let parent_theme_toml = load_theme(parent_theme_name);
        merge_themes(parent_theme_toml, theme_toml)
    } else {
        theme_toml
    }
}

fn load_theme_toml(theme_name: &str) -> Value {
    let url = format!(
            "https://raw.githubusercontent.com/helix-editor/helix/a79292b630ae4a0e6e37814ad21411ab50926c73/runtime/themes/{theme_name}.toml",
        );

    let theme = ureq::get(url)
        .call()
        .unwrap()
        .body_mut()
        .read_to_string()
        .unwrap();

    let value = toml::from_str(&theme).unwrap();

    value
}

fn main() {
    let theme_name = std::env::args()
        .skip(1)
        .next()
        .expect("provide name of helix theme as argument");

    let theme_toml = load_theme(&theme_name);

    let Value::Table(table) = theme_toml else {
        panic!()
    };
    let theme = Theme::from_keys(table).0;

    let mut s = String::new();

    writeln!(s, "#let {theme_name} = (");
    for (scope, highlight) in std::iter::zip(theme.scopes, theme.highlights) {
        write!(s, r#"  "{scope}": "#);

        let mut modifier = Modifier::empty();
        modifier.insert(highlight.add_modifier);
        modifier.remove(highlight.sub_modifier);

        let resolve = |color| {
            let (r, g, b) = if let Color::Rgb(r, g, b) = color {
                (r, g, b)
            } else {
                (0, 0, 0)
            };
            format!(r##"rgb("#{r:02x}{g:02x}{b:02x}")"##)
        };
        let fg = highlight.fg.map(resolve);
        let bg = highlight.bg.map(resolve);
        let underline_color = highlight.underline_color.map(resolve);

        if bg.is_none()
            && highlight.underline_color.is_none()
            && highlight.underline_style.is_none()
            && modifier.is_empty()
            && let Some(fg) = fg
        {
            // Just the color. Use simpler syntax
            writeln!(s, "{fg},");
        } else {
            writeln!(s, "(");
            if let Some(fg) = fg {
                writeln!(s, "    foreground: {fg},");
            }
            if let Some(bg) = bg {
                writeln!(s, "    background: {bg},");
            }
            if modifier.contains(Modifier::BOLD) {
                writeln!(s, "    bold: true,");
            }
            if let Some(color) = underline_color
                && highlight.underline_style.is_some()
            {
                writeln!(s, "    underline: {color},");
            }
            if modifier.contains(Modifier::ITALIC) {
                writeln!(s, "    italic: true,");
            }
            writeln!(s, "  ),");
        }
    }
    writeln!(s, ")");

    use syntect::easy::HighlightLines;
    use syntect::highlighting::{Style, ThemeSet};
    use syntect::parsing::SyntaxSet;
    use syntect::util::{as_24_bit_terminal_escaped, LinesWithEndings};

    let ps = SyntaxSet::load_defaults_newlines();
    let ts = ThemeSet::load_defaults();

    let syntax = ps.find_syntax_by_extension("rs").unwrap();
    let mut h = HighlightLines::new(syntax, &ts.themes["base16-ocean.dark"]);
    let mut output = String::new();
    for line in LinesWithEndings::from(&s) {
        // LinesWithEndings enables use of newlines mode
        let ranges: Vec<(Style, &str)> = h.highlight_line(line, &ps).unwrap();
        let escaped = as_24_bit_terminal_escaped(&ranges[..], true);
        write!(output, "{}", escaped);
    }
    anstream::println!("{output}");
}

#[derive(Clone, Debug, Default)]
pub struct Theme {
    pub name: String,
    // UI styles are stored in a HashMap
    pub styles: HashMap<String, Style>,
    // tree-sitter highlight styles are stored in a Vec to optimize lookups
    pub scopes: Vec<String>,
    pub highlights: Vec<Style>,
    pub rainbow_length: usize,
}

impl Theme {
    fn from_keys(toml_keys: Map<String, Value>) -> (Self, Vec<String>) {
        let (styles, scopes, highlights, rainbow_length, load_errors) =
            build_theme_values(toml_keys);

        let theme = Self {
            styles,
            scopes,
            highlights,
            rainbow_length,
            ..Default::default()
        };
        (theme, load_errors)
    }
}

impl<'de> Deserialize<'de> for Theme {
    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
    where
        D: Deserializer<'de>,
    {
        let values = toml::map::Map::<String, toml::Value>::deserialize(deserializer)?;
        let (theme, warnings) = Theme::from_keys(values);
        if !warnings.is_empty() {
            panic!("{warnings:?}");
        }
        Ok(theme)
    }
}

#[derive(Debug, Clone, Copy, PartialEq, Eq)]
pub struct Style {
    pub fg: Option<Color>,
    pub bg: Option<Color>,
    pub underline_color: Option<Color>,
    pub underline_style: Option<UnderlineStyle>,
    pub add_modifier: Modifier,
    pub sub_modifier: Modifier,
}

impl From<Color> for syntect::highlighting::Color {
    fn from(value: Color) -> Self {
        let Color::Rgb(r, g, b) = value else {
            panic!("expected `Color::Rgb`")
        };
        syntect::highlighting::Color { r, g, b, a: 255 }
    }
}

impl From<Style> for syntect::highlighting::Style {
    fn from(value: Style) -> Self {
        syntect::highlighting::Style {
            foreground: value.fg.unwrap_or(Color::Rgb(255, 0, 0)).into(),
            background: value.bg.unwrap_or(Color::Rgb(255, 0, 0)).into(),
            font_style: {
                let mut style = syntect::highlighting::FontStyle::default();

                if value.underline_style.is_some() {
                    style.insert(syntect::highlighting::FontStyle::UNDERLINE);
                }

                let mut modifier = Modifier::empty();
                modifier.insert(value.add_modifier);
                modifier.remove(value.sub_modifier);

                if modifier.contains(Modifier::BOLD) {
                    style.insert(syntect::highlighting::FontStyle::BOLD)
                }

                if modifier.contains(Modifier::ITALIC) {
                    style.insert(syntect::highlighting::FontStyle::ITALIC)
                }

                style
            },
        }
    }
}

#[derive(Debug, Clone, Copy, PartialEq, Eq)]
pub enum Color {
    Reset,
    Black,
    Red,
    Green,
    Yellow,
    Blue,
    Magenta,
    Cyan,
    Gray,
    LightRed,
    LightGreen,
    LightYellow,
    LightBlue,
    LightMagenta,
    LightCyan,
    LightGray,
    White,
    Rgb(u8, u8, u8),
    Indexed(u8),
}

impl Default for Color {
    fn default() -> Self {
        Self::Rgb(0, 0, 0)
    }
}

#[derive(Debug, Clone, Copy, PartialEq, Eq)]
pub enum UnderlineStyle {
    Reset,
    Line,
    Curl,
    Dotted,
    Dashed,
    DoubleLine,
}

bitflags::bitflags! {
    /// Modifier changes the way a piece of text is displayed.
    ///
    /// They are bitflags so they can easily be composed.
    ///
    /// ## Examples
    ///
    /// ```rust
    /// # use helix_view::graphics::Modifier;
    ///
    /// let m = Modifier::BOLD | Modifier::ITALIC;
    /// ```
    #[derive(PartialEq, Eq, Debug, Clone, Copy)]
    pub struct Modifier: u16 {
        const BOLD              = 0b0000_0000_0001;
        const DIM               = 0b0000_0000_0010;
        const ITALIC            = 0b0000_0000_0100;
        const SLOW_BLINK        = 0b0000_0001_0000;
        const RAPID_BLINK       = 0b0000_0010_0000;
        const REVERSED          = 0b0000_0100_0000;
        const HIDDEN            = 0b0000_1000_0000;
        const CROSSED_OUT       = 0b0001_0000_0000;
    }
}

#[allow(clippy::type_complexity)]
fn build_theme_values(
    mut values: Map<String, Value>,
) -> (
    HashMap<String, Style>,
    Vec<String>,
    Vec<Style>,
    usize,
    Vec<String>,
) {
    let mut styles = HashMap::new();
    let mut scopes = Vec::new();
    let mut highlights = Vec::new();
    let mut rainbow_length = 0;

    let mut warnings = Vec::new();

    // TODO: alert user of parsing failures in editor
    let palette = values
        .remove("palette")
        .map(|value| {
            ThemePalette::try_from(value).unwrap_or_else(|err| {
                warnings.push(err);
                ThemePalette::default()
            })
        })
        .unwrap_or_default();
    // remove inherits from value to prevent errors
    let _ = values.remove("inherits");
    styles.reserve(values.len());
    scopes.reserve(values.len());
    highlights.reserve(values.len());

    for (i, style) in values
        .remove("rainbow")
        .and_then(|value| match palette.parse_style_array(value) {
            Ok(styles) => Some(styles),
            Err(err) => {
                warnings.push(err);
                None
            }
        })
        .unwrap_or_else(default_rainbow)
        .into_iter()
        .enumerate()
    {
        let name = format!("rainbow.{i}");
        styles.insert(name.clone(), style);
        scopes.push(name);
        highlights.push(style);
        rainbow_length += 1;
    }

    for (name, style_value) in values {
        let mut style = Style::default();
        if let Err(err) = palette.parse_style(&mut style, style_value) {
            warnings.push(format!("Failed to parse style for key {name:?}. {err}"));
        }

        // these are used both as UI and as highlights
        styles.insert(name.clone(), style);
        scopes.push(name);
        highlights.push(style);
    }

    (styles, scopes, highlights, rainbow_length, warnings)
}

struct ThemePalette {
    palette: HashMap<String, Color>,
}

impl Default for ThemePalette {
    fn default() -> Self {
        Self {
            palette: hashmap! {
                "default".to_string() => Color::Reset,
                "black".to_string() => Color::Black,
                "red".to_string() => Color::Red,
                "green".to_string() => Color::Green,
                "yellow".to_string() => Color::Yellow,
                "blue".to_string() => Color::Blue,
                "magenta".to_string() => Color::Magenta,
                "cyan".to_string() => Color::Cyan,
                "gray".to_string() => Color::Gray,
                "light-red".to_string() => Color::LightRed,
                "light-green".to_string() => Color::LightGreen,
                "light-yellow".to_string() => Color::LightYellow,
                "light-blue".to_string() => Color::LightBlue,
                "light-magenta".to_string() => Color::LightMagenta,
                "light-cyan".to_string() => Color::LightCyan,
                "light-gray".to_string() => Color::LightGray,
                "white".to_string() => Color::White,
            },
        }
    }
}

impl ThemePalette {
    pub fn new(palette: HashMap<String, Color>) -> Self {
        let ThemePalette {
            palette: mut default,
        } = ThemePalette::default();

        default.extend(palette);
        Self { palette: default }
    }

    pub fn string_to_rgb(s: &str) -> Result<Color, String> {
        if s.starts_with('#') {
            Self::hex_string_to_rgb(s)
        } else {
            Self::ansi_string_to_rgb(s)
        }
    }

    fn ansi_string_to_rgb(s: &str) -> Result<Color, String> {
        if let Ok(index) = s.parse::<u8>() {
            return Ok(Color::Indexed(index));
        }
        Err(format!("Malformed ANSI: {}", s))
    }

    fn hex_string_to_rgb(s: &str) -> Result<Color, String> {
        if s.len() >= 7 {
            if let (Ok(red), Ok(green), Ok(blue)) = (
                u8::from_str_radix(&s[1..3], 16),
                u8::from_str_radix(&s[3..5], 16),
                u8::from_str_radix(&s[5..7], 16),
            ) {
                return Ok(Color::Rgb(red, green, blue));
            }
        }

        Err(format!("Malformed hexcode: {}", s))
    }

    fn parse_value_as_str(value: &Value) -> Result<&str, String> {
        value
            .as_str()
            .ok_or(format!("Unrecognized value: {}", value))
    }

    pub fn parse_color(&self, value: Value) -> Result<Color, String> {
        let value = Self::parse_value_as_str(&value)?;

        self.palette
            .get(value)
            .copied()
            .ok_or("")
            .or_else(|_| Self::string_to_rgb(value))
    }

    pub fn parse_modifier(value: &Value) -> Result<Modifier, String> {
        value
            .as_str()
            .and_then(|s| s.parse().ok())
            .ok_or(format!("Invalid modifier: {}", value))
    }

    pub fn parse_underline_style(value: &Value) -> Result<UnderlineStyle, String> {
        value
            .as_str()
            .and_then(|s| s.parse().ok())
            .ok_or(format!("Invalid underline style: {}", value))
    }

    pub fn parse_style(&self, style: &mut Style, value: Value) -> Result<(), String> {
        if let Value::Table(entries) = value {
            for (name, mut value) in entries {
                match name.as_str() {
                    "fg" => *style = style.fg(self.parse_color(value)?),
                    "bg" => *style = style.bg(self.parse_color(value)?),
                    "underline" => {
                        let table = value.as_table_mut().ok_or("Underline must be table")?;
                        if let Some(value) = table.remove("color") {
                            *style = style.underline_color(self.parse_color(value)?);
                        }
                        if let Some(value) = table.remove("style") {
                            *style = style.underline_style(Self::parse_underline_style(&value)?);
                        }

                        if let Some(attr) = table.keys().next() {
                            return Err(format!("Invalid underline attribute: {attr}"));
                        }
                    }
                    "modifiers" => {
                        let modifiers = value.as_array().ok_or("Modifiers should be an array")?;

                        for modifier in modifiers {
                            if modifier.as_str() == Some("underlined") {
                                *style = style.underline_style(UnderlineStyle::Line);
                            } else {
                                *style = style.add_modifier(Self::parse_modifier(modifier)?);
                            }
                        }
                    }
                    _ => return Err(format!("Invalid style attribute: {}", name)),
                }
            }
        } else {
            *style = style.fg(self.parse_color(value)?);
        }
        Ok(())
    }

    fn parse_style_array(&self, value: Value) -> Result<Vec<Style>, String> {
        let mut styles = Vec::new();

        for v in value
            .as_array()
            .ok_or_else(|| format!("Could not parse value as an array: '{value}'"))?
        {
            let mut style = Style::default();
            self.parse_style(&mut style, v.clone())?;
            styles.push(style);
        }

        Ok(styles)
    }
}

impl TryFrom<Value> for ThemePalette {
    type Error = String;

    fn try_from(value: Value) -> Result<Self, Self::Error> {
        let map = match value {
            Value::Table(entries) => entries,
            _ => return Ok(Self::default()),
        };

        let mut palette = HashMap::with_capacity(map.len());
        for (name, value) in map {
            let value = Self::parse_value_as_str(&value)?;
            let color = Self::string_to_rgb(value)?;
            palette.insert(name, color);
        }

        Ok(Self::new(palette))
    }
}

macro_rules! hashmap {
    (@single $($x:tt)*) => (());
    (@count $($rest:expr),*) => (<[()]>::len(&[$(hashmap!(@single $rest)),*]));

    ($($key:expr => $value:expr,)+) => { hashmap!($($key => $value),+) };
    ($($key:expr => $value:expr),*) => {
        {
            let _cap = hashmap!(@count $($key),*);
            let mut _map = ::std::collections::HashMap::with_capacity(_cap);
            $(
                let _ = _map.insert($key, $value);
            )*
            _map
        }
    };
}
use hashmap;

fn default_rainbow() -> Vec<Style> {
    vec![
        Style::default().fg(Color::Red),
        Style::default().fg(Color::Yellow),
        Style::default().fg(Color::Green),
        Style::default().fg(Color::Blue),
        Style::default().fg(Color::Cyan),
        Style::default().fg(Color::Magenta),
    ]
}

impl Default for Style {
    fn default() -> Self {
        Self::new()
    }
}

impl Style {
    pub const fn new() -> Self {
        Style {
            fg: None,
            bg: None,
            underline_color: None,
            underline_style: None,
            add_modifier: Modifier::empty(),
            sub_modifier: Modifier::empty(),
        }
    }

    /// Returns a `Style` resetting all properties.
    pub const fn reset() -> Self {
        Self {
            fg: Some(Color::Reset),
            bg: Some(Color::Reset),
            underline_color: None,
            underline_style: None,
            add_modifier: Modifier::empty(),
            sub_modifier: Modifier::all(),
        }
    }

    /// Changes the foreground color.
    ///
    /// ## Examples
    ///
    /// ```rust
    /// # use helix_view::graphics::{Color, Style};
    /// let style = Style::default().fg(Color::Blue);
    /// let diff = Style::default().fg(Color::Red);
    /// assert_eq!(style.patch(diff), Style::default().fg(Color::Red));
    /// ```
    pub const fn fg(mut self, color: Color) -> Style {
        self.fg = Some(color);
        self
    }

    /// Changes the background color.
    ///
    /// ## Examples
    ///
    /// ```rust
    /// # use helix_view::graphics::{Color, Style};
    /// let style = Style::default().bg(Color::Blue);
    /// let diff = Style::default().bg(Color::Red);
    /// assert_eq!(style.patch(diff), Style::default().bg(Color::Red));
    /// ```
    pub const fn bg(mut self, color: Color) -> Style {
        self.bg = Some(color);
        self
    }

    /// Changes the underline color.
    ///
    /// ## Examples
    ///
    /// ```rust
    /// # use helix_view::graphics::{Color, Style};
    /// let style = Style::default().underline_color(Color::Blue);
    /// let diff = Style::default().underline_color(Color::Red);
    /// assert_eq!(style.patch(diff), Style::default().underline_color(Color::Red));
    /// ```
    pub const fn underline_color(mut self, color: Color) -> Style {
        self.underline_color = Some(color);
        self
    }

    /// Changes the underline style.
    ///
    /// ## Examples
    ///
    /// ```rust
    /// # use helix_view::graphics::{UnderlineStyle, Style};
    /// let style = Style::default().underline_style(UnderlineStyle::Line);
    /// let diff = Style::default().underline_style(UnderlineStyle::Curl);
    /// assert_eq!(style.patch(diff), Style::default().underline_style(UnderlineStyle::Curl));
    /// ```
    pub const fn underline_style(mut self, style: UnderlineStyle) -> Style {
        self.underline_style = Some(style);
        self
    }

    /// Changes the text emphasis.
    ///
    /// When applied, it adds the given modifier to the `Style` modifiers.
    ///
    /// ## Examples
    ///
    /// ```rust
    /// # use helix_view::graphics::{Color, Modifier, Style};
    /// let style = Style::default().add_modifier(Modifier::BOLD);
    /// let diff = Style::default().add_modifier(Modifier::ITALIC);
    /// let patched = style.patch(diff);
    /// assert_eq!(patched.add_modifier, Modifier::BOLD | Modifier::ITALIC);
    /// assert_eq!(patched.sub_modifier, Modifier::empty());
    /// ```
    pub fn add_modifier(mut self, modifier: Modifier) -> Style {
        self.sub_modifier.remove(modifier);
        self.add_modifier.insert(modifier);
        self
    }

    /// Changes the text emphasis.
    ///
    /// When applied, it removes the given modifier from the `Style` modifiers.
    ///
    /// ## Examples
    ///
    /// ```rust
    /// # use helix_view::graphics::{Color, Modifier, Style};
    /// let style = Style::default().add_modifier(Modifier::BOLD | Modifier::ITALIC);
    /// let diff = Style::default().remove_modifier(Modifier::ITALIC);
    /// let patched = style.patch(diff);
    /// assert_eq!(patched.add_modifier, Modifier::BOLD);
    /// assert_eq!(patched.sub_modifier, Modifier::ITALIC);
    /// ```
    pub fn remove_modifier(mut self, modifier: Modifier) -> Style {
        self.add_modifier.remove(modifier);
        self.sub_modifier.insert(modifier);
        self
    }

    /// Results in a combined style that is equivalent to applying the two individual styles to
    /// a style one after the other.
    ///
    /// ## Examples
    /// ```
    /// # use helix_view::graphics::{Color, Modifier, Style};
    /// let style_1 = Style::default().fg(Color::Yellow);
    /// let style_2 = Style::default().bg(Color::Red);
    /// let combined = style_1.patch(style_2);
    /// assert_eq!(
    ///     Style::default().patch(style_1).patch(style_2),
    ///     Style::default().patch(combined));
    /// ```
    pub fn patch(mut self, other: Style) -> Style {
        self.fg = other.fg.or(self.fg);
        self.bg = other.bg.or(self.bg);
        self.underline_color = other.underline_color.or(self.underline_color);
        self.underline_style = other.underline_style.or(self.underline_style);

        self.add_modifier.remove(other.sub_modifier);
        self.add_modifier.insert(other.add_modifier);
        self.sub_modifier.remove(other.add_modifier);
        self.sub_modifier.insert(other.sub_modifier);

        self
    }
}

impl std::str::FromStr for UnderlineStyle {
    type Err = &'static str;

    fn from_str(modifier: &str) -> Result<Self, Self::Err> {
        match modifier {
            "line" => Ok(Self::Line),
            "curl" => Ok(Self::Curl),
            "dotted" => Ok(Self::Dotted),
            "dashed" => Ok(Self::Dashed),
            "double_line" => Ok(Self::DoubleLine),
            _ => Err("Invalid underline style"),
        }
    }
}

impl std::str::FromStr for Modifier {
    type Err = &'static str;

    fn from_str(modifier: &str) -> Result<Self, Self::Err> {
        match modifier {
            "bold" => Ok(Self::BOLD),
            "dim" => Ok(Self::DIM),
            "italic" => Ok(Self::ITALIC),
            "slow_blink" => Ok(Self::SLOW_BLINK),
            "rapid_blink" => Ok(Self::RAPID_BLINK),
            "reversed" => Ok(Self::REVERSED),
            "hidden" => Ok(Self::HIDDEN),
            "crossed_out" => Ok(Self::CROSSED_OUT),
            _ => Err("Invalid modifier"),
        }
    }
}
`````

</details>

For every `.wasm` grammar, you'll also need these 3 files:

- `locals.scm`
- `highlights.scm`
- `injections.scm`

You can get these 3 files from the Helix repository as well, in the `runtime/queries/<lang>` directory.

# How to obtain tree-sitter `.wasm` files

Every tree-sitter grammar is loaded via a Web Assembly (WASM) file.

Go to any tree-sitter repository, like `git@github.com:tree-sitter/tree-sitter-rust.git`. Clone it, and run `tree-sitter build --wasm`. This produces a `.wasm` file that you can use.

For nix users:

<details>

<summary>

`flake.nix`

</summary>

```nix
{
  inputs = {
    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
    flake-parts.url = "github:hercules-ci/flake-parts";
    systems.url = "github:nix-systems/default";

    crane.url = "github:ipetkov/crane";
    fenix = {
      url = "github:nix-community/fenix";
      inputs.nixpkgs.follows = "nixpkgs";
    };
    rust-manifest = {
      url = "https://static.rust-lang.org/dist/channel-rust-1.91.0.toml";
      flake = false;
    };
  };

  outputs =
    inputs@{
      flake-parts,
      crane,
      nixpkgs,
      fenix,
      rust-manifest,
      self,
      ...
    }:
    flake-parts.lib.mkFlake { inherit inputs; } {
      systems = import inputs.systems;

      imports = [
        inputs.flake-parts.flakeModules.easyOverlay
      ];

      perSystem =
        {
          self',
          pkgs,
          lib,
          system,
          ...
        }:
        let
          cargoToml = lib.importTOML ./Cargo.toml;

          pname = "typst";
          version = cargoToml.workspace.package.version;

          rust-toolchain = fenix.packages.${system}.fromManifestFile rust-manifest;

          # Crane-based Nix flake configuration.
          # Based on https://github.com/ipetkov/crane/blob/master/examples/trunk-workspace/flake.nix
          craneLib = (crane.mkLib pkgs).overrideToolchain rust-toolchain.defaultToolchain;

          # Typst files to include in the derivation.
          # Here we include Rust files, docs and tests.
          src = lib.fileset.toSource {
            root = ./.;
            fileset = lib.fileset.unions [
              ./Cargo.toml
              ./Cargo.lock
              ./rustfmt.toml
              ./crates
              ./docs
              ./tests
            ];
          };

          # Typst derivation's args, used within crane's derivation generation
          # functions.
          commonCraneArgs = {
            inherit src pname version;

            buildInputs = [
              pkgs.openssl
            ];

            nativeBuildInputs = [
              pkgs.pkg-config
              pkgs.openssl.dev
            ];
          };

          # Derivation with just the dependencies, so we don't have to keep
          # re-building them.
          cargoArtifacts = craneLib.buildDepsOnly commonCraneArgs;

          typst = craneLib.buildPackage (
            commonCraneArgs
            // {
              inherit cargoArtifacts;

              nativeBuildInputs = commonCraneArgs.nativeBuildInputs ++ [
                pkgs.installShellFiles
              ];

              postInstall = ''
                installManPage crates/typst-cli/artifacts/*.1
                installShellCompletion \
                  crates/typst-cli/artifacts/typst.{bash,fish} \
                  --zsh crates/typst-cli/artifacts/_typst
              '';

              GEN_ARTIFACTS = "artifacts";
              TYPST_VERSION = cargoToml.workspace.package.version;
              TYPST_COMMIT_SHA = self.shortRev or "dirty";

              meta.mainProgram = "typst";
            }
          );
        in
        {
          formatter = pkgs.nixfmt-tree;

          packages = {
            default = typst;
            typst-dev = self'.packages.default;
          };

          overlayAttrs = builtins.removeAttrs self'.packages [ "default" ];

          apps.default = {
            type = "app";
            program = lib.getExe typst;
          };

          checks = {
            typst-fmt = craneLib.cargoFmt commonCraneArgs;
            typst-clippy = craneLib.cargoClippy (
              commonCraneArgs
              // {
                inherit cargoArtifacts;
                cargoClippyExtraArgs = "--workspace -- --deny warnings";
              }
            );
            typst-test = craneLib.cargoTest (
              commonCraneArgs
              // {
                inherit cargoArtifacts;
                cargoTestExtraArgs = "--workspace";
              }
            );
          };

          devShells.default = craneLib.devShell {
            checks = self'.checks;
            inputsFrom = [ typst ];

            buildInputs = [
              pkgs.cmake
              rust-toolchain.rust-analyzer
              rust-toolchain.rust-src
            ];

            RUST_SRC_PATH = "${rust-toolchain.rust-src}/lib/rustlib/src/rust/library";

            packages = [
              # A script for quickly running tests.
              # See https://github.com/typst/typst/blob/main/tests/README.md#making-an-alias
              (pkgs.writeShellScriptBin "testit" ''
                cargo test --workspace --test tests -- "$@"
              '')
            ];
          };
        };
    };
}
```

</details>

# Important notice about query and grammar compatibility

The 3 files `highlights.scm`, `injections.scm` and `locals.scm` must be configured for the same commit of a given grammar as its `.wasm` file was built.
Helix is currently at commit `a79292b630ae4a0e6e37814ad21411ab50926c73`. The [`languages.toml`](https://github.com/helix-editor/helix/blob/master/languages.toml) file mentions `rust` and `comment` language:

```toml
[[grammar]]
name = "rust"
source = { git = "https://github.com/tree-sitter/tree-sitter-rust", rev = "261b20226c04ef601adbdf185a800512a5f66291" }

[[grammar]]
name = "comment"
source = { git = "https://github.com/stsewd/tree-sitter-comment", rev = "aefcc2813392eb6ffe509aa0fc8b4e9b57413ee1" }
```

When you obtain the `runtime/queries/rust/injections.scm` and the other files at this Helix commit,
you must build the corresponding tree-sitter grammar exactly at the commit specified in `rev`.

So here, you'd do this:

```sh
git clone https://github.com/stsewd/tree-sitter-comment.git
cd tree-sitter-comment
git checkout aefcc2813392eb6ffe509aa0fc8b4e9b57413ee1
tree-sitter build --wasm

cd ..

git clone https://github.com/tree-sitter/tree-sitter-rust
cd tree-sitter-comment
git checkout 261b20226c04ef601adbdf185a800512a5f66291
tree-sitter build --wasm
```
