### PR TITLE
Update Rust nightly version used in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-05-10
+          toolchain: nightly-2025-10-28
       - uses: Swatinem/rust-cache@v2
       - run: cargo install --locked cargo-fuzz@0.12.0
       - run: cd tests/fuzz && cargo fuzz build --dev
@@ -112,6 +112,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           components: miri
-          toolchain: nightly-2025-05-10
+          toolchain: nightly-2025-10-28
       - uses: Swatinem/rust-cache@v2
       - run: cargo miri test -p typst-library test_miri


### PR DESCRIPTION
Followup to https://github.com/typst/typst/pull/7363 as the current nightly version is a bit outdated and doesn't suffice to compile the updated `krilla` version due to which the MSRV bump was done in the first place. 