### PR TITLE
Yeet `as_any` methods

### DIFF
--- a/crates/typst-library/src/foundations/bytes.rs
+++ b/crates/typst-library/src/foundations/bytes.rs
@@ -259,9 +259,10 @@ impl AddAssign for Bytes {
             // Nothing to do
         } else if self.is_empty() {
             *self = rhs;
-        } else if let Some(vec) = Arc::get_mut(&mut self.0)
-            .and_then(|unique| (&mut **unique as &mut dyn Any).downcast_mut::<Vec<u8>>())
-        {
+        } else if let Some(vec) = Arc::get_mut(&mut self.0).and_then(|unique| {
+            let inner: &mut dyn Bytelike = &mut **unique;
+            (inner as &mut dyn Any).downcast_mut::<Vec<u8>>()
+        }) {
             vec.extend_from_slice(&rhs);
         } else {
             *self = Self::new([self.as_slice(), rhs.as_slice()].concat());

--- a/crates/typst-library/src/foundations/styles.rs
+++ b/crates/typst-library/src/foundations/styles.rs
@@ -394,7 +394,8 @@ impl Block {
 
     /// Downcasts the block to the specified type.
     fn downcast<T: 'static>(&self, func: Element, id: u8) -> &T {
-        (&*self.0 as &dyn Any)
+        let inner: &dyn Blockable = &*self.0;
+        (inner as &dyn Any)
             .downcast_ref()
             .unwrap_or_else(|| block_wrong_type(func, id, self))
     }

--- a/crates/typst-library/src/foundations/value.rs
+++ b/crates/typst-library/src/foundations/value.rs
@@ -507,12 +507,14 @@ impl Dynamic {
 
     /// Whether the wrapped type is `T`.
     pub fn is<T: 'static>(&self) -> bool {
-        (&*self.0 as &dyn Any).is::<T>()
+        let inner: &dyn Bounds = &*self.0;
+        (inner as &dyn Any).is::<T>()
     }
 
     /// Try to downcast to a reference to a specific type.
     pub fn downcast<T: 'static>(&self) -> Option<&T> {
-        (&*self.0 as &dyn Any).downcast_ref()
+        let inner: &dyn Bounds = &*self.0;
+        (inner as &dyn Any).downcast_ref()
     }
 
     /// The name of the stored value's type.

--- a/crates/typst-library/src/introspection/convergence.rs
+++ b/crates/typst-library/src/introspection/convergence.rs
@@ -192,7 +192,8 @@ where
     }
 
     fn dyn_eq(&self, other: &Introspection) -> bool {
-        let Some(other) = (&*other.0 as &dyn Any).downcast_ref::<Self>() else {
+        let inner: &dyn Bounds = &*other.0;
+        let Some(other) = (inner as &dyn Any).downcast_ref::<Self>() else {
             return false;
         };
         self == other


### PR DESCRIPTION
Trait upcasting was stabilized in Rust 1.86.