### PR TITLE
Allow `clippy::derived_hash_with_manual_eq` globally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,3 +168,5 @@ manual_range_contains = "allow"
 mutable_key_type = "allow"
 uninlined_format_args = "warn"
 wildcard_in_or_patterns = "allow"
+# See https://github.com/typst/typst/pull/6560#issuecomment-3045393640
+derived_hash_with_manual_eq = "allow"

--- a/crates/typst-library/src/foundations/args.rs
+++ b/crates/typst-library/src/foundations/args.rs
@@ -41,7 +41,6 @@ use crate::foundations::{
 /// ```
 #[ty(scope, cast, name = "arguments")]
 #[derive(Clone, Hash)]
-#[allow(clippy::derived_hash_with_manual_eq)]
 pub struct Args {
     /// The callsite span for the function. This is not the span of the argument
     /// list itself, but of the whole function call.
@@ -392,7 +391,6 @@ impl Add for Args {
 
 /// An argument to a function call: `12` or `draw: false`.
 #[derive(Clone, Hash)]
-#[allow(clippy::derived_hash_with_manual_eq)]
 pub struct Arg {
     /// The span of the whole argument.
     pub span: Span,

--- a/crates/typst-library/src/foundations/bytes.rs
+++ b/crates/typst-library/src/foundations/bytes.rs
@@ -43,7 +43,6 @@ use crate::foundations::{Array, Reflect, Repr, Str, Value, cast, func, scope, ty
 /// ```
 #[ty(scope, cast)]
 #[derive(Clone, Hash)]
-#[allow(clippy::derived_hash_with_manual_eq)]
 pub struct Bytes(Arc<LazyHash<dyn Bytelike>>);
 
 impl Bytes {

--- a/crates/typst-library/src/foundations/func.rs
+++ b/crates/typst-library/src/foundations/func.rs
@@ -134,7 +134,6 @@ use crate::foundations::{
 /// called on.
 #[ty(scope, cast, name = "function")]
 #[derive(Clone, Hash)]
-#[allow(clippy::derived_hash_with_manual_eq)]
 pub struct Func {
     /// The internal representation.
     repr: Repr,

--- a/crates/typst-library/src/foundations/module.rs
+++ b/crates/typst-library/src/foundations/module.rs
@@ -47,7 +47,6 @@ use crate::foundations::{Content, Scope, Value, repr, ty};
 /// constructor]($dictionary/#constructor).
 #[ty(cast)]
 #[derive(Clone, Hash)]
-#[allow(clippy::derived_hash_with_manual_eq)]
 pub struct Module {
     /// The module's name.
     name: Option<EcoString>,

--- a/crates/typst-library/src/foundations/value.rs
+++ b/crates/typst-library/src/foundations/value.rs
@@ -494,7 +494,6 @@ impl<'de> Visitor<'de> for ValueVisitor {
 
 /// A value that is not part of the built-in enum.
 #[derive(Clone, Hash)]
-#[allow(clippy::derived_hash_with_manual_eq)]
 pub struct Dynamic(Arc<dyn Bounds>);
 
 impl Dynamic {

--- a/crates/typst-library/src/foundations/version.rs
+++ b/crates/typst-library/src/foundations/version.rs
@@ -24,7 +24,6 @@ use crate::foundations::{Repr, cast, func, repr, scope, ty};
 /// the [`array`] constructor.
 #[ty(scope, cast)]
 #[derive(Debug, Default, Clone, Hash)]
-#[allow(clippy::derived_hash_with_manual_eq)]
 pub struct Version(EcoVec<u32>);
 
 impl Version {

--- a/crates/typst-library/src/layout/container.rs
+++ b/crates/typst-library/src/layout/container.rs
@@ -500,7 +500,6 @@ mod callbacks {
     macro_rules! callback {
         ($name:ident = ($($param:ident: $param_ty:ty),* $(,)?) -> $ret:ty) => {
             #[derive(Debug, Clone, Hash)]
-            #[allow(clippy::derived_hash_with_manual_eq)]
             pub struct $name {
                 captured: Content,
                 f: fn(&Content, $($param_ty),*) -> $ret,

--- a/crates/typst-library/src/text/raw.rs
+++ b/crates/typst-library/src/text/raw.rs
@@ -525,10 +525,6 @@ impl PlainText for Packed<RawElem> {
 
 /// The content of the raw text.
 #[derive(Debug, Clone, Hash)]
-#[allow(
-    clippy::derived_hash_with_manual_eq,
-    reason = "https://github.com/typst/typst/pull/6560#issuecomment-3045393640"
-)]
 pub enum RawContent {
     /// From a string.
     Text(EcoString),

--- a/crates/typst-macros/src/elem.rs
+++ b/crates/typst-macros/src/elem.rs
@@ -297,7 +297,6 @@ fn create_struct(element: &Elem) -> TokenStream {
     quote! {
         #[doc = #docs]
         #[derive(Hash, #debug Clone)]
-        #[allow(clippy::derived_hash_with_manual_eq)]
         #[allow(rustdoc::broken_intra_doc_links)]
         #vis struct #ident {
             #(#fields,)*


### PR DESCRIPTION
This is used in various places. See https://github.com/typst/typst/pull/6560#issuecomment-3045393640 for details on why we do this.