### PR TITLE
Improve error for incomplete datetime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3164,6 +3164,7 @@ dependencies = [
 name = "typst-library"
 version = "0.14.0"
 dependencies = [
+ "arrayvec",
  "az",
  "bitflags 2.9.1",
  "bumpalo",

--- a/crates/typst-library/Cargo.toml
+++ b/crates/typst-library/Cargo.toml
@@ -18,6 +18,7 @@ typst-macros = { workspace = true }
 typst-syntax = { workspace = true }
 typst-timing = { workspace = true }
 typst-utils = { workspace = true }
+arrayvec = { workspace = true }
 az = { workspace = true }
 bitflags = { workspace = true }
 bumpalo = { workspace = true }

--- a/tests/suite/foundations/datetime.typ
+++ b/tests/suite/foundations/datetime.typ
@@ -1,7 +1,7 @@
 --- datetime-constructor-empty paged ---
 // Error: 2-12 at least one of date or time must be fully specified
-// Hint: 2-12 add arguments `hour`, `minute`, and `second` to get a valid time
-// Hint: 2-12 add arguments `year`, `month`, and `day` to get a valid date
+// Hint: 2-12 add the `hour`, `minute`, and `second` arguments to get a valid time
+// Hint: 2-12 add the `year`, `month`, and `day` arguments to get a valid date
 #datetime()
 
 --- datetime-constructor-time-invalid paged ---
@@ -76,22 +76,22 @@
 
 --- datetime-incomplete-time-1 paged ---
 // Error: 2-34 time is incomplete
-// Hint: 2-34 add argument `hour` to get a valid time
+// Hint: 2-34 add the `hour` argument to get a valid time
 #datetime(minute: 14, second: 30)
 
 --- datetime-incomplete-time-2 paged ---
 // Error: 2-20 time is incomplete
-// Hint: 2-20 add arguments `minute` and `second` to get a valid time
+// Hint: 2-20 add the `minute` and `second` arguments to get a valid time
 #datetime(hour: 14)
 
 --- datetime-incomplete-date-1 paged ---
 // Error: 2-31 date is incomplete
-// Hint: 2-31 add argument `month` to get a valid date
+// Hint: 2-31 add the `month` argument to get a valid date
 #datetime(year: 2014, day: 30)
 
 --- datetime-incomplete-date-2 paged ---
 // Error: 2-20 date is incomplete
-// Hint: 2-20 add arguments `year` and `day` to get a valid date
+// Hint: 2-20 add the `year` and `day` arguments to get a valid date
 #datetime(month: 5)
 
 --- datetime-display-missing-closing-bracket paged ---


### PR DESCRIPTION
May close #7321.

I'm not sure if this coding style is consistent with the rest of `typst`, let me know if I messed up.

Some notes about this PR:

- `format_missing_fields` currently does not assume at most two missing fields, although this is the case for datetime. Perhaps our diagnostic messages elsewhere might also use it so it shall be move to somewhere outside? I'm not sure.
- I'm not sure if we should issue both warnings for incomplete `date` and `time` in examples like `datetime(year: 10, hour: 12)`, as this would also alter the error reporting logic, this PR just keeps unchanged.


Any suggestions are welcome.



