### PR TITLE
Setup LD_LIBRARY_PATH in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -152,6 +152,7 @@
             ];
 
             RUST_SRC_PATH = "${rust-toolchain.rust-src}/lib/rustlib/src/rust/library";
+            LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.openssl ];
 
             packages = [
               # A script for quickly running tests.


### PR DESCRIPTION
To test a PR, I cloned the repo and used nix to setup a dev shell.

Everything compiled fine, however running the executable yields:
```
error while loading shared libraries: libssl.so.3: cannot open shared object file: No such file or directory
```

[Setting the `LD_LIBRARY_PATH` env var](https://discourse.nixos.org/t/program-compiled-with-rust-cannot-find-libssl-so-3-at-runtime/27196) fixes this issue (when running inside the devShell).

I wasn't able to set [`OPENSSL_NO_VENDOR = true;`](https://github.com/NixOS/nixpkgs/blob/c2448301fb856e351aab33e64c33a3fc8bcf637d/pkgs/by-name/ty/typst/package.nix#L37C5-L37C22) so that the binary does not load the libssl.so...