### PR TITLE
Lazily scan fonts

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -552,6 +552,13 @@ pub enum OutputFormat {
     Html,
 }
 
+impl OutputFormat {
+    /// Whether this format results in a `PagedDocument`.
+    pub fn is_paged(&self) -> bool {
+        matches!(self, Self::Pdf | Self::Png | Self::Svg)
+    }
+}
+
 display_possible_values!(OutputFormat);
 
 /// Which format to use for a generated dependency file.

--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -35,7 +35,10 @@ type CodespanResult<T> = Result<T, CodespanError>;
 type CodespanError = codespan_reporting::files::Error;
 
 /// Execute a compilation command.
-pub fn compile(timer: &mut Timer, command: &CompileCommand) -> HintedStrResult<()> {
+pub fn compile(
+    timer: &mut Timer,
+    command: &'static CompileCommand,
+) -> HintedStrResult<()> {
     let mut config = CompileConfig::new(command)?;
     let mut world =
         SystemWorld::new(&command.args.input, &command.args.world, &command.args.process)

--- a/crates/typst-cli/src/query.rs
+++ b/crates/typst-cli/src/query.rs
@@ -16,7 +16,7 @@ use crate::set_failed;
 use crate::world::SystemWorld;
 
 /// Execute a query command.
-pub fn query(command: &QueryCommand) -> HintedStrResult<()> {
+pub fn query(command: &'static QueryCommand) -> HintedStrResult<()> {
     let mut world = SystemWorld::new(&command.input, &command.world, &command.process)?;
 
     // Reset everything and ensure that the main file is present.

--- a/crates/typst-cli/src/watch.rs
+++ b/crates/typst-cli/src/watch.rs
@@ -21,7 +21,7 @@ use crate::world::{SystemWorld, WorldCreationError};
 use crate::{print_error, terminal};
 
 /// Execute a watching compilation command.
-pub fn watch(timer: &mut Timer, command: &WatchCommand) -> HintedStrResult<()> {
+pub fn watch(timer: &mut Timer, command: &'static WatchCommand) -> HintedStrResult<()> {
     let mut config = CompileConfig::watching(command)?;
 
     let Output::Path(output) = &config.output else {
@@ -52,6 +52,14 @@ pub fn watch(timer: &mut Timer, command: &WatchCommand) -> HintedStrResult<()> {
             Err(err) => return Err(err.into()),
         }
     };
+
+    // Eagerly scan fonts if we expect to need them so that it's not counted as
+    // part of the displayed compilation time. The duration of font scanning is
+    // heavily system-dependant, so it could result in confusion why compilation
+    // is so much faster/slower.
+    if config.output_format.is_paged() {
+        world.scan_fonts();
+    }
 
     // Perform initial compilation.
     timer.record(&mut world, |world| compile_once(world, &mut config))??;


### PR DESCRIPTION
This PR changes the CLI implementation such that fonts are scanned for lazily when first needed instead of eagerly doing it on construction of the `SystemWorld`. This means that unnecessary font scanning can be avoided in cases like HTML export or the upcoming [`typst eval`](https://github.com/typst/typst/pull/7362).

Depending on the number of fonts on your system, font scanning can take a non-trivial amount of time (we should probably optimize or cache this somehow ...). To avoid this being a factor of confusion in the compile time displayed by `typst watch`, watch mode for paged export targets will continue to scan fonts eagerly. 