### PR TITLE
Correct a typo in v0.14.0 changelog

### DIFF
--- a/docs/changelog/0.14.0.md
+++ b/docs/changelog/0.14.0.md
@@ -208,7 +208,7 @@ _Thanks to [@mkorje](https://github.com/mkorje) for his work on math!_
 - Added [`from`]($direction.from), [`to`]($direction.to), and [`sign`]($direction.sign) methods to `direction` type [#5893]
 - [Labels]($label) cannot be empty anymore [#6332] **(Minor breaking change)**
 - The WebAssembly runtime used by the [`plugin`] system was updated and now supports SIMD [#6997]
-- Numberings and counters now use 64-bit numbers instead of platform-dependant numbers for consistency across platforms [#6026]
+- Numberings and counters now use 64-bit numbers instead of platform-dependent numbers for consistency across platforms [#6026]
 - Improved consistency of how large numbers are handled in data loading functions [#6836]
 - The [`toml`] function is now guaranteed to return a [dictionary] and [`toml.encode`] must receive a dictionary (it already errored before when passed something else, but the new function signature makes the error clearer) [#6743]
 - Serialization of [`bytes`] in human-readable formats now uses [`repr`] [#6743]


### PR DESCRIPTION
_platform-dependant_ → _platform-dependent_. (-ant → -ent)


> In summary, _dependant_ can be used for the noun in either British or American English, but _dependent_ for either noun or adjective is a safe choice in American English.

https://www.merriam-webster.com/dictionary/dependant