### PR TITLE
Implement basic vertical text direction support

### DIFF
--- a/crates/typst-layout/src/flow/compose.rs
+++ b/crates/typst-layout/src/flow/compose.rs
@@ -234,7 +234,7 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
             self.float(placed, &regions, false, false)?;
         }
 
-        distribute(self, regions)
+        distribute(self, regions, self.config.columns.dir.axis())
     }
 
     /// Lays out an item with floating placement.

--- a/crates/typst-layout/src/inline/collect.rs
+++ b/crates/typst-layout/src/inline/collect.rs
@@ -84,12 +84,12 @@ impl<'a> Item<'a> {
         self.textual().len()
     }
 
-    /// The natural layouted width of the item.
-    pub fn natural_width(&self) -> Abs {
+    /// The natural layouted length of the item.
+    pub fn natural_length(&self, dir: Dir) -> Abs {
         match self {
-            Self::Text(shaped) => shaped.width(),
+            Self::Text(shaped) => shaped.length(),
             Self::Absolute(v, _) => *v,
-            Self::Frame(frame) => frame.width(),
+            Self::Frame(frame) => frame.axis_length(dir.axis()),
             Self::Fractional(_, _) | Self::Tag(_) => Abs::zero(),
             Self::Skip(_) => Abs::zero(),
         }

--- a/crates/typst-layout/src/inline/finalize.rs
+++ b/crates/typst-layout/src/inline/finalize.rs
@@ -13,23 +13,26 @@ pub fn finalize(
     expand: bool,
     locator: &mut SplitLocator<'_>,
 ) -> SourceResult<Fragment> {
-    // Determine the resulting width: Full width of the region if we should
-    // expand or there's fractional spacing, fit-to-width otherwise.
-    let width = if !region.x.is_finite()
+    let flow_len = region.axis_length(p.config.dir.axis());
+    let cross_len = region.axis_length(p.config.dir.axis().other());
+
+    // Determine the resulting length: Full flow dimension of the region if we should
+    // expand or there's fractional spacing, fit-to-length otherwise.
+    let length = if !flow_len.is_finite()
         || (!expand && lines.iter().all(|line| line.fr().is_zero()))
     {
-        region.x.min(
+        flow_len.min(
             p.config.hanging_indent
-                + lines.iter().map(|line| line.width).max().unwrap_or_default(),
+                + lines.iter().map(|line| line.length).max().unwrap_or_default(),
         )
     } else {
-        region.x
+        flow_len
     };
 
     // Stack the lines into one frame per region.
     lines
         .iter()
-        .map(|line| commit(engine, p, line, width, region.y, locator))
+        .map(|line| commit(engine, p, line, length, cross_len, locator))
         .collect::<SourceResult<_>>()
         .map(Fragment::frames)
 }

--- a/crates/typst-layout/src/inline/linebreak.rs
+++ b/crates/typst-layout/src/inline/linebreak.rs
@@ -142,11 +142,11 @@ impl Trim {
 pub fn linebreak<'a>(
     engine: &Engine,
     p: &'a Preparation<'a>,
-    width: Abs,
+    length: Abs,
 ) -> Vec<Line<'a>> {
     match p.config.linebreaks {
-        Linebreaks::Simple => linebreak_simple(engine, p, width),
-        Linebreaks::Optimized => linebreak_optimized(engine, p, width),
+        Linebreaks::Simple => linebreak_simple(engine, p, length),
+        Linebreaks::Optimized => linebreak_optimized(engine, p, length),
     }
 }
 
@@ -157,7 +157,7 @@ pub fn linebreak<'a>(
 fn linebreak_simple<'a>(
     engine: &Engine,
     p: &'a Preparation<'a>,
-    width: Abs,
+    length: Abs,
 ) -> Vec<Line<'a>> {
     let mut lines = Vec::with_capacity(16);
     let mut start = 0;
@@ -170,7 +170,7 @@ fn linebreak_simple<'a>(
         // If the line doesn't fit anymore, we push the last fitting attempt
         // into the stack and rebuild the line from the attempt's end. The
         // resulting line cannot be broken up further.
-        if !width.fits(attempt.width)
+        if !length.fits(attempt.length)
             && let Some((last_attempt, last_end)) = last.take()
         {
             lines.push(last_attempt);
@@ -181,7 +181,7 @@ fn linebreak_simple<'a>(
         // Finish the current line if there is a mandatory line break (i.e. due
         // to "\n") or if the line doesn't fit horizontally already since then
         // no shorter line will be possible.
-        if breakpoint == Breakpoint::Mandatory || !width.fits(attempt.width) {
+        if breakpoint == Breakpoint::Mandatory || !length.fits(attempt.length) {
             lines.push(attempt);
             start = end;
             last = None;
@@ -217,17 +217,17 @@ fn linebreak_simple<'a>(
 fn linebreak_optimized<'a>(
     engine: &Engine,
     p: &'a Preparation<'a>,
-    width: Abs,
+    length: Abs,
 ) -> Vec<Line<'a>> {
     let metrics = CostMetrics::compute(p);
 
     // Determines the exact costs of a likely good layout through Knuth-Plass
     // with approximate metrics. We can use this cost as an upper bound to prune
     // the search space in our proper optimization pass below.
-    let upper_bound = linebreak_optimized_approximate(engine, p, width, &metrics);
+    let upper_bound = linebreak_optimized_approximate(engine, p, length, &metrics);
 
     // Using the upper bound, perform exact optimized linebreaking.
-    linebreak_optimized_bounded(engine, p, width, &metrics, upper_bound)
+    linebreak_optimized_bounded(engine, p, length, &metrics, upper_bound)
 }
 
 /// Performs line breaking in optimized Knuth-Plass style, but with an upper
@@ -312,7 +312,7 @@ fn linebreak_optimized_bounded<'a>(
             // lower bound in that case.
             if line_ratio > 0.0
                 && line_lower_bound.is_none()
-                && !attempt.has_negative_width_items()
+                && !attempt.has_negative_length_items(p.config.dir)
             {
                 line_lower_bound = Some(line_cost);
             }
@@ -533,7 +533,7 @@ fn ratio_and_cost(
     let ratio = raw_ratio(
         p,
         available_width,
-        attempt.width,
+        attempt.length,
         attempt.stretchability(),
         attempt.shrinkability(),
         attempt.justifiables(),
@@ -965,7 +965,7 @@ impl Estimates {
                     justifiables.push(byte_len, g.is_justifiable() as usize);
                 }
             } else {
-                widths.push(range.len(), item.natural_width());
+                widths.push(range.len(), item.natural_length(p.config.dir));
             }
 
             widths.adjust(range.end);

--- a/crates/typst-layout/src/inline/mod.rs
+++ b/crates/typst-layout/src/inline/mod.rs
@@ -171,7 +171,11 @@ fn layout_inline_impl<'a>(
     let p = prepare(engine, &config, &text, segments, spans)?;
 
     // Break the text into lines.
-    let lines = linebreak(engine, &p, region.x - config.hanging_indent);
+    let lines = linebreak(
+        engine,
+        &p,
+        region.axis_length(p.config.dir.axis()) - config.hanging_indent,
+    );
 
     // Turn the selected lines into frames.
     finalize(engine, &p, &lines, region, expand, locator)

--- a/crates/typst-library/src/layout/axes.rs
+++ b/crates/typst-library/src/layout/axes.rs
@@ -192,6 +192,20 @@ impl Axis {
             Self::Y => Self::X,
         }
     }
+
+    /// Executes a function with the two arguments swapped if the axis is vertical,
+    /// and executes without swapping if the axis is horizontal.
+    /// In general, arg1 should be the flow element,
+    /// and arg2 should be the cross element.
+    pub fn consider_axis<F, A, R>(self, func: F, arg1: A, arg2: A) -> R
+    where
+        F: FnOnce(A, A) -> R,
+    {
+        match self {
+            Axis::X => func(arg1, arg2),
+            Axis::Y => func(arg2, arg1),
+        }
+    }
 }
 
 cast! {

--- a/crates/typst-library/src/layout/frame.rs
+++ b/crates/typst-library/src/layout/frame.rs
@@ -9,7 +9,7 @@ use typst_utils::{LazyHash, Numeric};
 
 use crate::foundations::{Dict, Label, Value, cast, dict};
 use crate::introspection::{Location, Tag};
-use crate::layout::{Abs, Axes, FixedAlignment, Length, Point, Size, Transform};
+use crate::layout::{Abs, Axes, Axis, FixedAlignment, Length, Point, Size, Transform};
 use crate::model::Destination;
 use crate::text::TextItem;
 use crate::visualize::{Color, Curve, FixedStroke, Geometry, Image, Paint, Shape};
@@ -108,6 +108,11 @@ impl Frame {
         self.size.y
     }
 
+    /// The length of the frame along the axis
+    pub fn axis_length(&self, axis: Axis) -> Abs {
+        self.size.axis_length(axis)
+    }
+
     /// The vertical position of the frame's baseline.
     pub fn baseline(&self) -> Abs {
         self.baseline.unwrap_or(self.size.y)
@@ -134,6 +139,16 @@ impl Frame {
     /// The distance from the baseline to the bottom of the frame.
     pub fn descent(&self) -> Abs {
         self.size.y - self.baseline()
+    }
+
+    /// The horizontal position of the frame's leading edge (for vertical layout).
+    pub fn leading(&self) -> Abs {
+        Abs::zero()
+    }
+
+    /// The horizontal position of the frame's trailing edge (for vertical layout).
+    pub fn trailing(&self) -> Abs {
+        self.size.x
     }
 
     /// An iterator over the items inside this frame alongside their positions

--- a/crates/typst-library/src/layout/size.rs
+++ b/crates/typst-library/src/layout/size.rs
@@ -2,7 +2,7 @@ use std::ops::{Add, Div, Mul, Neg};
 
 use typst_utils::Numeric;
 
-use crate::layout::{Abs, Axes, Point, Ratio};
+use crate::layout::{Abs, Axes, Axis, Point, Ratio};
 
 /// A size in 2D.
 pub type Size = Axes<Abs>;
@@ -26,6 +26,22 @@ impl Size {
     /// Converts to a ratio of width to height.
     pub fn aspect_ratio(self) -> Ratio {
         Ratio::new(self.x / self.y)
+    }
+
+    /// The length along the axis
+    pub fn axis_length(&self, axis: Axis) -> Abs {
+        match axis {
+            Axis::X => self.x,
+            Axis::Y => self.y,
+        }
+    }
+
+    /// The length along the axis
+    pub fn axis_length_mut(&mut self, axis: Axis) -> &mut Abs {
+        match axis {
+            Axis::X => &mut self.x,
+            Axis::Y => &mut self.y,
+        }
     }
 }
 

--- a/crates/typst-library/src/model/par.rs
+++ b/crates/typst-library/src/model/par.rs
@@ -206,6 +206,7 @@ pub struct ParElem {
     /// #show ". ": it => it + parbreak()
     /// #lorem(55)
     /// ```
+    // TODO: default to 1.25em when text direction is vertical.
     #[default(Em::new(0.65).into())]
     pub leading: Length,
 


### PR DESCRIPTION
## Overview
This PR adds very minimal vertical text direction (mainly TTB-RTL) support. `TTB` and `BTT` directions were already present in the code, but were largely unimplemented and ignored; this PR attempts to implement some of the basic required features. The features proposed in RFC #5908 are not implemented at all: hopefully this PR provides the basis.

Importantly, merging this PR should not alter the output of any .typ file, unless the text direction is explicitly set to TTB (with something like `set #text(dir: ttb)`).

## Changes
Since the goal was to extend the support of text directions (`LTR`, `RTL`) to vertical directions, most of the changes abstract direction for logic written with horizontal text direction in mind. Additions of new fields to structs were avoided when the struct is widely used, while new fields were added to structs that were primarily used with text direction logic.

## Issues
The support for vertical text direction is minimal at best, and some essential features are left unimplemented. Some missing essential features include:
- Inserting figures or pretty much anything other than basic text
- Mixing vertical and horizontal text
- Page breaking
- Preventing single newlines from inserting spaces (spaces are rarely used in TTB-RTL, at least in Japanese)

## Notes
Most of the testing was done in Japanese. Using other languages may produce more bugs.

This PR was written by @SFizz405, @RaikiSakaguchi, and @GenOgane. This is our first ever PR to a large repo, and we do not have a lot of experience with Rust; apologies in advance for any bad code. We understand that our PR may not meet the minimal required quality for merging.