### PR TITLE
Fix potential EOL issues in CI tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Should fix CI errors in https://github.com/typst/typst/pull/7211.

See https://github.com/actions/checkout/issues/135.
