### PR TITLE
Add colors to `--help/-h`

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -43,10 +43,8 @@ const AFTER_HELP: &str = color_print::cstr!("\
 ");
 
 const STYLES: Styles = Styles::styled()
-    .header(AnsiColor::Yellow.on_default().effects(Effects::BOLD))
-    .usage(AnsiColor::Green.on_default().effects(Effects::BOLD))
-    .literal(AnsiColor::Green.on_default().effects(Effects::BOLD))
-    .placeholder(AnsiColor::Green.on_default());
+    .literal(AnsiColor::Cyan.on_default().effects(Effects::BOLD))
+    .placeholder(AnsiColor::Blue.on_default());
 
 /// The Typst compiler.
 #[derive(Debug, Clone, Parser)]


### PR DESCRIPTION
User can disable colors via `NO_COLOR=1` environment variable if needed

Output of `typst -h`:
| before | after | `NO_COLOR=1` |
| - | - | - |
| <img width="769" height="613" alt="typst-before" src="https://github.com/user-attachments/assets/f4704e21-a0da-42a1-9673-ecf96594addd" /> | <img width="769" height="613" alt="typst-colors" src="https://github.com/user-attachments/assets/a3784580-1d2e-4fd4-868c-55cb91c43082" /> | <img width="769" height="613" alt="typst-no-color" src="https://github.com/user-attachments/assets/67d6bf25-9000-4810-88d1-ef5ba04d4e41" /> |
