### PR TITLE
Slightly more accurate path separator replacement in tests

### DIFF
--- a/tests/src/run.rs
+++ b/tests/src/run.rs
@@ -1,8 +1,10 @@
 use std::fmt::Write;
 use std::ops::Range;
 use std::str::FromStr;
+use std::sync::LazyLock;
 
 use parking_lot::RwLock;
+use regex::{Captures, Regex};
 use rustc_hash::FxHashMap;
 use typst::diag::{SourceDiagnostic, Warned};
 use typst::layout::PagedDocument;
@@ -436,13 +438,8 @@ impl<'a> Runner<'a> {
             return;
         }
 
-        let message = if diag.message.contains("\\u{") {
-            &diag.message
-        } else {
-            &diag.message.replace("\\", "/")
-        };
         let range = self.world.range(diag.span);
-        self.validate_note(kind, diag.span.id(), range, message, stage);
+        self.validate_note(kind, diag.span.id(), range, &diag.message, stage);
 
         // Check hints.
         for hint in &diag.hints {
@@ -465,6 +462,15 @@ impl<'a> Runner<'a> {
         message: &str,
         stage: impl TestStage,
     ) {
+        // HACK: Replace backslashes path sepators with slashes for cross
+        // platform reproducible error messages.
+        static RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new("\\((.*) (at|in) (.+)\\)").unwrap());
+        let message = RE.replace(message, |caps: &Captures| {
+            let path = caps[3].replace('\\', "/");
+            format!("({} {} {})", &caps[1], &caps[2], path)
+        });
+
         // Try to find perfect match.
         let file = file.unwrap_or(self.test.source.id());
         if let Some((i, _)) = self.test.notes.iter().enumerate().find(|&(i, note)| {

--- a/tests/suite/text/raw.typ
+++ b/tests/suite/text/raw.typ
@@ -105,7 +105,7 @@ contexts:
     - match: '\'
 ```.text
 
-// Error: 35-56 failed to parse syntax (Error while compiling regex '/': Parsing error at position 0: Backslash without following character)
+// Error: 35-56 failed to parse syntax (Error while compiling regex '\': Parsing error at position 0: Backslash without following character)
 #raw("text", lang: "a", syntaxes: bytes(sublime-syntax))
 
 --- raw-theme paged ---


### PR DESCRIPTION
Should precede #7450

This treats the backslash replacement more like the special case instead of the default.
I've also caught one case where the previous check was a bit overzealous.