### PR TITLE
Use original logical index of line fallback text item

### DIFF
--- a/crates/typst-layout/src/inline/line.rs
+++ b/crates/typst-layout/src/inline/line.rs
@@ -222,9 +222,9 @@ fn collect_items<'a>(
 
     // Add fallback text to expand the line height, if necessary.
     if !items.iter().any(|item| matches!(item, Item::Text(_)))
-        && let Some(fallback) = fallback
+        && let Some((idx, fallback)) = fallback
     {
-        items.push(fallback, LogicalIndex::FALLBACK_TEXT);
+        items.push(fallback, idx);
     }
 }
 
@@ -287,7 +287,7 @@ fn collect_range<'a>(
     range: Range,
     trim: &Trim,
     items: &mut Items<'a>,
-    fallback: &mut Option<ItemEntry<'a>>,
+    fallback: &mut Option<(LogicalIndex, ItemEntry<'a>)>,
 ) {
     for (i, (subrange, item)) in p.slice(range.clone()) {
         let idx = LogicalIndex::from_item_index(i);
@@ -310,7 +310,7 @@ fn collect_range<'a>(
             // When there is no text, still keep this as a fallback item, which
             // we can use to force a non-zero line-height when the line doesn't
             // contain any other text.
-            *fallback = Some(ItemEntry::from(Item::Text(shaped.empty())));
+            *fallback = Some((idx, ItemEntry::from(Item::Text(shaped.empty()))));
             continue;
         }
 
@@ -782,7 +782,6 @@ pub struct LogicalIndex(usize);
 
 impl LogicalIndex {
     const START_HYPHEN: Self = Self(0);
-    const FALLBACK_TEXT: Self = Self(usize::MAX - 1);
     const END_HYPHEN: Self = Self(usize::MAX);
 
     /// Create a logical index from the index of an item in the [`p.items`](Preparation::items).

--- a/tests/ref/pdftags/issue-7301-link-tags-empty-link-body-footnote.yml
+++ b/tests/ref/pdftags/issue-7301-link-tags-empty-link-body-footnote.yml
@@ -1,0 +1,15 @@
+- Tag: P
+  /K:
+    - Tag: Lbl
+      /K:
+        - Tag: Link
+          /K:
+            - Annotation: page=0 subtype=Link
+              /Contents: "Footnote "
+    - Tag: Note
+      /Id: "Note 1"
+      /K:
+        - Tag: Lbl
+          /K:
+            - Tag: Link
+        - Content: page=0 mcid=0

--- a/tests/ref/pdftags/issue-7301-link-tags-empty-link-body-linebreak.yml
+++ b/tests/ref/pdftags/issue-7301-link-tags-empty-link-body-linebreak.yml
@@ -1,0 +1,7 @@
+- Tag: P
+  /K:
+    - Tag: Link
+      /K:
+        - Annotation: page=0 subtype=Link
+          /Contents: "asf"
+          /URI: "asf"

--- a/tests/ref/pdftags/issue-7301-link-tags-empty-link-body-mutliple.yml
+++ b/tests/ref/pdftags/issue-7301-link-tags-empty-link-body-mutliple.yml
@@ -1,0 +1,12 @@
+- Tag: P
+  /K:
+    - Tag: Link
+      /K:
+        - Annotation: page=0 subtype=Link
+          /Contents: "asf"
+          /URI: "asf"
+    - Tag: Link
+      /K:
+        - Annotation: page=0 subtype=Link
+          /Contents: "asf"
+          /URI: "asf"

--- a/tests/ref/pdftags/issue-7301-link-tags-empty-link-body.yml
+++ b/tests/ref/pdftags/issue-7301-link-tags-empty-link-body.yml
@@ -1,0 +1,7 @@
+- Tag: P
+  /K:
+    - Tag: Link
+      /K:
+        - Annotation: page=0 subtype=Link
+          /Contents: "asf"
+          /URI: "asf"

--- a/tests/suite/pdftags/link.typ
+++ b/tests/suite/pdftags/link.typ
@@ -57,19 +57,13 @@ Look #link("https://github.com/typst/typst")[this #parbreak() thing].
 Look #link("https://github.com/typst/typst")[this #parbreak() thing].
 
 --- issue-7301-link-tags-empty-link-body pdftags ---
-// Error: internal error: expected link ancestor in logical tree (occurred at crates/typst-pdf/src/link.rs:88:10)
-// Hint: please report this as a bug
-// Hint: set `RUST_BACKTRACE` to `1` or `full` to capture a backtrace
 #link("asf")[#none\ #none]
 
 --- issue-7301-link-tags-empty-link-body-linebreak pdftags ---
-// Error: internal error: expected link ancestor in logical tree (occurred at crates/typst-pdf/src/link.rs:88:10)
-// Hint: please report this as a bug
-// Hint: set `RUST_BACKTRACE` to `1` or `full` to capture a backtrace
 #link("asf", linebreak())
 
 --- issue-7301-link-tags-empty-link-body-footnote pdftags ---
-// Error: internal error: expected link ancestor in logical tree (occurred at crates/typst-pdf/src/link.rs:88:10)
-// Hint: please report this as a bug
-// Hint: set `RUST_BACKTRACE` to `1` or `full` to capture a backtrace
 #footnote(numbering: it => "", [asdf])
+
+--- issue-7301-link-tags-empty-link-body-mutliple pdftags ---
+#link("asf")[#none\ #none] #link("asf")[#none\ #none]


### PR DESCRIPTION
Fixes #7301.
Should be merged after #7450.

The `ShapedText` stores the `StyleChain` which contains the `LinkElem::current` property. Previously the fallback text item received a custom `LogicalIndex` which would always move it to the end of the line. And thus `modify_frame` would generate the `FrameItem::Link` outside of the `LinkMarker` introspection tags.
The fix just stores the original `LogicalIndex` in addition to the fallback text `ItemEntry`.