### PR TITLE
Fix caching of pdf tagging text attribute parameters

### DIFF
--- a/crates/typst-pdf/src/tags/tree/text.rs
+++ b/crates/typst-pdf/src/tags/tree/text.rs
@@ -1,7 +1,7 @@
 use krilla::tagging::{LineHeight, NaiveRgbColor, TextDecorationType};
 use typst_library::diag::{SourceDiagnostic, error};
 use typst_library::foundations::{Content, Packed, Smart};
-use typst_library::layout::{Abs, Length};
+use typst_library::layout::Length;
 use typst_library::text::{
     HighlightElem, OverlineElem, ScriptKind, StrikeElem, SubElem, SuperElem, TextItem,
     TextSize, UnderlineElem,
@@ -16,8 +16,8 @@ use crate::util::AbsExt;
 
 #[derive(Debug, Clone)]
 pub struct TextAttrs {
-    /// Store the last resolved set of text attribute. The resolution isn't that
-    /// expensive, but for large bodies of text it is resolved quite often.
+    /// Store the last resolved set of text attributes. The resolution isn't
+    /// that expensive, but for large bodies of text it is resolved quite often.
     last_resolved: Option<(TextParams, ResolvedTextAttrs)>,
     items: Vec<(GroupId, TextAttr)>,
 }
@@ -113,19 +113,13 @@ impl TextDecoKind {
     }
 }
 
+/// A hash of relevant text parameters.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-struct TextParams {
-    pub font_index: u32,
-    pub size: Abs,
-}
+struct TextParams(u128);
 
 impl TextParams {
     fn new(text: &TextItem) -> TextParams {
-        TextParams {
-            // Comparing font indices is enough.
-            font_index: text.font.index(),
-            size: text.size,
-        }
+        TextParams(typst_utils::hash128(&(&text.font, text.size)))
     }
 }
 


### PR DESCRIPTION
I had a messed up understand of what the font index actually is. This was just plain wrong :sweat_smile: 