### PR TITLE
Return friendly error when loading JSON has a leading UTF‑8 BOM

### DIFF
--- a/tests/suite/loading/json.typ
+++ b/tests/suite/loading/json.typ
@@ -6,7 +6,8 @@
 #test(data.at(2).weight, 150)
 
 --- json-with-bom paged ---
-// Error: 7-43 failed to parse JSON (Byte Order Mark (BOM) present at start of file, JSON requires UTF-8 without a BOM at 1:1)
+// Error: 7-43 failed to parse JSON (unexpected Byte Order Mark at 1:1)
+// Hint: 7-43 JSON requires UTF-8 without a BOM
 #json(bytes("\u{FEFF}{\"name\": \"BOM\"}"))
 
 --- json-invalid paged ---


### PR DESCRIPTION
close #5440
close #3157

This pull request improves the handling of JSON files in the loading library by adding explicit detection and error reporting for files that start with a UTF-8 Byte Order Mark (BOM), which is not allowed by the JSON specification.

Although the JSON specification does not allow BOM, we could consider a more forgiving approach that removes the BOM when encountering BOM-prefixed JSON files. However, in my opinion, most major programming languages throw an error for JSON files with a BOM. To maintain consistent and clear behavior, this PR opts to throw a friendly error message in such cases.