### PR TITLE
Show full font file path in `typst fonts --variants`

### DIFF
--- a/crates/typst-cli/src/fonts.rs
+++ b/crates/typst-cli/src/fonts.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use typst::text::FontVariant;
 use typst_kit::fonts::Fonts;
 
@@ -15,20 +17,18 @@ pub fn fonts(command: &FontsCommand) {
         println!("{family}");
         if command.variants {
             for index in indices {
-                if let Some(font_info) = fonts.book.info(index) {
-                    let FontVariant { style, weight, stretch } = font_info.variant;
-                    let path = fonts
-                        .slots
-                        .get(index)
-                        .and_then(|slot| {
-                            slot.path().map(|p| p.to_string_lossy().to_string())
-                        })
-                        .unwrap_or_else(|| "<embedded>".to_string());
+                let Some(font_info) = fonts.book.info(index) else { continue };
+                let FontVariant { style, weight, stretch } = font_info.variant;
+                let path = fonts
+                    .slots
+                    .get(index)
+                    .and_then(|slot| slot.path())
+                    .unwrap_or_else(|| Path::new("<embedded>"))
+                    .display();
 
-                    println!(
-                        "- Style: {style:?}, Weight: {weight:?}, Stretch: {stretch:?}, Path: {path}"
-                    );
-                }
+                println!(
+                    "- Style: {style:?}, Weight: {weight:?}, Stretch: {stretch:?}, Path: {path}",
+                );
             }
         }
     }

--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -1184,10 +1184,10 @@ impl<'a> CompletionContext<'a> {
 
     /// Add completions for all font families.
     fn font_completions(&mut self) {
+        let book = self.world.book();
         let equation = is_in_equation_show_rule(self.leaf);
-        for (family, iter) in self.world.book().families() {
-            let variants: Vec<_> =
-                iter.filter_map(|id| self.world.book().info(id)).collect();
+        for (family, iter) in book.families() {
+            let variants: Vec<_> = iter.filter_map(|id| book.info(id)).collect();
             let is_math = variants.iter().any(|f| f.flags.contains(FontFlags::MATH));
             let detail = summarize_font_family(variants);
             if !equation || is_math {

--- a/crates/typst-ide/src/tooltip.rs
+++ b/crates/typst-ide/src/tooltip.rs
@@ -255,13 +255,12 @@ fn font_tooltip(world: &dyn IdeWorld, leaf: &LinkedNode) -> Option<Tooltip> {
         && named.name().as_str() == "font"
 
         // Find the font family.
-        && let Some((_, iter)) = world
-            .book()
+        && let book = world.book()
+        && let Some((_, iter)) = book
             .families()
             .find(|&(family, _)| family.to_lowercase().as_str() == lower.as_str())
     {
-        let detail =
-            summarize_font_family(iter.filter_map(|id| world.book().info(id)).collect());
+        let detail = summarize_font_family(iter.filter_map(|id| book.info(id)).collect());
         return Some(Tooltip::Text(detail));
     }
 

--- a/crates/typst-library/src/text/font/book.rs
+++ b/crates/typst-library/src/text/font/book.rs
@@ -67,8 +67,7 @@ impl FontBook {
         // first face's info.
         self.families.values().map(|ids| {
             let family = self.infos[ids[0]].family.as_str();
-            let ids_iter = ids.iter().copied();
-            (family, ids_iter)
+            (family, ids.iter().copied())
         })
     }
 


### PR DESCRIPTION
close #6943

This pull request adds full font file paths to the detailed information displayed by `typst fonts --variants`.

If this change is acceptable, we can also consider implementing json output functionality for integration with external tools, as proposed in https://github.com/typst/typst/issues/6943#issuecomment-3553447343.
