### PR TITLE
Allow trailing semicolon for hints in `bail!`, `error!`, and `warning!` macros

### DIFF
--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -119,7 +119,7 @@ impl CompileConfig {
                 _ => bail!(
                     "could not infer output format for path {}.\n\
                      consider providing the format manually with `--format/-f`",
-                    output.display()
+                    output.display(),
                 ),
             }
         } else {
@@ -169,7 +169,7 @@ impl CompileConfig {
                     } else {
                         bail!(
                             "cannot disable PDF tags when exporting a {name} document";
-                            hint: "using --pages implies --no-pdf-tags"
+                            hint: "using --pages implies --no-pdf-tags";
                         );
                     }
                 }

--- a/crates/typst-cli/src/main.rs
+++ b/crates/typst-cli/src/main.rs
@@ -158,7 +158,7 @@ mod update {
         bail!(
             "self-updating is not enabled for this executable, \
              please update with the package manager or mechanism \
-             used for initial installation"
+             used for initial installation",
         )
     }
 }

--- a/crates/typst-cli/src/update.rs
+++ b/crates/typst-cli/src/update.rs
@@ -58,7 +58,7 @@ pub fn update(command: &UpdateCommand) -> StrResult<()> {
         if !command.force && version < &current_tag {
             bail!(
                 "downgrading requires the --force flag: \
-                `typst update <VERSION> --force`"
+                `typst update <VERSION> --force`",
             );
         }
     }
@@ -75,7 +75,7 @@ pub fn update(command: &UpdateCommand) -> StrResult<()> {
         if !backup_path.exists() {
             bail!(
                 "unable to revert, no backup found (searched at {})",
-                backup_path.display()
+                backup_path.display(),
             );
         }
 

--- a/crates/typst-cli/src/watch.rs
+++ b/crates/typst-cli/src/watch.rs
@@ -354,7 +354,7 @@ fn warn_watching_std(world: &SystemWorld, config: &CompileConfig) -> StrResult<(
         Span::detached(),
         "cannot watch changes for stdin";
         hint: "to recompile on changes, watch a regular file instead";
-        hint: "to compile once and exit, please use `typst compile` instead"
+        hint: "to compile once and exit, please use `typst compile` instead";
     );
     print_diagnostics(world, &[], &[warning], config.diagnostic_format)
         .map_err(|err| eco_format!("failed to print diagnostics ({err})"))

--- a/crates/typst-eval/src/binding.rs
+++ b/crates/typst-eval/src/binding.rs
@@ -204,6 +204,6 @@ fn wrong_number_of_elements(
     error!(
         destruct.span(), "{quantifier} elements to destructure";
         hint: "the provided array has a length of {len}, \
-               but the pattern expects {expected}",
+               but the pattern expects {expected}";
     )
 }

--- a/crates/typst-eval/src/call.rs
+++ b/crates/typst-eval/src/call.rs
@@ -375,7 +375,7 @@ fn missing_field_call_error(target: Value, field: Ident) -> SourceDiagnostic {
             field.span(),
             "type {} has no method `{}`",
             target.ty(),
-            field.as_str()
+            field.as_str(),
         ),
     };
 

--- a/crates/typst-eval/src/code.rs
+++ b/crates/typst-eval/src/code.rs
@@ -380,7 +380,7 @@ fn warn_for_discarded_content(engine: &mut Engine, event: &FlowEvent, joined: &V
     let mut warning = warning!(
         *span,
         "this return unconditionally discards the content before it";
-        hint: "try omitting the `return` to automatically join all values"
+        hint: "try omitting the `return` to automatically join all values";
     );
 
     if tree.query_first_naive(selector).is_some() {

--- a/crates/typst-eval/src/import.rs
+++ b/crates/typst-eval/src/import.rs
@@ -38,7 +38,7 @@ impl Eval for ast::ModuleImport<'_> {
                 bail!(
                     source_span,
                     "expected path, module, function, or type, found {}",
-                    v.ty()
+                    v.ty(),
                 )
             }
         }
@@ -79,11 +79,11 @@ impl Eval for ast::ModuleImport<'_> {
                         }
                         Ok(_) | Err(BareImportError::Dynamic) => bail!(
                             source_span, "dynamic import requires an explicit name";
-                            hint: "you can name the import with `as`"
+                            hint: "you can name the import with `as`";
                         ),
                         Err(BareImportError::PathInvalid) => bail!(
                             source_span, "module name would not be a valid identifier";
-                            hint: "you can rename the import with `as`",
+                            hint: "you can rename the import with `as`";
                         ),
                         // Bad package spec would have failed the import already.
                         Err(BareImportError::PackageInvalid) => unreachable!(),
@@ -116,7 +116,7 @@ impl Eval for ast::ModuleImport<'_> {
                                 {
                                     error!(
                                         component.span(),
-                                        "cannot import from user-defined functions"
+                                        "cannot import from user-defined functions",
                                     )
                                 } else if !matches!(
                                     value,
@@ -125,7 +125,7 @@ impl Eval for ast::ModuleImport<'_> {
                                     error!(
                                         component.span(),
                                         "expected module, function, or type, found {}",
-                                        value.ty()
+                                        value.ty(),
                                     )
                                 } else {
                                     panic!("unexpected nested import failure")

--- a/crates/typst-eval/src/markup.rs
+++ b/crates/typst-eval/src/markup.rs
@@ -57,7 +57,7 @@ fn eval_markup<'a>(
                         if elem.label().is_some() {
                             vm.engine.sink.warn(warning!(
                                 elem.span(), "content labelled multiple times";
-                                hint: "only the last label is used, the rest are ignored",
+                                hint: "only the last label is used, the rest are ignored";
                             ));
                         }
 
@@ -66,7 +66,7 @@ fn eval_markup<'a>(
                         vm.engine.sink.warn(warning!(
                             expr.span(),
                             "label `{}` is not attached to anything",
-                            label.repr()
+                            label.repr(),
                         ));
                     }
                 }
@@ -148,12 +148,10 @@ impl Eval for ast::Strong<'_> {
     fn eval(self, vm: &mut Vm) -> SourceResult<Self::Output> {
         let body = self.body();
         if body.exprs().next().is_none() {
-            vm.engine
-                .sink
-                .warn(warning!(
-                    self.span(), "no text within stars";
-                    hint: "using multiple consecutive stars (e.g. **) has no additional effect",
-                ));
+            vm.engine.sink.warn(warning!(
+                self.span(), "no text within stars";
+                hint: "using multiple consecutive stars (e.g. **) has no additional effect";
+            ));
         }
 
         Ok(StrongElem::new(body.eval(vm)?).pack())
@@ -166,12 +164,11 @@ impl Eval for ast::Emph<'_> {
     fn eval(self, vm: &mut Vm) -> SourceResult<Self::Output> {
         let body = self.body();
         if body.exprs().next().is_none() {
-            vm.engine
-                .sink
-                .warn(warning!(
-                    self.span(), "no text within underscores";
-                    hint: "using multiple consecutive underscores (e.g. __) has no additional effect"
-                ));
+            vm.engine.sink.warn(warning!(
+                self.span(), "no text within underscores";
+                hint: "using multiple consecutive underscores (e.g. __) has no \
+                       additional effect";
+            ));
         }
 
         Ok(EmphElem::new(body.eval(vm)?).pack())

--- a/crates/typst-eval/src/rules.rs
+++ b/crates/typst-eval/src/rules.rs
@@ -70,10 +70,11 @@ fn check_show_par_set_block(vm: &mut Vm, recipe: &Recipe) {
         && (styles.has(BlockElem::above) || styles.has(BlockElem::below))
     {
         vm.engine.sink.warn(warning!(
-                recipe.span(),
-                "`show par: set block(spacing: ..)` has no effect anymore";
-                hint: "write `set par(spacing: ..)` instead";
-                hint: "this is specific to paragraphs as they are not considered blocks anymore"
-            ))
+            recipe.span(),
+            "`show par: set block(spacing: ..)` has no effect anymore";
+            hint: "write `set par(spacing: ..)` instead";
+            hint: "this is specific to paragraphs as they are not considered blocks \
+                   anymore";
+        ))
     }
 }

--- a/crates/typst-eval/src/vm.rs
+++ b/crates/typst-eval/src/vm.rs
@@ -66,7 +66,7 @@ impl<'a> Vm<'a> {
                 "`is` will likely become a keyword in future versions and will \
                 not be allowed as an identifier";
                 hint: "rename this variable to avoid future errors";
-                hint: "try `is_` instead"
+                hint: "try `is_` instead";
             ));
         }
 

--- a/crates/typst-html/src/convert.rs
+++ b/crates/typst-html/src/convert.rs
@@ -140,7 +140,7 @@ fn handle(
         converter.engine.sink.warn(warning!(
             child.span(),
             "{} was ignored during HTML export",
-            child.elem().name()
+            child.elem().name(),
         ));
     }
     Ok(())

--- a/crates/typst-html/src/encode.rs
+++ b/crates/typst-html/src/encode.rs
@@ -183,7 +183,7 @@ fn write_raw(w: &mut Writer, element: &HtmlElement) -> SourceResult<()> {
         bail!(
             element.span,
             "HTML raw text element cannot contain its own closing tag";
-            hint: "the sequence `{closing}` appears in the raw text",
+            hint: "the sequence `{closing}` appears in the raw text";
         )
     }
 

--- a/crates/typst-html/src/rules.rs
+++ b/crates/typst-html/src/rules.rs
@@ -214,7 +214,7 @@ impl Introspect for HtmlIdIntrospection {
         };
         warning!(
             self.1,
-            "HTML element ID assigned to the destination {what} did not stabilize"
+            "HTML element ID assigned to the destination {what} did not stabilize",
         )
         .with_hint(history.hint("IDs", |id| match id {
             Some(id) => id.clone(),
@@ -263,7 +263,7 @@ const HEADING_RULE: ShowFn<HeadingElem> = |elem, engine, styles| {
             level, level + 1;
             hint: "HTML only supports <h1> to <h6>, not <h{}>", level + 1;
             hint: "you may want to restructure your document so that \
-                   it doesn't contain deep headings"
+                   it doesn't contain deep headings";
         ));
         HtmlElem::new(tag::div)
             .with_body(Some(realized))
@@ -381,7 +381,7 @@ impl FootnoteContainer {
                     marker.span(),
                     "footnotes are not currently supported in combination \
                      with a custom `<html>` or `<body>` element";
-                    hint: "you can still use footnotes with a custom footnote show rule"
+                    hint: "you can still use footnotes with a custom footnote show rule";
                 )
             })
             .collect())
@@ -793,7 +793,7 @@ const BLOCK_RULE: ShowFn<BlockElem> = |elem, _, styles| {
             bail!(
                 elem.span(),
                 "blocks with layout routines should not occur in \
-                 HTML export – this is a bug"
+                 HTML export – this is a bug";
             )
         }
     };

--- a/crates/typst-html/src/typed.rs
+++ b/crates/typst-html/src/typed.rs
@@ -332,7 +332,7 @@ impl ListType {
                     bail!(
                         "array item may not contain a {name}";
                         hint: "the array attribute will be encoded as a \
-                               {name}-separated string"
+                               {name}-separated string";
                     );
                 }
                 if i > 0 {

--- a/crates/typst-layout/src/flow/collect.rs
+++ b/crates/typst-layout/src/flow/collect.rs
@@ -93,13 +93,13 @@ impl<'a> Collector<'a, '_, '_> {
             } else if child.is::<PagebreakElem>() {
                 bail!(
                     child.span(), "pagebreaks are not allowed inside of containers";
-                    hint: "try using a `#colbreak()` instead",
+                    hint: "try using a `#colbreak()` instead";
                 );
             } else {
                 self.engine.sink.warn(warning!(
                     child.span(),
                     "{} was ignored during paged export",
-                    child.func().name()
+                    child.func().name(),
                 ));
             }
         }
@@ -300,7 +300,7 @@ impl<'a> Collector<'a, '_, '_> {
             (false, Smart::Auto) => bail!(
                 elem.span(),
                 "automatic positioning is only available for floating placement";
-                hint: "you can enable floating placement with `place(float: true, ..)`"
+                hint: "you can enable floating placement with `place(float: true, ..)`";
             ),
             _ => {}
         }
@@ -309,7 +309,7 @@ impl<'a> Collector<'a, '_, '_> {
             bail!(
                 elem.span(),
                 "parent-scoped positioning is currently only available for floating placement";
-                hint: "you can enable floating placement with `place(float: true, ..)`"
+                hint: "you can enable floating placement with `place(float: true, ..)`";
             );
         }
 

--- a/crates/typst-layout/src/inline/collect.rs
+++ b/crates/typst-layout/src/inline/collect.rs
@@ -239,7 +239,7 @@ pub fn collect<'a>(
             engine.sink.warn(warning!(
                 child.span(),
                 "{} may not occur inside of a paragraph and was ignored",
-                child.func().name()
+                child.func().name(),
             ));
         };
 

--- a/crates/typst-layout/src/math/fragment.rs
+++ b/crates/typst-layout/src/math/fragment.rs
@@ -759,7 +759,7 @@ fn assemble(
                        base.item.span,
                        "glyph has assembly parts with overlap less than minConnectorOverlap";
                        hint: "its rendering may appear broken - this is probably a font bug";
-                       hint: "please file an issue at https://github.com/typst/typst/issues"
+                       hint: "please file an issue at https://github.com/typst/typst/issues";
                     ));
                 }
 

--- a/crates/typst-layout/src/math/mat.rs
+++ b/crates/typst-layout/src/math/mat.rs
@@ -203,7 +203,7 @@ fn layout_body(
                 ctx.engine.sink.warn(warning!(
                    cell_span,
                    "linebreaks are ignored in {}", children;
-                   hint: "use commas instead to separate each line"
+                   hint: "use commas instead to separate each line";
                 ));
             }
 

--- a/crates/typst-layout/src/math/mod.rs
+++ b/crates/typst-layout/src/math/mod.rs
@@ -682,7 +682,7 @@ fn warn_non_math_font(font: &Font, engine: &mut Engine, span: Span) {
         engine.sink.warn(warning!(
             span,
             "current font is not designed for math";
-            hint: "rendering may be poor"
+            hint: "rendering may be poor";
         ))
     }
 }

--- a/crates/typst-layout/src/math/stretch.rs
+++ b/crates/typst-layout/src/math/stretch.rs
@@ -60,7 +60,7 @@ pub fn stretch_fragment(
                    glyph.item.span,
                    "glyph has both vertical and horizontal constructions";
                    hint: "this is probably a font bug";
-                   hint: "please file an issue at https://github.com/typst/typst/issues"
+                   hint: "please file an issue at https://github.com/typst/typst/issues";
                 ));
                 return;
             }

--- a/crates/typst-layout/src/rules.rs
+++ b/crates/typst-layout/src/rules.rs
@@ -340,7 +340,7 @@ const FIGURE_RULE: ShowFn<FigureElem> = |elem, _, styles| {
         bail!(
             span,
             "parent-scoped placement is only available for floating figures";
-            hint: "you can enable floating placement with `figure(placement: auto, ..)`"
+            hint: "you can enable floating placement with `figure(placement: auto, ..)`";
         );
     }
 

--- a/crates/typst-library/src/engine.rs
+++ b/crates/typst-library/src/engine.rs
@@ -349,7 +349,7 @@ impl Route<'_> {
             bail!(
                 "maximum show rule depth exceeded";
                 hint: "maybe a show rule matches its own output";
-                hint: "maybe there are too deeply nested elements"
+                hint: "maybe there are too deeply nested elements";
             );
         }
         Ok(())
@@ -360,7 +360,7 @@ impl Route<'_> {
         if !self.within(Route::MAX_LAYOUT_DEPTH) {
             bail!(
                 "maximum layout depth exceeded";
-                hint: "try to reduce the amount of nesting in your layout",
+                hint: "try to reduce the amount of nesting in your layout";
             );
         }
         Ok(())
@@ -371,7 +371,7 @@ impl Route<'_> {
         if !self.within(Route::MAX_HTML_DEPTH) {
             bail!(
                 "maximum HTML depth exceeded";
-                hint: "try to reduce the amount of nesting of your HTML",
+                hint: "try to reduce the amount of nesting of your HTML";
             );
         }
         Ok(())

--- a/crates/typst-library/src/foundations/args.rs
+++ b/crates/typst-library/src/foundations/args.rs
@@ -154,7 +154,7 @@ impl Args {
                 return error!(
                     item.span,
                     "the argument `{what}` is positional";
-                    hint: "try removing `{}:`", name,
+                    hint: "try removing `{}:`", name;
                 );
             }
         }

--- a/crates/typst-library/src/foundations/array.rs
+++ b/crates/typst-library/src/foundations/array.rs
@@ -519,7 +519,7 @@ impl Array {
                     other_span,
                     "second array has different length ({}) from first array ({})",
                     other.len(),
-                    self.len()
+                    self.len(),
                 );
             }
             return Ok(self

--- a/crates/typst-library/src/foundations/calc.rs
+++ b/crates/typst-library/src/foundations/calc.rs
@@ -218,7 +218,7 @@ pub fn root(
         if index.v % 2 == 0 {
             bail!(
                 index.span,
-                "negative numbers do not have a real nth root when n is even"
+                "negative numbers do not have a real nth root when n is even",
             );
         } else {
             Ok(-(-radicand).powf(1.0 / index.v as f64))

--- a/crates/typst-library/src/foundations/datetime.rs
+++ b/crates/typst-library/src/foundations/datetime.rs
@@ -304,7 +304,7 @@ impl Datetime {
                 bail!(
                     "time is incomplete";
                     hint: "add {} to get a valid time",
-                    format_missing_args(args.into_iter().flatten().collect())
+                    format_missing_args(args.into_iter().flatten().collect());
                 )
             }
         };
@@ -326,7 +326,7 @@ impl Datetime {
                 bail!(
                     "date is incomplete";
                     hint: "add {} to get a valid date",
-                    format_missing_args(args.into_iter().flatten().collect())
+                    format_missing_args(args.into_iter().flatten().collect());
                 )
             }
         };
@@ -341,7 +341,7 @@ impl Datetime {
                 bail!(
                     "at least one of date or time must be fully specified";
                     hint: "add the `hour`, `minute`, and `second` arguments to get a valid time";
-                    hint: "add the `year`, `month`, and `day` arguments to get a valid date"
+                    hint: "add the `year`, `month`, and `day` arguments to get a valid date";
                 )
             }
         })

--- a/crates/typst-library/src/foundations/decimal.rs
+++ b/crates/typst-library/src/foundations/decimal.rs
@@ -333,7 +333,7 @@ fn warn_on_float_literal(engine: &mut Engine, span: Span) -> Option<()> {
             "creating a decimal using imprecise float literal";
             hint: "use a string in the decimal constructor to avoid loss \
                    of precision: `decimal({})`",
-            node.text().repr()
+            node.text().repr();
         ));
     }
     Some(())

--- a/crates/typst-library/src/foundations/mod.rs
+++ b/crates/typst-library/src/foundations/mod.rs
@@ -208,7 +208,7 @@ impl assert {
                 bail!(
                     "equality assertion failed: value {} was not equal to {}",
                     left.repr(),
-                    right.repr()
+                    right.repr(),
                 );
             }
         }
@@ -241,7 +241,7 @@ impl assert {
                 bail!(
                     "inequality assertion failed: value {} was equal to {}",
                     left.repr(),
-                    right.repr()
+                    right.repr(),
                 );
             }
         }

--- a/crates/typst-library/src/foundations/plugin.rs
+++ b/crates/typst-library/src/foundations/plugin.rs
@@ -460,7 +460,7 @@ impl PluginInstance {
         // match the schema.
         if ty.params().iter().any(|&v| v != wasmi::core::ValType::I32) {
             bail!(
-                "plugin function `{func}` has a parameter that is not a 32-bit integer"
+                "plugin function `{func}` has a parameter that is not a 32-bit integer",
             );
         }
         if ty.results() != [wasmi::core::ValType::I32] {

--- a/crates/typst-library/src/foundations/scope.rs
+++ b/crates/typst-library/src/foundations/scope.rs
@@ -319,7 +319,7 @@ impl Binding {
                 match capturer {
                     Capturer::Function => "function",
                     Capturer::Context => "context expression",
-                }
+                },
             ),
         }
     }

--- a/crates/typst-library/src/foundations/str.rs
+++ b/crates/typst-library/src/foundations/str.rs
@@ -169,7 +169,7 @@ impl Str {
                 if b == 1 && n > 0 {
                     bail!(
                         base.span, "base must be between 2 and 36";
-                        hint: "generate a unary representation with `\"1\" * {}`", n
+                        hint: "generate a unary representation with `\"1\" * {n}`";
                     );
                 }
                 if b < 2 || b > 36 {

--- a/crates/typst-library/src/foundations/symbol.rs
+++ b/crates/typst-library/src/foundations/symbol.rs
@@ -252,7 +252,7 @@ impl Symbol {
             if v.1.is_empty() || v.1.graphemes(true).nth(1).is_some() {
                 errors.push(error!(
                     span, "invalid variant value: {}", v.1.repr();
-                    hint: "variant value must be exactly one grapheme cluster"
+                    hint: "variant value must be exactly one grapheme cluster";
                 ));
             }
 
@@ -263,7 +263,7 @@ impl Symbol {
                         errors.push(error!(
                             span,
                             "invalid symbol modifier: {}",
-                            modifier.repr()
+                            modifier.repr(),
                         ));
                         continue 'variants;
                     }
@@ -278,7 +278,7 @@ impl Symbol {
             if let Some(ms) = modifiers.windows(2).find(|ms| ms[0] == ms[1]) {
                 errors.push(error!(
                     span, "duplicate modifier within variant: {}", ms[0].repr();
-                    hint: "modifiers are not ordered, so each one may appear only once"
+                    hint: "modifiers are not ordered, so each one may appear only once";
                 ));
                 continue 'variants;
             }
@@ -293,7 +293,8 @@ impl Symbol {
                 } else {
                     error!(
                         span, "duplicate variant: {}", v.0.repr();
-                        hint: "variants with the same modifiers are identical, regardless of their order"
+                        hint: "variants with the same modifiers are identical, \
+                               regardless of their order";
                     )
                 });
                 continue 'variants;

--- a/crates/typst-library/src/foundations/version.rs
+++ b/crates/typst-library/src/foundations/version.rs
@@ -117,7 +117,7 @@ impl Version {
                 Some(pos_index) if pos_index >= 0 => index = pos_index,
                 _ => bail!(
                     "component index out of bounds (index: {index}, len: {})",
-                    self.0.len()
+                    self.0.len(),
                 ),
             }
         }

--- a/crates/typst-library/src/introspection/convergence.rs
+++ b/crates/typst-library/src/introspection/convergence.rs
@@ -63,7 +63,7 @@ pub fn analyze(
             hint: "see {} additional warning{} for more details",
                 diags.len(),
                 if diags.len() > 1 { "s" } else { "" };
-            hint: "see https://typst.app/help/convergence for help",
+            hint: "see https://typst.app/help/convergence for help";
         );
         diags.insert(0, summary);
     }

--- a/crates/typst-library/src/introspection/locator.rs
+++ b/crates/typst-library/src/introspection/locator.rs
@@ -328,7 +328,7 @@ impl Introspect for MeasureIntrospection {
         let mut diag = warning!(
             self.measure_span, "a measured element did not stabilize";
             hint: "measurement tries to resolve introspections by finding the \
-                   closest matching elements in the real document"
+                   closest matching elements in the real document";
         );
         if !self.elem_span.is_detached() {
             diag.spanned_hint(

--- a/crates/typst-library/src/layout/align.rs
+++ b/crates/typst-library/src/layout/align.rs
@@ -360,7 +360,7 @@ impl TryFrom<Alignment> for HAlignment {
             Alignment::H(h) => Ok(h),
             v => bail!(
                 "expected `start`, `left`, `center`, `right`, or `end`, found {}",
-                v.repr()
+                v.repr(),
             ),
         }
     }

--- a/crates/typst-library/src/layout/axes.rs
+++ b/crates/typst-library/src/layout/axes.rs
@@ -301,7 +301,7 @@ impl<T: FromValue> FromValue for Axes<T> {
             _ => bail!(
                 "array must contain exactly two items";
                 hint: "the first item determines the value for the X axis \
-                       and the second item the value for the Y axis"
+                       and the second item the value for the Y axis";
             ),
         }
     }

--- a/crates/typst-library/src/layout/grid/mod.rs
+++ b/crates/typst-library/src/layout/grid/mod.rs
@@ -484,13 +484,13 @@ impl TryFrom<Content> for GridChild {
         if value.is::<TableHeader>() {
             bail!(
                 "cannot use `table.header` as a grid header";
-                hint: "use `grid.header` instead"
+                hint: "use `grid.header` instead";
             )
         }
         if value.is::<TableFooter>() {
             bail!(
                 "cannot use `table.footer` as a grid footer";
-                hint: "use `grid.footer` instead"
+                hint: "use `grid.footer` instead";
             )
         }
 
@@ -540,19 +540,19 @@ impl TryFrom<Content> for GridItem {
         if value.is::<TableCell>() {
             bail!(
                 "cannot use `table.cell` as a grid cell";
-                hint: "use `grid.cell` instead"
+                hint: "use `grid.cell` instead";
             );
         }
         if value.is::<TableHLine>() {
             bail!(
                 "cannot use `table.hline` as a grid line";
-                hint: "use `grid.hline` instead"
+                hint: "use `grid.hline` instead";
             );
         }
         if value.is::<TableVLine>() {
             bail!(
                 "cannot use `table.vline` as a grid line";
-                hint: "use `grid.vline` instead"
+                hint: "use `grid.vline` instead";
             );
         }
 

--- a/crates/typst-library/src/layout/grid/resolve.rs
+++ b/crates/typst-library/src/layout/grid/resolve.rs
@@ -1413,7 +1413,8 @@ impl CellGridResolver<'_, '_> {
                 bail!(
                     cell_span,
                     "cell's colspan would cause it to exceed the available column(s)";
-                    hint: "try placing the cell in another position or reducing its colspan"
+                    hint: "try placing the cell in another position or reducing its \
+                           colspan";
                 )
             }
 
@@ -1427,7 +1428,7 @@ impl CellGridResolver<'_, '_> {
                 bail!(
                     cell_span,
                     "cell would span an exceedingly large position";
-                    hint: "try reducing the cell's rowspan or colspan"
+                    hint: "try reducing the cell's rowspan or colspan";
                 )
             };
 
@@ -1499,7 +1500,7 @@ impl CellGridResolver<'_, '_> {
                 bail!(
                     cell_span,
                     "attempted to place a second cell at column {x}, row {y}";
-                    hint: "try specifying your cells in a different order"
+                    hint: "try specifying your cells in a different order";
                 );
             }
 
@@ -1522,8 +1523,10 @@ impl CellGridResolver<'_, '_> {
                     if slot.is_some() {
                         bail!(
                             cell_span,
-                            "cell would span a previously placed cell at column {spanned_x}, row {spanned_y}";
-                            hint: "try specifying your cells in a different order or reducing the cell's rowspan or colspan"
+                            "cell would span a previously placed cell at column \
+                             {spanned_x}, row {spanned_y}";
+                            hint: "try specifying your cells in a different order or \
+                                   reducing the cell's rowspan or colspan";
                         )
                     }
                     *slot = Some(Entry::Merged { parent: resolved_index });
@@ -1727,8 +1730,10 @@ impl CellGridResolver<'_, '_> {
             if y == row_amount && line.position == LinePosition::After {
                 bail!(
                     line_span,
-                    "cannot place horizontal line at the 'bottom' position of the bottom border (y = {y})";
-                    hint: "set the line's position to 'top' or place it at a smaller 'y' index"
+                    "cannot place horizontal line at the 'bottom' position of the \
+                     bottom border (y = {y})";
+                    hint: "set the line's position to 'top' or place it at a smaller \
+                           'y' index";
                 );
             }
             let line = if line.position == LinePosition::After
@@ -1765,8 +1770,10 @@ impl CellGridResolver<'_, '_> {
             if x == columns && line.position == LinePosition::After {
                 bail!(
                     line_span,
-                    "cannot place vertical line at the 'end' position of the end border (x = {columns})";
-                    hint: "set the line's position to 'start' or place it at a smaller 'x' index"
+                    "cannot place vertical line at the 'end' position of the end border \
+                     (x = {columns})";
+                    hint: "set the line's position to 'start' or place it at a smaller \
+                           'x' index";
                 );
             }
             let line = if line.position == LinePosition::After
@@ -2018,7 +2025,7 @@ fn expand_row_group(
             "cell would cause {} to expand to non-empty row {}",
             group_kind.name(),
             first_available_row.saturating_sub(1);
-            hint: "try moving its cells to available rows"
+            hint: "try moving its cells to available rows";
         );
     }
 
@@ -2083,7 +2090,7 @@ fn expand_row_group(
                 bail!(
                     "cell would cause {} to expand to non-empty row {new_y}",
                     group_kind.name();
-                    hint: "try moving its cells to available rows",
+                    hint: "try moving its cells to available rows";
                 )
             }
         } else {
@@ -2115,7 +2122,7 @@ fn check_for_conflicting_cell_row(
     {
         bail!(
             "cell would conflict with header also spanning row {row}";
-            hint: "try moving the cell or the header"
+            hint: "try moving the cell or the header";
         );
     }
 
@@ -2134,7 +2141,7 @@ fn check_for_conflicting_cell_row(
 
         bail!(
             "cell would conflict with footer also spanning row {row}";
-            hint: "try reducing the cell's rowspan or moving the footer"
+            hint: "try reducing the cell's rowspan or moving the footer";
         );
     }
 

--- a/crates/typst-library/src/layout/length.rs
+++ b/crates/typst-library/src/layout/length.rs
@@ -88,7 +88,7 @@ impl Length {
             self.repr();
             hint: "use `length.to-absolute()` to resolve its em component \
                    (requires context)";
-            hint: "or use `length.abs.{unit}()` instead to ignore its em component"
+            hint: "or use `length.abs.{unit}()` instead to ignore its em component";
         )
     }
 }

--- a/crates/typst-library/src/model/bibliography.rs
+++ b/crates/typst-library/src/model/bibliography.rs
@@ -634,7 +634,7 @@ impl Introspect for CiteGroupIntrospection {
         warning!(
             self.0, "citation grouping did not stabilize";
             hint: "this can happen if the citations and bibliographies in the \
-                   document did not stabilize by the end of the third layout iteration"
+                   document did not stabilize by the end of the third layout iteration";
         )
     }
 }
@@ -729,7 +729,7 @@ impl<'a> Generator<'a> {
                     errors.push(error!(
                         child.span(),
                         "key `{}` does not exist in the bibliography",
-                        child.key.resolve()
+                        child.key.resolve(),
                     ));
                     continue;
                 };

--- a/crates/typst-library/src/model/cite.rs
+++ b/crates/typst-library/src/model/cite.rs
@@ -178,6 +178,6 @@ fn failed_to_format_citation() -> HintedString {
     error!(
         "cannot format citation in isolation";
         hint: "check whether this citation is measured \
-               without being inserted into the document"
+               without being inserted into the document";
     )
 }

--- a/crates/typst-library/src/model/footnote.rs
+++ b/crates/typst-library/src/model/footnote.rs
@@ -303,7 +303,7 @@ impl Packed<FootnoteEntry> {
         let Some(loc) = self.note.location() else {
             bail!(
                 self.span(), "footnote entry must have a location";
-                hint: "try using a query or a show rule to customize the footnote instead"
+                hint: "try using a query or a show rule to customize the footnote instead";
             );
         };
 

--- a/crates/typst-library/src/model/outline.rs
+++ b/crates/typst-library/src/model/outline.rs
@@ -756,7 +756,7 @@ impl OutlineEntry {
             if elem.can::<dyn Outlinable>() {
                 error!(
                     "{} must have a location", elem.func().name();
-                    hint: "try using a show rule to customize the outline.entry instead",
+                    hint: "try using a show rule to customize the outline.entry instead";
                 )
             } else {
                 error!("cannot outline {}", elem.func().name())

--- a/crates/typst-library/src/model/reference.rs
+++ b/crates/typst-library/src/model/reference.rs
@@ -267,7 +267,7 @@ impl Packed<RefElem> {
                     self.target.repr();
                     hint: "change either the {}'s label or the \
                            bibliography key to resolve the ambiguity",
-                    elem.func().name(),
+                    elem.func().name();
                 );
             }
 

--- a/crates/typst-library/src/model/table.rs
+++ b/crates/typst-library/src/model/table.rs
@@ -357,13 +357,13 @@ impl TryFrom<Content> for TableChild {
         if value.is::<GridHeader>() {
             bail!(
                 "cannot use `grid.header` as a table header";
-                hint: "use `table.header` instead"
+                hint: "use `table.header` instead";
             )
         }
         if value.is::<GridFooter>() {
             bail!(
                 "cannot use `grid.footer` as a table footer";
-                hint: "use `table.footer` instead"
+                hint: "use `table.footer` instead";
             )
         }
 
@@ -414,19 +414,19 @@ impl TryFrom<Content> for TableItem {
         if value.is::<GridCell>() {
             bail!(
                 "cannot use `grid.cell` as a table cell";
-                hint: "use `table.cell` instead"
+                hint: "use `table.cell` instead";
             );
         }
         if value.is::<GridHLine>() {
             bail!(
                 "cannot use `grid.hline` as a table line";
-                hint: "use `table.hline` instead"
+                hint: "use `table.hline` instead";
             );
         }
         if value.is::<GridVLine>() {
             bail!(
                 "cannot use `grid.vline` as a table line";
-                hint: "use `table.vline` instead"
+                hint: "use `table.vline` instead";
             );
         }
 

--- a/crates/typst-library/src/text/mod.rs
+++ b/crates/typst-library/src/text/mod.rs
@@ -275,7 +275,7 @@ pub struct TextElem {
                 bail!(
                     paint.span,
                     "gradients and tilings on text must be relative to the parent";
-                    hint: "make sure to set `relative: auto` on your text fill"
+                    hint: "make sure to set `relative: auto` on your text fill";
                 );
             }
         paint.map(|paint| paint.v)
@@ -929,7 +929,7 @@ cast! {
             ) => {}
             _ => bail!(
                 "coverage regex may only use dot, letters, and character classes";
-                hint: "the regex is applied to each letter individually"
+                hint: "the regex is applied to each letter individually";
             ),
         }
         Covers::Regex(regex)
@@ -1463,8 +1463,10 @@ fn check_font_list(engine: &mut Engine, list: &Spanned<FontList>) {
                 {
                     engine.sink.warn(warning!(
                         list.span,
-                        "variable fonts are not currently supported and may render incorrectly";
-                        hint: "try installing a static version of \"{}\" instead", family.as_str()
+                        "variable fonts are not currently supported and may render \
+                         incorrectly";
+                        hint: "try installing a static version of \"{}\" instead",
+                            family.as_str();
                     ))
                 }
             }

--- a/crates/typst-library/src/text/smartquote.rs
+++ b/crates/typst-library/src/text/smartquote.rs
@@ -336,7 +336,7 @@ fn str_to_set(value: &str) -> StrResult<[EcoString; 2]> {
             let count = value.graphemes(true).count();
             bail!(
                 "expected 2 characters, found {count} character{}",
-                if count > 1 { "s" } else { "" }
+                if count > 1 { "s" } else { "" },
             );
         }
     }
@@ -348,7 +348,7 @@ fn array_to_set(value: Array) -> HintedStrResult<[EcoString; 2]> {
         bail!(
             "expected 2 quotes, found {} quote{}",
             value.len(),
-            if value.len() > 1 { "s" } else { "" }
+            if value.len() > 1 { "s" } else { "" },
         );
     }
 

--- a/crates/typst-library/src/visualize/color.rs
+++ b/crates/typst-library/src/visualize/color.rs
@@ -892,7 +892,7 @@ impl Color {
         Ok(match self {
             Self::Luma(_) => bail!(
                 span, "cannot saturate grayscale color";
-                hint: "try converting your color to RGB first"
+                hint: "try converting your color to RGB first";
             ),
             Self::Hsl(c) => Self::Hsl(c.saturate(f)),
             Self::Hsv(c) => Self::Hsv(c.saturate(f)),
@@ -918,7 +918,7 @@ impl Color {
         Ok(match self {
             Self::Luma(_) => bail!(
                 span, "cannot desaturate grayscale color";
-                hint: "try converting your color to RGB first"
+                hint: "try converting your color to RGB first";
             ),
             Self::Hsl(c) => Self::Hsl(c.desaturate(f)),
             Self::Hsv(c) => Self::Hsv(c.desaturate(f)),

--- a/crates/typst-library/src/visualize/gradient.rs
+++ b/crates/typst-library/src/visualize/gradient.rs
@@ -243,7 +243,7 @@ impl Gradient {
         if stops.len() < 2 {
             bail!(
                 span, "a gradient must have at least two stops";
-                hint: "try filling the shape with a single color instead"
+                hint: "try filling the shape with a single color instead";
             );
         }
 
@@ -345,7 +345,7 @@ impl Gradient {
         if stops.len() < 2 {
             bail!(
                 span, "a gradient must have at least two stops";
-                hint: "try filling the shape with a single color instead"
+                hint: "try filling the shape with a single color instead";
             );
         }
 
@@ -353,7 +353,7 @@ impl Gradient {
             bail!(
                 focal_radius.span,
                 "the focal radius must be smaller than the end radius";
-                hint: "try using a focal radius of `0%` instead"
+                hint: "try using a focal radius of `0%` instead";
             );
         }
 
@@ -364,7 +364,7 @@ impl Gradient {
             bail!(
                 span,
                 "the focal circle must be inside of the end circle";
-                hint: "try using a focal center of `auto` instead"
+                hint: "try using a focal center of `auto` instead";
             );
         }
 
@@ -436,7 +436,7 @@ impl Gradient {
         if stops.len() < 2 {
             bail!(
                 span, "a gradient must have at least two stops";
-                hint: "try filling the shape with a single color instead"
+                hint: "try filling the shape with a single color instead";
             );
         }
 
@@ -1227,7 +1227,7 @@ fn process_stops(stops: &[Spanned<GradientStop>]) -> SourceResult<Vec<(Color, Ra
             let Some(stop) = stop.offset else {
                 bail!(
                     *span, "either all stops must have an offset or none of them can";
-                    hint: "try adding an offset to all stops"
+                    hint: "try adding an offset to all stops";
                 );
             };
 
@@ -1252,7 +1252,7 @@ fn process_stops(stops: &[Spanned<GradientStop>]) -> SourceResult<Vec<(Color, Ra
             bail!(
                 stops[0].span,
                 "first stop must have an offset of 0";
-                hint: "try setting this stop to `0%`"
+                hint: "try setting this stop to `0%`";
             );
         }
 
@@ -1260,7 +1260,7 @@ fn process_stops(stops: &[Spanned<GradientStop>]) -> SourceResult<Vec<(Color, Ra
             bail!(
                 stops[out.len() - 1].span,
                 "last stop must have an offset of 100%";
-                hint: "try setting this stop to `100%`"
+                hint: "try setting this stop to `100%`";
             );
         }
 

--- a/crates/typst-library/src/visualize/image/mod.rs
+++ b/crates/typst-library/src/visualize/image/mod.rs
@@ -296,8 +296,10 @@ impl Packed<ImageElem> {
                     engine.sink.warn(warning!(
                         span,
                         "image contains foreign object";
-                        hint: "SVG images with foreign objects might render incorrectly in Typst";
-                        hint: "see https://github.com/typst/typst/issues/1421 for more information"
+                        hint: "SVG images with foreign objects might render incorrectly \
+                               in Typst";
+                        hint: "see https://github.com/typst/typst/issues/1421 for more \
+                               information";
                     ));
                 }
 
@@ -326,14 +328,14 @@ impl Packed<ImageElem> {
                                 span,
                                 "the PDF is encrypted or password-protected";
                                 hint: "such PDFs are currently not supported";
-                                hint: "preprocess the PDF to remove the encryption"
+                                hint: "preprocess the PDF to remove the encryption";
                             );
                         }
                         LoadPdfError::Invalid => {
                             bail!(
                                 span,
                                 "the PDF could not be loaded";
-                                hint: "perhaps the PDF file is malformed"
+                                hint: "perhaps the PDF file is malformed";
                             );
                         }
                     },
@@ -345,7 +347,8 @@ impl Packed<ImageElem> {
                         span,
                         "PDF contains optional content groups";
                         hint: "the image might display incorrectly in PDF export";
-                        hint: "preprocess the PDF to flatten or remove optional content groups"
+                        hint: "preprocess the PDF to flatten or remove optional content \
+                               groups";
                     ));
                 }
 
@@ -360,7 +363,7 @@ impl Packed<ImageElem> {
                     bail!(
                         span,
                         "page {page_num} does not exist";
-                        hint: "the document only has {num_pages} page{s}"
+                        hint: "the document only has {num_pages} page{s}";
                     );
                 };
 

--- a/crates/typst-library/src/visualize/tiling.rs
+++ b/crates/typst-library/src/visualize/tiling.rs
@@ -208,7 +208,7 @@ impl Tiling {
         if frame.width().is_zero() || frame.height().is_zero() {
             bail!(
                 span, "tile size must be non-zero";
-                hint: "try setting the size manually"
+                hint: "try setting the size manually";
             );
         }
 

--- a/crates/typst-macros/src/elem.rs
+++ b/crates/typst-macros/src/elem.rs
@@ -178,7 +178,7 @@ fn parse(stream: TokenStream, body: &syn::ItemStruct) -> Result<Elem> {
     {
         bail!(
             body.ident,
-            "cannot have public ghost fields and an auto-generated constructor"
+            "cannot have public ghost fields and an auto-generated constructor",
         );
     }
 

--- a/crates/typst-pdf/src/convert.rs
+++ b/crates/typst-pdf/src/convert.rs
@@ -384,7 +384,7 @@ fn finish(
                     "failed to process {} ({err})",
                     display_font(gc.fonts_backward.get(&f));
                     hint: "make sure the font is valid";
-                    hint: "the used font might be unsupported by Typst"
+                    hint: "the used font might be unsupported by Typst";
                 );
             }
             KrillaError::Validation(ve) => {
@@ -402,7 +402,7 @@ fn finish(
                 let span = gc.image_to_spans.get(&image).unwrap();
                 bail!(
                     *span, "16 bit images are not supported in this export mode";
-                    hint: "convert the image to 8 bit instead"
+                    hint: "convert the image to 8 bit instead";
                 )
             }
             KrillaError::Pdf(_, e, loc) => {
@@ -412,7 +412,7 @@ fn finish(
                     PdfError::InvalidPage(_) => bail!(
                         span,
                         "invalid page number for PDF file";
-                        hint: "please report this as a bug"
+                        hint: "please report this as a bug";
                     ),
                     PdfError::VersionMismatch(v) => {
                         let pdf_ver = v.as_str();
@@ -420,9 +420,10 @@ fn finish(
                         let cur_ver = config_ver.as_str();
                         bail!(span,
                             "the version of the PDF is too high";
-                            hint: "the current export target is {cur_ver}, while the PDF has version {pdf_ver}";
+                            hint: "the current export target is {cur_ver}, while the PDF \
+                                   has version {pdf_ver}";
                             hint: "raise the export target to {pdf_ver} or higher";
-                            hint: "or preprocess the PDF to convert it to a lower version"
+                            hint: "or preprocess the PDF to convert it to a lower version";
                         );
                     }
                 }
@@ -431,14 +432,14 @@ fn finish(
                 let span = to_span(loc);
                 bail!(span,
                     "duplicate tag id";
-                    hint: "please report this as a bug"
+                    hint: "please report this as a bug";
                 );
             }
             KrillaError::UnknownTagId(_, loc) => {
                 let span = to_span(loc);
                 bail!(span,
                     "unknown tag id";
-                    hint: "please report this as a bug"
+                    hint: "please report this as a bug";
                 );
             }
         },
@@ -456,57 +457,57 @@ fn convert_error(
         ValidationError::TooLongString => error!(
             Span::detached(),
             "{prefix} a PDF string is longer than 32767 characters";
-            hint: "ensure title and author names are short enough"
+            hint: "ensure title and author names are short enough";
         ),
         // Should in theory never occur, as krilla always trims font names.
         ValidationError::TooLongName => error!(
             Span::detached(),
             "{prefix} a PDF name is longer than 127 characters";
-            hint: "perhaps a font name is too long"
+            hint: "perhaps a font name is too long";
         ),
 
         ValidationError::TooLongArray => error!(
             Span::detached(),
             "{prefix} a PDF array is longer than 8191 elements";
-            hint: "this can happen if you have a very long text in a single line"
+            hint: "this can happen if you have a very long text in a single line";
         ),
         ValidationError::TooLongDictionary => error!(
             Span::detached(),
             "{prefix} a PDF dictionary has more than 4095 entries";
-            hint: "try reducing the complexity of your document"
+            hint: "try reducing the complexity of your document";
         ),
         ValidationError::TooLargeFloat => error!(
             Span::detached(),
             "{prefix} a PDF floating point number is larger than the allowed limit";
-            hint: "try exporting with a higher PDF version"
+            hint: "try exporting with a higher PDF version";
         ),
         ValidationError::TooManyIndirectObjects => error!(
             Span::detached(),
             "{prefix} the PDF has too many indirect objects";
-            hint: "reduce the size of your document"
+            hint: "reduce the size of your document";
         ),
         // Can only occur if we have 27+ nested clip paths
         ValidationError::TooHighQNestingLevel => error!(
             Span::detached(),
             "{prefix} the PDF has too high q nesting";
-            hint: "reduce the number of nested containers"
+            hint: "reduce the number of nested containers";
         ),
         ValidationError::ContainsPostScript(loc) => error!(
             to_span(*loc),
             "{prefix} the PDF contains PostScript code";
-            hint: "conic gradients are not supported in this PDF standard"
+            hint: "conic gradients are not supported in this PDF standard";
         ),
         ValidationError::MissingCMYKProfile => error!(
             Span::detached(),
             "{prefix} the PDF is missing a CMYK profile";
-            hint: "CMYK colors are not yet supported in this export mode"
+            hint: "CMYK colors are not yet supported in this export mode";
         ),
         ValidationError::ContainsNotDefGlyph(f, loc, text) => error!(
             to_span(*loc),
             "{prefix} the text `{}` could not be displayed with {}",
             text.repr(),
             display_font(gc.fonts_backward.get(f));
-            hint: "try using a different font"
+            hint: "try using a different font";
         ),
         ValidationError::NoCodepointMapping(_, _, loc) => {
             let msg = if loc.is_some() {
@@ -518,7 +519,7 @@ fn convert_error(
                 to_span(*loc),
                 "{prefix} {msg}";
                 hint: "for complex scripts like Arabic, it might not be \
-                       possible to produce a compliant document"
+                       possible to produce a compliant document";
             )
         }
         ValidationError::InvalidCodepointMapping(_, _, c, loc) => {
@@ -530,7 +531,7 @@ fn convert_error(
             error!(
                 to_span(*loc),
                 "{prefix} {msg} the disallowed codepoint `{}`",
-                c.repr()
+                c.repr(),
             )
         }
         ValidationError::UnicodePrivateArea(_, _, c, loc) => {
@@ -539,16 +540,18 @@ fn convert_error(
                 to_span(*loc),
                 "{prefix} {msg} contains the codepoint `{}`", c.repr();
                 hint: "codepoints from the Unicode private area are \
-                       forbidden in this export mode",
+                       forbidden in this export mode";
             )
         }
         ValidationError::RestrictedLicense(f) => error!(
             Span::detached(),
             "{prefix} license of {} is too restrictive",
             display_font(gc.fonts_backward.get(f));
-            hint: "the font has specified \"Restricted License embedding\" in its metadata";
-            hint: "restrictive font licenses are prohibited by {} because they limit the suitability for archival",
-            validator.as_str()
+            hint: "the font has specified \"Restricted License embedding\" in its \
+                   metadata";
+            hint: "restrictive font licenses are prohibited by {} because they limit \
+                   the suitability for archival",
+            validator.as_str();
         ),
         ValidationError::Transparency(loc) => {
             let span = to_span(*loc);
@@ -561,20 +564,20 @@ fn convert_error(
                         hint: "{hint1}";
                         hint: "or convert the image to a non-transparent one";
                         hint: "you might have to convert SVGs into \
-                               non-transparent bitmap images"
+                               non-transparent bitmap images";
                     )
                 } else {
                     error!(
                         span, "{prefix} the used fill or stroke has transparency";
                         hint: "{hint1}";
                         hint: "or don't use colors with transparency in \
-                               this export mode"
+                               this export mode";
                     )
                 }
             } else {
                 error!(
                     span, "{prefix} the PDF contains transparency";
-                    hint: "{hint1}"
+                    hint: "{hint1}";
                 )
             }
         }
@@ -583,12 +586,12 @@ fn convert_error(
             if loc.is_some() {
                 error!(
                     span, "{prefix} the image has smooth scaling";
-                    hint: "set the `scaling` attribute to `pixelated`"
+                    hint: "set the `scaling` attribute to `pixelated`";
                 )
             } else {
                 error!(
                     span, "{prefix} an image in the PDF has smooth scaling";
-                    hint: "set the `scaling` attribute of all images to `pixelated`"
+                    hint: "set the `scaling` attribute of all images to `pixelated`";
                 )
             }
         }
@@ -599,14 +602,14 @@ fn convert_error(
                 EmbedError::Existence => {
                     error!(
                         span, "{prefix} document contains an attached file";
-                        hint: "file attachments are not supported in this export mode"
+                        hint: "file attachments are not supported in this export mode";
                     )
                 }
                 EmbedError::MissingDate => {
                     error!(
                         span, "{prefix} document date is missing";
                         hint: "the document must have a date when attaching files";
-                        hint: "`set document(date: none)` must not be used in this case"
+                        hint: "`set document(date: none)` must not be used in this case";
                     )
                 }
                 EmbedError::MissingDescription => {
@@ -623,52 +626,52 @@ fn convert_error(
             let span = to_span(*loc);
             error!(
                 span, "{prefix} missing annotation alt text";
-                hint: "please report this as a bug"
+                hint: "please report this as a bug";
             )
         }
         ValidationError::MissingAltText(loc) => {
             let span = to_span(*loc);
             error!(
                 span, "{prefix} missing alt text";
-                hint: "make sure your images and equations have alt text"
+                hint: "make sure your images and equations have alt text";
             )
         }
         ValidationError::NoDocumentLanguage => error!(
             Span::detached(),
             "{prefix} missing document language";
-            hint: "set the language of the document"
+            hint: "set the language of the document";
         ),
         // Needs to be set by typst-pdf.
         ValidationError::MissingHeadingTitle => error!(
             Span::detached(),
             "{prefix} missing heading title";
-            hint: "please report this as a bug"
+            hint: "please report this as a bug";
         ),
         ValidationError::MissingDocumentOutline => error!(
             Span::detached(),
             "{prefix} missing document outline";
-            hint: "please report this as a bug"
+            hint: "please report this as a bug";
         ),
         ValidationError::MissingTagging => error!(
             Span::detached(),
             "{prefix} missing document tags";
-            hint: "please report this as a bug"
+            hint: "please report this as a bug";
         ),
         ValidationError::NoDocumentTitle => error!(
             Span::detached(),
             "{prefix} missing document title";
-            hint: "set the title with `set document(title: [...])`"
+            hint: "set the title with `set document(title: [...])`";
         ),
         ValidationError::MissingDocumentDate => error!(
             Span::detached(),
             "{prefix} missing document date";
-            hint: "set the date of the document"
+            hint: "set the date of the document";
         ),
         ValidationError::EmbeddedPDF(loc) => {
             error!(
                 to_span(*loc),
                 "embedding PDFs is currently not supported in this export mode";
-                hint: "try converting the PDF to an SVG before embedding it"
+                hint: "try converting the PDF to an SVG before embedding it";
             )
         }
     }

--- a/crates/typst-pdf/src/lib.rs
+++ b/crates/typst-pdf/src/lib.rs
@@ -100,7 +100,7 @@ impl PdfStandards {
                 bail!(
                     "PDF cannot conform to {} and {} at the same time",
                     prev.as_str(),
-                    v.as_str()
+                    v.as_str(),
                 );
             }
             version = Some(v);

--- a/crates/typst-pdf/src/link.rs
+++ b/crates/typst-pdf/src/link.rs
@@ -67,7 +67,7 @@ pub(crate) fn handle_link(
                 "{validator} error: PDF artifacts may not contain links";
                 hint: "a link was used within a tiling";
                 hint: "references, citations, and footnotes \
-                       are also considered links in PDF"
+                       are also considered links in PDF";
             );
         }
 
@@ -96,7 +96,7 @@ pub(crate) fn handle_link(
                 link.span(),
                 "{validator} error: PDF artifacts may not contain links";
                 hint: "references, citations, and footnotes \
-                       are also considered links in PDF"
+                       are also considered links in PDF";
             );
         }
 

--- a/crates/typst-pdf/src/tags/resolve.rs
+++ b/crates/typst-pdf/src/tags/resolve.rs
@@ -324,14 +324,14 @@ fn build_group_tag(rs: &mut Resolver, group: &Group) -> Option<TagKind> {
             if rs.last_heading_level.is_none() {
                 rs.errors.push(error!(
                     span,
-                    "{validator} error: the first heading must be of level 1"
+                    "{validator} error: the first heading must be of level 1",
                 ));
             } else {
                 rs.errors.push(error!(
                     span,
                     "{validator} error: skipped from heading level \
                      {prev_level} to {next_level}";
-                    hint: "heading levels must be consecutive"
+                    hint: "heading levels must be consecutive";
                 ));
             }
         }
@@ -530,7 +530,7 @@ fn validate_children_groups(
                 span,
                 "{validator} error: invalid {parent} structure";
                 hint: "{parent} may not contain {child}";
-                hint: "this is probably caused by a show rule"
+                hint: "this is probably caused by a show rule";
             ));
         } else if matches!(&child.tag, TagKind::Caption(_)) {
             caption_spans.push(to_span(child.tag.location()));
@@ -547,7 +547,7 @@ fn validate_children_groups(
                 span,
                 "{validator} error: invalid {parent} structure";
                 hint: "{parent} may not contain multiple {child} tags";
-                hint: "avoid manually calling `figure.caption`"
+                hint: "avoid manually calling `figure.caption`";
             )
         };
         if caption_spans.iter().all(|s| !s.is_detached()) {
@@ -564,7 +564,7 @@ fn validate_children_groups(
             parent_span,
             "{validator} error: invalid {parent} structure";
             hint: "{parent} may not contain marked content directly";
-            hint: "this is probably caused by a show rule"
+            hint: "this is probably caused by a show rule";
         ));
     }
 }

--- a/crates/typst-pdf/src/tags/tree/build.rs
+++ b/crates/typst-pdf/src/tags/tree/build.rs
@@ -206,7 +206,7 @@ pub fn build(document: &PagedDocument, options: &PdfOptions) -> SourceResult<Tre
             bail!(
                 group.span,
                 "{validator} error: ambiguous logical parent";
-                hint: "please report this as a bug"
+                hint: "please report this as a bug";
             );
         }
 
@@ -462,8 +462,10 @@ fn progress_tree_start(tree: &mut TreeBuilder, elem: &Content) -> GroupId {
                 error!(
                     heading.span(),
                     "{validator} error: heading title could not be determined";
-                    hint: "this seems to be caused by a context expression within the heading";
-                    hint: "consider wrapping the entire heading in a context expression instead"
+                    hint: "this seems to be caused by a context expression within the \
+                           heading";
+                    hint: "consider wrapping the entire heading in a context expression \
+                           instead";
                 )
             } else {
                 error!(heading.span(), "{validator} error: heading title is empty")
@@ -651,14 +653,14 @@ fn progress_tree_end(tree: &mut TreeBuilder, loc: Location) -> SourceResult<Grou
                     "{validator} error: invalid document structure, \
                      this element's PDF tag would be split up";
                     hint: "this is probably caused by paragraph grouping";
-                    hint: "maybe you've used a `parbreak`, `colbreak`, or `pagebreak`"
+                    hint: "maybe you've used a `parbreak`, `colbreak`, or `pagebreak`";
                 );
             } else {
                 bail!(
                     non_breakable_span,
                     "invalid document structure, \
                      this element's PDF tag would be split up";
-                    hint: "please report this as a bug"
+                    hint: "please report this as a bug";
                 );
             }
         }

--- a/crates/typst-pdf/src/tags/tree/text.rs
+++ b/crates/typst-pdf/src/tags/tree/text.rs
@@ -266,7 +266,7 @@ fn compute_deco<'a>(
                 let span = elem.span();
                 *err = Some(error!(
                     span,
-                    "{validator} error: cannot combine underline, overline, or strike"
+                    "{validator} error: cannot combine underline, overline, or strike",
                 ));
             }
         }

--- a/crates/typst-pdf/src/text.rs
+++ b/crates/typst-pdf/src/text.rs
@@ -90,7 +90,7 @@ fn build_font(typst_font: Font) -> SourceResult<krilla::text::Font> {
             bail!(
                 Span::detached(),
                 "failed to process {}",
-                display_font(Some(&typst_font))
+                display_font(Some(&typst_font)),
             )
         }
     }

--- a/crates/typst-realize/src/lib.rs
+++ b/crates/typst-realize/src/lib.rs
@@ -599,7 +599,7 @@ fn visit_styled<'a>(
             } else {
                 bail!(
                     style.span(),
-                    "document set rules are not allowed inside of containers"
+                    "document set rules are not allowed inside of containers",
                 );
             }
         } else if elem == TextElem::ELEM {
@@ -611,7 +611,7 @@ fn visit_styled<'a>(
             if !matches!(s.kind, RealizationKind::LayoutDocument { .. }) {
                 bail!(
                     style.span(),
-                    "page configuration is not allowed inside of containers"
+                    "page configuration is not allowed inside of containers",
                 );
             }
 

--- a/crates/typst/src/lib.rs
+++ b/crates/typst/src/lib.rs
@@ -252,14 +252,14 @@ fn warn_or_error_for_html(
             "html export is under active development and incomplete";
             hint: "its behaviour may change at any time";
             hint: "do not rely on this feature for production use cases";
-            hint: "see {ISSUE} for more information"
+            hint: "see {ISSUE} for more information";
         ));
     } else {
         bail!(
             Span::detached(),
             "html export is only available when `--features html` is passed";
             hint: "html export is under active development and incomplete";
-            hint: "see {ISSUE} for more information"
+            hint: "see {ISSUE} for more information";
         );
     }
     Ok(())


### PR DESCRIPTION
It was annoying me how using the `hint: "..."` syntax in the `bail!` macro would error with a trailing semicolon (especially because one of the examples in the docstring used one!), so I rolled up my sleaves and figured out how to change it. Quite tricky, but works great now. It even errors if you use a trailing comma instead of a trailing semicolon on a hint.

I updated all the macro callsites to use trailing semicolons (if the macro had hints), and I fixed some other formatting issues like splitting long lines or adding trailing commas (if used multiline with no hints).

I also updated the comments on the macros in `diag.rs`, LMK if any of those need rewording.