### PR TITLE
Link boxes like LaTeX's hyperref

### DIFF
--- a/crates/typst-layout/src/rules.rs
+++ b/crates/typst-layout/src/rules.rs
@@ -224,9 +224,10 @@ const LINK_RULE: ShowFn<LinkElem> = |elem, engine, styles| {
     let body = elem.body.clone();
     let dest = elem.dest.resolve(engine, span)?;
     let alt = dest.alt_text(engine, styles, span)?;
+    let border = elem.border.get_cloned(styles);
     // Manually construct link marker that spans the whole link elem, not just
     // the body.
-    Ok(LinkMarker::new(body, Some(alt))
+    Ok(LinkMarker::new(body, Some(alt), border)
         .pack()
         .spanned(span)
         .set(LinkElem::current, Some(dest)))

--- a/crates/typst-library/src/foundations/content/mod.rs
+++ b/crates/typst-library/src/foundations/content/mod.rs
@@ -467,7 +467,7 @@ impl Content {
     /// Link the content somewhere.
     pub fn linked(self, dest: Destination, alt: Option<EcoString>) -> Self {
         let span = self.span();
-        LinkMarker::new(self, alt)
+        LinkMarker::new(self, alt, None)
             .pack()
             .spanned(span)
             .set(LinkElem::current, Some(dest))

--- a/crates/typst-library/src/model/link.rs
+++ b/crates/typst-library/src/model/link.rs
@@ -17,6 +17,7 @@ use crate::introspection::{
 use crate::layout::{PageElem, Position};
 use crate::model::{NumberingPattern, Refable};
 use crate::text::{LocalName, TextElem};
+use crate::visualize::Color;
 
 /// Links to a URL or a location in the document.
 ///
@@ -146,6 +147,8 @@ pub struct LinkElem {
         _ => args.expect("body")?,
     })]
     pub body: Content,
+
+    pub border: Option<Color>,
 
     /// A destination style that should be applied to elements.
     #[internal]
@@ -403,6 +406,9 @@ pub struct LinkMarker {
     #[internal]
     #[required]
     pub alt: Option<EcoString>,
+    #[internal]
+    #[required]
+    pub border: Option<Color>,
 }
 
 impl Construct for LinkMarker {

--- a/crates/typst-pdf/src/link.rs
+++ b/crates/typst-pdf/src/link.rs
@@ -5,6 +5,7 @@ use krilla::geom as kg;
 use typst_library::diag::{At, ExpectInternal, SourceResult, bail};
 use typst_library::layout::{Abs, Point, Position, Size};
 use typst_library::model::Destination;
+use typst_library::visualize::Color;
 use typst_syntax::Span;
 
 use crate::convert::{FrameContext, GlobalContext, PageIndexConverter};
@@ -17,6 +18,7 @@ pub(crate) struct LinkAnnotation {
     pub span: Span,
     pub rects: Vec<kg::Rect>,
     pub target: Target,
+    pub border: Option<Color>,
 }
 
 pub(crate) enum LinkAnnotationKind {
@@ -79,6 +81,7 @@ pub(crate) fn handle_link(
                 span: Span::detached(),
                 rects: vec![rect],
                 target,
+                border: None,
             },
         );
         return Ok(());
@@ -88,6 +91,7 @@ pub(crate) fn handle_link(
         .expect_internal("expected link ancestor in logical tree")
         .at(Span::detached())?;
     let alt = link.alt.as_ref().map(Into::into);
+    let border = link.border;
 
     if gc.tags.tree.parent_artifact().is_some() {
         if gc.options.is_pdf_ua() {
@@ -108,6 +112,7 @@ pub(crate) fn handle_link(
                 span: link.span(),
                 rects: vec![rect],
                 target,
+                border,
             },
         );
         return Ok(());
@@ -136,6 +141,7 @@ pub(crate) fn handle_link(
                     span: link.span(),
                     rects: vec![rect],
                     target,
+                    border,
                 },
             );
             let group = gc.tags.tree.groups.get_mut(group_id);

--- a/crates/typst-pdf/src/paint.rs
+++ b/crates/typst-pdf/src/paint.rs
@@ -86,7 +86,7 @@ fn convert_paint(
     }
 }
 
-fn convert_solid(color: &Color) -> (color::Color, u8) {
+pub(crate) fn convert_solid(color: &Color) -> (color::Color, u8) {
     match color.space() {
         ColorSpace::D65Gray => {
             let (c, a) = convert_luma(color);


### PR DESCRIPTION
It would be cool if typst was able to produce link boxes similar to LaTeX's hyperref. There is interest in this feature and the usually suggested workarounds use Box elements around links. These workarounds have the downside that, unlike hyperref boxes, the boxes also appear in printed documents.
https://forum.typst.app/t/how-to-add-color-box-to-a-non-citation-reference/3735
#2585
#2613

The possibility to add boxes to links has been implemented in the PDF backend with LaurenzV/krilla#301. With this, it is possible to add borders to links in PDF which behave like hyperref link borders. I'm not sure what the best way is to integrate this in typst as I don't really know the typst codebase. This PR is a draft where I have added a `border` attribute to the `link` element and propagated it all the way to the PDF backend:

```typst
#link("https://example.com", border: blue)
```

Does this approach make sense? It works as intended in my document.