### PR TITLE
Consistently write `UTF-8` in upper case in diagnostics

### DIFF
--- a/crates/typst-cli/src/deps.rs
+++ b/crates/typst-cli/src/deps.rs
@@ -35,7 +35,7 @@ fn write_deps_json(
         dep.into_os_string().into_string().map_err(|dep| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("{kind} {dep:?} is not valid utf-8"),
+                format!("{kind} {dep:?} is not valid UTF-8"),
             )
         })
     };

--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -193,7 +193,7 @@ impl SystemWorld {
                 source.lines().clone()
             } else if let Some(bytes) = slot.file.get() {
                 let bytes = bytes.as_ref().expect("file is not valid");
-                Lines::try_from(bytes).expect("file is not valid utf-8")
+                Lines::try_from(bytes).expect("file is not valid UTF-8")
             } else {
                 panic!("file id does not point to any source file");
             }

--- a/crates/typst-library/src/diag.rs
+++ b/crates/typst-library/src/diag.rs
@@ -538,7 +538,7 @@ impl Display for FileError {
             Self::AccessDenied => f.pad("failed to load file (access denied)"),
             Self::IsDirectory => f.pad("failed to load file (is a directory)"),
             Self::NotSource => f.pad("not a Typst source file"),
-            Self::InvalidUtf8 => f.pad("file is not valid utf-8"),
+            Self::InvalidUtf8 => f.pad("file is not valid UTF-8"),
             Self::Package(error) => error.fmt(f),
             Self::Other(Some(err)) => write!(f, "failed to load file ({err})"),
             Self::Other(None) => f.pad("failed to load file"),
@@ -667,7 +667,7 @@ impl From<Utf8Error> for LoadError {
         LoadError::new(
             start..end,
             "failed to convert to string",
-            "file is not valid utf-8",
+            "file is not valid UTF-8",
         )
     }
 }
@@ -692,15 +692,15 @@ where
 }
 
 /// Report an error, possibly in an external file. This will delegate to
-/// [`load_err_in_invalid_text`] if the data isn't valid utf-8.
+/// [`load_err_in_invalid_text`] if the data isn't valid UTF-8.
 fn load_err_in_text(
     loaded: &Loaded,
     pos: impl Into<ReportPos>,
     mut message: EcoString,
 ) -> EcoVec<SourceDiagnostic> {
     let pos = pos.into();
-    // This also does utf-8 validation. Only report an error in an external
-    // file if it is human readable (valid utf-8), otherwise fall back to
+    // This also does UTF-8 validation. Only report an error in an external
+    // file if it is human readable (valid UTF-8), otherwise fall back to
     // `load_err_in_invalid_text`.
     let lines = Lines::try_from(&loaded.data);
     match (loaded.source.v, lines) {
@@ -733,7 +733,7 @@ fn load_err_in_text(
     }
 }
 
-/// Report an error (possibly from an external file) that isn't valid utf-8.
+/// Report an error (possibly from an external file) that isn't valid UTF-8.
 fn load_err_in_invalid_text(
     loaded: &Loaded,
     pos: impl Into<ReportPos>,
@@ -828,7 +828,7 @@ impl ReportPos {
     }
 
     /// Either gets the line/column pair, or tries to compute it from possibly
-    /// invalid utf-8 data.
+    /// invalid UTF-8 data.
     fn try_line_col(&self, bytes: &[u8]) -> Option<LineCol> {
         match self {
             &ReportPos::Full(_, pair) => Some(pair),
@@ -864,7 +864,7 @@ impl LineCol {
         Self::zero_based(line.saturating_sub(1), col.saturating_sub(1))
     }
 
-    /// Try to compute a line/column pair from possibly invalid utf-8 data.
+    /// Try to compute a line/column pair from possibly invalid UTF-8 data.
     pub fn try_from_byte_pos(pos: usize, bytes: &[u8]) -> Option<Self> {
         let bytes = &bytes[..pos];
         let mut line = 0;

--- a/crates/typst-library/src/foundations/str.rs
+++ b/crates/typst-library/src/foundations/str.rs
@@ -852,7 +852,7 @@ cast! {
     v: f64 => Self::Str(repr::display_float(v).into()),
     v: Decimal => Self::Str(format_str!("{}", v)),
     v: Version => Self::Str(format_str!("{}", v)),
-    v: Bytes => Self::Str(v.to_str().map_err(|_| "bytes are not valid utf-8")?),
+    v: Bytes => Self::Str(v.to_str().map_err(|_| "bytes are not valid UTF-8")?),
     v: Label => Self::Str(v.resolve().as_str().into()),
     v: Type => Self::Str(v.long_name().into()),
     v: Str => Self::Str(v),

--- a/crates/typst-library/src/loading/csv.rs
+++ b/crates/typst-library/src/loading/csv.rs
@@ -177,7 +177,7 @@ fn format_csv_error(err: ::csv::Error, line: usize) -> LoadError {
         .unwrap_or(LineCol::one_based(line, 1).into());
     match err.kind() {
         ::csv::ErrorKind::Utf8 { .. } => {
-            LoadError::new(pos, msg, "file is not valid utf-8")
+            LoadError::new(pos, msg, "file is not valid UTF-8")
         }
         ::csv::ErrorKind::UnequalLengths { expected_len, len, .. } => {
             let err =

--- a/crates/typst-library/src/text/lang.rs
+++ b/crates/typst-library/src/text/lang.rs
@@ -712,7 +712,7 @@ mod tests {
                     file.file_stem()
                         .expect("translation file should have basename")
                         .to_str()
-                        .expect("translation file name should be utf-8 encoded")
+                        .expect("translation file name should be UTF-8 encoded")
                 ),
                 "translation from {:?} should be registered in TRANSLATIONS in {}",
                 file.file_name().unwrap(),
@@ -727,7 +727,7 @@ mod tests {
     fn test_all_translation_files_formatted() {
         for file in translation_files_iter() {
             let content = std::fs::read_to_string(&file)
-                .expect("translation file should be in utf-8 encoding");
+                .expect("translation file should be in UTF-8 encoding");
             let filename = file.file_name().unwrap();
             assert!(
                 content.ends_with('\n'),

--- a/crates/typst-library/src/visualize/image/svg.rs
+++ b/crates/typst-library/src/visualize/image/svg.rs
@@ -147,7 +147,7 @@ fn tree_size(tree: &usvg::Tree) -> Axes<f64> {
 /// Format the user-facing SVG decoding error message.
 fn format_usvg_error(error: usvg::Error) -> LoadError {
     let error = match error {
-        usvg::Error::NotAnUtf8Str => "file is not valid utf-8",
+        usvg::Error::NotAnUtf8Str => "file is not valid UTF-8",
         usvg::Error::MalformedGZip => "file is not compressed correctly",
         usvg::Error::ElementsLimitReached => "file is too large",
         usvg::Error::InvalidSize => "width, height, or viewbox is invalid",

--- a/tests/src/collect.rs
+++ b/tests/src/collect.rs
@@ -762,7 +762,7 @@ impl<'a> Parser<'a> {
         let start = self.parse_line_col()?;
         let lines = Lines::try_from(&bytes).expect(
             "errors shouldn't be annotated for files \
-            that aren't human readable (not valid utf-8)",
+            that aren't human readable (not valid UTF-8)",
         );
         let range = if self.s.eat_if('-') {
             let (line, col) = start;

--- a/tests/src/pdftags.rs
+++ b/tests/src/pdftags.rs
@@ -153,8 +153,8 @@ fn format_xmp_metadata(f: &mut Formatter, stream: Stream) -> StrResult<()> {
         .decoded()
         .map_err(|e| eco_format!("failed to decode stream: {e:?}"))?;
     let xml_str =
-        std::str::from_utf8(&bytes).map_err(|e| eco_format!("invalid utf-8: {e}"))?;
-    let xmp = Document::parse(xml_str).map_err(|e| eco_format!("invalid xml: {e}"))?;
+        std::str::from_utf8(&bytes).map_err(|e| eco_format!("invalid UTF-8: {e}"))?;
+    let xmp = Document::parse(xml_str).map_err(|e| eco_format!("invalid XML: {e}"))?;
 
     let xmpmeta = xmp.root_element();
     let rdf = child(&xmpmeta, "RDF").ok_or("missing rdf:RDF")?;

--- a/tests/src/world.rs
+++ b/tests/src/world.rs
@@ -95,7 +95,7 @@ impl TestWorld {
                 source.lines().clone()
             } else if let Some(bytes) = slot.file.get() {
                 let bytes = bytes.as_ref().expect("file is not valid");
-                Lines::try_from(bytes).expect("file is not valid utf-8")
+                Lines::try_from(bytes).expect("file is not valid UTF-8")
             } else {
                 panic!("file id does not point to any source file");
             }

--- a/tests/suite/loading/read.typ
+++ b/tests/suite/loading/read.typ
@@ -8,5 +8,5 @@
 #let data = read("/assets/text/missing.txt")
 
 --- read-invalid-utf-8 paged ---
-// Error: 18-40 failed to convert to string (file is not valid utf-8 in assets/text/bad.txt:1:1)
+// Error: 18-40 failed to convert to string (file is not valid UTF-8 in assets/text/bad.txt:1:1)
 #let data = read("/assets/text/bad.txt")

--- a/tests/suite/scripting/import.typ
+++ b/tests/suite/scripting/import.typ
@@ -319,7 +319,7 @@
 
 --- import-file-not-valid-utf-8 paged ---
 // Some non-text stuff.
-// Error: 9-35 file is not valid utf-8
+// Error: 9-35 file is not valid UTF-8
 #import "/assets/images/rhino.png"
 
 --- import-item-not-found paged ---


### PR DESCRIPTION
We generally write error messages all lowercase but there is an exception for proper names and `UTF-8` is the proper canonical name.