### PR TITLE
Change color of values in `typst info`

### DIFF
--- a/crates/typst-cli/src/info.rs
+++ b/crates/typst-cli/src/info.rs
@@ -511,13 +511,13 @@ fn write_value_simple(
     Ok(())
 }
 
-/// Writes a special value in magenta with optional right padding.
+/// Writes a special value in blue with optional right padding.
 fn write_value_special(
     out: &mut TermOut,
     val: impl Display,
     pad: Option<usize>,
 ) -> io::Result<()> {
-    out.set_color(ColorSpec::new().set_fg(Some(Color::Magenta)))?;
+    out.set_color(ColorSpec::new().set_fg(Some(Color::Blue)))?;
     if let Some(pad) = pad {
         write!(out, "{val: <pad$}")?;
     } else {


### PR DESCRIPTION
This is easier to read (at least in my terminal, YMMV), more in line with Typst's brand colors and also in line with the colors we opted for in https://github.com/typst/typst/pull/7443.