### PR TITLE
Do not hash Type ID for `LazyHash`

### DIFF
--- a/crates/typst-utils/src/hash.rs
+++ b/crates/typst-utils/src/hash.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::fmt::{self, Debug};
 use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut};
@@ -37,6 +36,19 @@ pub fn hash128<T: Hash + ?Sized>(value: &T) -> u128 {
 /// # Usage
 /// If the value is expected to be cloned, it is best used inside of an `Arc`
 /// or `Rc` to best re-use the hash once it has been computed.
+///
+/// # Unsized coercions
+/// The `LazyHash` type supports unsized payload types and coercions to such.
+/// For instance, a `LazyHash<&'static str>` can be coerced to a
+/// `LazyHash<dyn YourTrait>` when `&'static str: YourTrait`. When it is hashed,
+/// a `LazyHash` will always use the [`Hash`] impl of the underlying type. This
+/// underlying type changes through an unsized coercion. When coercing a
+/// [`LazyHash`] that has an already populated internal hash, you'll thus get a
+/// cached hash that was hashed with another impl than a fresh hash would have
+/// used. To avoid this, when performing unsized coercions, avoid hashing the
+/// value before the coercion and overall try to minimize the timespan in which
+/// the original type is active. Typical usages of unsized coercions have a very
+/// minimal lifetime of the original type only upon construction.
 #[derive(Clone)]
 pub struct LazyHash<T: ?Sized> {
     /// The hash for the value.
@@ -70,19 +82,8 @@ impl<T: Hash + ?Sized + 'static> LazyHash<T> {
     /// Get the hash or compute it if not set yet.
     #[inline]
     fn load_or_compute_hash(&self) -> u128 {
-        self.hash.get_or_insert_with(|| hash_item(&self.value))
+        self.hash.get_or_insert_with(|| hash128(&self.value))
     }
-}
-
-/// Hash the item.
-#[inline]
-fn hash_item<T: Hash + ?Sized + 'static>(item: &T) -> u128 {
-    // Also hash the TypeId because the type might be converted
-    // through an unsized coercion.
-    let mut state = SipHasher13::new();
-    item.type_id().hash(&mut state);
-    item.hash(&mut state);
-    state.finish128().as_u128()
 }
 
 impl<T: Hash + ?Sized + 'static> Hash for LazyHash<T> {


### PR DESCRIPTION
The purpose of this was to have correct hashing in the presence of unsized coercions from a concrete prehashed type to a prehashed trait object. This ensures that a `Prehashed<dyn SomeTrait>` did not result in hash collisions due to hashes coming from different concrete types that implement `SomeTrait`.

This exact problem does not occur with `LazyHash` because it will not be hashed immediately upon construction, but rather lazily and that's typically after coercion has already occurred. However, this also means that the type ID hashing of `Prehashed` is completely ineffective for `LazyHash`: The hash is only populated lazily and then pretty much always with the Type ID of the trait object. Thus, it's basically static and does not contribute anything meaningful to the trait. 

There is one exception, when the trait object has `Any` as a supertrait. This is what prompted this PR (see CI failures in https://github.com/typst/typst/pull/7367). But even then, it does not make any sense to hash the type ID since it does not solve the issue that the hash can differ depending on which `Hash` impl is used. Since unsized coercions are necessary, but cannot trigger code execution (for clearing the hash), the only way I see to catch this would be dynamically at runtime by checking the type ID in the `Hash` impl. For a problem that's primarily theoretical this is definitely not worth it.[^1]

[^1]: We could consider doing this only in debug builds, but even there it would involve a `Mutex` since a `TypeId` cannot be operated on atomically. We could consider doing this, but it still seems a bit overkill and I don't want to spend time on it.