### PR TITLE
Explicitly mark block equations in accessibility documentation

### DIFF
--- a/crates/typst-library/src/math/equation.rs
+++ b/crates/typst-library/src/math/equation.rs
@@ -111,6 +111,7 @@ pub struct EquationElem {
     /// ```example
     /// #math.equation(
     ///   alt: "integral from 1 to infinity of a x squared plus b with respect to x",
+    ///   block: true,
     ///   $ integral_1^oo a x^2 + b dif x $,
     /// )
     /// ```

--- a/docs/guides/accessibility.md
+++ b/docs/guides/accessibility.md
@@ -203,6 +203,7 @@ Finally, you can specify an alternative description on math using [`math.equatio
 ```typ
 #math.equation(
   alt: "a squared plus b squared equals c squared",
+  block: true,
   $ a^2 + b^2 = c^2 $,
 )
 ```

--- a/docs/reference/library/math.md
+++ b/docs/reference/library/math.md
@@ -110,6 +110,7 @@ Guide]($guides/accessibility/#textual-representations).
 ```example
 #math.equation(
   alt: "d S equals delta q divided by T",
+  block: true,
   $ dif S = (delta q) / T $,
 )
 ```


### PR DESCRIPTION
`math.equation` generates an inline equation by default, even if the equations passed as the body is a block equation.
This updates a few misleading examples in the documentation.
For `0.15` it might make sense to infer the `eqation.block` parameter from the body, if it is an equation.