### PR TITLE
Warn instead of erroring for page set rule in HTML export

### DIFF
--- a/crates/typst-realize/src/lib.rs
+++ b/crates/typst-realize/src/lib.rs
@@ -12,7 +12,7 @@ use bumpalo::Bump;
 use bumpalo::collections::{CollectIn, String as BumpString, Vec as BumpVec};
 use comemo::Track;
 use ecow::EcoString;
-use typst_library::diag::{At, SourceResult, bail};
+use typst_library::diag::{At, SourceResult, bail, warning};
 use typst_library::engine::Engine;
 use typst_library::foundations::{
     Content, Context, ContextElem, Element, NativeElement, NativeShowRule, Packed,
@@ -608,16 +608,22 @@ fn visit_styled<'a>(
                 info.populate_locale(&local)
             }
         } else if elem == PageElem::ELEM {
-            if !matches!(s.kind, RealizationKind::LayoutDocument { .. }) {
-                bail!(
+            match s.kind {
+                RealizationKind::LayoutDocument { .. } => {
+                    // When there are page styles, we "break free" from our show
+                    // rule cage.
+                    pagebreak = true;
+                    s.outside = true;
+                }
+                RealizationKind::HtmlDocument { .. } => s.engine.sink.warn(warning!(
+                    style.span(),
+                    "page set rule was ignored during HTML export"
+                )),
+                _ => bail!(
                     style.span(),
                     "page configuration is not allowed inside of containers",
-                );
+                ),
             }
-
-            // When there are page styles, we "break free" from our show rule cage.
-            pagebreak = true;
-            s.outside = true;
         }
     }
 

--- a/tests/ref/html/page-set-html.html
+++ b/tests/ref/html/page-set-html.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body>
+    <p>Hi</p>
+  </body>
+</html>

--- a/tests/suite/layout/page.typ
+++ b/tests/suite/layout/page.typ
@@ -353,6 +353,11 @@ A
 // Hint: 2-17 customize pages with `set page(..)` instead
 #show page: none
 
+--- page-set-html html ---
+// Warning: 2-16 page set rule was ignored during HTML export
+#set page("a4")
+Hi
+
 --- issue-2631-page-header-ordering paged ---
 #set text(6pt)
 #show heading: set text(6pt, weight: "regular")


### PR DESCRIPTION
Closes https://github.com/typst/typst/issues/6238.

This make it consistent with warnings for ignored elements and is actually still stricter than what we do for most other unsupported set rules (which is nothing).

Once HTML export stabilizes, I'll want to reconsider what exactly to do here, but for now I think this simply makes things consistent. It's not like the previous error was intentional, it was just an artifact of the implementation and the error message ("page configuration is not allowed inside of containers") was pretty bad.