### PR TITLE
Bump krilla

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,8 +1439,7 @@ dependencies = [
 [[package]]
 name = "krilla"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ddfec86fec13d068075e14f22a7e217c281f3ed69ddcb427bf3f5d504fd674"
+source = "git+https://github.com/LaurenzV/krilla?rev=84c6332#84c6332a4d6459427b02bb40c8eb7e46b6a173d1"
 dependencies = [
  "base64",
  "bumpalo",
@@ -1471,8 +1470,7 @@ dependencies = [
 [[package]]
 name = "krilla-svg"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f485e1a850201a01dcd8d73e7cf09f2cd4c4cc85c2cd296359094d49336d8ef7"
+source = "git+https://github.com/LaurenzV/krilla?rev=84c6332#84c6332a4d6459427b02bb40c8eb7e46b6a173d1"
 dependencies = [
  "flate2",
  "fontdb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,8 +77,8 @@ image = { version = "0.25.5", default-features = false, features = ["png", "jpeg
 indexmap = { version = "2", features = ["serde"] }
 infer = { version = "0.19.0", default-features = false }
 kamadak-exif = "0.6"
-krilla = { version = "0.6.0", default-features = false, features = ["raster-images", "comemo", "rayon", "pdf"] }
-krilla-svg = "0.3.0"
+krilla = { git = "https://github.com/LaurenzV/krilla", rev = "84c6332", default-features = false, features = ["raster-images", "comemo", "rayon", "pdf"] }
+krilla-svg = { git = "https://github.com/LaurenzV/krilla", rev = "84c6332" }
 kurbo = "0.12"
 libfuzzer-sys = "0.4"
 lipsum = "0.9"

--- a/tests/suite/pdf/attach.typ
+++ b/tests/suite/pdf/attach.typ
@@ -20,6 +20,9 @@
   description: "A description",
 )
 
+--- pdf-attach-zero-bytes paged ---
+#pdf.attach("file", bytes(()))
+
 --- pdf-attach-invalid-relationship paged ---
 #pdf.attach(
   "/assets/text/hello.txt",


### PR DESCRIPTION
Fixes https://github.com/typst/typst/issues/7518.

Bring fix from https://github.com/LaurenzV/krilla/pull/319.

I tried

```toml
krilla = { git = "https://github.com/LaurenzV/krilla", rev = "84c6332", default-features = false, features = ["raster-images", "comemo", "rayon", "pdf"] }
```

But it creates 2 versions of the dependency in the lock file and causes errors. With patch it compiles cleanly.

@LaurenzV, will you create a new release just for this or nah?
