### PR TITLE
Fix crash in `array.sorted`

### DIFF
--- a/crates/typst-library/src/foundations/array.rs
+++ b/crates/typst-library/src/foundations/array.rs
@@ -894,6 +894,10 @@ impl Array {
         #[named]
         by: Option<Func>,
     ) -> SourceResult<Array> {
+        // We use `glidesort` instead of the standard library sorting algorithm
+        // to prevent panics in case the comparison function does not define a
+        // valid order (see https://github.com/typst/typst/pull/5627 and
+        // https://github.com/typst/typst/issues/6285).
         match by {
             Some(by) => {
                 let mut are_in_order = |mut x, mut y| {
@@ -914,10 +918,7 @@ impl Array {
                         }
                     }
                 };
-                // If a comparison function is provided, we use `glidesort`
-                // instead of the standard library sorting algorithm to prevent
-                // panics in case the comparison function does not define a
-                // valid order (see https://github.com/typst/typst/pull/5627).
+
                 let mut result = Ok(());
                 let mut vec = self.0.into_iter().enumerate().collect::<Vec<_>>();
                 glidesort::sort_by(&mut vec, |(i, x), (j, y)| {
@@ -970,12 +971,10 @@ impl Array {
                     Some(f) => f.call(engine, context, [x]),
                     None => Ok(x),
                 };
-                // If no comparison function is provided, we know the order is
-                // valid, so we can use the standard library sort and prevent an
-                // extra allocation.
+
                 let mut result = Ok(());
                 let mut vec = self.0;
-                vec.make_mut().sort_by(|a, b| {
+                glidesort::sort_by(vec.make_mut(), |a, b| {
                     match (key_of(a.clone()), key_of(b.clone())) {
                         (Ok(a), Ok(b)) => ops::compare(&a, &b).unwrap_or_else(|err| {
                             if result.is_ok() {

--- a/tests/suite/foundations/array.typ
+++ b/tests/suite/foundations/array.typ
@@ -556,3 +556,7 @@
 --- array-reduce-unexpected-argument paged ---
 // Error: 19-21 unexpected argument
 #(1, 2, 3).reduce(() => none)
+
+--- issue-6285-crashed-with-sorting-non-total-order paged ---
+// Error: 2-66 cannot compare none and string
+#(("a", "b", "c", "d", "e", "z") * 3 + ("c", none, "a")).sorted()


### PR DESCRIPTION
Fixes https://github.com/typst/typst/issues/6285.

Simpler alternative to https://github.com/typst/typst/pull/7451.