### PR TITLE
Add `block: true` in docs example for `read` function

### DIFF
--- a/crates/typst-library/src/loading/read.rs
+++ b/crates/typst-library/src/loading/read.rs
@@ -16,7 +16,7 @@ use crate::loading::{DataSource, Load, Readable};
 /// ```example
 /// An example for a HTML file: \
 /// #let text = read("example.html")
-/// #raw(text, lang: "html")
+/// #raw(text, block: true, lang: "html")
 ///
 /// Raw bytes:
 /// #read("tiger.jpg", encoding: none)


### PR DESCRIPTION
A friend was learning about typst, and wondering why his code looked like this:

<img width="685" height="788" alt="image" src="https://github.com/user-attachments/assets/999a7b1b-4706-4f20-9653-7fedd33ce727" />

Turns out he had followed the editor hover for read:

<img width="401" height="141" alt="image" src="https://github.com/user-attachments/assets/53b93288-8d60-437b-9549-4a03d7c626ea" />

Since this is importing an HTML file, it is very probably more than a single line (plus, `read`ing a file for a single line would be a little overkill I believe).

Adding `block: true` fixed it:

<img width="657" height="544" alt="image" src="https://github.com/user-attachments/assets/6b17d880-aeab-4aee-9ee6-5e4a4d0bb34f" />
