### PR TITLE
Fix wording in `grid.footer` docs

### DIFF
--- a/crates/typst-library/src/layout/grid/mod.rs
+++ b/crates/typst-library/src/layout/grid/mod.rs
@@ -598,7 +598,7 @@ pub struct GridHeader {
 /// A repeatable grid footer.
 ///
 /// Just like the [`grid.header`] element, the footer can repeat itself on every
-/// page of the table.
+/// page of the grid.
 ///
 /// No other grid cells may be placed after the footer.
 #[elem(name = "footer", title = "Grid Footer")]


### PR DESCRIPTION
In [Grid Footer](https://typst.app/docs/reference/layout/grid/#definitions-footer) document, it currently states:

> Just like the [grid.header](https://typst.app/docs/reference/layout/grid/#definitions-header) element, the footer can repeat itself on every page of the table.

It would be more precise to say:

> Just like the [grid.header](https://typst.app/docs/reference/layout/grid/#definitions-header) element, the footer can repeat itself on every page of the grid.