### PR TITLE
Rename `Repr` types to `...Inner`

### DIFF
--- a/crates/typst-cli/src/terminal.rs
+++ b/crates/typst-cli/src/terminal.rs
@@ -13,26 +13,6 @@ pub fn out() -> TermOut {
     }
 }
 
-/// The stuff that has to be shared between instances of [`TermOut`].
-struct TermOutInner {
-    stream: termcolor::StandardStream,
-}
-
-impl TermOutInner {
-    fn new() -> Self {
-        let color_choice = match ARGS.color {
-            clap::ColorChoice::Auto if std::io::stderr().is_terminal() => {
-                ColorChoice::Auto
-            }
-            clap::ColorChoice::Always => ColorChoice::Always,
-            _ => ColorChoice::Never,
-        };
-
-        let stream = termcolor::StandardStream::stderr(color_choice);
-        TermOutInner { stream }
-    }
-}
-
 /// A utility that allows users to write colored terminal output.
 /// If colors are not supported by the terminal, they are disabled.
 /// This type also allows for deletion of previously written lines.
@@ -89,5 +69,25 @@ impl WriteColor for TermOut {
 
     fn reset(&mut self) -> io::Result<()> {
         self.inner.stream.lock().reset()
+    }
+}
+
+/// The stuff that has to be shared between instances of [`TermOut`].
+struct TermOutInner {
+    stream: termcolor::StandardStream,
+}
+
+impl TermOutInner {
+    fn new() -> Self {
+        let color_choice = match ARGS.color {
+            clap::ColorChoice::Auto if std::io::stderr().is_terminal() => {
+                ColorChoice::Auto
+            }
+            clap::ColorChoice::Always => ColorChoice::Always,
+            _ => ColorChoice::Never,
+        };
+
+        let stream = termcolor::StandardStream::stderr(color_choice);
+        TermOutInner { stream }
     }
 }

--- a/crates/typst-library/src/foundations/func.rs
+++ b/crates/typst-library/src/foundations/func.rs
@@ -12,8 +12,8 @@ use typst_utils::{LazyHash, Static, singleton};
 use crate::diag::{At, DeprecationSink, SourceResult, StrResult, bail};
 use crate::engine::Engine;
 use crate::foundations::{
-    Args, Bytes, CastInfo, Content, Context, Element, IntoArgs, PluginFunc, Scope,
-    Selector, Type, Value, cast, repr, scope, ty,
+    Args, Bytes, CastInfo, Content, Context, Element, IntoArgs, PluginFunc, Repr, Scope,
+    Selector, Type, Value, cast, scope, ty,
 };
 
 /// A mapping from argument values to a return value.
@@ -136,14 +136,14 @@ use crate::foundations::{
 #[derive(Clone, Hash)]
 pub struct Func {
     /// The internal representation.
-    repr: Repr,
+    inner: FuncInner,
     /// The span with which errors are reported when this function is called.
     span: Span,
 }
 
 /// The different kinds of function representations.
 #[derive(Clone, PartialEq, Hash)]
-enum Repr {
+enum FuncInner {
     /// A native Rust function.
     Native(Static<NativeFuncData>),
     /// A function for an element.
@@ -161,12 +161,12 @@ impl Func {
     ///
     /// Returns `None` if this is an anonymous closure.
     pub fn name(&self) -> Option<&str> {
-        match &self.repr {
-            Repr::Native(native) => Some(native.name),
-            Repr::Element(elem) => Some(elem.name()),
-            Repr::Closure(closure) => closure.name(),
-            Repr::Plugin(func) => Some(func.name()),
-            Repr::With(with) => with.0.name(),
+        match &self.inner {
+            FuncInner::Native(native) => Some(native.name),
+            FuncInner::Element(elem) => Some(elem.name()),
+            FuncInner::Closure(closure) => closure.name(),
+            FuncInner::Plugin(func) => Some(func.name()),
+            FuncInner::With(with) => with.0.name(),
         }
     }
 
@@ -174,42 +174,42 @@ impl Func {
     ///
     /// Returns `None` if this is a closure.
     pub fn title(&self) -> Option<&'static str> {
-        match &self.repr {
-            Repr::Native(native) => Some(native.title),
-            Repr::Element(elem) => Some(elem.title()),
-            Repr::Closure(_) => None,
-            Repr::Plugin(_) => None,
-            Repr::With(with) => with.0.title(),
+        match &self.inner {
+            FuncInner::Native(native) => Some(native.title),
+            FuncInner::Element(elem) => Some(elem.title()),
+            FuncInner::Closure(_) => None,
+            FuncInner::Plugin(_) => None,
+            FuncInner::With(with) => with.0.title(),
         }
     }
 
     /// Documentation for the function (as Markdown).
     pub fn docs(&self) -> Option<&'static str> {
-        match &self.repr {
-            Repr::Native(native) => Some(native.docs),
-            Repr::Element(elem) => Some(elem.docs()),
-            Repr::Closure(_) => None,
-            Repr::Plugin(_) => None,
-            Repr::With(with) => with.0.docs(),
+        match &self.inner {
+            FuncInner::Native(native) => Some(native.docs),
+            FuncInner::Element(elem) => Some(elem.docs()),
+            FuncInner::Closure(_) => None,
+            FuncInner::Plugin(_) => None,
+            FuncInner::With(with) => with.0.docs(),
         }
     }
 
     /// Whether the function is known to be contextual.
     pub fn contextual(&self) -> Option<bool> {
-        match &self.repr {
-            Repr::Native(native) => Some(native.contextual),
+        match &self.inner {
+            FuncInner::Native(native) => Some(native.contextual),
             _ => None,
         }
     }
 
     /// Get details about this function's parameters if available.
     pub fn params(&self) -> Option<&'static [ParamInfo]> {
-        match &self.repr {
-            Repr::Native(native) => Some(&native.0.params),
-            Repr::Element(elem) => Some(elem.params()),
-            Repr::Closure(_) => None,
-            Repr::Plugin(_) => None,
-            Repr::With(with) => with.0.params(),
+        match &self.inner {
+            FuncInner::Native(native) => Some(&native.0.params),
+            FuncInner::Element(elem) => Some(elem.params()),
+            FuncInner::Closure(_) => None,
+            FuncInner::Plugin(_) => None,
+            FuncInner::With(with) => with.0.params(),
         }
     }
 
@@ -220,36 +220,36 @@ impl Func {
 
     /// Get details about the function's return type.
     pub fn returns(&self) -> Option<&'static CastInfo> {
-        match &self.repr {
-            Repr::Native(native) => Some(&native.0.returns),
-            Repr::Element(_) => {
+        match &self.inner {
+            FuncInner::Native(native) => Some(&native.0.returns),
+            FuncInner::Element(_) => {
                 Some(singleton!(CastInfo, CastInfo::Type(Type::of::<Content>())))
             }
-            Repr::Closure(_) => None,
-            Repr::Plugin(_) => None,
-            Repr::With(with) => with.0.returns(),
+            FuncInner::Closure(_) => None,
+            FuncInner::Plugin(_) => None,
+            FuncInner::With(with) => with.0.returns(),
         }
     }
 
     /// Search keywords for the function.
     pub fn keywords(&self) -> &'static [&'static str] {
-        match &self.repr {
-            Repr::Native(native) => native.keywords,
-            Repr::Element(elem) => elem.keywords(),
-            Repr::Closure(_) => &[],
-            Repr::Plugin(_) => &[],
-            Repr::With(with) => with.0.keywords(),
+        match &self.inner {
+            FuncInner::Native(native) => native.keywords,
+            FuncInner::Element(elem) => elem.keywords(),
+            FuncInner::Closure(_) => &[],
+            FuncInner::Plugin(_) => &[],
+            FuncInner::With(with) => with.0.keywords(),
         }
     }
 
     /// The function's associated scope of sub-definition.
     pub fn scope(&self) -> Option<&'static Scope> {
-        match &self.repr {
-            Repr::Native(native) => Some(&native.0.scope),
-            Repr::Element(elem) => Some(elem.scope()),
-            Repr::Closure(_) => None,
-            Repr::Plugin(_) => None,
-            Repr::With(with) => with.0.scope(),
+        match &self.inner {
+            FuncInner::Native(native) => Some(&native.0.scope),
+            FuncInner::Element(elem) => Some(elem.scope()),
+            FuncInner::Closure(_) => None,
+            FuncInner::Plugin(_) => None,
+            FuncInner::With(with) => with.0.scope(),
         }
     }
 
@@ -272,16 +272,16 @@ impl Func {
 
     /// Extract the element function, if it is one.
     pub fn element(&self) -> Option<Element> {
-        match self.repr {
-            Repr::Element(func) => Some(func),
+        match self.inner {
+            FuncInner::Element(func) => Some(func),
             _ => None,
         }
     }
 
     /// Extract the plugin function, if it is one.
     pub fn to_plugin(&self) -> Option<&PluginFunc> {
-        match &self.repr {
-            Repr::Plugin(func) => Some(func),
+        match &self.inner {
+            FuncInner::Plugin(func) => Some(func),
             _ => None,
         }
     }
@@ -304,18 +304,18 @@ impl Func {
         context: Tracked<Context>,
         mut args: Args,
     ) -> SourceResult<Value> {
-        match &self.repr {
-            Repr::Native(native) => {
+        match &self.inner {
+            FuncInner::Native(native) => {
                 let value = (native.function.0)(engine, context, &mut args)?;
                 args.finish()?;
                 Ok(value)
             }
-            Repr::Element(func) => {
+            FuncInner::Element(func) => {
                 let value = func.construct(engine, &mut args)?;
                 args.finish()?;
                 Ok(Value::Content(value))
             }
-            Repr::Closure(closure) => (engine.routines.eval_closure)(
+            FuncInner::Closure(closure) => (engine.routines.eval_closure)(
                 self,
                 closure,
                 engine.routines,
@@ -327,13 +327,13 @@ impl Func {
                 context,
                 args,
             ),
-            Repr::Plugin(func) => {
+            FuncInner::Plugin(func) => {
                 let inputs = args.all::<Bytes>()?;
                 let output = func.call(inputs).at(args.span)?;
                 args.finish()?;
                 Ok(Value::Bytes(output))
             }
-            Repr::With(with) => {
+            FuncInner::With(with) => {
                 args.items = with.1.items.iter().cloned().chain(args.items).collect();
                 with.0.call(engine, context, args)
             }
@@ -368,7 +368,7 @@ impl Func {
     ) -> Func {
         let span = self.span;
         Self {
-            repr: Repr::With(Arc::new((self, args.take()))),
+            inner: FuncInner::With(Arc::new((self, args.take()))),
             span,
         }
     }
@@ -421,29 +421,29 @@ impl Debug for Func {
     }
 }
 
-impl repr::Repr for Func {
+impl Repr for Func {
     fn repr(&self) -> EcoString {
         const DEFAULT: &str = "(..) => ..";
-        match &self.repr {
-            Repr::Native(native) => native.name.into(),
-            Repr::Element(elem) => elem.name().into(),
-            Repr::Closure(closure) => closure.name().unwrap_or(DEFAULT).into(),
-            Repr::Plugin(func) => func.name().clone(),
-            Repr::With(_) => DEFAULT.into(),
+        match &self.inner {
+            FuncInner::Native(native) => native.name.into(),
+            FuncInner::Element(elem) => elem.name().into(),
+            FuncInner::Closure(closure) => closure.name().unwrap_or(DEFAULT).into(),
+            FuncInner::Plugin(func) => func.name().clone(),
+            FuncInner::With(_) => DEFAULT.into(),
         }
     }
 }
 
 impl PartialEq for Func {
     fn eq(&self, other: &Self) -> bool {
-        self.repr == other.repr
+        self.inner == other.inner
     }
 }
 
 impl PartialEq<&'static NativeFuncData> for Func {
     fn eq(&self, other: &&'static NativeFuncData) -> bool {
-        match &self.repr {
-            Repr::Native(native) => *native == Static(*other),
+        match &self.inner {
+            FuncInner::Native(native) => *native == Static(*other),
             _ => false,
         }
     }
@@ -451,40 +451,40 @@ impl PartialEq<&'static NativeFuncData> for Func {
 
 impl PartialEq<Element> for Func {
     fn eq(&self, other: &Element) -> bool {
-        match &self.repr {
-            Repr::Element(elem) => elem == other,
+        match &self.inner {
+            FuncInner::Element(elem) => elem == other,
             _ => false,
         }
     }
 }
 
-impl From<Repr> for Func {
-    fn from(repr: Repr) -> Self {
-        Self { repr, span: Span::detached() }
+impl From<FuncInner> for Func {
+    fn from(inner: FuncInner) -> Self {
+        Self { inner, span: Span::detached() }
     }
 }
 
 impl From<&'static NativeFuncData> for Func {
     fn from(data: &'static NativeFuncData) -> Self {
-        Repr::Native(Static(data)).into()
+        FuncInner::Native(Static(data)).into()
     }
 }
 
 impl From<Element> for Func {
     fn from(func: Element) -> Self {
-        Repr::Element(func).into()
+        FuncInner::Element(func).into()
     }
 }
 
 impl From<Closure> for Func {
     fn from(closure: Closure) -> Self {
-        Repr::Closure(Arc::new(LazyHash::new(closure))).into()
+        FuncInner::Closure(Arc::new(LazyHash::new(closure))).into()
     }
 }
 
 impl From<PluginFunc> for Func {
     fn from(func: PluginFunc) -> Self {
-        Repr::Plugin(Arc::new(func)).into()
+        FuncInner::Plugin(Arc::new(func)).into()
     }
 }
 

--- a/crates/typst-library/src/foundations/module.rs
+++ b/crates/typst-library/src/foundations/module.rs
@@ -5,7 +5,7 @@ use ecow::{EcoString, eco_format};
 use typst_syntax::FileId;
 
 use crate::diag::{DeprecationSink, StrResult, bail};
-use crate::foundations::{Content, Scope, Value, repr, ty};
+use crate::foundations::{Content, Repr, Scope, Value, ty};
 
 /// A collection of variables and functions that are commonly related to
 /// a single theme.
@@ -51,12 +51,12 @@ pub struct Module {
     /// The module's name.
     name: Option<EcoString>,
     /// The reference-counted inner fields.
-    inner: Arc<Repr>,
+    inner: Arc<ModuleInner>,
 }
 
-/// The internal representation.
+/// The internal representation of a [`Module`].
 #[derive(Debug, Clone, Hash)]
-struct Repr {
+struct ModuleInner {
     /// The top-level definitions that were bound in this module.
     scope: Scope,
     /// The module's layoutable contents.
@@ -70,7 +70,11 @@ impl Module {
     pub fn new(name: impl Into<EcoString>, scope: Scope) -> Self {
         Self {
             name: Some(name.into()),
-            inner: Arc::new(Repr { scope, content: Content::empty(), file_id: None }),
+            inner: Arc::new(ModuleInner {
+                scope,
+                content: Content::empty(),
+                file_id: None,
+            }),
         }
     }
 
@@ -78,7 +82,11 @@ impl Module {
     pub fn anonymous(scope: Scope) -> Self {
         Self {
             name: None,
-            inner: Arc::new(Repr { scope, content: Content::empty(), file_id: None }),
+            inner: Arc::new(ModuleInner {
+                scope,
+                content: Content::empty(),
+                file_id: None,
+            }),
         }
     }
 
@@ -158,7 +166,7 @@ impl Debug for Module {
     }
 }
 
-impl repr::Repr for Module {
+impl Repr for Module {
     fn repr(&self) -> EcoString {
         match &self.name {
             Some(module) => eco_format!("<module {module}>"),

--- a/crates/typst-library/src/text/font/mod.rs
+++ b/crates/typst-library/src/text/font/mod.rs
@@ -27,10 +27,10 @@ use crate::text::{
 ///
 /// Values of this type are cheap to clone and hash.
 #[derive(Clone)]
-pub struct Font(Arc<Repr>);
+pub struct Font(Arc<FontInner>);
 
-/// The internal representation of a font.
-struct Repr {
+/// The internal representation of a [`Font`].
+struct FontInner {
     /// The font's index in the buffer.
     index: u32,
     /// Metadata about the font.
@@ -68,7 +68,7 @@ impl Font {
         let metrics = FontMetrics::from_ttf(&ttf);
         let info = FontInfo::from_ttf(&ttf)?;
 
-        Some(Self(Arc::new(Repr { data, index, info, metrics, ttf, rusty })))
+        Some(Self(Arc::new(FontInner { data, index, info, metrics, ttf, rusty })))
     }
 
     /// Parse all fonts in the given data.

--- a/crates/typst-library/src/visualize/image/mod.rs
+++ b/crates/typst-library/src/visualize/image/mod.rs
@@ -440,11 +440,11 @@ pub enum ImageFit {
 ///
 /// Values of this type are cheap to clone and hash.
 #[derive(Clone, Eq, PartialEq, Hash)]
-pub struct Image(Arc<LazyHash<Repr>>);
+pub struct Image(Arc<LazyHash<ImageInner>>);
 
-/// The internal representation.
+/// The internal representation of an [`Image`].
 #[derive(Hash)]
-struct Repr {
+struct ImageInner {
     /// The raw, undecoded image data.
     kind: ImageKind,
     /// A text describing the image.
@@ -483,7 +483,7 @@ impl Image {
         alt: Option<EcoString>,
         scaling: Smart<ImageScaling>,
     ) -> Image {
-        Self(Arc::new(LazyHash::new(Repr { kind, alt, scaling })))
+        Self(Arc::new(LazyHash::new(ImageInner { kind, alt, scaling })))
     }
 
     /// The format of the image.

--- a/crates/typst-library/src/visualize/image/pdf.rs
+++ b/crates/typst-library/src/visualize/image/pdf.rs
@@ -8,10 +8,10 @@ use crate::foundations::Bytes;
 
 /// A PDF document.
 #[derive(Clone, Hash)]
-pub struct PdfDocument(Arc<DocumentRepr>);
+pub struct PdfDocument(Arc<PdfDocumentInner>);
 
-/// The internal representation of a `PdfDocument`.
-struct DocumentRepr {
+/// The internal representation of a [`PdfDocument`].
+struct PdfDocumentInner {
     pdf: Arc<Pdf>,
     data: Bytes,
 }
@@ -22,7 +22,7 @@ impl PdfDocument {
     #[typst_macros::time(name = "load pdf document")]
     pub fn new(data: Bytes) -> Result<PdfDocument, LoadPdfError> {
         let pdf = Arc::new(Pdf::new(Arc::new(data.clone()))?);
-        Ok(Self(Arc::new(DocumentRepr { data, pdf })))
+        Ok(Self(Arc::new(PdfDocumentInner { data, pdf })))
     }
 
     /// Returns the underlying PDF document.
@@ -36,7 +36,7 @@ impl PdfDocument {
     }
 }
 
-impl Hash for DocumentRepr {
+impl Hash for PdfDocumentInner {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.data.hash(state);
     }
@@ -44,10 +44,10 @@ impl Hash for DocumentRepr {
 
 /// A specific page of a PDF acting as an image.
 #[derive(Clone, Hash)]
-pub struct PdfImage(Arc<ImageRepr>);
+pub struct PdfImage(Arc<PdfImageInner>);
 
-/// The internal representation of a `PdfImage`.
-struct ImageRepr {
+/// The internal representation of a [`PdfImage`].
+struct PdfImageInner {
     document: PdfDocument,
     page_index: usize,
     width: f32,
@@ -61,7 +61,7 @@ impl PdfImage {
     #[comemo::memoize]
     pub fn new(document: PdfDocument, page_index: usize) -> Option<PdfImage> {
         let (width, height) = document.0.pdf.pages().get(page_index)?.render_dimensions();
-        Some(Self(Arc::new(ImageRepr { document, page_index, width, height })))
+        Some(Self(Arc::new(PdfImageInner { document, page_index, width, height })))
     }
 
     /// Returns the underlying Typst PDF document.
@@ -90,7 +90,7 @@ impl PdfImage {
     }
 }
 
-impl Hash for ImageRepr {
+impl Hash for PdfImageInner {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.document.hash(state);
         self.page_index.hash(state);

--- a/crates/typst-library/src/visualize/image/raster.rs
+++ b/crates/typst-library/src/visualize/image/raster.rs
@@ -16,10 +16,10 @@ use image::{
 
 /// A decoded raster image.
 #[derive(Clone, Hash)]
-pub struct RasterImage(Arc<Repr>);
+pub struct RasterImage(Arc<RasterImageInner>);
 
-/// The internal representation.
-struct Repr {
+/// The internal representation of a [`RasterImage`].
+struct RasterImageInner {
     data: Bytes,
     format: RasterFormat,
     dynamic: Arc<DynamicImage>,
@@ -141,7 +141,7 @@ impl RasterImage {
             }
         };
 
-        Ok(Self(Arc::new(Repr {
+        Ok(Self(Arc::new(RasterImageInner {
             data,
             format,
             exif_rotation: exif_rot,
@@ -197,7 +197,7 @@ impl RasterImage {
     }
 }
 
-impl Hash for Repr {
+impl Hash for RasterImageInner {
     fn hash<H: Hasher>(&self, state: &mut H) {
         // The image is fully defined by data, format, and ICC profile.
         self.data.hash(state);

--- a/crates/typst-library/src/visualize/tiling.rs
+++ b/crates/typst-library/src/visualize/tiling.rs
@@ -8,7 +8,7 @@ use typst_utils::{LazyHash, Numeric};
 use crate::World;
 use crate::diag::{SourceResult, bail};
 use crate::engine::Engine;
-use crate::foundations::{Content, Smart, StyleChain, func, repr, scope, ty};
+use crate::foundations::{Content, Repr, Smart, StyleChain, func, scope, ty};
 use crate::introspection::Locator;
 use crate::layout::{Abs, Axes, Frame, Length, Region, Size};
 use crate::visualize::RelativeTo;
@@ -100,11 +100,11 @@ use crate::visualize::RelativeTo;
 /// deprecated since Typst 0.13.
 #[ty(scope, cast, keywords = ["pattern"])]
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct Tiling(Arc<Repr>);
+pub struct Tiling(Arc<TilingInner>);
 
-/// Internal representation of [`Tiling`].
+/// The internal representation of a [`Tiling`].
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-struct Repr {
+struct TilingInner {
     /// The tiling's rendered content.
     frame: LazyHash<Frame>,
     /// The tiling's tile size.
@@ -212,7 +212,7 @@ impl Tiling {
             );
         }
 
-        Ok(Self(Arc::new(Repr {
+        Ok(Self(Arc::new(TilingInner {
             size: frame.size(),
             frame: LazyHash::new(frame),
             spacing: spacing.v.map(|l| l.abs),
@@ -227,7 +227,7 @@ impl Tiling {
         if let Some(this) = Arc::get_mut(&mut self.0) {
             this.relative = Smart::Custom(relative);
         } else {
-            self.0 = Arc::new(Repr {
+            self.0 = Arc::new(TilingInner {
                 relative: Smart::Custom(relative),
                 ..self.0.as_ref().clone()
             });
@@ -264,7 +264,7 @@ impl Tiling {
     }
 }
 
-impl repr::Repr for Tiling {
+impl Repr for Tiling {
     fn repr(&self) -> EcoString {
         let mut out =
             eco_format!("tiling(({}, {})", self.0.size.x.repr(), self.0.size.y.repr());

--- a/crates/typst-pdf/src/image.rs
+++ b/crates/typst-pdf/src/image.rs
@@ -80,7 +80,12 @@ pub(crate) fn handle_image(
     Ok(())
 }
 
-struct Repr {
+/// A wrapper around `RasterImage` so that we can implement `CustomImage`.
+#[derive(Clone)]
+struct PdfRasterImage(Arc<PdfRasterImageInner>);
+
+/// The internal representation of a [`PdfRasterImage`].
+struct PdfRasterImageInner {
     /// The original, underlying raster image.
     raster: RasterImage,
     /// The alpha channel of the raster image, if existing.
@@ -91,13 +96,10 @@ struct Repr {
     actual_dynamic: OnceLock<Arc<DynamicImage>>,
 }
 
-/// A wrapper around `RasterImage` so that we can implement `CustomImage`.
-#[derive(Clone)]
-struct PdfRasterImage(Arc<Repr>);
-
 impl PdfRasterImage {
+    /// Wraps a raster image.
     pub fn new(raster: RasterImage) -> Self {
-        Self(Arc::new(Repr {
+        Self(Arc::new(PdfRasterImageInner {
             raster,
             alpha_channel: OnceLock::new(),
             actual_dynamic: OnceLock::new(),

--- a/crates/typst-syntax/src/lines.rs
+++ b/crates/typst-syntax/src/lines.rs
@@ -9,10 +9,11 @@ use crate::is_newline;
 ///
 /// This is internally reference-counted and thus cheap to clone.
 #[derive(Clone)]
-pub struct Lines<S>(Arc<Repr<S>>);
+pub struct Lines<S>(Arc<LinesInner<S>>);
 
+/// The internal representation of [`Lines`].
 #[derive(Clone)]
-struct Repr<T> {
+struct LinesInner<T> {
     lines: Vec<Line>,
     text: T,
 }
@@ -30,7 +31,7 @@ impl<T: AsRef<str>> Lines<T> {
     /// Create from the text buffer and compute the line metadata.
     pub fn new(text: T) -> Self {
         let lines = lines(text.as_ref());
-        Lines(Arc::new(Repr { lines, text }))
+        Lines(Arc::new(LinesInner { lines, text }))
     }
 
     /// The text as a string slice.

--- a/crates/typst-syntax/src/source.rs
+++ b/crates/typst-syntax/src/source.rs
@@ -18,11 +18,11 @@ use crate::{FileId, LinkedNode, Span, SyntaxNode, VirtualPath, parse};
 ///
 /// Values of this type are cheap to clone and hash.
 #[derive(Clone)]
-pub struct Source(Arc<Repr>);
+pub struct Source(Arc<SourceInner>);
 
-/// The internal representation.
+/// The internal representation of a [`Source`].
 #[derive(Clone)]
-struct Repr {
+struct SourceInner {
     id: FileId,
     root: LazyHash<SyntaxNode>,
     lines: LazyHash<Lines<String>>,
@@ -34,7 +34,7 @@ impl Source {
         let _scope = typst_timing::TimingScope::new("create source");
         let mut root = parse(&text);
         root.numberize(id, Span::FULL).unwrap();
-        Self(Arc::new(Repr {
+        Self(Arc::new(SourceInner {
             id,
             lines: LazyHash::new(Lines::new(text)),
             root: LazyHash::new(root),

--- a/crates/typst-utils/src/pico.rs
+++ b/crates/typst-utils/src/pico.rs
@@ -132,7 +132,7 @@ impl PicoStr {
             exceptions::LIST[index]
         };
 
-        ResolvedPicoStr(Repr::Static(string))
+        ResolvedPicoStr(ResolvedPicoStrInner::Static(string))
     }
 }
 
@@ -145,7 +145,7 @@ impl Debug for PicoStr {
 /// A 5-bit encoding for strings with length up two 12 that are restricted to a
 /// specific charset.
 mod bitcode {
-    use super::{Repr, ResolvedPicoStr};
+    use super::{ResolvedPicoStr, ResolvedPicoStrInner};
 
     /// Maps from encodings to their bytes.
     const DECODE: &[u8; 32] = b"\0abcdefghijklmnopqrstuvwxyz-1234";
@@ -197,7 +197,7 @@ mod bitcode {
             value >>= 5;
         }
 
-        ResolvedPicoStr(Repr::Inline(buf, len))
+        ResolvedPicoStr(ResolvedPicoStrInner::Inline(buf, len))
     }
 
     /// A failure during compile-time interning.
@@ -339,10 +339,10 @@ mod exceptions {
 /// This is returned by [`PicoStr::resolve`].
 ///
 /// Dereferences to a `str`.
-pub struct ResolvedPicoStr(Repr);
+pub struct ResolvedPicoStr(ResolvedPicoStrInner);
 
-/// Representation of a resolved string.
-enum Repr {
+/// The internal representation of a [`ResolvedPicoStr`].
+enum ResolvedPicoStrInner {
     Inline([u8; 12], u8),
     Static(&'static str),
 }
@@ -351,10 +351,10 @@ impl ResolvedPicoStr {
     /// Retrieve the underlying string.
     pub fn as_str(&self) -> &str {
         match &self.0 {
-            Repr::Inline(buf, len) => unsafe {
+            ResolvedPicoStrInner::Inline(buf, len) => unsafe {
                 std::str::from_utf8_unchecked(&buf[..*len as usize])
             },
-            Repr::Static(s) => s,
+            ResolvedPicoStrInner::Static(s) => s,
         }
     }
 }


### PR DESCRIPTION
This PR renames the `Repr` types that are used as implementation details of various types to the new naming scheme `...Inner`, e.g. `Symbol` + `SymbolInner`. 

This:
- avoids the naming collision with the `Repr` trait
- is more self-explanatory