### PR TITLE
Introduce `ext` attribute on `#[scope]` instead of hardcoding primitives

### DIFF
--- a/crates/typst-library/src/foundations/float.rs
+++ b/crates/typst-library/src/foundations/float.rs
@@ -28,7 +28,7 @@ use crate::layout::Ratio;
 #[ty(scope, cast, name = "float")]
 type f64;
 
-#[scope]
+#[scope(ext)]
 impl f64 {
     /// Positive infinity.
     const INF: f64 = f64::INFINITY;

--- a/crates/typst-library/src/foundations/int.rs
+++ b/crates/typst-library/src/foundations/int.rs
@@ -40,7 +40,7 @@ use crate::foundations::{
 #[ty(scope, cast, name = "int", title = "Integer")]
 type i64;
 
-#[scope]
+#[scope(ext)]
 impl i64 {
     /// Converts a value to an integer. Raises an error if there is an attempt
     /// to parse an invalid string or produce an integer that doesn't fit

--- a/crates/typst-macros/src/util.rs
+++ b/crates/typst-macros/src/util.rs
@@ -259,4 +259,5 @@ pub mod kw {
     syn::custom_keyword!(constructor);
     syn::custom_keyword!(keywords);
     syn::custom_keyword!(parent);
+    syn::custom_keyword!(ext);
 }


### PR DESCRIPTION
This makes it possible to use other types than `bool`, `i64`, and `f64` as native types with a scope definition without them being defined in `typst-library`.