### PR TITLE
Fix wrong path to `typst-eval` in dev docs

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -83,10 +83,9 @@ incremental compilation.
 
 
 ## Evaluation
-The evaluation phase lives in `crates/typst-eval`. It takes a parsed
-`Source` file and evaluates it to a `Module`. A module consists of the `Content`
-that was written in it and a `Scope` with the bindings that were defined within
-it.
+The evaluation phase lives in `crates/typst-eval`. It takes a parsed `Source`
+file and evaluates it to a `Module`. A module consists of the `Content` that was
+written in it and a `Scope` with the bindings that were defined within it.
 
 A source file may depend on other files (imported sources, images, data files),
 which need to be resolved. Since Typst is deployed in different environments


### PR DESCRIPTION
### Summary

Correct the path to `typst-eval` in `docs/dev/architecture.md` as described in #7548.

Fixes #7548