### PR TITLE
Add list of countable elements for counter() function

### DIFF
--- a/docs/reference/library/introspection.md
+++ b/docs/reference/library/introspection.md
@@ -8,3 +8,42 @@ headers which show the current chapter title.
 
 Most of the functions are _contextual._ It is recommended to read the chapter on
 [context] before continuing here.
+
+
+## Countable Elements
+
+The `counter()` function can be used in three ways:
+
+### 1. Built-in Element Counters
+For counting built-in document elements that implement the `Locatable` trait:
+- `page` - Page numbers
+- `heading` - Headings (all levels)
+- `figure` - Figures
+- `equation` - Equations
+- `footnote` - Footnotes
+- `table` - Tables
+- `list` - List items
+- `enum` - Enumerated items
+
+Example:
+
+**typst
+#let page-counter = counter(page)
+
+### 2. Custom String Counters
+For creating your own counters with string keys:
+
+**typst
+#let questions = counter("questions")
+questions.step()
+questions.display()  // Displays: 1
+
+### 3. Label-based Counters
+For counting specific labeled elements:
+**typst
+#let label = <appendix>
+#let appendix-counter = counter(label)
+#heading(label)[Appendix]
+#appendix-counter.display()
+
+*Note: This list of built-in elements is based on Typst v0.10.0. The available elements may change in future versions.*


### PR DESCRIPTION
Fixes #2728

Adds a comprehensive list of all elements that implement `Locatable` and can be used with the `counter()` function, as requested in the issue.

## Changes
- Add "Countable Elements" section to `docs/reference/library/introspection.md`
- List all built-in elements: `page`, `heading`, `figure`, `equation`, `footnote`, `table`, `list`, `enum`
- Include examples for:
  - Built-in element counters
  - Custom string counters
  - Label-based counters
- Add version note for future reference

## Testing
The list is based on the existing test suite and source code analysis.