### PR TITLE
Add `path.exists` function

### DIFF
--- a/tests/suite/foundations/path.typ
+++ b/tests/suite/foundations/path.typ
@@ -4,6 +4,15 @@
   "path(\"/tests/suite/foundations/hi/there.txt\")",
 )
 
+--- path-file-exists paged ---
+#assert(path("./path.typ").exists())
+
+--- path-dir-exists paged ---
+#assert(path("/tests").exists())
+
+--- path-none-exists paged ---
+#assert(not path("./unknown.typ").exists())
+
 --- path-escapes paged ---
 // Error: 7-29 path `"../../../../file.txt"` would escape the project root
 // Hint: 7-29 cannot access files outside of the project sandbox


### PR DESCRIPTION
This PR adds support for a `path.exists` function that checks whether a file or directory exists at a path. It depends on https://github.com/typst/typst/pull/7555.

The implementation right now uses the existing `World` infrastructure. It tries to load the path, and matches on the result to make a decision. In particular, it depends on World implementors correctly returning `FileError::IsDirectory` for directories.

I am not 100% decided whether we should keep it this way or whether we should extend the `World` interface to make this more explicit (maybe with a default impl mirroring what I've done here), also allowing it to be more efficient. We should also consider how the `World` interface needs to be adapted to support [directory walking](https://github.com/typst/typst/issues/2123). Maybe there is some overlap.

The function also still needs some more documentation.

This closes https://github.com/typst/typst/issues/2025.