### PR TITLE
Add functions for HTML content models

### DIFF
--- a/crates/typst-html/src/encode.rs
+++ b/crates/typst-html/src/encode.rs
@@ -310,7 +310,7 @@ fn allows_pretty_inside(tag: HtmlTag) -> bool {
 /// In contrast to `allows_pretty_inside`, which is purely spec-driven, this is
 /// more subjective and depends on preference.
 fn wants_pretty_around(tag: HtmlTag) -> bool {
-    allows_pretty_inside(tag) || tag::is_metadata(tag) || tag == tag::pre
+    allows_pretty_inside(tag) || tag::is_metadata_content(tag) || tag == tag::pre
 }
 
 /// Escape a character.

--- a/crates/typst-html/src/tag.rs
+++ b/crates/typst-html/src/tag.rs
@@ -118,6 +118,8 @@ pub const var: HtmlTag = HtmlTag::constant("var");
 pub const video: HtmlTag = HtmlTag::constant("video");
 pub const wbr: HtmlTag = HtmlTag::constant("wbr");
 
+// HTML spec § 13.1.2 Elements
+
 /// Whether this is a void tag whose associated element may not have
 /// children.
 pub fn is_void(tag: HtmlTag) -> bool {
@@ -149,8 +151,10 @@ pub fn is_escapable_raw(tag: HtmlTag) -> bool {
     matches!(tag, self::textarea | self::title)
 }
 
-/// Whether an element is considered metadata.
-pub fn is_metadata(tag: HtmlTag) -> bool {
+// HTML spec § 3.2.5.2 Kinds of content
+
+/// Whether an element is considered metadata content.
+pub fn is_metadata_content(tag: HtmlTag) -> bool {
     matches!(
         tag,
         self::base
@@ -163,6 +167,293 @@ pub fn is_metadata(tag: HtmlTag) -> bool {
             | self::title
     )
 }
+
+/// Wether an element is considered flow content.
+pub fn is_flow_content(tag: HtmlTag) -> bool {
+    matches!(
+        tag,
+        self::a
+            | self::abbr
+            | self::address
+            | self::area
+            | self::article
+            | self::aside
+            | self::audio
+            | self::b
+            | self::bdi
+            | self::bdo
+            | self::blockquote
+            | self::br
+            | self::button
+            | self::canvas
+            | self::cite
+            | self::code
+            | self::data
+            | self::datalist
+            | self::del
+            | self::details
+            | self::dfn
+            | self::dialog
+            | self::div
+            | self::dl
+            | self::em
+            | self::embed
+            | self::fieldset
+            | self::figure
+            | self::footer
+            | self::form
+            | self::h1
+            | self::h2
+            | self::h3
+            | self::h4
+            | self::h5
+            | self::h6
+            | self::header
+            | self::hgroup
+            | self::hr
+            | self::i
+            | self::iframe
+            | self::img
+            | self::input
+            | self::ins
+            | self::kbd
+            | self::label
+            | self::link
+            | self::main
+            | self::map
+            | self::mark
+            | self::menu
+            | self::meta
+            | self::meter
+            | self::nav
+            | self::noscript
+            | self::object
+            | self::ol
+            | self::output
+            | self::p
+            | self::picture
+            | self::pre
+            | self::progress
+            | self::q
+            | self::ruby
+            | self::s
+            | self::samp
+            | self::script
+            | self::search
+            | self::section
+            | self::select
+            | self::slot
+            | self::small
+            | self::span
+            | self::strong
+            | self::sub
+            | self::sup
+            | self::table
+            | self::template
+            | self::textarea
+            | self::time
+            | self::u
+            | self::ul
+            | self::var
+            | self::video
+            | self::wbr
+    )
+}
+
+/// Whether an element is considered sectioning content.
+pub fn is_sectioning_content(tag: HtmlTag) -> bool {
+    matches!(tag, self::article | self::aside | self::nav | self::section)
+}
+
+/// Whether an element is considered heading content.
+pub fn is_heading_content(tag: HtmlTag) -> bool {
+    matches!(
+        tag,
+        self::h1 | self::h2 | self::h3 | self::h4 | self::h5 | self::h6 | self::hgroup
+    )
+}
+
+/// Whether an element is considered phrasing content.
+pub fn is_phrasing_content(tag: HtmlTag) -> bool {
+    matches!(
+        tag,
+        self::a
+            | self::abbr
+            | self::area
+            | self::audio
+            | self::b
+            | self::bdi
+            | self::bdo
+            | self::br
+            | self::button
+            | self::canvas
+            | self::cite
+            | self::code
+            | self::data
+            | self::datalist
+            | self::del
+            | self::dfn
+            | self::em
+            | self::embed
+            | self::i
+            | self::iframe
+            | self::img
+            | self::input
+            | self::ins
+            | self::kbd
+            | self::label
+            | self::link
+            | self::map
+            | self::mark
+            | self::meta
+            | self::meter
+            | self::noscript
+            | self::object
+            | self::output
+            | self::picture
+            | self::progress
+            | self::q
+            | self::ruby
+            | self::s
+            | self::samp
+            | self::script
+            | self::select
+            | self::slot
+            | self::small
+            | self::span
+            | self::strong
+            | self::sub
+            | self::sup
+            | self::template
+            | self::textarea
+            | self::time
+            | self::u
+            | self::var
+            | self::video
+            | self::wbr
+    )
+}
+
+/// Whether an element is considered embedded content.
+pub fn is_embedded_content(tag: HtmlTag) -> bool {
+    matches!(
+        tag,
+        self::audio
+            | self::canvas
+            | self::embed
+            | self::iframe
+            | self::img
+            | self::object
+            | self::picture
+            | self::video
+    )
+}
+
+/// Whether an element is considered interactive content.
+pub fn is_interactive_content(tag: HtmlTag) -> bool {
+    matches!(
+        tag,
+        self::a
+            | self::audio
+            | self::button
+            | self::details
+            | self::embed
+            | self::iframe
+            | self::img
+            | self::input
+            | self::label
+            | self::select
+            | self::textarea
+            | self::video
+    )
+}
+
+/// Whether an element is considered palpable content.
+pub fn is_palpable_content(tag: HtmlTag) -> bool {
+    matches!(
+        tag,
+        self::a
+            | self::abbr
+            | self::address
+            | self::article
+            | self::aside
+            | self::audio
+            | self::b
+            | self::bdi
+            | self::bdo
+            | self::blockquote
+            | self::button
+            | self::canvas
+            | self::cite
+            | self::code
+            | self::data
+            | self::del
+            | self::details
+            | self::dfn
+            | self::div
+            | self::dl
+            | self::em
+            | self::embed
+            | self::fieldset
+            | self::figure
+            | self::footer
+            | self::form
+            | self::h1
+            | self::h2
+            | self::h3
+            | self::h4
+            | self::h5
+            | self::h6
+            | self::header
+            | self::hgroup
+            | self::i
+            | self::iframe
+            | self::img
+            | self::input
+            | self::ins
+            | self::kbd
+            | self::label
+            | self::main
+            | self::map
+            | self::mark
+            | self::menu
+            | self::meter
+            | self::nav
+            | self::object
+            | self::ol
+            | self::output
+            | self::p
+            | self::picture
+            | self::pre
+            | self::progress
+            | self::q
+            | self::ruby
+            | self::s
+            | self::samp
+            | self::search
+            | self::section
+            | self::select
+            | self::small
+            | self::span
+            | self::strong
+            | self::sub
+            | self::sup
+            | self::table
+            | self::textarea
+            | self::time
+            | self::u
+            | self::ul
+            | self::var
+            | self::video
+    )
+}
+
+/// Whether an element is considered a script-supporting element.
+pub fn is_script_supporting_element(tag: HtmlTag) -> bool {
+    matches!(tag, self::script | self::template)
+}
+
+// Defaults of the CSS `display` property.
 
 /// Whether nodes with the tag have the CSS property `display: block` by
 /// default.


### PR DESCRIPTION
These are generally useful (see e.g. https://github.com/typst/typst/pull/7505) and I had that branch lying around already.