### PR TITLE
When testing, don't print ANSI sequence if the output is not TTY

### DIFF
--- a/tests/src/collect.rs
+++ b/tests/src/collect.rs
@@ -1,4 +1,5 @@
 use std::fmt::{self, Display, Formatter};
+use std::io::IsTerminal;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -40,7 +41,11 @@ pub struct Test {
 impl Display for Test {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         // underline path
-        write!(f, "{} (\x1B[4m{}\x1B[0m)", self.name, self.pos)
+        if std::io::stdout().is_terminal() {
+            write!(f, "{} (\x1B[4m{}\x1B[0m)", self.name, self.pos)
+        } else {
+            write!(f, "{} ({})", self.name, self.pos)
+        }
     }
 }
 


### PR DESCRIPTION
When the output destination is not a terminal, let's not print the ANSI escape sequence to draw underline `\x1B[4m`/`\x1B[0m`.

|                           |  Before this PR | After this PR |
|:---------------:|----------------|-------------|
|terminal              |<img width="400" src="https://github.com/user-attachments/assets/1a9019dd-30aa-4fee-905e-cc7ac78b713b" /> | same as left |
|test-helper view|<img width="400" src="https://github.com/user-attachments/assets/0b7f280e-346a-4f48-83a7-b23edcff09a3" />| <img width="400" src="https://github.com/user-attachments/assets/d5dfade5-26a8-407f-bec3-27e3b92db5ec" />|