### PR TITLE
Mention `match` in the `regex` documentation

### DIFF
--- a/crates/typst-library/src/foundations/str.rs
+++ b/crates/typst-library/src/foundations/str.rs
@@ -955,7 +955,7 @@ fn string_is_empty() -> EcoString {
 /// A regular expression.
 ///
 /// Can be used as a [show rule selector]($styling/#show-rules) and with
-/// [string methods]($str) like `find`, `split`, and `replace`.
+/// [string methods]($str) like `find`, `split`, `replace`, and `match`.
 ///
 /// [See here](https://docs.rs/regex/latest/regex/#syntax) for a specification
 /// of the supported syntax.


### PR DESCRIPTION
I was surprised [`str.match`](https://typst.app/docs/reference/foundations/str/#definitions-match) isn't mentioned at all in the documentation of the [`regex`](https://typst.app/docs/reference/foundations/regex/) type, as it's arguably what gives it the most utility[^util] (only way to access capture groups & the end index of matches). It is what allows us to "execute a regex", broadly speaking.

[^util]: Strictly so even; I'm pretty sure it (or rather `matches`, but let's mention the basic variant) is the only method utilizing regex (assuming implementing a regex engine in Typst is against the rules), which immediately yields all the information necessary to then implement all the other ones.

One can find it by clicking the link to "string methods", but on that page there are so many methods and mentions of "regex" (currently 20+ each), it's somewhat difficult to navigate :sweat_smile:. Explicitly stating `match` as one of the places to look would make `regex` friendlier to learn (especially if a user knows about and has certain expectations of regexes).

Personally, I'd even put it first in the list and change the example to show it in action, but I understand it's a bit technical and perhaps overwhelming as well; thus I feel this is a well-balanced solution.