### PR TITLE
Preview pdftags tests' YAML output in the test-helper extension

### DIFF
--- a/tools/test-helper/src/extension.ts
+++ b/tools/test-helper/src/extension.ts
@@ -407,7 +407,7 @@ enum Format {
 const FORMAT_TO_FILE_EXTENSION = {
   [Format.HTML]: "html",
   [Format.RENDER]: "png",
-  [Format.PDFTAGS]: "yml"
+  [Format.PDFTAGS]: "yml",
 };
 
 function getUri(name: string, bucket: Bucket, format: Format) {
@@ -546,7 +546,11 @@ async function getWebviewContent(
     <body>
       ${showRender ? renderSection(panel, name) : ""}
       ${showHtml ? await textSection(name, Format.HTML, htmlSnippet) : ""}
-      ${showPdftags ? await textSection(name, Format.PDFTAGS, pdftagsSnippet): ""}
+      ${
+        showPdftags
+          ? await textSection(name, Format.PDFTAGS, pdftagsSnippet)
+          : ""
+      }
       ${stdout}
       ${stderr}
     </body>
@@ -587,7 +591,8 @@ type ColumnSuffix = "Output" | "Reference";
 async function textSection(
   name: string,
   format: Format.HTML | Format.PDFTAGS,
-  makeSnippet: (suffix: ColumnSuffix, uri: vscode.Uri) => Promise<string>) {
+  makeSnippet: (suffix: ColumnSuffix, uri: vscode.Uri) => Promise<string>
+) {
   const store = await makeSnippet("Output", getUri(name, "store", format));
   const ref = await makeSnippet("Reference", getUri(name, "ref", format));
   return `<div
@@ -600,7 +605,9 @@ async function textSection(
 }
 
 async function htmlSnippet(
-  suffix: ColumnSuffix, uri: vscode.Uri): Promise<string> {
+  suffix: ColumnSuffix,
+  uri: vscode.Uri
+): Promise<string> {
   const title = `HTML ${suffix}`;
   try {
     const data = await vscode.workspace.fs.readFile(uri);
@@ -618,7 +625,9 @@ async function htmlSnippet(
 }
 
 async function pdftagsSnippet(
-  suffix: ColumnSuffix, uri: vscode.Uri): Promise<string> {
+  suffix: ColumnSuffix,
+  uri: vscode.Uri
+): Promise<string> {
   const title = `PdfTags YAML ${suffix}`;
   try {
     const data = await vscode.workspace.fs.readFile(uri);
@@ -639,7 +648,7 @@ function linkedTitle(title: string, uri: vscode.Uri) {
 }
 
 async function highlight(code: string, lang: string): Promise<string> {
-  return (await shiki).codeToHtml(code, {lang, theme: selectTheme()});
+  return (await shiki).codeToHtml(code, { lang, theme: selectTheme() });
 }
 
 function selectTheme() {


### PR DESCRIPTION
This PR allows previewing the output and reference of tests with attribute`pdftags` (e.g. `footnote-tags-basic`) in the test-helper extension.

Such result files are YAML files, so essentially this PR adds the support of previewing YAML files.

<img height="500" alt="Screenshot 2025-12-21 at 19 49 46" src="https://github.com/user-attachments/assets/13c694ba-2539-4ed2-9481-c2c2fc3e4313" />

---

Also, from a better web design, this PR adds a small `5px` vertical padding to the body of the web view, so that there will be a small gap between the end of previewing box and the bottom of the web view (see below), so that readers know there's no more to scroll down.
<img height="250" alt="Screenshot 2025-12-21 at 19 55 25" src="https://github.com/user-attachments/assets/f0f732ab-f6f2-47c9-845f-d76cc0648ba1" />

