### PR TITLE
Clamp SVG size to 1x1pt

### DIFF
--- a/crates/typst-svg/src/lib.rs
+++ b/crates/typst-svg/src/lib.rs
@@ -231,6 +231,10 @@ impl<'a> SVGRenderer<'a> {
         size: Size,
         write_custom_attrs: impl FnOnce(&mut XmlWriter),
     ) {
+        // Clamp the size of SVGs to at least one pt. resvg and probably also
+        // other SVG parsers don't handle SVGs with 0 sized dimensions.
+        let size = size.max(Size::splat(Abs::pt(1.0)));
+
         self.xml.start_element("svg");
         write_custom_attrs(&mut self.xml);
         self.xml.write_attribute_fmt(


### PR DESCRIPTION
Complementing #7454. While there SVGs with a width and height of 0 are legal, I ran into similar issues with different SVG viewers and `resvg`.