### PR TITLE
Remove yaml-front-matter dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,12 +922,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -941,11 +935,11 @@ dependencies = [
  "biblatex",
  "ciborium",
  "citationberg",
- "indexmap 2.12.1",
+ "indexmap",
  "paste",
  "roman-numerals-rs",
  "serde",
- "serde_yaml 0.9.34+deprecated",
+ "serde_yaml",
  "thiserror",
  "unic-langid",
  "unicode-segmentation",
@@ -1310,22 +1304,12 @@ checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown",
  "rayon",
  "serde",
  "serde_core",
@@ -1450,7 +1434,7 @@ dependencies = [
  "hayro-write",
  "image-webp",
  "imagesize 0.14.0",
- "indexmap 2.12.1",
+ "indexmap",
  "once_cell",
  "pdf-writer",
  "png",
@@ -1857,7 +1841,7 @@ dependencies = [
  "bitvec",
  "crossbeam-channel",
  "filetime",
- "indexmap 2.12.1",
+ "indexmap",
  "libdeflater",
  "log",
  "rayon",
@@ -2014,7 +1998,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016"
 dependencies = [
  "base64",
- "indexmap 2.12.1",
+ "indexmap",
  "quick-xml 0.32.0",
  "serde",
  "time",
@@ -2481,23 +2465,11 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
-dependencies = [
- "indexmap 1.9.3",
- "ryu",
- "serde",
- "yaml-rust",
-]
-
-[[package]]
-name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.12.1",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -2911,7 +2883,7 @@ version = "0.22.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
 dependencies = [
- "indexmap 2.12.1",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2993,7 +2965,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "serde_yaml 0.9.34+deprecated",
+ "serde_yaml",
  "shell-escape",
  "sigpipe",
  "tar",
@@ -3033,7 +3005,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "serde_yaml 0.9.34+deprecated",
+ "serde_yaml",
  "syntect",
  "typed-arena",
  "typst",
@@ -3043,7 +3015,6 @@ dependencies = [
  "typst-utils",
  "unicode-math-class",
  "unscanny",
- "yaml-front-matter",
 ]
 
 [[package]]
@@ -3052,7 +3023,7 @@ version = "0.14.2"
 dependencies = [
  "comemo",
  "ecow",
- "indexmap 2.12.1",
+ "indexmap",
  "rustc-hash",
  "stacker",
  "toml",
@@ -3197,7 +3168,7 @@ dependencies = [
  "icu_provider",
  "icu_provider_blob",
  "image",
- "indexmap 2.12.1",
+ "indexmap",
  "kamadak-exif",
  "kurbo 0.12.0",
  "lipsum",
@@ -3215,7 +3186,7 @@ dependencies = [
  "rustybuzz",
  "serde",
  "serde_json",
- "serde_yaml 0.9.34+deprecated",
+ "serde_yaml",
  "siphasher",
  "smallvec",
  "syntect",
@@ -3259,7 +3230,7 @@ dependencies = [
  "comemo",
  "ecow",
  "image",
- "indexmap 2.12.1",
+ "indexmap",
  "infer",
  "krilla",
  "krilla-svg",
@@ -3356,14 +3327,14 @@ dependencies = [
  "comemo",
  "ecow",
  "hayro-syntax",
- "indexmap 2.12.1",
+ "indexmap",
  "oxipng",
  "parking_lot",
  "rayon",
  "regex",
  "roxmltree",
  "rustc-hash",
- "serde_yaml 0.9.34+deprecated",
+ "serde_yaml",
  "tiny-skia",
  "typst",
  "typst-assets",
@@ -3889,7 +3860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "886614b5ce857341226aa091f3c285e450683894acaaa7887f366c361efef79d"
 dependencies = [
  "font-types",
- "indexmap 2.12.1",
+ "indexmap",
  "kurbo 0.12.0",
  "log",
  "read-fonts",
@@ -3952,16 +3923,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
-]
-
-[[package]]
-name = "yaml-front-matter"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a94fb32d2b438e3fddf901fbfe9eb87b34d63853ca6c6da5d2ab7e27031e0bae"
-dependencies = [
- "serde",
- "serde_yaml 0.8.26",
 ]
 
 [[package]]
@@ -4116,7 +4077,7 @@ dependencies = [
  "arbitrary",
  "crc32fast",
  "flate2",
- "indexmap 2.12.1",
+ "indexmap",
  "memchr",
  "zopfli",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,6 @@ web-sys = "0.3"
 xmlparser = "0.13.5"
 xmlwriter = "0.1.0"
 xz2 = { version = "0.1", features = ["static"] }
-yaml-front-matter = "0.1"
 zip = { version = "5", default-features = false, features = ["deflate"] }
 
 [profile.dev.package."*"]

--- a/docs/Cargo.toml
+++ b/docs/Cargo.toml
@@ -35,7 +35,6 @@ syntect = { workspace = true, features = ["html"] }
 typed-arena = { workspace = true }
 unicode-math-class = { workspace = true }
 unscanny = { workspace = true }
-yaml-front-matter = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
The dependency didn't do much, but it depended on an outdated `serde-yaml` version. Since this was only used to generate docs this isn't really a problem, but I've found myself wondering at least 2 times, which crate requires that old `serde_yaml` version and wasting a bit of time, so I decided to remove it before I do it again :)