### PR TITLE
Add a clipping example to the image docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3153,7 +3153,7 @@ dependencies = [
 [[package]]
 name = "typst-dev-assets"
 version = "0.15.1"
-source = "git+https://github.com/typst/typst-dev-assets?rev=79ba7c3#79ba7c354e39d9cd0a074bc41becc05f0119eee3"
+source = "git+https://github.com/typst/typst-dev-assets?rev=5a10d90#5a10d90b044e030d793e700c7c5052759621ae38"
 
 [[package]]
 name = "typst-docs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ typst-syntax = { path = "crates/typst-syntax", version = "0.15.1" }
 typst-timing = { path = "crates/typst-timing", version = "0.15.1" }
 typst-utils = { path = "crates/typst-utils", version = "0.15.1" }
 typst-assets = { git = "https://github.com/typst/typst-assets", rev = "94dcb99" }
-typst-dev-assets = { git = "https://github.com/typst/typst-dev-assets", rev = "79ba7c3" }
+typst-dev-assets = { git = "https://github.com/typst/typst-dev-assets", rev = "5a10d90" }
 arrayvec = "0.7.4"
 az = "1.2"
 base64 = "0.22"

--- a/crates/typst-library/src/layout/container.rs
+++ b/crates/typst-library/src/layout/container.rs
@@ -16,7 +16,12 @@ use crate::visualize::{Paint, Stroke};
 /// All elements except inline math, text, and boxes are block-level and cannot
 /// occur inside of a @par[paragraph]. The box function can be used to integrate
 /// such elements into a paragraph. Boxes take the size of their contents by
-/// default but can also be sized explicitly.
+/// default but can also be @box.width[sized] explicitly.
+///
+/// Similarly to blocks, boxes can be used to @box.clip[clip] content or to give
+/// it a @box.fill[background] or @box.stroke[border]. However, they should only
+/// be used for these purposes if the resulting container is used in an
+/// inline-level context. Otherwise, a @block is preferable.
 ///
 /// = Example <example>
 /// ```example
@@ -214,8 +219,9 @@ pub enum InlineItem {
 
 /// A block-level container.
 ///
-/// Such a container can be used to separate content, size it, and give it a
-/// background or border.
+/// Such a container can be used to separate content, to @block.width[size] or
+/// @block.clip[clip] it, or to give it a @block.fill[background] or
+/// @block.stroke[border].
 ///
 /// Blocks are also the primary way to control whether text becomes part of a
 /// paragraph or not. See

--- a/crates/typst-library/src/visualize/image/mod.rs
+++ b/crates/typst-library/src/visualize/image/mod.rs
@@ -48,6 +48,32 @@ use crate::visualize::image::pdf::PdfDocument;
 ///   ],
 /// )
 /// ```
+///
+/// = Clipping <clipping>
+/// You can wrap an image in a @block or @box #footnote[A box should only be
+/// used if the image shall be displayed inline as part of a paragraph.
+/// Otherwise, a block is preferable.] with negative @block.inset[`inset`] and
+/// `{clip: true}` to clip it. Note that the clipped parts are only visually
+/// hidden. The full image data is still embedded in the output (except when
+/// exporting to PNG). This approach is thus not suitable for redacting parts of
+/// an image.
+///
+/// ```example
+/// #let lynx = image("lynx.jpg", height: 150pt, fit: "cover")
+/// #grid(
+///   columns: 2,
+///   column-gutter: 1fr,
+///   // The full image on the left.
+///   lynx,
+///   // Two cropped parts on the right: One cropped by 80pt
+///   // from the bottom and one cropped by 75pt from the top.
+///   stack(
+///     spacing: 5pt,
+///     block(lynx, clip: true, inset: (bottom: -80pt)),
+///     block(lynx, clip: true, inset: (top: -75pt)),
+///   )
+/// )
+/// ```
 #[elem(since = "forever", Locatable, Tagged, Synthesize, LocalName, Figurable)]
 pub struct ImageElem {
     /// A path to an image file or raw bytes making up an image in one of the


### PR DESCRIPTION
See also https://github.com/typst/typst/issues/3147. I went looking for how to do this and pretty immediately found the GitHub issue and the (excellent) example within, but this is a common enough use case that I think it should be in the docs.