### PR TITLE
Implement field access for `arguments`

### DIFF
--- a/crates/typst-eval/src/access.rs
+++ b/crates/typst-eval/src/access.rs
@@ -84,7 +84,11 @@ pub(crate) fn access_dict<'a>(
             let span = access.target().span();
             if matches!(
                 value, // those types have their own field getters
-                Value::Symbol(_) | Value::Content(_) | Value::Module(_) | Value::Func(_)
+                Value::Symbol(_)
+                    | Value::Content(_)
+                    | Value::Module(_)
+                    | Value::Func(_)
+                    | Value::Args(_)
             ) {
                 bail!(span, "cannot mutate fields on {ty}");
             } else if typst_library::foundations::fields_on(ty).is_empty() {

--- a/crates/typst-eval/src/call.rs
+++ b/crates/typst-eval/src/call.rs
@@ -387,6 +387,13 @@ fn missing_field_call_error(target: Value, field: Ident) -> SourceDiagnostic {
                 field.as_str(),
             ));
         }
+        Value::Args(ref args) if matches!(args.field(&field), Ok(Value::Func(_))) => {
+            error.hint(eco_format!(
+                "to call the function stored in a named argument, surround \
+                the field access with parentheses, e.g. `(args.{})(..)`",
+                field.as_str(),
+            ));
+        }
         _ if target.field(&field, ()).is_ok() => {
             error.hint(eco_format!(
                 "did you mean to access the field `{}`?",

--- a/crates/typst-library/src/foundations/args.rs
+++ b/crates/typst-library/src/foundations/args.rs
@@ -304,7 +304,7 @@ impl Args {
         self.items
             .iter()
             .rfind(|item| item.name.as_ref().map(|name| name.as_str()) == Some(field))
-            .ok_or_else(|| eco_format!("arguments do not contain key {}", field.repr()))
+            .ok_or_else(|| eco_format!("no named argument {}", field.repr()))
             .map(|item| &item.value.v)
     }
 }
@@ -565,8 +565,7 @@ where
 #[cold]
 fn missing_key_no_default(key: ArgumentKey) -> EcoString {
     eco_format!(
-        "arguments do not contain key {} \
-         and no default value was specified",
+        "no named argument {} and no default value was specified",
         match key {
             ArgumentKey::Index(i) => i.repr(),
             ArgumentKey::Name(name) => name.repr(),

--- a/crates/typst-library/src/foundations/args.rs
+++ b/crates/typst-library/src/foundations/args.rs
@@ -299,6 +299,20 @@ impl Args {
         };
         item.map(|item| &item.value.v)
     }
+
+    pub fn contains(&self, key: &str) -> bool {
+        self.items
+            .iter()
+            .any(|item| item.name.as_ref().map(|n| n.as_str()) == Some(key))
+    }
+
+    pub fn field(&self, field: &str) -> StrResult<&Value> {
+        self.items
+            .iter()
+            .rfind(|item| item.name.as_ref().map(|name| name.as_str()) == Some(field))
+            .ok_or_else(|| eco_format!("arguments do not contain key {}", field.repr()))
+            .map(|item| &item.value.v)
+    }
 }
 
 #[scope]
@@ -330,6 +344,8 @@ impl Args {
 
     /// Returns the positional argument at the specified index, or the named
     /// argument with the specified name.
+    /// Named arguments can also be accessed with field syntax `arguments(key: 42).key`
+    /// if no default is needed.
     ///
     /// If the key is an [integer]($int), this is equivalent to first calling
     /// [`pos`]($arguments.pos) and then [`array.at`]. If it is a [string]($str),

--- a/crates/typst-library/src/foundations/args.rs
+++ b/crates/typst-library/src/foundations/args.rs
@@ -300,12 +300,6 @@ impl Args {
         item.map(|item| &item.value.v)
     }
 
-    pub fn contains(&self, key: &str) -> bool {
-        self.items
-            .iter()
-            .any(|item| item.name.as_ref().map(|n| n.as_str()) == Some(key))
-    }
-
     pub fn field(&self, field: &str) -> StrResult<&Value> {
         self.items
             .iter()

--- a/crates/typst-library/src/foundations/args.rs
+++ b/crates/typst-library/src/foundations/args.rs
@@ -564,11 +564,14 @@ where
 /// The missing key access error message when no default was given.
 #[cold]
 fn missing_key_no_default(key: ArgumentKey) -> EcoString {
-    eco_format!(
-        "no named argument {} and no default value was specified",
-        match key {
-            ArgumentKey::Index(i) => i.repr(),
-            ArgumentKey::Name(name) => name.repr(),
-        }
-    )
+    match key {
+        ArgumentKey::Index(i) => eco_format!(
+            "no positional argument at index {} and no default value was specified",
+            i.repr()
+        ),
+        ArgumentKey::Name(name) => eco_format!(
+            "no named argument {} and no default value was specified",
+            name.repr()
+        ),
+    }
 }

--- a/crates/typst-library/src/foundations/dict.rs
+++ b/crates/typst-library/src/foundations/dict.rs
@@ -197,6 +197,9 @@ impl Dict {
     }
 
     /// Returns the value associated with the specified key in the dictionary.
+    /// Values may also be accessed with field syntax `(key: 42).key` if no default
+    /// is needed.
+    ///
     /// May be used on the left-hand side of an assignment if the key is already
     /// present in the dictionary. Returns the default value if the key is not
     /// part of the dictionary or fails with an error if no default value was

--- a/crates/typst-library/src/foundations/ops.rs
+++ b/crates/typst-library/src/foundations/ops.rs
@@ -558,6 +558,7 @@ pub fn contains(lhs: &Value, rhs: &Value) -> Option<bool> {
         (Str(a), Str(b)) => Some(b.as_str().contains(a.as_str())),
         (Dyn(a), Str(b)) => a.downcast::<Regex>().map(|regex| regex.is_match(b)),
         (Str(a), Dict(b)) => Some(b.contains(a)),
+        (Str(a), Args(b)) => Some(b.contains(a)),
         (Str(a), Module(b)) => Some(b.scope().get(a).is_some()),
         (a, Array(b)) => Some(b.contains(a.clone())),
 

--- a/crates/typst-library/src/foundations/ops.rs
+++ b/crates/typst-library/src/foundations/ops.rs
@@ -558,7 +558,6 @@ pub fn contains(lhs: &Value, rhs: &Value) -> Option<bool> {
         (Str(a), Str(b)) => Some(b.as_str().contains(a.as_str())),
         (Dyn(a), Str(b)) => a.downcast::<Regex>().map(|regex| regex.is_match(b)),
         (Str(a), Dict(b)) => Some(b.contains(a)),
-        (Str(a), Args(b)) => Some(b.contains(a)),
         (Str(a), Module(b)) => Some(b.scope().get(a).is_some()),
         (a, Array(b)) => Some(b.contains(a.clone())),
 

--- a/crates/typst-library/src/foundations/value.rs
+++ b/crates/typst-library/src/foundations/value.rs
@@ -162,6 +162,7 @@ impl Value {
             }
             Self::Version(version) => version.component(field).map(Self::Int),
             Self::Dict(dict) => dict.get(field).cloned(),
+            Self::Args(args) => args.field(field).cloned(),
             Self::Content(content) => content.field_by_name(field),
             Self::Type(ty) => ty.field(field, sink).cloned(),
             Self::Func(func) => func.field(field, sink).cloned(),

--- a/tests/suite/foundations/arguments.typ
+++ b/tests/suite/foundations/arguments.typ
@@ -16,7 +16,7 @@
 
 --- arguments-at-invalid-index eval ---
 #let args = arguments(0, 1, a: 2, 3)
-// Error: 2-12 no named argument 4 and no default value was specified
+// Error: 2-12 no positional argument at index 4 and no default value was specified
 #args.at(4)
 
 --- arguments-name-access eval ---

--- a/tests/suite/foundations/arguments.typ
+++ b/tests/suite/foundations/arguments.typ
@@ -24,12 +24,6 @@
 #test(args.a, 2)
 #test(args.b, 4)
 
---- arguments-name-in eval ---
-#let args = arguments(0, 1, a: 2, 3, b: 4, c: 5)
-#test("a" in args, true)
-#test("z" in args, false)
-#test("b" not in args, false)
-
 --- arguments-at-invalid-name eval ---
 #let args = arguments(0, 1, a: 2, 3)
 // Error: 2-14 arguments do not contain key "b" and no default value was specified

--- a/tests/suite/foundations/arguments.typ
+++ b/tests/suite/foundations/arguments.typ
@@ -34,27 +34,6 @@
 // Error: 7-8 no named argument "b"
 #args.b
 
---- arguments-function-item-not-a-method eval ---
-#{
-  let args = arguments(
-    call-me: () => 1,
-  )
-  // Error: 8-15 type arguments has no method `call-me`
-  // Hint: 8-15 to call the function stored in a named argument, surround the field access with parentheses, e.g. `(args.call-me)(..)`
-  args.call-me()
-}
-
---- arguments-item-missing-method eval ---
-#{
-  let args = arguments(
-    nonfunc: 1
-  )
-
-  // Error: 8-15 type arguments has no method `nonfunc`
-  // Hint: 8-15 did you mean to access the field `nonfunc`?
-  args.nonfunc()
-}
-
 --- arguments-plus-sum-join eval ---
 #let lhs = arguments(0, "1", key: "value", 3)
 #let rhs = arguments(other-key: 4, key: "other value", 3)

--- a/tests/suite/foundations/arguments.typ
+++ b/tests/suite/foundations/arguments.typ
@@ -16,7 +16,7 @@
 
 --- arguments-at-invalid-index eval ---
 #let args = arguments(0, 1, a: 2, 3)
-// Error: 2-12 arguments do not contain key 4 and no default value was specified
+// Error: 2-12 no named argument 4 and no default value was specified
 #args.at(4)
 
 --- arguments-name-access eval ---
@@ -26,12 +26,12 @@
 
 --- arguments-at-invalid-name eval ---
 #let args = arguments(0, 1, a: 2, 3)
-// Error: 2-14 arguments do not contain key "b" and no default value was specified
+// Error: 2-14 no named argument "b" and no default value was specified
 #args.at("b")
 
 --- arguments-invalid-name eval ---
 #let args = arguments(0, 1, a: 2, 3)
-// Error: 7-8 arguments do not contain key "b"
+// Error: 7-8 no named argument "b"
 #args.b
 
 --- arguments-plus-sum-join eval ---

--- a/tests/suite/foundations/arguments.typ
+++ b/tests/suite/foundations/arguments.typ
@@ -19,10 +19,26 @@
 // Error: 2-12 arguments do not contain key 4 and no default value was specified
 #args.at(4)
 
+--- arguments-name-access eval ---
+#let args = arguments(0, 1, a: 2, 3, b: 4, c: 5)
+#test(args.a, 2)
+#test(args.b, 4)
+
+--- arguments-name-in eval ---
+#let args = arguments(0, 1, a: 2, 3, b: 4, c: 5)
+#test("a" in args, true)
+#test("z" in args, false)
+#test("b" not in args, false)
+
 --- arguments-at-invalid-name eval ---
 #let args = arguments(0, 1, a: 2, 3)
 // Error: 2-14 arguments do not contain key "b" and no default value was specified
 #args.at("b")
+
+--- arguments-invalid-name eval ---
+#let args = arguments(0, 1, a: 2, 3)
+// Error: 7-8 arguments do not contain key "b"
+#args.b
 
 --- arguments-plus-sum-join eval ---
 #let lhs = arguments(0, "1", key: "value", 3)

--- a/tests/suite/foundations/arguments.typ
+++ b/tests/suite/foundations/arguments.typ
@@ -34,6 +34,27 @@
 // Error: 7-8 no named argument "b"
 #args.b
 
+--- arguments-function-item-not-a-method eval ---
+#{
+  let args = arguments(
+    call-me: () => 1,
+  )
+  // Error: 8-15 type arguments has no method `call-me`
+  // Hint: 8-15 to call the function stored in a named argument, surround the field access with parentheses, e.g. `(args.call-me)(..)`
+  args.call-me()
+}
+
+--- arguments-item-missing-method eval ---
+#{
+  let args = arguments(
+    nonfunc: 1
+  )
+
+  // Error: 8-15 type arguments has no method `nonfunc`
+  // Hint: 8-15 did you mean to access the field `nonfunc`?
+  args.nonfunc()
+}
+
 --- arguments-plus-sum-join eval ---
 #let lhs = arguments(0, "1", key: "value", 3)
 #let rhs = arguments(other-key: 4, key: "other value", 3)

--- a/tests/suite/foundations/dict.typ
+++ b/tests/suite/foundations/dict.typ
@@ -221,27 +221,6 @@
 // Error: 3-15 cannot mutate a temporary value
 #((key: "val").other = "some")
 
---- dict-function-item-not-a-method eval ---
-#{
-  let dict = (
-    call-me: () => 1,
-  )
-  // Error: 8-15 type dictionary has no method `call-me`
-  // Hint: 8-15 to call the function stored in the dictionary, surround the field access with parentheses, e.g. `(dict.call-me)(..)`
-  dict.call-me()
-}
-
---- dict-item-missing-method eval ---
-#{
-  let dict = (
-    nonfunc: 1
-  )
-
-  // Error: 8-15 type dictionary has no method `nonfunc`
-  // Hint: 8-15 did you mean to access the field `nonfunc`?
-  dict.nonfunc()
-}
-
 --- dict-dynamic-duplicate-key eval ---
 #let a = "hello"
 #let b = "world"

--- a/tests/suite/scripting/methods.typ
+++ b/tests/suite/scripting/methods.typ
@@ -49,3 +49,45 @@
 --- method-mutate-on-std-constant eval ---
 // Error: 2-5 cannot mutate a constant: box
 #box.push(1)
+
+--- method-dict-function-item-not-a-method eval ---
+#{
+  let dict = (
+    call-me: () => 1,
+  )
+  // Error: 8-15 type dictionary has no method `call-me`
+  // Hint: 8-15 to call the function stored in the dictionary, surround the field access with parentheses, e.g. `(dict.call-me)(..)`
+  dict.call-me()
+}
+
+--- method-arguments-function-item-not-a-method eval ---
+#{
+  let args = arguments(
+    call-me: () => 1,
+  )
+  // Error: 8-15 type arguments has no method `call-me`
+  // Hint: 8-15 to call the function stored in a named argument, surround the field access with parentheses, e.g. `(args.call-me)(..)`
+  args.call-me()
+}
+
+--- method-dict-item-missing-method eval ---
+#{
+  let dict = (
+    nonfunc: 1
+  )
+
+  // Error: 8-15 type dictionary has no method `nonfunc`
+  // Hint: 8-15 did you mean to access the field `nonfunc`?
+  dict.nonfunc()
+}
+
+--- method-arguments-item-missing-method eval ---
+#{
+  let args = arguments(
+    nonfunc: 1
+  )
+
+  // Error: 8-15 type arguments has no method `nonfunc`
+  // Hint: 8-15 did you mean to access the field `nonfunc`?
+  args.nonfunc()
+}


### PR DESCRIPTION
This adds field access to `arguments` to more closely align them with `dictionary`, which has precedent in #7284. 

This is motivated by the desire to reduce the syntactical noise of scripting things like `args => args.named().left + args.named().right` or `args => args.at("left") + args.at("right")` which would become `args => args.left + args.right`.

However, this also implements `in`, so that `key in args` is equivalent to `key in args.named()`. This may be unexpected if someone could think that `value in args` means `value in args.pos()`, but I personally think the proposed behaviour is as you'd expect.