### PR TITLE
Use correct font constants for fractions without a rule

### DIFF
--- a/crates/typst-library/src/text/font/mod.rs
+++ b/crates/typst-library/src/text/font/mod.rs
@@ -359,6 +359,16 @@ impl FontMetrics {
                         .to_em(constants.lower_limit_gap_min().value),
                     lower_limit_baseline_drop_min: font
                         .to_em(constants.lower_limit_baseline_drop_min().value),
+                    stack_top_shift_up: font.to_em(constants.stack_top_shift_up().value),
+                    stack_top_display_style_shift_up: font
+                        .to_em(constants.stack_top_display_style_shift_up().value),
+                    stack_bottom_shift_down: font
+                        .to_em(constants.stack_bottom_shift_down().value),
+                    stack_bottom_display_style_shift_down: font
+                        .to_em(constants.stack_bottom_display_style_shift_down().value),
+                    stack_gap_min: font.to_em(constants.stack_gap_min().value),
+                    stack_display_style_gap_min: font
+                        .to_em(constants.stack_display_style_gap_min().value),
                     fraction_numerator_shift_up: font
                         .to_em(constants.fraction_numerator_shift_up().value),
                     fraction_numerator_display_style_shift_up: font.to_em(
@@ -454,6 +464,12 @@ impl FontMetrics {
                     upper_limit_baseline_rise_min: Em::zero(),
                     lower_limit_gap_min: Em::zero(),
                     lower_limit_baseline_drop_min: Em::zero(),
+                    stack_top_shift_up: Em::zero(),
+                    stack_top_display_style_shift_up: Em::zero(),
+                    stack_bottom_shift_down: Em::zero(),
+                    stack_bottom_display_style_shift_down: Em::zero(),
+                    stack_gap_min: 3.0 * metrics.underline.thickness,
+                    stack_display_style_gap_min: 7.0 * metrics.underline.thickness,
                     fraction_numerator_shift_up: Em::zero(),
                     fraction_numerator_display_style_shift_up: Em::zero(),
                     fraction_denominator_shift_down: Em::zero(),
@@ -552,6 +568,12 @@ pub struct MathConstants {
     pub upper_limit_baseline_rise_min: Em,
     pub lower_limit_gap_min: Em,
     pub lower_limit_baseline_drop_min: Em,
+    pub stack_top_shift_up: Em,
+    pub stack_top_display_style_shift_up: Em,
+    pub stack_bottom_shift_down: Em,
+    pub stack_bottom_display_style_shift_down: Em,
+    pub stack_gap_min: Em,
+    pub stack_display_style_gap_min: Em,
     pub fraction_numerator_shift_up: Em,
     pub fraction_numerator_display_style_shift_up: Em,
     pub fraction_denominator_shift_down: Em,


### PR DESCRIPTION
For fractions without a fraction rule, the layout is actually slightly different according to the spec[^1] (called a "stack"). In particular, different constants are used. This PR implements this.

Most fonts appear to make the constants for a "stack" such that its layout exactly matches a fraction but with the fraction rule invisible, hence no tests have needed updating.

Note that this construct is currently only visible to the user through the `math.binom` function (cf. #7686).

[^1]: See https://github.com/notofonts/math/blob/main/documentation/building-math-fonts/index.md#stacktopshiftup-stacktopdisplaystyleshiftup-stackbottomshiftdown-stackbottomdisplaystyleshiftdown-stackgapmin-stackdisplaystylegapmin for a detailed explanation.