### PR TITLE
Robust `VirtualPath` type that pre-validates paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "ecow"
-version = "0.2.3"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42fc0a93992b20c58b99e59d61eaf1635a25bfbe49e4275c34ba0aee98119ba"
+checksum = "78e4f79b296fbaab6ce2e22d52cb4c7f010fe0ebe7a32e34fa25885fd797bd02"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ comemo = "0.5.0"
 csv = "1"
 ctrlc = "3.4.1"
 dirs = "6"
-ecow = { version = "0.2", features = ["serde"] }
+ecow = { version = "0.2.6", features = ["serde"] }
 either = "1"
 env_proxy = "0.4"
 fastrand = "2.3"

--- a/NOTICE
+++ b/NOTICE
@@ -11,6 +11,11 @@ The MIT License applies to:
    closely modelled after the `DownloadTracker` from rustup
    (https://github.com/rust-lang/rustup/blob/master/src/cli/download_tracker.rs)
 
+* The path diffing algorithm in `crates/typst-syntax/src/path.rs` which is
+  modified from rustc's `path_relative_from` function
+  (https://github.com/rust-lang/rust/blob/e1d0de82cc40b666b88d4a6d2c9dcbc81d7ed27f/src/librustc_back/rpath.rs#L116-L158)
+  Copyright 2012-2015 The Rust Project Developers.
+
 * The `SyntaxSet` defined in `crates/typst-syntax/src/set.rs` which is
   based on the `TokenSet` from rust-analyzer
   (https://github.com/rust-lang/rust-analyzer/blob/master/crates/parser/src/token_set.rs)

--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -685,16 +685,13 @@ impl<'a> codespan_reporting::files::Files<'a> for SystemWorld {
     fn name(&'a self, id: FileId) -> CodespanResult<Self::Name> {
         let vpath = id.vpath();
         Ok(if let Some(package) = id.package() {
-            format!("{package}{}", vpath.as_rooted_path().display())
+            format!("{package}{}", vpath.get_with_slash())
         } else {
             // Try to express the path relative to the working directory.
-            vpath
-                .resolve(self.root())
-                .and_then(|abs| pathdiff::diff_paths(abs, self.workdir()))
-                .as_deref()
-                .unwrap_or_else(|| vpath.as_rootless_path())
-                .to_string_lossy()
-                .into()
+            let rooted = vpath.realize(self.root());
+            pathdiff::diff_paths(rooted, self.workdir())
+                .map(|path| path.to_string_lossy().into_owned())
+                .unwrap_or_else(|| vpath.get_without_slash().into())
         })
     }
 

--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -8,8 +8,8 @@ use ecow::{EcoString, eco_format};
 use parking_lot::Mutex;
 use rustc_hash::FxHashMap;
 use typst::diag::{FileError, FileResult};
-use typst::foundations::{Bytes, Datetime, Dict, IntoValue};
-use typst::syntax::{FileId, Lines, Source, VirtualPath};
+use typst::foundations::{Bytes, Datetime, Dict, IntoValue, Repr};
+use typst::syntax::{FileId, Lines, PathError, Source, VirtualPath, VirtualizeError};
 use typst::text::{Font, FontBook};
 use typst::utils::LazyHash;
 use typst::{Library, LibraryExt, World};
@@ -24,12 +24,12 @@ use crate::package;
 /// Static `FileId` allocated for stdin.
 /// This is to ensure that a file is read in the correct way.
 static STDIN_ID: LazyLock<FileId> =
-    LazyLock::new(|| FileId::new_fake(VirtualPath::new("<stdin>")));
+    LazyLock::new(|| FileId::new_fake(VirtualPath::new("<stdin>").unwrap()));
 
 /// Static `FileId` allocated for empty/no input at all.
 /// This is to ensure that we can create a [SystemWorld] based on no main file or stdin at all.
 static EMPTY_ID: LazyLock<FileId> =
-    LazyLock::new(|| FileId::new_fake(VirtualPath::new("<empty>")));
+    LazyLock::new(|| FileId::new_fake(VirtualPath::new("<empty>").unwrap()));
 
 /// A world that provides access to the operating system.
 pub struct SystemWorld {
@@ -99,8 +99,7 @@ impl SystemWorld {
 
         let main = if let Some(path) = &input_path {
             // Resolve the virtual path of the main file within the project root.
-            let main_path = VirtualPath::within_root(path, &root)
-                .ok_or(WorldCreationError::InputOutsideRoot)?;
+            let main_path = VirtualPath::virtualize(path, &root)?;
             FileId::new(None, main_path)
         } else if matches!(input, Some(Input::Stdin)) {
             // Return the special id of STDIN.
@@ -422,10 +421,7 @@ fn system_path(
         buf = package_storage.prepare_package(spec, &mut PrintDownload(&spec))?;
         root = &buf;
     }
-
-    // Join the path to the root. If it tries to escape, deny
-    // access. Note: It can still escape via symlinks.
-    id.vpath().resolve(root).ok_or(FileError::AccessDenied)
+    Ok(id.vpath().realize(root))
 }
 
 /// Reads a file from a `FileId`.
@@ -487,8 +483,8 @@ enum Now {
 pub enum WorldCreationError {
     /// The input file does not appear to exist.
     InputNotFound(PathBuf),
-    /// The input file is not contained within the root folder.
-    InputOutsideRoot,
+    /// The input file path was malformed.
+    InputMalformed(VirtualizeError),
     /// The root directory does not appear to exist.
     RootNotFound(PathBuf),
     /// Another type of I/O error.
@@ -498,17 +494,32 @@ pub enum WorldCreationError {
 impl fmt::Display for WorldCreationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            WorldCreationError::InputMalformed(err) => match err {
+                VirtualizeError::Path(PathError::Escapes) => {
+                    write!(f, "source file must be contained in project root")
+                }
+                VirtualizeError::Path(PathError::Backslash) => {
+                    write!(f, "source path must not contain a backslash")
+                }
+                VirtualizeError::Invalid(s) => {
+                    write!(f, "source path contains invalid sequence `{}`", s.repr())
+                }
+                VirtualizeError::Utf8 => write!(f, "source path must be valid UTF-8"),
+            },
             WorldCreationError::InputNotFound(path) => {
                 write!(f, "input file not found (searched at {})", path.display())
-            }
-            WorldCreationError::InputOutsideRoot => {
-                write!(f, "source file must be contained in project root")
             }
             WorldCreationError::RootNotFound(path) => {
                 write!(f, "root directory not found (searched at {})", path.display())
             }
             WorldCreationError::Io(err) => write!(f, "{err}"),
         }
+    }
+}
+
+impl From<VirtualizeError> for WorldCreationError {
+    fn from(err: VirtualizeError) -> Self {
+        Self::InputMalformed(err)
     }
 }
 

--- a/crates/typst-eval/src/import.rs
+++ b/crates/typst-eval/src/import.rs
@@ -233,7 +233,8 @@ fn resolve_package(
     span: Span,
 ) -> SourceResult<(EcoString, FileId)> {
     // Evaluate the manifest.
-    let manifest_id = FileId::new(Some(spec.clone()), VirtualPath::new("typst.toml"));
+    let manifest_id =
+        FileId::new(Some(spec.clone()), VirtualPath::new("typst.toml").unwrap());
     let bytes = engine.world.file(manifest_id).at(span)?;
     let string = bytes.as_str().map_err(FileError::from).at(span)?;
     let manifest: PackageManifest = toml::from_str(string)
@@ -242,5 +243,8 @@ fn resolve_package(
     manifest.validate(&spec).at(span)?;
 
     // Evaluate the entry point.
-    Ok((manifest.package.name, manifest_id.join(&manifest.package.entrypoint)))
+    Ok((
+        manifest.package.name,
+        manifest_id.resolve_path(&manifest.package.entrypoint).at(span)?,
+    ))
 }

--- a/crates/typst-eval/src/lib.rs
+++ b/crates/typst-eval/src/lib.rs
@@ -84,12 +84,7 @@ pub fn eval(
     }
 
     // Assemble the module.
-    let name = id
-        .vpath()
-        .as_rootless_path()
-        .file_stem()
-        .unwrap_or_default()
-        .to_string_lossy();
+    let name = id.vpath().file_stem().unwrap_or_default();
 
     Ok(Module::new(name, vm.scopes.top).with_content(output).with_file_id(id))
 }

--- a/crates/typst-ide/src/definition.rs
+++ b/crates/typst-ide/src/definition.rs
@@ -111,10 +111,7 @@ mod tests {
             match self.1 {
                 Some(Definition::Span(span)) => {
                     let range = self.0.range(span);
-                    assert_eq!(
-                        span.id().unwrap().vpath().as_rootless_path().to_string_lossy(),
-                        path
-                    );
+                    assert_eq!(span.id().unwrap().vpath().get_without_slash(), path);
                     assert_eq!(range, Some(expected));
                 }
                 _ => panic!("expected span definition"),

--- a/crates/typst-ide/src/tests.rs
+++ b/crates/typst-ide/src/tests.rs
@@ -37,8 +37,9 @@ impl TestWorld {
     }
 
     /// Add an additional source file to the test world.
+    #[track_caller]
     pub fn with_source(mut self, path: &str, text: &str) -> Self {
-        let id = FileId::new(None, VirtualPath::new(path));
+        let id = FileId::new(None, VirtualPath::new(path).unwrap());
         let source = Source::new(id, text.into());
         Arc::make_mut(&mut self.files).sources.insert(id, source);
         self
@@ -53,7 +54,7 @@ impl TestWorld {
     /// Add an additional asset file to the test world.
     #[track_caller]
     pub fn with_asset_at(mut self, path: &str, filename: &str) -> Self {
-        let id = FileId::new(None, VirtualPath::new(path));
+        let id = FileId::new(None, VirtualPath::new(path).unwrap());
         let data = typst_dev_assets::get_by_name(filename).unwrap();
         let bytes = Bytes::new(data);
         Arc::make_mut(&mut self.files).assets.insert(id, bytes);
@@ -62,7 +63,7 @@ impl TestWorld {
 
     /// The ID of the main file in a `TestWorld`.
     pub fn main_id() -> FileId {
-        *singleton!(FileId, FileId::new(None, VirtualPath::new("main.typ")))
+        *singleton!(FileId, FileId::new(None, VirtualPath::new("main.typ").unwrap()))
     }
 }
 
@@ -85,14 +86,14 @@ impl World for TestWorld {
         } else if let Some(source) = self.files.sources.get(&id) {
             Ok(source.clone())
         } else {
-            Err(FileError::NotFound(id.vpath().as_rootless_path().into()))
+            Err(FileError::NotFound(id.vpath().get_without_slash().into()))
         }
     }
 
     fn file(&self, id: FileId) -> FileResult<Bytes> {
         match self.files.assets.get(&id) {
             Some(bytes) => Ok(bytes.clone()),
-            None => Err(FileError::NotFound(id.vpath().as_rootless_path().into())),
+            None => Err(FileError::NotFound(id.vpath().get_without_slash().into())),
         }
     }
 
@@ -218,7 +219,7 @@ impl FilePos for isize {
 impl FilePos for (&str, isize) {
     #[track_caller]
     fn resolve(self, world: &TestWorld) -> (Source, usize) {
-        let id = FileId::new(None, VirtualPath::new(self.0));
+        let id = FileId::new(None, VirtualPath::new(self.0).unwrap());
         let source = world.source(id).unwrap();
         let cursor = cursor(&source, self.1);
         (source, cursor)

--- a/crates/typst-library/src/diag.rs
+++ b/crates/typst-library/src/diag.rs
@@ -758,15 +758,10 @@ fn load_err_in_invalid_text(
         (LoadSource::Path(file), _) => {
             message.pop();
             if let Some(package) = file.package() {
-                write!(
-                    &mut message,
-                    " in {package}{}",
-                    file.vpath().as_rooted_path().display()
-                )
-                .ok();
-            } else {
-                write!(&mut message, " in {}", file.vpath().as_rootless_path().display())
+                write!(&mut message, " in {package}{}", file.vpath().get_with_slash())
                     .ok();
+            } else {
+                write!(&mut message, " in {}", file.vpath().get_without_slash()).ok();
             };
             if let Some((line, col)) = line_col {
                 write!(&mut message, ":{line}:{col}").ok();

--- a/crates/typst-library/src/model/bibliography.rs
+++ b/crates/typst-library/src/model/bibliography.rs
@@ -1,5 +1,4 @@
 use std::any::TypeId;
-use std::ffi::OsStr;
 use std::fmt::{self, Debug, Formatter};
 use std::num::NonZeroUsize;
 use std::path::Path;
@@ -310,13 +309,7 @@ fn decode_library(loaded: &Loaded) -> SourceResult<Library> {
     if let LoadSource::Path(file_id) = loaded.source.v {
         // If we got a path, use the extension to determine whether it is
         // YAML or BibLaTeX.
-        let ext = file_id
-            .vpath()
-            .as_rooted_path()
-            .extension()
-            .and_then(OsStr::to_str)
-            .unwrap_or_default();
-
+        let ext = file_id.vpath().extension().unwrap_or_default();
         match ext.to_lowercase().as_str() {
             "yml" | "yaml" => hayagriva::io::from_yaml_str(data)
                 .map_err(format_yaml_error)

--- a/crates/typst-library/src/pdf/attach.rs
+++ b/crates/typst-library/src/pdf/attach.rs
@@ -41,7 +41,7 @@ pub struct AttachElem {
             args.expect::<Spanned<EcoString>>("path")?;
         let id = span.resolve_path(&path).at(span)?;
         // The derived part is the project-relative resolved path.
-        let resolved = id.vpath().as_rootless_path().to_string_lossy().replace("\\", "/").into();
+        let resolved = id.vpath().get_without_slash().into();
         Derived::new(path.clone(), resolved)
     )]
     pub path: Derived<EcoString, EcoString>,

--- a/crates/typst-library/src/visualize/image/svg.rs
+++ b/crates/typst-library/src/visualize/image/svg.rs
@@ -382,7 +382,7 @@ impl<'a> ImageResolver<'a> {
             return Err("cannot access file system from here".into());
         }
         // Replace the file name in svg_file by href.
-        let href_file = self.svg_file.unwrap().join(href);
+        let href_file = self.svg_file.unwrap().resolve_path(href)?;
 
         // Load image if file can be accessed.
         match self.world.file(href_file) {

--- a/crates/typst-syntax/src/file.rs
+++ b/crates/typst-syntax/src/file.rs
@@ -4,10 +4,12 @@ use std::fmt::{self, Debug, Formatter};
 use std::num::NonZeroU16;
 use std::sync::{LazyLock, RwLock};
 
+use ecow::{EcoString, eco_format};
 use rustc_hash::FxHashMap;
 
 use crate::VirtualPath;
 use crate::package::PackageSpec;
+use crate::path::PathError;
 
 /// The global package-path interner.
 static INTERNER: LazyLock<RwLock<Interner>> = LazyLock::new(|| {
@@ -92,9 +94,29 @@ impl FileId {
         &self.pair().1
     }
 
-    /// Resolve a file location relative to this file.
-    pub fn join(self, path: &str) -> Self {
-        Self::new(self.package().cloned(), self.vpath().join(path))
+    /// Resolve a path relative to this file.
+    pub fn resolve_path(self, path: &str) -> Result<Self, EcoString> {
+        let (package, base) = self.pair();
+
+        let joined = match base.parent() {
+            Some(parent) => parent.join(path),
+            None => base.join(path),
+        };
+
+        let resolved = joined.map_err(|err| match err {
+            PathError::Escapes => {
+                eco_format!(
+                    "path would escape the {} root",
+                    match package {
+                        None => "project",
+                        Some(_) => "package",
+                    }
+                )
+            }
+            PathError::Backslash => "path must not contain a backslash".into(),
+        })?;
+
+        Ok(Self::new(package.clone(), resolved))
     }
 
     /// The same file location, but with a different extension.

--- a/crates/typst-syntax/src/lib.rs
+++ b/crates/typst-syntax/src/lib.rs
@@ -26,7 +26,7 @@ pub use self::lexer::{
 pub use self::lines::Lines;
 pub use self::node::{LinkedChildren, LinkedNode, Side, SyntaxError, SyntaxNode};
 pub use self::parser::{parse, parse_code, parse_math};
-pub use self::path::VirtualPath;
+pub use self::path::{PathError, VirtualPath, VirtualizeError};
 pub use self::source::Source;
 pub use self::span::{Span, Spanned};
 

--- a/crates/typst-syntax/src/path.rs
+++ b/crates/typst-syntax/src/path.rs
@@ -1,99 +1,567 @@
-use std::fmt::{self, Debug, Display, Formatter};
-use std::path::{Component, Path, PathBuf};
+//! Virtual, cross-platform reproducible path handling.
 
-/// An absolute path in the virtual file system of a project or package.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct VirtualPath(PathBuf);
+use std::fmt::{self, Debug, Formatter};
+use std::path::{self, Path, PathBuf};
+
+use ecow::{EcoString, eco_format};
+
+// Special symbols in virtual paths.
+const SEPARATOR: char = '/';
+const CURRENT: &str = ".";
+const PARENT: &str = "..";
+
+/// A path in a virtual file system.
+#[derive(Clone, Eq, PartialEq, Hash)]
+pub struct VirtualPath(Segments);
 
 impl VirtualPath {
-    /// Create a new virtual path.
-    ///
-    /// Even if it doesn't start with `/` or `\`, it is still interpreted as
-    /// starting from the root.
-    pub fn new(path: impl AsRef<Path>) -> Self {
-        Self::new_impl(path.as_ref())
+    /// Creates a new virtual path.
+    pub fn new(path: impl AsRef<str>) -> Result<Self, PathError> {
+        let segments = Segments::normalize(components(path.as_ref()))?;
+        Ok(Self(segments))
     }
 
-    /// Non generic new implementation.
-    fn new_impl(path: &Path) -> Self {
-        let mut out = Path::new(&Component::RootDir).to_path_buf();
-        for component in path.components() {
-            match component {
-                Component::Prefix(_) | Component::RootDir => {}
-                Component::CurDir => {}
-                Component::ParentDir => match out.components().next_back() {
-                    Some(Component::Normal(_)) => {
-                        out.pop();
-                    }
-                    _ => out.push(component),
-                },
-                Component::Normal(_) => out.push(component),
-            }
-        }
-        Self(out)
-    }
-
-    /// Create a virtual path from a real path and a real root.
+    /// Creates a virtual path from a real path and a real root.
     ///
     /// Returns `None` if the file path is not contained in the root (i.e. if
-    /// `root` is not a lexical prefix of `path`). No file system operations are
-    /// performed.
+    /// `root_path` is not a lexical prefix of `path`). No file system
+    /// operations are performed.
+    ///
+    /// This is the single function that translates from a real path to a
+    /// virtual path. Its counterpart is [`VirtualPath::realize`].
+    pub fn virtualize(root_path: &Path, path: &Path) -> Result<Self, VirtualizeError> {
+        let path = path.strip_prefix(root_path).map_err(|_| PathError::Escapes)?;
+        let mut segments = Segments::new();
+        for c in path.components() {
+            let comp = match c {
+                path::Component::RootDir => Component::Root,
+                path::Component::CurDir => Component::Current,
+                path::Component::ParentDir => Component::Parent,
+                path::Component::Normal(s) => {
+                    let string = s.to_str().ok_or(VirtualizeError::Utf8)?;
+                    let segment = Segment::new(string)
+                        .map_err(|s| VirtualizeError::Invalid(s.into()))?;
+                    Component::Normal(segment)
+                }
+                path::Component::Prefix(_) => return Err(PathError::Escapes.into()),
+            };
+            segments.push_component(comp)?;
+        }
+        Ok(Self(segments))
+    }
+
+    /// Turns the virtual path into an actual file system path (where the
+    /// project or package resides). You need to provide the appropriate `root`
+    /// path, relative to which this path will be resolved.
+    ///
+    /// This can be used in the implementations of `World::source` and
+    /// `World::file`.
+    ///
+    /// This is the single function that translates from a virtual path to a
+    /// real path. Its counterpart is [`VirtualPath::virtualize`].
+    pub fn realize(&self, root: &Path) -> PathBuf {
+        let mut out = root.to_path_buf();
+        for s in self.0.iter() {
+            out.push(s.get());
+        }
+        out
+    }
+
+    /// Returns the path with a leading slash.
+    pub fn get_with_slash(&self) -> &str {
+        self.0.get_with_slash()
+    }
+
+    /// Returns the path without a leading slash.
+    pub fn get_without_slash(&self) -> &str {
+        self.0.get_without_slash()
+    }
+
+    /// Returns the file name portion of the path.
+    pub fn file_name(&self) -> Option<&str> {
+        self.0.last().map(Segment::get)
+    }
+
+    /// Returns the file name portion of the path without the extension.
+    pub fn file_stem(&self) -> Option<&str> {
+        let last = self.0.last()?;
+        let (before, after) = last.split_dot();
+        before.or(after)
+    }
+
+    /// Returns the file extension of the path.
+    pub fn extension(&self) -> Option<&str> {
+        let last = self.0.last()?;
+        let (before, after) = last.split_dot();
+        before.and(after)
+    }
+
+    /// Returns a modified path with an adjusted extension.
+    ///
+    /// # Panics
+    /// Panics if the resulting path segment would be invalid, e.g. because the
+    /// extension contains a forward or backslash.
+    #[track_caller]
+    pub fn with_extension(&self, ext: &str) -> Self {
+        let Some(stem) = self.file_stem() else { return self.clone() };
+        let buf = eco_format!("{stem}.{ext}");
+        let segment = Segment::new(&buf).expect("extension is invalid");
+
+        let mut segments = self.0.clone();
+        segments.pop();
+        segments.push(segment);
+        Self(segments)
+    }
+
+    /// Returns the path with its final component removed.
+    ///
+    /// Returns `None` if the path is already at the root.
+    pub fn parent(&self) -> Option<Self> {
+        let mut segments = self.0.clone();
+        if !segments.pop() {
+            return None;
+        }
+        Some(Self(segments))
+    }
+
+    /// Joins the given `path` to `self`.
+    pub fn join(&self, path: &str) -> Result<Self, PathError> {
+        let combined = self
+            .0
+            .iter()
+            .map(|c| Ok(Component::Normal(c)))
+            .chain(components(path));
+        let segments = Segments::normalize(combined)?;
+        Ok(Self(segments))
+    }
+
+    /// Tries to express this path as a relative path from the given base path.
+    pub fn relative_from(&self, base: &Self) -> Option<EcoString> {
+        // Adapted from rustc's `path_relative_from` function (MIT).
+        // Copyright 2012-2015 The Rust Project Developers.
+        // See NOTICE for full attribution.
+        let mut ita = self.0.iter();
+        let mut itb = base.0.iter();
+        let mut buf: Vec<&str> = vec![];
+        loop {
+            match (ita.next(), itb.next()) {
+                (None, None) => break,
+                (Some(a), None) => {
+                    buf.push(a.get());
+                    buf.extend(ita.map(Segment::get));
+                    break;
+                }
+                (None, Some(_)) => buf.push(".."),
+                (Some(a), Some(b)) if buf.is_empty() && a == b => (),
+                (Some(a), Some(_)) => {
+                    buf.extend(std::iter::repeat_n("..", 1 + itb.count()));
+                    buf.push(a.get());
+                    buf.extend(ita.map(Segment::get));
+                    break;
+                }
+            }
+        }
+
+        Some(buf.join("/").into())
+    }
+}
+
+impl VirtualPath {
+    /// Create a virtual path from a real path and a real root.
+    #[deprecated = "use `virtualize` instead"]
     pub fn within_root(path: &Path, root: &Path) -> Option<Self> {
-        path.strip_prefix(root).ok().map(Self::new)
-    }
-
-    /// Get the underlying path with a leading `/` or `\`.
-    pub fn as_rooted_path(&self) -> &Path {
-        &self.0
-    }
-
-    /// Get the underlying path without a leading `/` or `\`.
-    pub fn as_rootless_path(&self) -> &Path {
-        self.0.strip_prefix(Component::RootDir).unwrap_or(&self.0)
+        Self::virtualize(root, path).ok()
     }
 
     /// Resolve the virtual path relative to an actual file system root
     /// (where the project or package resides).
-    ///
-    /// Returns `None` if the path lexically escapes the root. The path might
-    /// still escape through symlinks.
+    #[deprecated = "use `realize` instead"]
     pub fn resolve(&self, root: &Path) -> Option<PathBuf> {
-        let root_len = root.as_os_str().len();
-        let mut out = root.to_path_buf();
-        for component in self.0.components() {
-            match component {
-                Component::Prefix(_) => {}
-                Component::RootDir => {}
-                Component::CurDir => {}
-                Component::ParentDir => {
-                    out.pop();
-                    if out.as_os_str().len() < root_len {
-                        return None;
-                    }
-                }
-                Component::Normal(_) => out.push(component),
-            }
-        }
-        Some(out)
+        Some(self.realize(root))
     }
 
-    /// Resolve a path relative to this virtual path.
-    pub fn join(&self, path: impl AsRef<Path>) -> Self {
-        if let Some(parent) = self.0.parent() {
-            Self::new(parent.join(path))
-        } else {
-            Self::new(path)
-        }
+    /// Get the underlying path without a leading `/` or `\`.
+    #[deprecated = "use `get_without_slash` instead"]
+    pub fn as_rootless_path(&self) -> &Path {
+        Path::new(self.get_without_slash())
     }
 
-    /// The same path, but with a different extension.
-    pub fn with_extension(&self, extension: &str) -> Self {
-        Self(self.0.with_extension(extension))
+    /// Get the underlying path with a leading `/` or `\`.
+    #[deprecated = "use `get_with_slash` instead"]
+    pub fn as_rooted_path(&self) -> &Path {
+        Path::new(self.get_with_slash())
     }
 }
 
 impl Debug for VirtualPath {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        Display::fmt(&self.0.display(), f)
+        self.get_with_slash().fmt(f)
+    }
+}
+
+/// A component in a virtual path.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+enum Component<'a> {
+    Root,
+    Current,
+    Parent,
+    Normal(Segment<'a>),
+}
+
+/// Splits a user-supplied path into its constituent parts.
+///
+/// This only splits and recognizes special segments. It does not check the
+/// validity of normal segments. This is done in [`Segments::push`].
+fn components(path: &str) -> impl Iterator<Item = Result<Component<'_>, PathError>> {
+    path.split(SEPARATOR).enumerate().map(|(i, s)| {
+        match s {
+            // A leading separator indicates an absolute path.
+            "" if i == 0 && !path.is_empty() => Ok(Component::Root),
+            // Consecutive separators have no effect.
+            "" => Ok(Component::Current),
+            CURRENT => Ok(Component::Current),
+            PARENT => Ok(Component::Parent),
+            other => match Segment::new(other) {
+                Ok(segment) => Ok(Component::Normal(segment)),
+                Err("\\") => Err(PathError::Backslash),
+                Err(_) => unreachable!(),
+            },
+        }
+    })
+}
+
+/// A segment in a normalized path.
+///
+/// A segments is never empty, `.`, or `..` and it never contains back- or
+/// forward slashes.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+struct Segment<'a>(&'a str);
+
+impl<'a> Segment<'a> {
+    fn new(segment: &'a str) -> Result<Self, &'a str> {
+        // These invariants are important to avoid the path from escaping the
+        // root after being realized, in particular the `..` part.
+        if matches!(segment, "" | CURRENT | PARENT) {
+            return Err(segment);
+        }
+
+        // Interior separators or backslashes are not allowed.
+        if let Some(m) = segment.matches([SEPARATOR, '\\']).next() {
+            return Err(m);
+        }
+
+        Ok(Self(segment))
+    }
+
+    fn new_unchecked(segment: &'a str) -> Self {
+        debug_assert!(Self::new(segment).is_ok());
+        Self(segment)
+    }
+
+    fn get(self) -> &'a str {
+        self.0
+    }
+
+    fn split_dot(self) -> (Option<&'a str>, Option<&'a str>) {
+        let mut iter = self.0.rsplitn(2, '.');
+        let after = iter.next();
+        let before = iter.next();
+        if before == Some("") { (Some(self.0), None) } else { (before, after) }
+    }
+}
+
+/// Stores a sequence of path segments as a string.
+///
+/// The underlying string always represents a normalized absolute path and is
+/// guaranteed to start with a slash. Segments are never empty, `.`, or `..` and
+/// they never contain back- or forward slashes.
+#[derive(Clone, Eq, PartialEq, Hash)]
+struct Segments(EcoString);
+
+impl Segments {
+    fn new() -> Self {
+        Self(EcoString::from(SEPARATOR))
+    }
+
+    fn normalize<'a>(
+        comps: impl IntoIterator<Item = Result<Component<'a>, PathError>>,
+    ) -> Result<Segments, PathError> {
+        let mut out = Segments::new();
+        for component in comps {
+            out.push_component(component?)?;
+        }
+        Ok(out)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.len() == 1
+    }
+
+    fn get_with_slash(&self) -> &str {
+        &self.0
+    }
+
+    fn get_without_slash(&self) -> &str {
+        self.0.strip_prefix(SEPARATOR).expect("path to start with slash")
+    }
+
+    fn clear(&mut self) {
+        self.0.truncate(1);
+    }
+
+    fn push_component(&mut self, component: Component) -> Result<(), PathError> {
+        match component {
+            // Root component resets the path.
+            Component::Root => self.clear(),
+            // Current component has no effect.
+            Component::Current => {}
+            // Parent component removes the last segment. If there is no
+            // segment, this indicates that the path would escape the root.
+            // In this case, we return an error.
+            Component::Parent => {
+                if !self.pop() {
+                    return Err(PathError::Escapes);
+                }
+            }
+            Component::Normal(segment) => self.push(segment),
+        }
+        Ok(())
+    }
+
+    fn push<'a>(&mut self, segment: Segment<'a>) {
+        if !self.is_empty() {
+            self.0.push(SEPARATOR);
+        }
+        self.0.push_str(segment.0);
+    }
+
+    fn pop(&mut self) -> bool {
+        if self.is_empty() {
+            return false;
+        }
+        let i = self.0.rfind(SEPARATOR).expect("to contain a slash");
+        self.0.truncate(std::cmp::max(1, i));
+        true
+    }
+
+    fn last(&self) -> Option<Segment<'_>> {
+        self.iter().next_back()
+    }
+
+    fn iter(&self) -> impl DoubleEndedIterator<Item = Segment<'_>> {
+        let mut iter = self.0[1..].split(SEPARATOR);
+        if self.is_empty() {
+            iter.next();
+        }
+        iter.map(Segment::new_unchecked)
+    }
+}
+
+/// An error that can occur on construction or modification of a
+/// [`VirtualPath`].
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum PathError {
+    /// The constructed or modified path would escape the root. This would
+    /// for instance, when trying to join `..` to the path `/`.
+    ///
+    /// Note that a path might still escape through symlinks.
+    Escapes,
+    /// The path contains a backslash. This is not allowed as it leads to
+    /// cross-platform compatibility hazards (since Windows uses backslashes as
+    /// a path separator).
+    Backslash,
+}
+
+/// An error that can occur in [`VirtualPath::virtualize`].
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum VirtualizeError {
+    /// A normal path error.
+    Path(PathError),
+    /// A path component contained an invalid string. This should almost never
+    /// occur under normal circumstances, but it could happen if some OS allows
+    /// forward slashes or dots in path components.
+    Invalid(EcoString),
+    /// The file path contains non-UTF-8 encodable bytes.
+    Utf8,
+}
+
+impl From<PathError> for VirtualizeError {
+    fn from(err: PathError) -> Self {
+        Self::Path(err)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[track_caller]
+    fn path(p: &str) -> VirtualPath {
+        VirtualPath::new(p).unwrap()
+    }
+
+    #[test]
+    fn test_new() {
+        #[track_caller]
+        fn test(path: &str, expected: Result<&str, PathError>) {
+            let path = VirtualPath::new(path);
+            assert_eq!(
+                path.as_ref().map(|s| s.get_with_slash()).map_err(Clone::clone),
+                expected
+            );
+        }
+
+        test("", Ok("/"));
+        test("a/./file.txt", Ok("/a/file.txt"));
+        test("file.txt", Ok("/file.txt"));
+        test("/file.txt", Ok("/file.txt"));
+        test("hello/world", Ok("/hello/world"));
+        test("hello/world/", Ok("/hello/world"));
+        test("a///b", Ok("/a/b"));
+        test("/a///b", Ok("/a/b"));
+        test("./world.txt", Ok("/world.txt"));
+        test("./world.txt/", Ok("/world.txt"));
+        test("hello/.././/wor/ld.typ.extra", Ok("/wor/ld.typ.extra"));
+        test("hello/.../world", Ok("/hello/.../world"));
+        test("\u{200b}..", Ok("/\u{200b}.."));
+        test("..", Err(PathError::Escapes));
+        test("../world.txt", Err(PathError::Escapes));
+        test("a\\world.txt", Err(PathError::Backslash));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_virtualize_unix() {
+        test_virtualize("/", "/main.typ", Ok("/main.typ"));
+        test_virtualize("//a/b", "/a//b///c//d", Ok("/c/d"));
+        test_virtualize(
+            "/home/typst/desktop/",
+            "/home/typst/desktop/src/main.typ",
+            Ok("/src/main.typ"),
+        );
+        test_virtualize(
+            "/home/typst/desktop/",
+            "/home/typst/main.typ",
+            Err(PathError::Escapes.into()),
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_virtualize_windows() {
+        test_virtualize(
+            "C:\\Users\\typst\\Desktop",
+            "C:\\Users\\typst\\Desktop\\src\\main.typ",
+            Ok("/src/main.typ"),
+        );
+        test_virtualize(
+            "C:\\Users\\typst\\Desktop",
+            "C:\\Users\\typst\\main.typ",
+            Err(PathError::Escapes.into()),
+        );
+    }
+
+    #[track_caller]
+    fn test_virtualize(
+        root_path: impl AsRef<Path>,
+        path: impl AsRef<Path>,
+        expected: Result<&str, VirtualizeError>,
+    ) {
+        assert_eq!(
+            VirtualPath::virtualize(root_path.as_ref(), path.as_ref(),)
+                .as_ref()
+                .map(|v| v.get_with_slash())
+                .map_err(Clone::clone),
+            expected,
+        );
+    }
+
+    #[test]
+    fn test_realize() {
+        let p = path("src/text/main.typ");
+        assert_eq!(
+            p.realize(Path::new("/home/users/typst")),
+            Path::new("/home/users/typst/src/text/main.typ")
+        );
+    }
+
+    #[test]
+    fn test_file_ops() {
+        let p1 = path("src/text/file.typ");
+        assert_eq!(p1.file_name(), Some("file.typ"));
+        assert_eq!(p1.file_stem(), Some("file"));
+        assert_eq!(p1.extension(), Some("typ"));
+        assert_eq!(p1.with_extension("txt"), path("src/text/file.txt"));
+        assert_eq!(p1.parent(), Some(path("src/text")));
+
+        let p2 = path("src");
+        assert_eq!(p2.file_name(), Some("src"));
+        assert_eq!(p2.file_stem(), Some("src"));
+        assert_eq!(p2.extension(), None);
+        assert_eq!(p2.with_extension("txt"), path("src.txt"));
+        assert_eq!(p2.parent(), Some(path("/")));
+
+        let p3 = path("");
+        assert_eq!(p3.file_name(), None);
+        assert_eq!(p3.file_stem(), None);
+        assert_eq!(p3.extension(), None);
+        assert_eq!(p3.with_extension("txt"), p3);
+        assert_eq!(p3.parent(), None);
+    }
+
+    #[test]
+    fn test_join() {
+        let p1 = path("src");
+        assert_eq!(p1.join("a\\b"), Err(PathError::Backslash));
+        let p2 = p1.join("text").unwrap();
+        assert_eq!(p2.get_with_slash(), "/src/text");
+        let p3 = p2.join("..").unwrap();
+        assert_eq!(p1, p3);
+        assert_eq!(p3.get_with_slash(), "/src");
+        let p4 = p3.join("..").unwrap();
+        assert_eq!(p4.get_with_slash(), "/");
+        assert_eq!(p4.join(".."), Err(PathError::Escapes));
+    }
+
+    #[test]
+    fn test_relative_from() {
+        let p1 = path("src/text/main.typ");
+        assert_eq!(p1.relative_from(&path("/src/text")), Some("main.typ".into()));
+        assert_eq!(p1.relative_from(&path("/src/data")), Some("../text/main.typ".into()));
+        assert_eq!(p1.relative_from(&path("src/")), Some("text/main.typ".into()));
+        assert_eq!(p1.relative_from(&path("/")), Some("src/text/main.typ".into()));
+
+        let p2 = path("src");
+        assert_eq!(p2.relative_from(&path("src")), Some("".into()));
+        assert_eq!(p2.relative_from(&path("src/data")), Some("..".into()));
+    }
+
+    #[test]
+    fn test_segments() {
+        let mut s = Segments::new();
+        assert_eq!(s.get_with_slash(), "/");
+        assert_eq!(s.get_without_slash(), "");
+        s.push(Segment::new("to").unwrap());
+        assert_eq!(s.get_with_slash(), "/to");
+        s.push(Segment::new("hi.txt").unwrap());
+        assert_eq!(s.get_with_slash(), "/to/hi.txt");
+        assert_eq!(s.get_without_slash(), "to/hi.txt");
+        assert_eq!(s.last().map(Segment::get), Some("hi.txt"));
+        assert!(s.pop());
+        assert_eq!(s.get_with_slash(), "/to");
+        assert!(s.pop());
+        assert_eq!(s.get_with_slash(), "/");
+        assert!(!s.pop());
+        assert_eq!(s.get_with_slash(), "/");
+        assert_eq!(s.last(), None);
+    }
+
+    #[test]
+    fn test_segment() {
+        assert_eq!(Segment::new("\\b"), Err("\\"));
+        assert_eq!(Segment::new("a/b"), Err("/"));
+        assert_eq!(Segment::new(""), Err(""));
+        assert_eq!(Segment::new("."), Err("."));
+        assert_eq!(Segment::new(".."), Err(".."));
     }
 }

--- a/crates/typst-syntax/src/source.rs
+++ b/crates/typst-syntax/src/source.rs
@@ -43,7 +43,7 @@ impl Source {
 
     /// Create a source file without a real id and path, usually for testing.
     pub fn detached(text: impl Into<String>) -> Self {
-        Self::new(FileId::new(None, VirtualPath::new("main.typ")), text.into())
+        Self::new(FileId::new(None, VirtualPath::new("main.typ").unwrap()), text.into())
     }
 
     /// The root node of the file's untyped syntax tree.

--- a/crates/typst-syntax/src/span.rs
+++ b/crates/typst-syntax/src/span.rs
@@ -170,7 +170,7 @@ impl Span {
         let Some(file) = self.id() else {
             return Err("cannot access file system from here".into());
         };
-        Ok(file.join(path))
+        file.resolve_path(path)
     }
 }
 

--- a/crates/typst/src/lib.rs
+++ b/crates/typst/src/lib.rs
@@ -210,19 +210,14 @@ fn hint_invalid_main_file(
     // mistyped the filename. For example, they could have written "file.pdf"
     // instead of "file.typ".
     if is_utf8_error {
-        let path = input.vpath();
-        let extension = path.as_rootless_path().extension();
-        if extension.is_some_and(|extension| extension == "typ") {
-            // No hints if the file is already a .typ file.
-            // The file is indeed just invalid.
-            return eco_vec![diagnostic];
-        }
+        match input.vpath().extension() {
+            // No hints if the file is already a .typ file. The file is indeed
+            // just invalid.
+            Some("typ") => return eco_vec![diagnostic],
 
-        match extension {
-            Some(extension) => {
+            Some(ext) => {
                 diagnostic.hint(eco_format!(
-                    "a file with the `.{}` extension is not usually a Typst file",
-                    extension.to_string_lossy()
+                    "a file with the `.{ext}` extension is not usually a Typst file",
                 ));
             }
 

--- a/docs/src/html.rs
+++ b/docs/src/html.rs
@@ -458,7 +458,7 @@ fn code_block(resolver: &dyn Resolver, tag: &str, text: &str) -> Html {
         highlighted = Some(html);
     }
 
-    let id = FileId::new(None, VirtualPath::new("main.typ"));
+    let id = FileId::new(None, VirtualPath::new("main.typ").unwrap());
     let source = Source::new(id, compile);
     let world = DocWorld(source);
 
@@ -523,17 +523,15 @@ impl World for DocWorld {
         if id == self.0.id() {
             Ok(self.0.clone())
         } else {
-            Err(FileError::NotFound(id.vpath().as_rootless_path().into()))
+            Err(FileError::NotFound(id.vpath().get_without_slash().into()))
         }
     }
 
     fn file(&self, id: FileId) -> FileResult<Bytes> {
         assert!(id.package().is_none());
         Ok(Bytes::new(
-            typst_dev_assets::get_by_name(
-                &id.vpath().as_rootless_path().to_string_lossy(),
-            )
-            .unwrap_or_else(|| panic!("failed to load {:?}", id.vpath())),
+            typst_dev_assets::get_by_name(id.vpath().get_without_slash())
+                .unwrap_or_else(|| panic!("failed to load {:?}", id.vpath())),
         ))
     }
 

--- a/tests/fuzz/src/lib.rs
+++ b/tests/fuzz/src/lib.rs
@@ -43,12 +43,12 @@ impl World for FuzzWorld {
         if id == self.source.id() {
             Ok(self.source.clone())
         } else {
-            Err(FileError::NotFound(id.vpath().as_rootless_path().into()))
+            Err(FileError::NotFound(id.vpath().get_without_slash().into()))
         }
     }
 
     fn file(&self, id: FileId) -> FileResult<Bytes> {
-        Err(FileError::NotFound(id.vpath().as_rootless_path().into()))
+        Err(FileError::NotFound(id.vpath().get_without_slash().into()))
     }
 
     fn font(&self, _: usize) -> Option<Font> {

--- a/tests/src/collect.rs
+++ b/tests/src/collect.rs
@@ -585,7 +585,7 @@ impl<'a> Parser<'a> {
                 continue;
             }
 
-            let vpath = VirtualPath::new(self.path);
+            let vpath = VirtualPath::virtualize(Path::new(""), self.path).unwrap();
             let source = Source::new(FileId::new(None, vpath), text.into());
 
             self.s.jump(start);
@@ -709,7 +709,7 @@ impl<'a> Parser<'a> {
                 return None;
             }
 
-            let vpath = VirtualPath::new(path);
+            let vpath = VirtualPath::new(path).unwrap();
             file = Some(FileId::new(None, vpath));
 
             self.s.eat_if(' ');

--- a/tests/src/run.rs
+++ b/tests/src/run.rs
@@ -1,5 +1,6 @@
 use std::fmt::Write;
 use std::ops::Range;
+use std::path::Path;
 use std::str::FromStr;
 use std::sync::LazyLock;
 
@@ -36,7 +37,8 @@ pub fn update_hash_refs<T: HashOutputType>(hashes: &[RwLock<OutputHashes>]) {
             continue;
         }
 
-        let ref_path = T::OUTPUT.hashed_ref_path(source_path.as_rootless_path());
+        let ref_path =
+            T::OUTPUT.hashed_ref_path(Path::new(source_path.get_without_slash()));
         if hashed_refs.is_empty() {
             std::fs::remove_file(ref_path).ok();
         } else {
@@ -351,7 +353,8 @@ impl<'a> Runner<'a> {
             if let Some(hashed_refs) = self.hashes[T::INDEX].read().get(source_path) {
                 hashed_refs.get(&self.test.name)
             } else {
-                let ref_path = T::OUTPUT.hashed_ref_path(source_path.as_rootless_path());
+                let ref_path =
+                    T::OUTPUT.hashed_ref_path(Path::new(source_path.get_without_slash()));
                 let string = std::fs::read_to_string(&ref_path).unwrap_or_default();
                 let hashed_refs = HashedRefs::from_str(&string)
                     .inspect_err(|e| {
@@ -396,7 +399,8 @@ impl<'a> Runner<'a> {
         if crate::ARGS.update {
             let mut hashes = self.hashes[T::INDEX].write();
             let hashed_refs = hashes.get_mut(source_path).unwrap();
-            let ref_path = T::OUTPUT.hashed_ref_path(source_path.as_rootless_path());
+            let ref_path =
+                T::OUTPUT.hashed_ref_path(Path::new(source_path.get_without_slash()));
             if skippable {
                 hashed_refs.remove(&self.test.name);
                 log!(

--- a/tests/src/world.rs
+++ b/tests/src/world.rs
@@ -171,8 +171,7 @@ pub(crate) fn system_path(id: FileId) -> FileResult<PathBuf> {
         Some(spec) => format!("tests/packages/{}-{}", spec.name, spec.version).into(),
         None => PathBuf::new(),
     };
-
-    id.vpath().resolve(&root).ok_or(FileError::AccessDenied)
+    Ok(id.vpath().realize(&root))
 }
 
 /// Read a file.

--- a/tests/suite/foundations/path.typ
+++ b/tests/suite/foundations/path.typ
@@ -1,0 +1,7 @@
+--- path-escapes paged ---
+// Error: 7-29 path would escape the project root
+#read("../../../../file.txt")
+
+--- path-backslash paged ---
+// Error: 7-21 path must not contain a backslash
+#read("to\\file.txt")


### PR DESCRIPTION
This is split off from https://github.com/typst/typst/pull/7555. There is one difference: The `VirtualPath` type here remains just the true path part and does not contain the root information. I wasn't so happy with unifying both because a path without a root is also sometimes a useful abstraction (e.g. for multi-file HTML output assets). This is mostly the reason why #7555 hasn't landed yet. In the interest of getting it in piece by piece, I'm landing this first now.

This PR contains the two breaking changes describes in #7555. It does not contain the hints yet; those will be added in a future PR.