### PR TITLE
Introduce `VirtualRoot` enum

### DIFF
--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -14,7 +14,7 @@ use typst::diag::{
 };
 use typst::foundations::{Datetime, Smart};
 use typst::layout::{Page, PageRanges, PagedDocument};
-use typst::syntax::{FileId, Lines, Span};
+use typst::syntax::{FileId, Lines, Span, VirtualRoot};
 use typst_html::HtmlDocument;
 use typst_pdf::{PdfOptions, PdfStandards, Timestamp};
 
@@ -684,14 +684,17 @@ impl<'a> codespan_reporting::files::Files<'a> for SystemWorld {
 
     fn name(&'a self, id: FileId) -> CodespanResult<Self::Name> {
         let vpath = id.vpath();
-        Ok(if let Some(package) = id.package() {
-            format!("{package}{}", vpath.get_with_slash())
-        } else {
-            // Try to express the path relative to the working directory.
-            let rooted = vpath.realize(self.root());
-            pathdiff::diff_paths(rooted, self.workdir())
-                .map(|path| path.to_string_lossy().into_owned())
-                .unwrap_or_else(|| vpath.get_without_slash().into())
+        Ok(match id.root() {
+            VirtualRoot::Project => {
+                // Try to express the path relative to the working directory.
+                let rooted = vpath.realize(self.root());
+                pathdiff::diff_paths(rooted, self.workdir())
+                    .map(|path| path.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| vpath.get_without_slash().into())
+            }
+            VirtualRoot::Package(package) => {
+                format!("{package}{}", vpath.get_with_slash())
+            }
         })
     }
 

--- a/crates/typst-eval/src/import.rs
+++ b/crates/typst-eval/src/import.rs
@@ -8,7 +8,7 @@ use typst_library::engine::Engine;
 use typst_library::foundations::{Binding, Content, Module, Value};
 use typst_syntax::ast::{self, AstNode, BareImportError};
 use typst_syntax::package::{PackageManifest, PackageSpec};
-use typst_syntax::{FileId, Span, VirtualPath};
+use typst_syntax::{FileId, Span, VirtualPath, VirtualRoot};
 
 use crate::{Eval, Vm, eval};
 
@@ -233,8 +233,10 @@ fn resolve_package(
     span: Span,
 ) -> SourceResult<(EcoString, FileId)> {
     // Evaluate the manifest.
-    let manifest_id =
-        FileId::new(Some(spec.clone()), VirtualPath::new("typst.toml").unwrap());
+    let manifest_id = FileId::new(
+        VirtualRoot::Package(spec.clone()),
+        VirtualPath::new("typst.toml").unwrap(),
+    );
     let bytes = engine.world.file(manifest_id).at(span)?;
     let string = bytes.as_str().map_err(FileError::from).at(span)?;
     let manifest: PackageManifest = toml::from_str(string)

--- a/crates/typst-ide/src/tests.rs
+++ b/crates/typst-ide/src/tests.rs
@@ -7,7 +7,7 @@ use typst::diag::{FileError, FileResult};
 use typst::foundations::{Bytes, Datetime, Smart};
 use typst::layout::{Abs, Margin, PageElem};
 use typst::syntax::package::{PackageSpec, PackageVersion};
-use typst::syntax::{FileId, Source, VirtualPath};
+use typst::syntax::{FileId, Source, VirtualPath, VirtualRoot};
 use typst::text::{Font, FontBook, TextElem, TextSize};
 use typst::utils::{LazyHash, singleton};
 use typst::{Feature, Library, LibraryExt, World};
@@ -39,7 +39,7 @@ impl TestWorld {
     /// Add an additional source file to the test world.
     #[track_caller]
     pub fn with_source(mut self, path: &str, text: &str) -> Self {
-        let id = FileId::new(None, VirtualPath::new(path).unwrap());
+        let id = FileId::new(VirtualRoot::Project, VirtualPath::new(path).unwrap());
         let source = Source::new(id, text.into());
         Arc::make_mut(&mut self.files).sources.insert(id, source);
         self
@@ -54,7 +54,7 @@ impl TestWorld {
     /// Add an additional asset file to the test world.
     #[track_caller]
     pub fn with_asset_at(mut self, path: &str, filename: &str) -> Self {
-        let id = FileId::new(None, VirtualPath::new(path).unwrap());
+        let id = FileId::new(VirtualRoot::Project, VirtualPath::new(path).unwrap());
         let data = typst_dev_assets::get_by_name(filename).unwrap();
         let bytes = Bytes::new(data);
         Arc::make_mut(&mut self.files).assets.insert(id, bytes);
@@ -63,7 +63,10 @@ impl TestWorld {
 
     /// The ID of the main file in a `TestWorld`.
     pub fn main_id() -> FileId {
-        *singleton!(FileId, FileId::new(None, VirtualPath::new("main.typ").unwrap()))
+        *singleton!(
+            FileId,
+            FileId::new(VirtualRoot::Project, VirtualPath::new("main.typ").unwrap())
+        )
     }
 }
 
@@ -219,7 +222,7 @@ impl FilePos for isize {
 impl FilePos for (&str, isize) {
     #[track_caller]
     fn resolve(self, world: &TestWorld) -> (Source, usize) {
-        let id = FileId::new(None, VirtualPath::new(self.0).unwrap());
+        let id = FileId::new(VirtualRoot::Project, VirtualPath::new(self.0).unwrap());
         let source = world.source(id).unwrap();
         let cursor = cursor(&source, self.1);
         (source, cursor)

--- a/crates/typst-syntax/src/file.rs
+++ b/crates/typst-syntax/src/file.rs
@@ -23,7 +23,7 @@ struct Interner {
 }
 
 /// An interned pair of a package specification and a path.
-type Pair = &'static (Option<PackageSpec>, VirtualPath);
+type Pair = &'static (VirtualRoot, VirtualPath);
 
 /// Identifies a file in a project or package.
 ///
@@ -37,7 +37,7 @@ impl FileId {
     /// The path must start with a `/` or this function will panic.
     /// Note that the path is normalized before interning.
     #[track_caller]
-    pub fn new(package: Option<PackageSpec>, path: VirtualPath) -> Self {
+    pub fn new(package: VirtualRoot, path: VirtualPath) -> Self {
         // Try to find an existing entry that we can reuse.
         //
         // We could check with just a read lock, but if the pair is not yet
@@ -71,21 +71,30 @@ impl FileId {
     /// if the path is the same. This method should only be used for generating
     /// "virtual" file ids such as content read from stdin.
     #[track_caller]
-    pub fn new_fake(path: VirtualPath) -> Self {
+    pub fn new_fake(root: VirtualRoot, path: VirtualPath) -> Self {
         let mut interner = INTERNER.write().unwrap();
         let num = u16::try_from(interner.from_id.len() + 1)
             .and_then(NonZeroU16::try_from)
             .expect("out of file ids");
 
         let id = FileId(num);
-        let leaked = Box::leak(Box::new((None, path)));
+        let leaked = Box::leak(Box::new((root, path)));
         interner.from_id.push(leaked);
         id
     }
 
+    /// The root this file id is in.
+    pub fn root(&self) -> &'static VirtualRoot {
+        &self.pair().0
+    }
+
     /// The package the file resides in, if any.
+    #[deprecated = "use `root` instead"]
     pub fn package(&self) -> Option<&'static PackageSpec> {
-        self.pair().0.as_ref()
+        match self.root() {
+            VirtualRoot::Project => None,
+            VirtualRoot::Package(package) => Some(package),
+        }
     }
 
     /// The absolute and normalized path to the file _within_ the project or
@@ -96,7 +105,7 @@ impl FileId {
 
     /// Resolve a path relative to this file.
     pub fn resolve_path(self, path: &str) -> Result<Self, EcoString> {
-        let (package, base) = self.pair();
+        let (root, base) = self.pair();
 
         let joined = match base.parent() {
             Some(parent) => parent.join(path),
@@ -107,21 +116,21 @@ impl FileId {
             PathError::Escapes => {
                 eco_format!(
                     "path would escape the {} root",
-                    match package {
-                        None => "project",
-                        Some(_) => "package",
+                    match root {
+                        VirtualRoot::Project => "project",
+                        VirtualRoot::Package(_) => "package",
                     }
                 )
             }
             PathError::Backslash => "path must not contain a backslash".into(),
         })?;
 
-        Ok(Self::new(package.clone(), resolved))
+        Ok(Self::new(root.clone(), resolved))
     }
 
     /// The same file location, but with a different extension.
     pub fn with_extension(&self, extension: &str) -> Self {
-        Self::new(self.package().cloned(), self.vpath().with_extension(extension))
+        Self::new(self.root().clone(), self.vpath().with_extension(extension))
     }
 
     /// Construct from a raw number.
@@ -147,9 +156,20 @@ impl FileId {
 impl Debug for FileId {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let vpath = self.vpath();
-        match self.package() {
-            Some(package) => write!(f, "{package:?}{vpath:?}"),
-            None => write!(f, "{vpath:?}"),
+        match self.root() {
+            VirtualRoot::Project => write!(f, "{vpath:?}"),
+            VirtualRoot::Package(package) => write!(f, "{package:?}{vpath:?}"),
         }
     }
+}
+
+/// The root of a virtual file system.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub enum VirtualRoot {
+    /// The canonical root of the Typst project.
+    ///
+    /// This is what `TYPST_ROOT` defines.
+    Project,
+    /// A root in a package.
+    Package(PackageSpec),
 }

--- a/crates/typst-syntax/src/lib.rs
+++ b/crates/typst-syntax/src/lib.rs
@@ -16,7 +16,7 @@ mod set;
 mod source;
 mod span;
 
-pub use self::file::FileId;
+pub use self::file::{FileId, VirtualRoot};
 pub use self::highlight::{Tag, highlight, highlight_html};
 pub use self::kind::SyntaxKind;
 pub use self::lexer::{

--- a/crates/typst-syntax/src/source.rs
+++ b/crates/typst-syntax/src/source.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use typst_utils::LazyHash;
 
+use crate::file::VirtualRoot;
 use crate::lines::Lines;
 use crate::reparser::reparse;
 use crate::{FileId, LinkedNode, Span, SyntaxNode, VirtualPath, parse};
@@ -43,7 +44,10 @@ impl Source {
 
     /// Create a source file without a real id and path, usually for testing.
     pub fn detached(text: impl Into<String>) -> Self {
-        Self::new(FileId::new(None, VirtualPath::new("main.typ").unwrap()), text.into())
+        Self::new(
+            FileId::new(VirtualRoot::Project, VirtualPath::new("main.typ").unwrap()),
+            text.into(),
+        )
     }
 
     /// The root node of the file's untyped syntax tree.

--- a/docs/src/html.rs
+++ b/docs/src/html.rs
@@ -9,7 +9,7 @@ use typed_arena::Arena;
 use typst::diag::{FileError, FileResult, StrResult};
 use typst::foundations::{Bytes, Datetime};
 use typst::layout::{Abs, PagedDocument, Point, Size};
-use typst::syntax::{FileId, Source, VirtualPath};
+use typst::syntax::{FileId, Source, VirtualPath, VirtualRoot};
 use typst::text::{Font, FontBook};
 use typst::utils::LazyHash;
 use typst::{Library, World};
@@ -458,7 +458,7 @@ fn code_block(resolver: &dyn Resolver, tag: &str, text: &str) -> Html {
         highlighted = Some(html);
     }
 
-    let id = FileId::new(None, VirtualPath::new("main.typ").unwrap());
+    let id = FileId::new(VirtualRoot::Project, VirtualPath::new("main.typ").unwrap());
     let source = Source::new(id, compile);
     let world = DocWorld(source);
 
@@ -528,7 +528,7 @@ impl World for DocWorld {
     }
 
     fn file(&self, id: FileId) -> FileResult<Bytes> {
-        assert!(id.package().is_none());
+        assert_eq!(*id.root(), VirtualRoot::Project);
         Ok(Bytes::new(
             typst_dev_assets::get_by_name(id.vpath().get_without_slash())
                 .unwrap_or_else(|| panic!("failed to load {:?}", id.vpath())),

--- a/tests/src/collect.rs
+++ b/tests/src/collect.rs
@@ -12,7 +12,7 @@ use typst::foundations::Bytes;
 use typst_pdf::PdfStandard;
 use typst_syntax::package::PackageVersion;
 use typst_syntax::{
-    FileId, Lines, Source, VirtualPath, is_id_continue, is_ident, is_newline,
+    FileId, Lines, Source, VirtualPath, VirtualRoot, is_id_continue, is_ident, is_newline,
 };
 use unscanny::Scanner;
 
@@ -586,7 +586,8 @@ impl<'a> Parser<'a> {
             }
 
             let vpath = VirtualPath::virtualize(Path::new(""), self.path).unwrap();
-            let source = Source::new(FileId::new(None, vpath), text.into());
+            let source =
+                Source::new(FileId::new(VirtualRoot::Project, vpath), text.into());
 
             self.s.jump(start);
             self.line = self.test_start_line;
@@ -710,7 +711,7 @@ impl<'a> Parser<'a> {
             }
 
             let vpath = VirtualPath::new(path).unwrap();
-            file = Some(FileId::new(None, vpath));
+            file = Some(FileId::new(VirtualRoot::Project, vpath));
 
             self.s.eat_if(' ');
         }

--- a/tests/src/world.rs
+++ b/tests/src/world.rs
@@ -20,7 +20,7 @@ use typst::text::{Font, FontBook, TextElem, TextSize};
 use typst::utils::{LazyHash, singleton};
 use typst::visualize::Color;
 use typst::{Feature, Library, LibraryExt, World};
-use typst_syntax::Lines;
+use typst_syntax::{Lines, VirtualRoot};
 
 /// A world that provides access to the tests environment.
 #[derive(Clone)]
@@ -167,9 +167,11 @@ impl FileSlot {
 
 /// The file system path for a file ID.
 pub(crate) fn system_path(id: FileId) -> FileResult<PathBuf> {
-    let root: PathBuf = match id.package() {
-        Some(spec) => format!("tests/packages/{}-{}", spec.name, spec.version).into(),
-        None => PathBuf::new(),
+    let root = match id.root() {
+        VirtualRoot::Project => PathBuf::new(),
+        VirtualRoot::Package(spec) => {
+            format!("tests/packages/{}-{}", spec.name, spec.version).into()
+        }
     };
     Ok(id.vpath().realize(&root))
 }


### PR DESCRIPTION
Split off from https://github.com/typst/typst/pull/7555. Having an enum for this is semantically clearer and gives us the option to introduce additional kinds of roots, e.g. for something like https://github.com/typst/typst/issues/5382#issuecomment-3150286257.