### PR TITLE
Introduce `PathStr` to centralize path resolving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3076,7 +3076,6 @@ dependencies = [
  "comemo",
  "ecow",
  "once_cell",
- "pathdiff",
  "rustc-hash",
  "serde",
  "typst",

--- a/crates/typst-ide/Cargo.toml
+++ b/crates/typst-ide/Cargo.toml
@@ -18,7 +18,6 @@ typst-eval = { workspace = true }
 typst-html = { workspace = true }
 comemo = { workspace = true }
 ecow = { workspace = true }
-pathdiff = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 unscanny = { workspace = true }

--- a/crates/typst-library/src/diag.rs
+++ b/crates/typst-library/src/diag.rs
@@ -381,15 +381,7 @@ where
     S: Into<EcoString>,
 {
     fn at(self, span: Span) -> SourceResult<T> {
-        self.map_err(|message| {
-            let mut diagnostic = SourceDiagnostic::error(span, message);
-            if diagnostic.message.contains("(access denied)") {
-                diagnostic.hint("cannot read file outside of project root");
-                diagnostic
-                    .hint("you can adjust the project root with the --root argument");
-            }
-            eco_vec![diagnostic]
-        })
+        self.map_err(|message| eco_vec![SourceDiagnostic::error(span, message)])
     }
 }
 
@@ -490,7 +482,7 @@ impl<T> Hint<T> for HintedStrResult<T> {
 /// A result type with a file-related error.
 pub type FileResult<T> = Result<T, FileError>;
 
-/// An error that occurred while trying to load of a file.
+/// An error that occurred while trying to load a file.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum FileError {
     /// A file was not found at this path.
@@ -580,7 +572,7 @@ pub type PackageResult<T> = Result<T, PackageError>;
 pub enum PackageError {
     /// The specified package does not exist.
     NotFound(PackageSpec),
-    /// The specified package found, but the version does not exist.
+    /// The specified package was found, but the version does not exist.
     VersionNotFound(PackageSpec, PackageVersion),
     /// Failed to retrieve the package through the network.
     NetworkFailed(Option<EcoString>),

--- a/crates/typst-library/src/foundations/mod.rs
+++ b/crates/typst-library/src/foundations/mod.rs
@@ -24,6 +24,7 @@ mod int;
 mod label;
 mod module;
 mod none;
+mod path;
 #[path = "plugin.rs"]
 mod plugin_;
 mod scope;
@@ -55,6 +56,7 @@ pub use self::int::*;
 pub use self::label::*;
 pub use self::module::*;
 pub use self::none::*;
+pub use self::path::*;
 pub use self::plugin_::*;
 pub use self::repr::Repr;
 pub use self::scope::*;

--- a/crates/typst-library/src/foundations/path.rs
+++ b/crates/typst-library/src/foundations/path.rs
@@ -1,0 +1,89 @@
+use typst_syntax::PathError;
+use typst_syntax::{FileId, VirtualRoot};
+
+use crate::diag::{HintedStrResult, HintedString, error};
+use crate::foundations::{Repr, Str, cast};
+
+/// A path string.
+///
+/// This type is commonly accepted by functions that read from a path.
+#[derive(Debug, Clone, PartialEq, Hash)]
+pub struct PathStr(pub Str);
+
+impl PathStr {
+    /// Resolves this path string relative to the file that resides at `within`.
+    ///
+    /// The path string may be absolute or relative. If relative, it's resolved
+    /// relative to the parent directory of `within` (which should point to a
+    /// file rather than a directory).
+    pub fn resolve(&self, within: FileId) -> HintedStrResult<FileId> {
+        let root = within.root();
+        let base = within.vpath();
+        let resolved = match base.parent() {
+            Some(parent) => parent.join(&self.0),
+            None => base.join(&self.0),
+        }
+        .map_err(|err| format_path_error(err, root, &self.0))?;
+        Ok(FileId::new(root.clone(), resolved))
+    }
+
+    /// [Resolves](Self::resolve) the path if `within` is `Some(_)` or returns
+    /// an error that the file system could not be accessed, otherwise.
+    pub fn resolve_if_some(&self, within: Option<FileId>) -> HintedStrResult<FileId> {
+        self.resolve(within.ok_or("cannot access file system from here")?)
+    }
+}
+
+cast! {
+    PathStr,
+    self => self.0.into_value(),
+    v: Str => Self(v),
+}
+
+/// Format the user-facing path error message.
+fn format_path_error(err: PathError, root: &VirtualRoot, path: &str) -> HintedString {
+    match err {
+        PathError::Escapes => {
+            let kind = match root {
+                VirtualRoot::Project => "project",
+                VirtualRoot::Package(_) => "package",
+            };
+            let mut diag = error!(
+                "path would escape the {kind} root";
+                hint: "cannot access files outside of the {kind} sandbox";
+            );
+            if *root == VirtualRoot::Project {
+                diag.hint("you can adjust the project root with the `--root` argument");
+            }
+            diag
+        }
+        PathError::Backslash => error!(
+            "path must not contain a backslash";
+            hint: "use forward slashes instead: `{}`",
+            path.replace("\\", "/").repr();
+            hint: "in earlier Typst versions, backslashes indicated path separators on Windows";
+            hint: "this behavior is no longer supported as it is not portable";
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use typst_syntax::{VirtualPath, VirtualRoot};
+
+    use super::*;
+
+    #[test]
+    fn test_resolve() {
+        let id = |p| FileId::new(VirtualRoot::Project, VirtualPath::new(p).unwrap());
+        let id1 = id("src/main.typ");
+        let resolve =
+            |s: &str| PathStr(s.into()).resolve(id1).map_err(|err| err.message().clone());
+        assert_eq!(resolve("works.bib"), Ok(id("src/works.bib")));
+        assert_eq!(resolve(""), Ok(id("/src")));
+        assert_eq!(resolve("."), Ok(id("/src")));
+        assert_eq!(resolve(".."), Ok(id("/")));
+        assert_eq!(resolve("../.."), Err("path would escape the project root".into()));
+        assert_eq!(resolve("a\\b"), Err("path must not contain a backslash".into()));
+    }
+}

--- a/crates/typst-library/src/loading/read.rs
+++ b/crates/typst-library/src/loading/read.rs
@@ -1,9 +1,8 @@
-use ecow::EcoString;
 use typst_syntax::Spanned;
 
 use crate::diag::{LoadedWithin, SourceResult};
 use crate::engine::Engine;
-use crate::foundations::{Cast, func};
+use crate::foundations::{Cast, PathStr, func};
 use crate::loading::{DataSource, Load, Readable};
 
 /// Reads plain text or data from a file.
@@ -27,7 +26,7 @@ pub fn read(
     /// Path to a file.
     ///
     /// For more details, see the [Paths section]($syntax/#paths).
-    path: Spanned<EcoString>,
+    path: Spanned<PathStr>,
     /// The encoding to read the file with.
     ///
     /// If set to `{none}`, this function returns raw bytes.

--- a/crates/typst-syntax/src/span.rs
+++ b/crates/typst-syntax/src/span.rs
@@ -2,8 +2,6 @@ use std::fmt::{self, Debug, Formatter};
 use std::num::{NonZeroU16, NonZeroU64};
 use std::ops::Range;
 
-use ecow::EcoString;
-
 use crate::FileId;
 
 /// Defines a range in a file.
@@ -163,14 +161,6 @@ impl Span {
         iter.into_iter()
             .find(|span| !span.is_detached())
             .unwrap_or(Span::detached())
-    }
-
-    /// Resolve a file location relative to this span's source.
-    pub fn resolve_path(self, path: &str) -> Result<FileId, EcoString> {
-        let Some(file) = self.id() else {
-            return Err("cannot access file system from here".into());
-        };
-        file.resolve_path(path)
     }
 }
 

--- a/tests/suite/foundations/path.typ
+++ b/tests/suite/foundations/path.typ
@@ -1,7 +1,12 @@
 --- path-escapes paged ---
 // Error: 7-29 path would escape the project root
+// Hint: 7-29 cannot access files outside of the project sandbox
+// Hint: 7-29 you can adjust the project root with the `--root` argument
 #read("../../../../file.txt")
 
 --- path-backslash paged ---
 // Error: 7-21 path must not contain a backslash
+// Hint: 7-21 use forward slashes instead: `"to/file.txt"`
+// Hint: 7-21 in earlier Typst versions, backslashes indicated path separators on Windows
+// Hint: 7-21 this behavior is no longer supported as it is not portable
 #read("to\\file.txt")


### PR DESCRIPTION
Split off from https://github.com/typst/typst/pull/7555. Introduces the path error hints as promised in https://github.com/typst/typst/pull/7688.