### PR TITLE
Fix path handling regression in CLI

### DIFF
--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -103,7 +103,7 @@ impl SystemWorld {
 
         let main = if let Some(path) = &input_path {
             // Resolve the virtual path of the main file within the project root.
-            let main_path = VirtualPath::virtualize(path, &root)?;
+            let main_path = VirtualPath::virtualize(&root, path)?;
             FileId::new(VirtualRoot::Project, main_path)
         } else if matches!(input, Some(Input::Stdin)) {
             // Return the special id of STDIN.

--- a/crates/typst-syntax/src/path.rs
+++ b/crates/typst-syntax/src/path.rs
@@ -168,7 +168,7 @@ impl VirtualPath {
 
 impl VirtualPath {
     /// Create a virtual path from a real path and a real root.
-    #[deprecated = "use `virtualize` instead"]
+    #[deprecated = "use `virtualize` with swapped arguments instead"]
     pub fn within_root(path: &Path, root: &Path) -> Option<Self> {
         Self::virtualize(root, path).ok()
     }


### PR DESCRIPTION
Forgot to swap the arguments in #7688, leading to passing tests but broken CLI. We really need CLI tests.... (edit: see https://github.com/typst/typst/pull/7694!)