### PR TITLE
Allow specifying test stage on diagnostic note

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -99,11 +99,13 @@ There are, broadly speaking, three kinds of tests:
   target.
 
 - Tests that ensure the code emits particular diagnostic messages: Those have
-  inline annotations like `// Error: 2-7 thing was wrong`. An annotation can
-  start with either "Error", "Warning", or "Hint". The range designates the
-  code span the diagnostic message refers to in the first non-comment line
-  below. If the code span is in a line further below, you can write ranges
-  like `3:2-3:7` to indicate the 2-7 column in the 3rd non-comment line.
+  inline annotations like `// Error: [pdf] 2-7 thing was wrong`. An annotation
+  can start with either "Error", "Warning", or "Hint". In square brackets one
+  or more [stages](#test-stages) can be specified, this is only necessary in
+  specific cases, and the test suite will tell you about it. The range designates
+  the code span the diagnostic message refers to in the first non-comment line
+  below. If the code span is in a line further below, you can write ranges like
+  `3:2-3:7` to indicate the 2-7 column in the 3rd non-comment line.
 
 - Tests that ensure certain output is produced:
 

--- a/tests/src/args.rs
+++ b/tests/src/args.rs
@@ -92,7 +92,9 @@ impl CliArguments {
                     stages |= s.into();
                 }
 
-                stages = stages.with_implied();
+                // Must be in this order, otherwise any paged output target
+                // would enable all others.
+                stages = stages.with_implied().with_required();
             };
 
             CACHED.store(stages.bits(), Ordering::Relaxed);

--- a/tests/suite/pdf/validation.typ
+++ b/tests/suite/pdf/validation.typ
@@ -1,14 +1,14 @@
 --- pdf-validation-tofu paged pdfstandard(ua-1) ---
-// Error: 1-2 PDF/UA-1 error: the text `"ግ"` could not be displayed with font `"Libertinus Serif"`
-// Hint: 1-2 try using a different font
+// Error: [pdf] 1-2 PDF/UA-1 error: the text `"ግ"` could not be displayed with font `"Libertinus Serif"`
+// Hint: [pdf] 1-2 try using a different font
 ግ
 
 --- pdf-validation-tofu-in-svg paged pdfstandard(ua-1) ---
 // A spanless error without a font name is kinda bad, but this used to be a
 // crash, so it's already an improvement.
 
-// Error: PDF/UA-1 error: the text `"ግ"` could not be displayed with a font
-// Hint: try using a different font
+// Error: [pdf] PDF/UA-1 error: the text `"ግ"` could not be displayed with a font
+// Hint: [pdf] try using a different font
 #image(bytes(
   ```
   <?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
This is enforced for diagnostics that are only generated in a specific output/target that isn't hit by all possible branches of the stage tree:
```txt
        ╭─> render
 paged ─┼─> pdf ───> pdftags
        ╰─> svg
 html  ───> html
```
An example would be a `PDF/UA-1` error, that is only emitted in the `pdf` stage, but the test has a `paged` attribute, and will also run the `render` and `svg` stages.
The error annotation must specify the specific stage like this:
```
// Error: [pdf] 3:6-5:6 PDF/UA-1 error: PDF artifacts may not contain links
```