### PR TITLE
Remove `PartialOrd` and `Ord` for `FileId`

### DIFF
--- a/crates/typst-syntax/src/path.rs
+++ b/crates/typst-syntax/src/path.rs
@@ -92,7 +92,7 @@ struct Interner {
 /// An interned version of [`RootedPath`].
 ///
 /// This type is globally interned and thus cheap to copy, compare, and hash.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct FileId(NonZeroU16);
 
 impl FileId {


### PR DESCRIPTION
These are kinda dangerous because the are totally unsemantical and just compare the raw number. In _some_ cases this can be useful, e.g. if you want to use a `FileId` in a `BTreeMap` and don't care about the semantics of the ordering, but in those cases it would be better to use a wrapper type that makes use of `FileId::into_raw` to make this explicit.