### PR TITLE
Make `$  $` act like a block equation

### DIFF
--- a/crates/typst-syntax/src/ast.rs
+++ b/crates/typst-syntax/src/ast.rs
@@ -851,10 +851,33 @@ impl<'a> Equation<'a> {
 
     /// Whether the equation should be displayed as a separate block.
     pub fn block(self) -> bool {
-        let is_space = |node: Option<&SyntaxNode>| {
-            node.map(SyntaxNode::kind) == Some(SyntaxKind::Space)
-        };
-        is_space(self.0.children().nth(1)) && is_space(self.0.children().nth_back(1))
+        // The parser likes to group adjacent trivia, so if the equation's body
+        // is an empty Math node, e.g. in `$ /**/ $`, the CST will look like:
+        // `Eqn [ Math(<empty>) Space(" ") Trivia("/**/") Space(" ") ]`.
+        // Yet we still want to treat this as a block, so we check the following
+        // node by skipping an empty math node at the start.
+        let mut front_iter = self.0.children().enumerate().skip(1);
+        let mut front_pair = front_iter.next();
+        if let Some((_, front)) = front_pair
+            && front.is_empty()
+            && front.kind() == SyntaxKind::Math
+        {
+            front_pair = front_iter.next();
+        }
+
+        if let Some((front_idx, front)) = front_pair
+            && let Some((back_idx, back)) = self.0.children().enumerate().nth_back(1)
+        {
+            front.kind() == SyntaxKind::Space
+                && back.kind() == SyntaxKind::Space
+                // If the front and back spaces are the same one, require that
+                // it has multiple chars or, if one char, that it is a newline.
+                // `parse::<char>` is `Ok` if there was only a single char.
+                && (front_idx != back_idx
+                    || front.text().parse::<char>().map_or(true, is_newline))
+        } else {
+            false
+        }
     }
 }
 

--- a/tests/suite/math/equation.typ
+++ b/tests/suite/math/equation.typ
@@ -1,6 +1,86 @@
 // Test alignment of block equations.
 // Test show rules on equations.
 
+--- math-equation-block-syntax eval ---
+// Block equations require whitespace on both sides.
+#assert($ x $.block)
+#assert($ x y z $.block)
+#assert($
+x
+$.block)
+#assert($
+x
+y
+$.block)
+
+// Just whitespace only creates a block equation if it contains multiple
+// characters or a single newline.
+#assert($  $.block)
+#assert($       $.block)
+#assert(not $ $.block) // A single space doesn't make a block.
+#assert($
+$.block)
+#assert($
+
+
+$.block)
+
+// If either side lacks whitespace, we have an inline equation.
+#assert(not $x$.block)
+#assert(not $x
+$.block)
+#assert(not $
+x$.block)
+
+// Even if the inside has lots of whitespace.
+#assert(not $x
+
+
+y$.block)
+
+// And inline comments _do_ interrupt the block status.
+#assert($ /**/ $.block)
+#assert(not $/**/ $.block)
+#assert(not $ /**/$.block)
+#assert(not $/**/
+$.block)
+
+--- math-equation-block-syntax-unicode eval ---
+// Test equation block edge cases using odd unicode whitespace characters.
+// Just a representative sample, not exhaustive.
+#let spaces = ("\t", "\u{A0}", "\u{2009}", "\u{205F}", "\u{3000}")
+#let newlines = ("\r", "\u{B}", "\u{2029}")
+#let non-spaces = ("\u{200B}", "\u{200C}", "\u{2060}")
+
+// To debug these, add `message: str(thing.to-unicode(), base: 16)`.
+#for space in spaces {
+  assert(eval("not $" + space + "$.block"))
+  for space2 in spaces {
+    assert(eval("$" + space + space2 + "$.block"))
+  }
+  for newline in spaces {
+    assert(eval("$" + space + newline + "$.block"))
+    assert(eval("$" + newline + space + "$.block"))
+  }
+  for non-space in non-spaces {
+    assert(eval("$" + space + non-space + space + "$.block"))
+    assert(eval("not $" + space + non-space + "$.block"))
+    assert(eval("not $" + non-space + space + "$.block"))
+  }
+}
+
+#for newline in newlines {
+  assert(eval("$" + newline + "$.block"))
+  for newline2 in newlines {
+    assert(eval("$" + newline + newline2 + "$.block"))
+  }
+  for non-space in non-spaces {
+    assert(eval("$" + newline + non-space + newline + "$.block"))
+    assert(eval("not $" + newline + non-space + "$.block"))
+    assert(eval("not $" + non-space + newline + "$.block"))
+  }
+}
+
 --- math-equation-numbering paged ---
 #set page(width: 150pt)
 #set math.equation(numbering: "(I)")


### PR DESCRIPTION
**Part of the Math Syntax Refactor**
This PR is part of the exhaustive math syntax refactor. It should be considered exploratory, and not necessarily a final decision, even if merged to the `math-syntax` branch. Non-specific feedback for this change should go in one of its related issues.

---

Changes the parsing behavior of equation syntax so empty equations that contain whitespace do parse as block-level.

Closes #4791

This is related to #6430, but that change will be considered separately.
