### PR TITLE
Fix the warning of clippy::while_let_loop

### DIFF
--- a/crates/typst-layout/src/math/mod.rs
+++ b/crates/typst-layout/src/math/mod.rs
@@ -135,10 +135,9 @@ pub fn layout_equation_block(
         let mut last_first_pos = Point::zero();
         let mut regions = regions;
 
-        loop {
+        while let Some(&(_, first_pos)) = rows.peek() {
             // Keep track of the position of the first row in this region,
             // so that the offset can be reverted later.
-            let Some(&(_, first_pos)) = rows.peek() else { break };
             last_first_pos = first_pos;
 
             let mut frames = vec![];


### PR DESCRIPTION
With Rust 1.93, `cargo clippy` on the main branch produced the [clippy::while_let_loop](https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#while_let_loop) warning:
```
$ cargo clippy
warning: this loop could be written as a `while let` loop
   --> crates/typst-layout/src/math/mod.rs:138:9
    |
138 | /         loop {
139 | |             // Keep track of the position of the first row in this region,
140 | |             // so that the offset can be reverted later.
141 | |             let Some(&(_, first_pos)) = rows.peek() else { break };
...   |
168 | |             regions.next();
169 | |         }
    | |_________^ help: try: `while let Some(&(_, first_pos)) = rows.peek() { .. }`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#while_let_loop
    = note: `#[warn(clippy::while_let_loop)]` on by default

warning: `typst-layout` (lib) generated 1 warning
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.44s
```