### PR TITLE
Fix position where live reload script is injected in hot reload server

### DIFF
--- a/crates/typst-kit/src/server.rs
+++ b/crates/typst-kit/src/server.rs
@@ -147,7 +147,7 @@ fn handle_events_blocking(req: Request, bucket: &Bucket<String>) -> io::Result<(
 
 /// Injects the live reload script into a string of HTML.
 fn inject_live_reload_script(html: &mut String) {
-    let pos = html.rfind("</html>").unwrap_or(html.len());
+    let pos = html.rfind("</body>").unwrap_or(html.len());
     html.insert_str(pos, LIVE_RELOAD_SCRIPT);
 }
 


### PR DESCRIPTION
The previous version worked fine, but was wrong.