### PR TITLE
Illustrate predefined patterns for `stroke.dash` in docs

### DIFF
--- a/crates/typst-library/src/visualize/stroke.rs
+++ b/crates/typst-library/src/visualize/stroke.rs
@@ -160,7 +160,6 @@ impl Stroke {
         /// ```
         ///
         /// ```preview:"Predefined patterns"
-        ///
         /// #set page(width: auto, height: auto)
         ///
         /// #let patterns = (


### PR DESCRIPTION
Resolves part of #5982

- Document how to inspect a predefined pattern
- Display predefined patterns for stroke.dash in docs

<img width="600" alt="图片" src="https://github.com/user-attachments/assets/fd8c4cb8-348e-4fc6-bfe3-1c3d115f8acb" />

<!--
<img width="600" alt="图片" src="https://github.com/user-attachments/assets/38437b44-ddfa-4557-888a-be48d61b72de" />
-->

Inspired by [Table: Colors in Northern Kurdish - Wiktionary](https://en.wiktionary.org/wiki/pirteqal%C3%AE#See_also) and [15.3.2 Graphic Parameters: Dash Pattern - TikZ & PGF Manual v3.1.11a](https://texdoc.org/serve/tikz/0#subsubsection.15.3.2).
