### PR TITLE
Improve font stretch display in `typst fonts --variants`

### DIFF
--- a/crates/typst-library/src/text/font/variant.rs
+++ b/crates/typst-library/src/text/font/variant.rs
@@ -180,7 +180,7 @@ cast! {
 }
 
 /// The width of a font.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[derive(Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct FontStretch(pub(super) u16);
@@ -264,6 +264,12 @@ impl FontStretch {
 impl Default for FontStretch {
     fn default() -> Self {
         Self::NORMAL
+    }
+}
+
+impl Debug for FontStretch {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 


### PR DESCRIPTION
Hello,
In the output of the `typst fonts --variants` command, the stretch variant is shown differently from the others. `FontWeight` implements the `Debug` trait, but `FontStretch` does not, even though they both have essentially the same structure.
Before:
```
New Computer Modern
- Style: Normal, Weight: 400, Stretch: FontStretch(1000), Path: <embedded>
- Style: Normal, Weight: 700, Stretch: FontStretch(1000), Path: <embedded>
- Style: Italic, Weight: 400, Stretch: FontStretch(1000), Path: <embedded>
- Style: Italic, Weight: 700, Stretch: FontStretch(1000), Path: <embedded>
```
After:
```
New Computer Modern
- Style: Normal, Weight: 400, Stretch: 1000, Path: <embedded>
- Style: Normal, Weight: 700, Stretch: 1000, Path: <embedded>
- Style: Italic, Weight: 400, Stretch: 1000, Path: <embedded>
- Style: Italic, Weight: 700, Stretch: 1000, Path: <embedded>
```

Perhaps it would also be a good idea to add the name of the font weight and stretch associated with the number, like this:
```
- Style: Normal, Weight: Medium (500), Stretch: Normal (1000), Path: <embedded>
```
Maybe this output should rely on the `Repr` or `Display` trait rather than `Debug`, but I am not familiar enough with Rust to be sure.