### PR TITLE
HTML Export: Exclude metadata content from paragraph grouping

### DIFF
--- a/crates/typst-html/src/lib.rs
+++ b/crates/typst-html/src/lib.rs
@@ -119,10 +119,13 @@ impl HtmlElem {
         }
     }
 
-    /// Checks whether the given element is "phrasing content" in HTML.
+    /// Checks whether the given element is "phrasing content" in HTML for
+    /// paragraph grouping purposes. Excludes metadata content since those
+    /// elements should not be wrapped in paragraphs.
     fn is_phrasing(elem: &Content) -> bool {
-        elem.to_packed::<HtmlElem>()
-            .is_some_and(|elem| tag::is_phrasing_content(elem.tag))
+        elem.to_packed::<HtmlElem>().is_some_and(|elem| {
+            tag::is_phrasing_content(elem.tag) && !tag::is_metadata_content(elem.tag)
+        })
     }
 }
 

--- a/tests/ref/html/html-script.html
+++ b/tests/ref/html/html-script.html
@@ -5,23 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body>
-    <p>
-      <script>
-        const x = 1
-        const y = 2
-        console.log(x < y, Math.max(1, 2))
-      </script>
-    </p>
-    <p>
-      <script>
+    <script>
+      const x = 1
+      const y = 2
+      console.log(x < y, Math.max(1, 2))
+    </script>
+    <script>
 console.log(`Hello
 World`)
-      </script>
-    </p>
-    <p>
-      <script type="text/python">x = 1
+    </script>
+    <script type="text/python">x = 1
 y = 2
 print(x < y, max(x, y))</script>
-    </p>
   </body>
 </html>

--- a/tests/ref/html/html-typed.html
+++ b/tests/ref/html/html-typed.html
@@ -8,9 +8,7 @@
     <div id="hi"></div>
     <div aria-autocomplete="none"></div>
     <div aria-expanded="undefined"></div>
-    <p>
-      <link referrerpolicy>
-    </p>
+    <link referrerpolicy>
     <div></div>
     <div autofocus></div>
     <div></div>
@@ -33,16 +31,14 @@
     <div><input accept="image/jpeg, image/png"></div>
     <div><input accept="image/jpeg, image/png"></div>
     <p><area coords="2.3, 4, 5.6"></p>
-    <p>
-      <link color="#ff4136">
-      <link color="rgb(100% 32.94% 29.06%)">
-      <link color="rgb(50% 50% 50%)">
-      <link color="#958677">
-      <link color="oklab(27% 0.08 -0.012 / 50%)">
-      <link color="color(srgb-linear 20% 30% 40% / 50%)">
-      <link color="hsl(20deg 10% 20%)">
-      <link color="hsl(30deg 11.11% 27%)">
-    </p>
+    <link color="#ff4136">
+    <link color="rgb(100% 32.94% 29.06%)">
+    <link color="rgb(50% 50% 50%)">
+    <link color="#958677">
+    <link color="oklab(27% 0.08 -0.012 / 50%)">
+    <link color="color(srgb-linear 20% 30% 40% / 50%)">
+    <link color="hsl(20deg 10% 20%)">
+    <link color="hsl(30deg 11.11% 27%)">
     <div><time datetime="3w 4s"></time></div>
     <div><time datetime="1d 4m"></time></div>
     <div><time datetime="0s"></time></div>
@@ -62,8 +58,6 @@
     <div><input value="5.6"></div>
     <div><input value="#ff4136"></div>
     <div><input min="3" max="9"></div>
-    <p>
-      <link rel="icon" sizes="32x24 64x48">
-    </p>
+    <link rel="icon" sizes="32x24 64x48">
   </body>
 </html>


### PR DESCRIPTION
## Summary
Metadata elements (`<meta>, <link>, <script>, <style>`, ..) were incorrectly being wrapped in `<p>` tags during HTML. This issue was introduced in #7505.

## Problem
After #7505 changed paragraph grouping to use `is_phrasing_content`, metadata elements started being wrapped in `<p>` because they're technically phrasing content ([source](https://html.spec.whatwg.org/dev/dom.html#phrasing-content)). However, they should never be wrapped in `<p>` tags and doing so will break the page in browsers (they don't expect `<p>` tags in `<head>` and so will move that content to the `<body>`).

Ex.

```typst
#html.head({
  html.title("Test")
  html.meta(charset: "utf-8")
  html.meta(name: "viewport", content: "test")
})
```

incorrectly produces:
```html
<head>
  <title>Test</title>
  <p>
    <meta charset="utf-8">
    <meta name="viewport" content="test">
  </p>
</head>
```

which the browser (firefox in this case) converts to something completely wrong:
```html
<html>
  <head>
    <title>Test</title>
  </head>
  <body>
    <p>
      <meta charset="utf-8">
      <meta name="viewport" content="test">
    </p>
  </body>
</html>
```

## Fix
Exclude metadata content from the phrasing check used for paragraph grouping.

While this does fix the problem, it would probably be best to rename the function. I wanted to keep this PR minimal though.