### PR TITLE
Fix duplicated `match` branch and typo in `typst-pdf` crate

### DIFF
--- a/crates/typst-pdf/src/page.rs
+++ b/crates/typst-pdf/src/page.rs
@@ -23,7 +23,7 @@ impl PageLabelExt for PageLabel {
 
             let (prefix, kind) = pat.pieces.first()?;
 
-            // If there is a suffix, we cannot use the common style optimisation,
+            // If there is a suffix, we cannot use the common style optimization,
             // since PDF does not provide a suffix field.
             let style = if pat.suffix.is_empty() {
                 use krilla::page::NumberingStyle as Style;
@@ -33,7 +33,7 @@ impl PageLabelExt for PageLabel {
                     Kind::LowerRoman => Some(Style::LowerRoman),
                     Kind::UpperRoman => Some(Style::UpperRoman),
                     Kind::LowerLatin if number <= 26 => Some(Style::LowerAlpha),
-                    Kind::LowerLatin if number <= 26 => Some(Style::UpperAlpha),
+                    Kind::UpperLatin if number <= 26 => Some(Style::UpperAlpha),
                     _ => None,
                 }
             } else {


### PR DESCRIPTION
There was a duplicated `match` branch in page.rs file of typst-pdf crate, and it couldn't be caused in any way. Also, there was a typo in word "optimization"