### PR TITLE
Improve diagnostic for compiler error when spreading multiple dictionaries together

### DIFF
--- a/crates/typst-eval/src/code.rs
+++ b/crates/typst-eval/src/code.rs
@@ -228,13 +228,10 @@ impl Eval for ast::Array<'_> {
 
         let mut vec = EcoVec::with_capacity(items.size_hint().0);
 
-        // We raise an error when one of the array items is
-        // the spread of a dictionary. If _all_ of the array
-        // items are spreads of dictionaries, the user probably
-        // wanted to write `(: ..dict_a, ..dict_b)` instead to
-        // create a dictionary, not an array. In this case we
-        // provide a hint to that effect. This boolean is to
-        // track whether we should emit that hint.
+        // We raise an error when one of the array items is the spread of a
+        // dictionary. If _all_ of the array items are spreads of dictionaries,
+        // the user probably wanted to write `(: ..dict_a, ..dict_b)` instead
+        // to create a dictionary, not an array.
         let mut items_seen_are_spread_dicts = true;
 
         while let Some(item) = items.next() {

--- a/crates/typst-eval/src/code.rs
+++ b/crates/typst-eval/src/code.rs
@@ -3,7 +3,7 @@ use typst_library::diag::{At, SourceResult, bail, error, warning};
 use typst_library::engine::Engine;
 use typst_library::foundations::{
     Array, Capturer, Closure, ClosureNode, Content, ContextElem, Dict, Func,
-    NativeElement, Selector, Str, Type, Value, ops,
+    NativeElement, Selector, Str, Value, ops,
 };
 use typst_library::introspection::{Counter, State};
 use typst_syntax::ast::{self, AstNode};
@@ -249,7 +249,7 @@ impl Eval for ast::Array<'_> {
                         items_seen_are_spread_dicts = false;
                         vec.extend(array.into_iter())
                     }
-                    v if items_seen_are_spread_dicts && v.ty() == Type::of::<Dict>() => {
+                    v @ Value::Dict(_) if items_seen_are_spread_dicts => {
                         // Lookahead to see whether remaining items
                         // are spreads of dicts
                         if items.all(|it| {
@@ -258,7 +258,7 @@ impl Eval for ast::Array<'_> {
                             };
                             spd.expr()
                                 .eval(vm)
-                                .is_ok_and(|val| val.ty() == Type::of::<Dict>())
+                                .is_ok_and(|spd| matches!(spd, Value::Dict(_)))
                         }) {
                             bail!(spread.span(), "cannot spread {} into array", v.ty(); hint: "open container with `(:` to create a dictionary")
                         } else {

--- a/crates/typst-eval/src/code.rs
+++ b/crates/typst-eval/src/code.rs
@@ -246,21 +246,22 @@ impl Eval for ast::Array<'_> {
                         items_seen_are_spread_dicts = false;
                         vec.extend(array.into_iter())
                     }
-                    v @ Value::Dict(_) if items_seen_are_spread_dicts => {
-                        // Lookahead to see whether remaining items
-                        // are spreads of dicts
-                        if items.all(|it| {
+                    v @ Value::Dict(_)
+                        if items_seen_are_spread_dicts
+                        // Lookahead to see whether remaining items are spreads
+                        // of dicts
+                        && items.all(|it| {
                             let ast::ArrayItem::Spread(spd) = it else {
                                 return false;
                             };
                             spd.expr()
                                 .eval(vm)
                                 .is_ok_and(|spd| matches!(spd, Value::Dict(_)))
-                        }) {
-                            bail!(spread.span(), "cannot spread {} into array", v.ty(); hint: "open container with `(:` to create a dictionary")
-                        } else {
-                            bail!(spread.span(), "cannot spread {} into array", v.ty())
-                        }
+                        }) =>
+                    {
+                        bail!(spread.span(), "cannot spread {} into array",
+                            v.ty();
+                        hint: "add a colon to create a dictionary instead `(: ..dict)`")
                     }
                     v => bail!(spread.span(), "cannot spread {} into array", v.ty()),
                 },

--- a/crates/typst-eval/src/code.rs
+++ b/crates/typst-eval/src/code.rs
@@ -250,8 +250,7 @@ impl Eval for ast::Array<'_> {
                             let ast::ArrayItem::Spread(spd) = it else {
                                 return false;
                             };
-                            spd
-                                .expr()
+                            spd.expr()
                                 .eval(vm)
                                 .is_ok_and(|val| val.ty() == Type::of::<Dict>())
                         }) {

--- a/crates/typst-eval/src/code.rs
+++ b/crates/typst-eval/src/code.rs
@@ -260,7 +260,7 @@ impl Eval for ast::Array<'_> {
                                 .eval(vm)
                                 .is_ok_and(|val| val.ty() == Type::of::<Dict>())
                         }) {
-                            bail!(spread.span(), "cannot spread {} into array", v.ty(); hint: "use `(:..spread)` syntax to spread multiple dictionaries together")
+                            bail!(spread.span(), "cannot spread {} into array", v.ty(); hint: "open container with `(:` to create a dictionary")
                         } else {
                             bail!(spread.span(), "cannot spread {} into array", v.ty())
                         }

--- a/crates/typst-eval/src/code.rs
+++ b/crates/typst-eval/src/code.rs
@@ -262,7 +262,7 @@ impl Eval for ast::Array<'_> {
                             self.to_untyped().clone().into_text().replacen("(", "(: ", 1);
                         bail!(
                             spread.span(), "cannot spread {} into array", v.ty();
-                            hint: "add a colon to create a dictionary instead `{fixed}`";
+                            hint: "add a colon to create a dictionary instead: `{fixed}`";
                         )
                     }
                     v => bail!(spread.span(), "cannot spread {} into array", v.ty()),

--- a/crates/typst-eval/src/code.rs
+++ b/crates/typst-eval/src/code.rs
@@ -232,22 +232,22 @@ impl Eval for ast::Array<'_> {
         // dictionary. If _all_ of the array items are spreads of dictionaries,
         // the user probably wanted to write `(: ..dict_a, ..dict_b)` instead
         // to create a dictionary, not an array.
-        let mut items_seen_are_spread_dicts = true;
+        let mut all_dict_spreads = true;
 
         while let Some(item) = items.next() {
             match item {
                 ast::ArrayItem::Pos(expr) => {
-                    items_seen_are_spread_dicts = false;
+                    all_dict_spreads = false;
                     vec.push(expr.eval(vm)?)
                 }
                 ast::ArrayItem::Spread(spread) => match spread.expr().eval(vm)? {
                     Value::None => {}
                     Value::Array(array) => {
-                        items_seen_are_spread_dicts = false;
+                        all_dict_spreads = false;
                         vec.extend(array.into_iter())
                     }
                     v @ Value::Dict(_)
-                        if items_seen_are_spread_dicts
+                        if all_dict_spreads
                         // Lookahead to see whether remaining items are spreads
                         // of dicts
                         && items.all(|item| matches!(

--- a/crates/typst-library/src/foundations/dict.rs
+++ b/crates/typst-library/src/foundations/dict.rs
@@ -73,8 +73,9 @@ pub use crate::__dict as dict;
 /// ```
 ///
 /// [^1]: When spreading into a dictionary, if all items between the parentheses
-/// are spread, you have to use the special `(:..spread)` syntax. Otherwise, it
-/// will spread into an array.
+/// are spread, you have to begin the container with `(:`,
+/// as in `(: ..dict, ..other_dict)`. Otherwise the container is inferred to
+/// be an array and an error is raised.
 #[ty(scope, cast, name = "dictionary")]
 #[derive(Default, Clone, PartialEq)]
 pub struct Dict(Arc<IndexMap<Str, Value, FxBuildHasher>>);

--- a/tests/suite/foundations/dict.typ
+++ b/tests/suite/foundations/dict.typ
@@ -61,14 +61,32 @@
   test((..(a: 1), b: 2), (a: 1, b: 2))
 }
 
---- spread-multiple-dicts-diagnostic paged ---
+--- spread-dicts-in-array-diagnostic paged ---
 
 #{
   let x = (a: 1)
   let y = (b: 2)
-  let z = (3,4)
   // Error: 4-7 cannot spread dictionary into array
-  // Hint: 4-7 use `(:..spread)` syntax to spread multiple dictionaries together
+  // Hint: 4-7 open container with `(:` to create a dictionary
+  (..x,..y)
+}
+
+--- spread-single-dict-in-array-diagnostic paged ---
+
+#{
+  let x = (a: 1)
+  // Error: 4-7 cannot spread dictionary into array
+  // Hint: 4-7 open container with `(:` to create a dictionary
+  (..x)
+}
+
+--- spread-dict-and-array-in-array-diagnostic paged ---
+// Here we should not emit a hint to use `(: <...>)` syntax
+// since the developer's intent is unclear
+#{
+  let x = (a: 1)
+  let y = (2,3)
+  // Error: 4-7 cannot spread dictionary into array
   (..x,..y)
 }
 

--- a/tests/suite/foundations/dict.typ
+++ b/tests/suite/foundations/dict.typ
@@ -68,6 +68,7 @@
   let y = (b: 2)
   let z = (3,4)
   // Error: 4-7 cannot spread dictionary into array
+  // Hint: 4-7 use `(:..spread)` syntax to spread multiple dictionaries together
   (..x,..y)
 }
 

--- a/tests/suite/foundations/dict.typ
+++ b/tests/suite/foundations/dict.typ
@@ -62,21 +62,19 @@
 }
 
 --- spread-dicts-in-array-diagnostic paged ---
-
 #{
   let x = (a: 1)
   let y = (b: 2)
   // Error: 4-7 cannot spread dictionary into array
-  // Hint: 4-7 open container with `(:` to create a dictionary
+  // Hint: 4-7 add a colon to create a dictionary instead `(: ..dict)`
   (..x,..y)
 }
 
 --- spread-single-dict-in-array-diagnostic paged ---
-
 #{
   let x = (a: 1)
   // Error: 4-7 cannot spread dictionary into array
-  // Hint: 4-7 open container with `(:` to create a dictionary
+  // Hint: 4-7 add a colon to create a dictionary instead `(: ..dict)`
   (..x)
 }
 
@@ -90,14 +88,13 @@
   (..x,..y)
 }
 
---- spread-multiple-dicts-diagnostic paged ---
-
+--- spread-dict-and-single-item paged ---
+// Here we should not emit a hint to use `(: <...>)` syntax
+// since the developer's intent is unclear
 #{
   let x = (a: 1)
-  let y = (b: 2)
-  let z = (3,4)
   // Error: 4-7 cannot spread dictionary into array
-  (..x,..y)
+  (..x,"item")
 }
 
 --- spread-array-into-dict eval ---

--- a/tests/suite/foundations/dict.typ
+++ b/tests/suite/foundations/dict.typ
@@ -61,7 +61,7 @@
   test((..(a: 1), b: 2), (a: 1, b: 2))
 }
 
---- spread-dicts-in-array-diagnostic paged ---
+--- spread-dicts-in-array-diagnostic eval ---
 #{
   let x = (a: 1)
   let y = (b: 2)
@@ -70,7 +70,7 @@
   (..x,..y)
 }
 
---- spread-single-dict-in-array-diagnostic paged ---
+--- spread-single-dict-in-array-diagnostic eval ---
 #{
   let x = (a: 1)
   // Error: 4-7 cannot spread dictionary into array
@@ -78,7 +78,7 @@
   (..x)
 }
 
---- spread-dict-and-array-in-array-diagnostic paged ---
+--- spread-dict-and-array-in-array-diagnostic eval ---
 // Here we should not emit a hint to use `(: <...>)` syntax
 // since the developer's intent is unclear
 #{
@@ -88,7 +88,7 @@
   (..x,..y)
 }
 
---- spread-dict-and-single-item paged ---
+--- spread-dict-and-single-item eval ---
 // Here we should not emit a hint to use `(: <...>)` syntax
 // since the developer's intent is unclear
 #{

--- a/tests/suite/foundations/dict.typ
+++ b/tests/suite/foundations/dict.typ
@@ -61,6 +61,26 @@
   test((..(a: 1), b: 2), (a: 1, b: 2))
 }
 
+--- spread-multiple-dicts-diagnostic paged ---
+
+#{
+  let x = (a: 1)
+  let y = (b: 2)
+  let z = (3,4)
+  // Error: 4-7 cannot spread dictionary into array
+  (..x,..y)
+}
+
+--- spread-multiple-dicts-diagnostic paged ---
+
+#{
+  let x = (a: 1)
+  let y = (b: 2)
+  let z = (3,4)
+  // Error: 4-7 cannot spread dictionary into array
+  (..x,..y)
+}
+
 --- spread-array-into-dict eval ---
 // Error: 3-11 cannot spread array into dictionary
 #(..(1, 2), a: 1)

--- a/tests/suite/foundations/dict.typ
+++ b/tests/suite/foundations/dict.typ
@@ -66,7 +66,7 @@
   let x = (a: 1)
   let y = (b: 2)
   // Error: 4-7 cannot spread dictionary into array
-  // Hint: 4-7 add a colon to create a dictionary instead `(: ..dict)`
+  // Hint: 4-7 add a colon to create a dictionary instead `(: ..x,..y)`
   (..x,..y)
 }
 
@@ -74,7 +74,7 @@
 #{
   let x = (a: 1)
   // Error: 4-7 cannot spread dictionary into array
-  // Hint: 4-7 add a colon to create a dictionary instead `(: ..dict)`
+  // Hint: 4-7 add a colon to create a dictionary instead `(: ..x)`
   (..x)
 }
 
@@ -95,6 +95,14 @@
   let x = (a: 1)
   // Error: 4-7 cannot spread dictionary into array
   (..x,"item")
+}
+
+--- spread-none-and-dict eval ---
+#{
+  let x = (a: 1)
+  // Error: 11-20 cannot spread dictionary into array
+  // Hint: 11-20 add a colon to create a dictionary instead `(: ..none,..(one:1))`
+  (..none,..(one:1))
 }
 
 --- spread-array-into-dict eval ---

--- a/tests/suite/foundations/dict.typ
+++ b/tests/suite/foundations/dict.typ
@@ -66,7 +66,7 @@
   let x = (a: 1)
   let y = (b: 2)
   // Error: 4-7 cannot spread dictionary into array
-  // Hint: 4-7 add a colon to create a dictionary instead `(: ..x,..y)`
+  // Hint: 4-7 add a colon to create a dictionary instead: `(: ..x,..y)`
   (..x,..y)
 }
 
@@ -74,7 +74,7 @@
 #{
   let x = (a: 1)
   // Error: 4-7 cannot spread dictionary into array
-  // Hint: 4-7 add a colon to create a dictionary instead `(: ..x)`
+  // Hint: 4-7 add a colon to create a dictionary instead: `(: ..x)`
   (..x)
 }
 
@@ -101,7 +101,7 @@
 #{
   let x = (a: 1)
   // Error: 11-20 cannot spread dictionary into array
-  // Hint: 11-20 add a colon to create a dictionary instead `(: ..none,..(one:1))`
+  // Hint: 11-20 add a colon to create a dictionary instead: `(: ..none,..(one:1))`
   (..none,..(one:1))
 }
 


### PR DESCRIPTION
If a user attempts to spread several dictionaries together without using the [special syntax](https://typst.app/docs/reference/foundations/dictionary#1) `(:..spread)` then they get a potentially confusing compiler error:

```typst
#{
  let x = (a: 1)
  let y = (b: 2)
  // This gives error "cannot spread dictionary into array"
  (..x,..y)
}
```

This PR detects when all the array items are spreads of dictionaries and suggests the special syntax as a hint in that case.

Closes #7795

Apologies for any gaffes, this is my first contribution - happy to make any adjustments if I've gone astray!