### PR TITLE
syntax: Allow specifying a preferred compiler version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3326,6 +3326,7 @@ dependencies = [
  "serde_json",
  "tar",
  "tiny_http",
+ "toml",
  "typst-assets",
  "typst-bundle",
  "typst-library",

--- a/crates/typst-cli/src/eval.rs
+++ b/crates/typst-cli/src/eval.rs
@@ -10,7 +10,8 @@ use typst::foundations::{
 };
 use typst::routines::SpanMode;
 use typst::syntax::{
-    FileId, RangeMapper, RootedPath, Source, Span, SyntaxMode, VirtualPath, VirtualRoot,
+    FileId, PreferredCompilerVersion, RangeMapper, RootedPath, Source, Span, SyntaxMode,
+    VirtualPath, VirtualRoot,
 };
 use typst::text::{Font, FontBook};
 use typst::{World, engine::Sink, introspection::Introspector};
@@ -204,6 +205,13 @@ impl World for ExpressionWorld {
         } else {
             self.world.file(id)
         }
+    }
+
+    fn preferred_version(
+        &self,
+        root: &VirtualRoot,
+    ) -> FileResult<PreferredCompilerVersion> {
+        self.world.preferred_version(root)
     }
 
     fn font(&self, index: usize) -> Option<Font> {

--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -8,7 +8,8 @@ use ecow::{EcoString, eco_format};
 use typst::diag::{FileError, FileResult};
 use typst::foundations::{Bytes, Datetime, Dict, Duration, IntoValue, Repr};
 use typst::syntax::{
-    FileId, PathError, RootedPath, Source, VirtualPath, VirtualRoot, VirtualizeError,
+    FileId, PathError, PreferredCompilerVersion, RootedPath, Source, VirtualPath,
+    VirtualRoot, VirtualizeError,
 };
 use typst::text::{Font, FontBook};
 use typst::utils::LazyHash;
@@ -129,6 +130,13 @@ impl World for SystemWorld {
 
     fn source(&self, id: FileId) -> FileResult<Source> {
         self.files.source(id)
+    }
+
+    fn preferred_version(
+        &self,
+        root: &VirtualRoot,
+    ) -> FileResult<PreferredCompilerVersion> {
+        self.files.preferred_version(root)
     }
 
     fn file(&self, id: FileId) -> FileResult<Bytes> {

--- a/crates/typst-eval/src/lib.rs
+++ b/crates/typst-eval/src/lib.rs
@@ -31,7 +31,7 @@ use typst_library::introspection::{EmptyIntrospector, Introspector};
 use typst_library::math::EquationElem;
 use typst_library::routines::SpanMode;
 use typst_library::{Library, World};
-use typst_syntax::{Source, SyntaxMode, ast, parse, parse_code, parse_math};
+use typst_syntax::{Source, Span, SyntaxMode, ast, parse, parse_code, parse_math};
 use typst_utils::{LazyHash, Protected};
 
 /// Evaluate a source file and return the resulting module.
@@ -51,6 +51,8 @@ pub fn eval(
         panic!("Tried to cyclicly evaluate {:?}", id.vpath());
     }
 
+    let preferred_version = world.preferred_version(id.root()).at(Span::detached())?;
+
     // Prepare the engine.
     let introspector = EmptyIntrospector;
     let engine = Engine {
@@ -59,7 +61,7 @@ pub fn eval(
         introspector: Protected::new(introspector.track()),
         traced,
         sink,
-        route: Route::extend(route).with_id(id),
+        route: Route::extend(route).with_id(id, preferred_version),
     };
 
     // Prepare VM.

--- a/crates/typst-ide/src/tests.rs
+++ b/crates/typst-ide/src/tests.rs
@@ -6,7 +6,7 @@ use rustc_hash::FxHashMap;
 use typst::diag::{FileError, FileResult};
 use typst::foundations::{Bytes, Datetime, Duration, Smart};
 use typst::layout::{Abs, Margin, PageElem};
-use typst::syntax::package::{PackageSpec, PackageVersion};
+use typst::syntax::package::{PackageSpec, PackageVersion, PreferredCompilerVersion};
 use typst::syntax::{FileId, RootedPath, Source, VirtualPath, VirtualRoot};
 use typst::text::{Font, FontBook, TextElem, TextSize};
 use typst::utils::{LazyHash, singleton};
@@ -101,6 +101,13 @@ impl World for TestWorld {
             Some(bytes) => Ok(bytes.clone()),
             None => Err(FileError::NotFound(id.vpath().get_without_slash().into())),
         }
+    }
+
+    fn preferred_version(
+        &self,
+        _root: &VirtualRoot,
+    ) -> FileResult<PreferredCompilerVersion> {
+        Ok(PreferredCompilerVersion::default())
     }
 
     fn font(&self, index: usize) -> Option<Font> {

--- a/crates/typst-kit/Cargo.toml
+++ b/crates/typst-kit/Cargo.toml
@@ -39,6 +39,7 @@ tar = { workspace = true, optional = true }
 tiny_http = { workspace = true, optional = true }
 ureq = { workspace = true, optional = true }
 url = { workspace = true }
+toml.workspace = true
 
 # Explicitly depend on OpenSSL if applicable, so that we can add the
 # `openssl/vendored` feature to it if `vendor-openssl` is enabled.

--- a/crates/typst-kit/src/files.rs
+++ b/crates/typst-kit/src/files.rs
@@ -7,11 +7,15 @@ use std::str;
 use std::str::Utf8Error;
 use std::sync::Arc;
 
+use ecow::eco_format;
 use parking_lot::Mutex;
 use rustc_hash::FxHashMap;
 use typst_library::diag::{FileError, FileResult};
 use typst_library::foundations::Bytes;
-use typst_syntax::{FileId, Source, VirtualPath};
+use typst_syntax::package::{CompilerVersion, PackageManifest};
+use typst_syntax::{
+    FileId, PreferredCompilerVersion, RootedPath, Source, VirtualPath, VirtualRoot,
+};
 
 #[cfg(feature = "system-files")]
 use {crate::packages::SystemPackages, typst_syntax::VirtualRoot};
@@ -35,7 +39,8 @@ use {crate::packages::SystemPackages, typst_syntax::VirtualRoot};
 #[derive(Default)]
 pub struct FileStore<L> {
     loader: L,
-    slots: Mutex<FxHashMap<FileId, FileSlot>>,
+    root_slots: Mutex<FxHashMap<VirtualRoot, RootSlot>>,
+    file_slots: Mutex<FxHashMap<FileId, FileSlot>>,
 }
 
 impl<L> FileStore<L>
@@ -44,7 +49,11 @@ where
 {
     /// Creates a new file store that loads file data via the provided `loader`.
     pub fn new(loader: L) -> Self {
-        Self { loader, slots: Mutex::new(FxHashMap::default()) }
+        Self {
+            loader,
+            root_slots: Mutex::new(FxHashMap::default()),
+            file_slots: Mutex::new(FxHashMap::default()),
+        }
     }
 
     /// Returns a reference to the underlying loader.
@@ -67,7 +76,7 @@ where
     /// Can directly be used to implement
     /// [`World::source`](typst_library::World::source).
     pub fn source(&self, id: FileId) -> FileResult<Source> {
-        self.slot(id, |slot| slot.source(&self.loader, id))
+        self.file_slot(id, |slot| slot.source(&self.loader, id))
     }
 
     /// Retrieves the given file id as a raw file.
@@ -75,7 +84,19 @@ where
     /// Can directly be used to implement
     /// [`World::file`](typst_library::World::file).
     pub fn file(&self, id: FileId) -> FileResult<Bytes> {
-        self.slot(id, |slot| slot.file(&self.loader, id))
+        self.file_slot(id, |slot| slot.file(&self.loader, id))
+    }
+
+    /// Retrieves the preferred compiler version for files within the given
+    /// root.
+    ///
+    /// Can directly be used to implement
+    /// [`World::source`](typst_library::World::preferred_version).
+    pub fn preferred_version(
+        &self,
+        root: &VirtualRoot,
+    ) -> FileResult<PreferredCompilerVersion> {
+        self.root_slot(root, |slot| slot.load(&self.loader, root))
     }
 
     /// Returns all files that were referenced since the last
@@ -90,17 +111,28 @@ where
     /// the fact.
     pub fn dependencies(&mut self) -> (&L, impl Iterator<Item = FileId> + '_) {
         let iter = self
-            .slots
+            .file_slots
             .get_mut()
             .iter()
             .filter(|(_, slot)| slot.accessed())
-            .map(|(&id, _)| id);
+            .map(|(&id, _)| id)
+            .chain(
+                self.root_slots
+                    .get_mut()
+                    .iter()
+                    .filter(|(_, slot)| slot.accessed())
+                    .map(|(root, _)| {
+                        root.join("typst.toml")
+                            .expect("`/typst.toml` is always valid within any root")
+                            .intern()
+                    }),
+            );
         (&self.loader, iter)
     }
 
     /// Resets the store.
     ///
-    /// This marks all loaded file as stale. On subsequent accesses, they will
+    /// This marks all loaded files as stale. On subsequent accesses, they will
     /// be loaded once more through the underlying loader. Moreover, calls to
     /// [`dependencies()`](Self::dependencies) will not yield files accessed
     /// before the call to `reset()`.
@@ -110,20 +142,81 @@ where
     /// performance.
     pub fn reset(&mut self) {
         #[expect(clippy::iter_over_hash_type, reason = "order does not matter")]
-        for slot in self.slots.get_mut().values_mut() {
+        for slot in self.root_slots.get_mut().values_mut() {
+            slot.reset();
+        }
+        #[allow(clippy::iter_over_hash_type, reason = "order does not matter")]
+        for slot in self.file_slots.get_mut().values_mut() {
             slot.reset();
         }
     }
 
-    /// Access the canonical slot for the given file id.
-    fn slot<F, T>(&self, id: FileId, f: F) -> FileResult<T>
+    /// Access the canonical root slot for the given root.
+    fn root_slot<F, T>(&self, root: &VirtualRoot, f: F) -> FileResult<T>
+    where
+        F: FnOnce(&mut RootSlot) -> FileResult<T>,
+    {
+        let mut map = self.root_slots.lock();
+        f(map.entry(root.clone()).or_default())
+    }
+
+    /// Access the canonical file slot for the given file id.
+    fn file_slot<F, T>(&self, id: FileId, f: F) -> FileResult<T>
     where
         F: FnOnce(&mut FileSlot) -> FileResult<T>,
     {
-        let mut map = self.slots.lock();
+        let mut map = self.file_slots.lock();
         f(map.entry(id).or_default())
     }
 }
+
+/// Holds the state for a root's preferred version.
+enum RootSlot {
+    /// Nothing has been loaded so far.
+    ///
+    /// Transitions to
+    /// - loaded if a preferred version is requested and the data could be
+    ///   loaded.
+    Empty,
+    /// The slot has been requested as a `load()`.
+    Loaded(FileResult<PreferredCompilerVersion>),
+}
+
+impl RootSlot {
+    /// Whether the slot has been accessed in any way since the last reset.
+    fn accessed(&self) -> bool {
+        !matches!(self, Self::Empty)
+    }
+
+    /// Resets the slot to its empty state.
+    fn reset(&mut self) {
+        *self = Self::Empty;
+    }
+
+    /// Retrieves the preferred version for this slot.
+    fn load(
+        &mut self,
+        loader: &impl FileLoader,
+        root: &VirtualRoot,
+    ) -> FileResult<PreferredCompilerVersion> {
+        match self {
+            RootSlot::Empty => {}
+            RootSlot::Loaded(preferred_version) => return preferred_version.clone(),
+        }
+
+        let preferred_version = loader.preferred_version(root);
+        *self = Self::Loaded(preferred_version.clone());
+        preferred_version
+    }
+}
+
+impl Default for RootSlot {
+    fn default() -> Self {
+        Self::Empty
+    }
+}
+
+/// Provides data for files, backing a [`FileStore`].
 
 /// Holds the state for a file.
 enum FileSlot {
@@ -133,7 +226,7 @@ enum FileSlot {
     ///
     /// Transitions to
     /// - loaded when a file is requested
-    /// - to parsed if a source is requested and the data could be loaded
+    /// - parsed if a source is requested and the data could be loaded
     ///   (otherwise to loaded).
     Empty(Stale<Source>),
     /// The slot has been requested as a `file()` but not as a `source()` (at
@@ -263,6 +356,52 @@ pub trait FileLoader {
     /// [`id.vpath()`](typst_syntax::RootedPath::vpath) in the project /
     /// package.
     fn load(&self, id: FileId) -> FileResult<Bytes>;
+
+    /// Retrieve the preferred version for a workspace root.
+    ///
+    /// This should return the current compiler version, i.e.
+    /// `PreferredCompilerVersion::compiler()`, when no preferred version is configured,
+    /// such as for regular project roots. For packages this should return the
+    /// `package.compiler.preferred` field in the `typst.toml` manifest or the
+    /// compiler version.
+    fn preferred_version(
+        &self,
+        root: &VirtualRoot,
+    ) -> FileResult<PreferredCompilerVersion> {
+        Ok(match root {
+            VirtualRoot::Project => PreferredCompilerVersion::default(),
+            VirtualRoot::Package(_) => {
+                let id = FileId::new(RootedPath::new(
+                    root.clone(),
+                    VirtualPath::new("typst.toml")
+                        .map_err(|e| FileError::Other(Some(eco_format!("{e:?}"))))?,
+                ));
+
+                let manifest = self.load(id)?;
+                let manifest = manifest
+                    .as_str()
+                    .map_err(|e| FileError::Other(Some(eco_format!("{e:?}"))))?;
+
+                let manifest: PackageManifest = toml::from_str(manifest)
+                    .map_err(|e| FileError::Other(Some(eco_format!("{e:?}"))))?;
+
+                match manifest.package.compiler {
+                    Some(CompilerVersion::Minimum(_)) | None => {
+                        PreferredCompilerVersion::default()
+                    }
+                    Some(CompilerVersion::Compatibility { preferred, .. }) => {
+                        if preferred.major != 0 {
+                            return Err(FileError::Other(Some(
+                                "major versions other than 0 are not supported for `compiler.preferred`".into()
+                            )));
+                        }
+
+                        preferred
+                    }
+                }
+            }
+        })
+    }
 }
 
 impl<F: FileLoader> FileLoader for Box<F> {
@@ -435,6 +574,13 @@ mod tests {
                 "e.bin" if self.0 > 3 => Bytes::from_string(E_TEXT),
                 path => return Err(FileError::NotFound(path.into())),
             })
+        }
+
+        fn preferred_version(
+            &self,
+            _root: &VirtualRoot,
+        ) -> FileResult<PreferredCompilerVersion> {
+            Ok(PreferredCompilerVersion::default())
         }
     }
 

--- a/crates/typst-kit/src/files.rs
+++ b/crates/typst-kit/src/files.rs
@@ -9,9 +9,13 @@ use std::sync::Arc;
 
 use parking_lot::Mutex;
 use rustc_hash::FxHashMap;
+use typst_library::diag::PackageError;
 use typst_library::diag::{FileError, FileResult};
 use typst_library::foundations::Bytes;
-use typst_syntax::{FileId, Source, VirtualPath};
+use typst_syntax::package::{CompilerVersion, PackageManifest};
+use typst_syntax::{
+    FileId, PreferredCompilerVersion, RootedPath, Source, VirtualPath, VirtualRoot,
+};
 
 #[cfg(feature = "system-files")]
 use {crate::packages::SystemPackages, typst_syntax::VirtualRoot};
@@ -35,7 +39,8 @@ use {crate::packages::SystemPackages, typst_syntax::VirtualRoot};
 #[derive(Default)]
 pub struct FileStore<L> {
     loader: L,
-    slots: Mutex<FxHashMap<FileId, FileSlot>>,
+    root_slots: Mutex<FxHashMap<VirtualRoot, RootSlot>>,
+    file_slots: Mutex<FxHashMap<FileId, FileSlot>>,
 }
 
 impl<L> FileStore<L>
@@ -44,7 +49,11 @@ where
 {
     /// Creates a new file store that loads file data via the provided `loader`.
     pub fn new(loader: L) -> Self {
-        Self { loader, slots: Mutex::new(FxHashMap::default()) }
+        Self {
+            loader,
+            root_slots: Mutex::new(FxHashMap::default()),
+            file_slots: Mutex::new(FxHashMap::default()),
+        }
     }
 
     /// Returns a reference to the underlying loader.
@@ -67,7 +76,7 @@ where
     /// Can directly be used to implement
     /// [`World::source`](typst_library::World::source).
     pub fn source(&self, id: FileId) -> FileResult<Source> {
-        self.slot(id, |slot| slot.source(&self.loader, id))
+        self.file_slot(id, |slot| slot.source(&self.loader, id))
     }
 
     /// Retrieves the given file id as a raw file.
@@ -75,7 +84,19 @@ where
     /// Can directly be used to implement
     /// [`World::file`](typst_library::World::file).
     pub fn file(&self, id: FileId) -> FileResult<Bytes> {
-        self.slot(id, |slot| slot.file(&self.loader, id))
+        self.file_slot(id, |slot| slot.file(&self.loader, id))
+    }
+
+    /// Retrieves the preferred compiler version for files within the given
+    /// root.
+    ///
+    /// Can directly be used to implement
+    /// [`World::source`](typst_library::World::preferred_version).
+    pub fn preferred_version(
+        &self,
+        root: &VirtualRoot,
+    ) -> FileResult<PreferredCompilerVersion> {
+        self.root_slot(root, |slot| slot.load(&self.loader, root))
     }
 
     /// Returns all files that were referenced since the last
@@ -90,17 +111,28 @@ where
     /// the fact.
     pub fn dependencies(&mut self) -> (&L, impl Iterator<Item = FileId> + '_) {
         let iter = self
-            .slots
+            .file_slots
             .get_mut()
             .iter()
             .filter(|(_, slot)| slot.accessed())
-            .map(|(&id, _)| id);
+            .map(|(&id, _)| id)
+            .chain(
+                self.root_slots
+                    .get_mut()
+                    .iter()
+                    .filter(|(_, slot)| slot.accessed())
+                    .map(|(root, _)| {
+                        root.join("typst.toml")
+                            .expect("`/typst.toml` is always a valid virtual path")
+                            .intern()
+                    }),
+            );
         (&self.loader, iter)
     }
 
     /// Resets the store.
     ///
-    /// This marks all loaded file as stale. On subsequent accesses, they will
+    /// This marks all loaded files as stale. On subsequent accesses, they will
     /// be loaded once more through the underlying loader. Moreover, calls to
     /// [`dependencies()`](Self::dependencies) will not yield files accessed
     /// before the call to `reset()`.
@@ -110,20 +142,81 @@ where
     /// performance.
     pub fn reset(&mut self) {
         #[expect(clippy::iter_over_hash_type, reason = "order does not matter")]
-        for slot in self.slots.get_mut().values_mut() {
+        for slot in self.root_slots.get_mut().values_mut() {
+            slot.reset();
+        }
+        #[allow(clippy::iter_over_hash_type, reason = "order does not matter")]
+        for slot in self.file_slots.get_mut().values_mut() {
             slot.reset();
         }
     }
 
-    /// Access the canonical slot for the given file id.
-    fn slot<F, T>(&self, id: FileId, f: F) -> FileResult<T>
+    /// Access the canonical root slot for the given root.
+    fn root_slot<F, T>(&self, root: &VirtualRoot, f: F) -> FileResult<T>
+    where
+        F: FnOnce(&mut RootSlot) -> FileResult<T>,
+    {
+        let mut map = self.root_slots.lock();
+        f(map.entry(root.clone()).or_default())
+    }
+
+    /// Access the canonical file slot for the given file id.
+    fn file_slot<F, T>(&self, id: FileId, f: F) -> FileResult<T>
     where
         F: FnOnce(&mut FileSlot) -> FileResult<T>,
     {
-        let mut map = self.slots.lock();
+        let mut map = self.file_slots.lock();
         f(map.entry(id).or_default())
     }
 }
+
+/// Holds the state for a root's preferred version.
+enum RootSlot {
+    /// Nothing has been loaded so far.
+    ///
+    /// Transitions to
+    /// - loaded if a preferred version is requested and the data could be
+    ///   loaded.
+    Empty,
+    /// The slot has been requested as a `load()`.
+    Loaded(FileResult<PreferredCompilerVersion>),
+}
+
+impl RootSlot {
+    /// Whether the slot has been accessed in any way since the last reset.
+    fn accessed(&self) -> bool {
+        !matches!(self, Self::Empty)
+    }
+
+    /// Resets the slot to its empty state.
+    fn reset(&mut self) {
+        *self = Self::Empty;
+    }
+
+    /// Retrieves the preferred version for this slot.
+    fn load(
+        &mut self,
+        loader: &impl FileLoader,
+        root: &VirtualRoot,
+    ) -> FileResult<PreferredCompilerVersion> {
+        match self {
+            RootSlot::Empty => {}
+            RootSlot::Loaded(preferred_version) => return preferred_version.clone(),
+        }
+
+        let preferred_version = loader.preferred_version(root);
+        *self = Self::Loaded(preferred_version.clone());
+        preferred_version
+    }
+}
+
+impl Default for RootSlot {
+    fn default() -> Self {
+        Self::Empty
+    }
+}
+
+/// Provides data for files, backing a [`FileStore`].
 
 /// Holds the state for a file.
 enum FileSlot {
@@ -133,7 +226,7 @@ enum FileSlot {
     ///
     /// Transitions to
     /// - loaded when a file is requested
-    /// - to parsed if a source is requested and the data could be loaded
+    /// - parsed if a source is requested and the data could be loaded
     ///   (otherwise to loaded).
     Empty(Stale<Source>),
     /// The slot has been requested as a `file()` but not as a `source()` (at
@@ -263,6 +356,69 @@ pub trait FileLoader {
     /// [`id.vpath()`](typst_syntax::RootedPath::vpath) in the project /
     /// package.
     fn load(&self, id: FileId) -> FileResult<Bytes>;
+
+    /// Retrieve the preferred version for a workspace root.
+    ///
+    /// This should return the current compiler version, i.e.
+    /// `PreferredCompilerVersion::current()`, when no preferred version is configured,
+    /// such as for regular project roots. For packages this should return the
+    /// `package.compiler.preferred` field in the `typst.toml` manifest or the
+    /// compiler version.
+    fn preferred_version(
+        &self,
+        root: &VirtualRoot,
+    ) -> FileResult<PreferredCompilerVersion> {
+        Ok(match root {
+            VirtualRoot::Project => PreferredCompilerVersion::default(),
+            VirtualRoot::Package(_) => {
+                let id = FileId::new(RootedPath::new(
+                    root.clone(),
+                    VirtualPath::new("/typst.toml")
+                        .expect("`/typst.toml` is always a valid virtual path"),
+                ));
+
+                let manifest = self.load(id)?;
+                let manifest = manifest.as_str().map_err(|_| {
+                    FileError::Package(PackageError::MalformedArchive(Some(
+                        "manifest was not valid UTF-8".into(),
+                    )))
+                })?;
+
+                let manifest: PackageManifest =
+                    toml::from_str(manifest).map_err(|e| {
+                        FileError::Package(PackageError::MalformedManifest(Some(
+                            e.message().into(),
+                        )))
+                    })?;
+
+                match manifest.package.compiler {
+                    None => PreferredCompilerVersion::default(),
+                    Some(CompilerVersion::Minimum(minimum)) => {
+                        // NOTE: Compiler version bounds without a minor version
+                        // effectively always degrade to the current compiler
+                        // version because `compiler = "0"` is nonsensical when
+                        // there are only `0.x` versions.
+                        minimum
+                            .minor
+                            .map(|minor| PreferredCompilerVersion {
+                                major: minimum.major,
+                                minor,
+                            })
+                            .unwrap_or_else(|| PreferredCompilerVersion::current())
+                    }
+                    Some(CompilerVersion::Compatibility { preferred, .. }) => {
+                        if preferred.major != 0 {
+                            return Err(FileError::Package(PackageError::MalformedManifest(Some(
+                                "major versions other than 0 are not supported for `compiler.preferred`".into()
+                            ))));
+                        }
+
+                        preferred
+                    }
+                }
+            }
+        })
+    }
 }
 
 impl<F: FileLoader> FileLoader for Box<F> {
@@ -435,6 +591,13 @@ mod tests {
                 "e.bin" if self.0 > 3 => Bytes::from_string(E_TEXT),
                 path => return Err(FileError::NotFound(path.into())),
             })
+        }
+
+        fn preferred_version(
+            &self,
+            _root: &VirtualRoot,
+        ) -> FileResult<PreferredCompilerVersion> {
+            Ok(PreferredCompilerVersion::default())
         }
     }
 

--- a/crates/typst-library/src/diag.rs
+++ b/crates/typst-library/src/diag.rs
@@ -707,6 +707,8 @@ pub enum PackageError {
     NetworkFailed(Option<EcoString>),
     /// The package archive was malformed.
     MalformedArchive(Option<EcoString>),
+    /// The package manifest was malformed.
+    MalformedManifest(Option<EcoString>),
     /// Another error.
     Other(Option<EcoString>),
 }
@@ -736,6 +738,10 @@ impl Display for PackageError {
             Self::MalformedArchive(None) => {
                 f.pad("failed to decompress package (archive malformed)")
             }
+            Self::MalformedManifest(Some(err)) => {
+                write!(f, "failed to read package manifest ({err})")
+            }
+            Self::MalformedManifest(None) => f.pad("failed to read package manifest"),
             Self::Other(Some(err)) => write!(f, "failed to load package ({err})"),
             Self::Other(None) => f.pad("failed to load package"),
         }

--- a/crates/typst-library/src/engine.rs
+++ b/crates/typst-library/src/engine.rs
@@ -6,7 +6,7 @@ use comemo::{Track, Tracked, TrackedMut};
 use ecow::EcoVec;
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use rustc_hash::FxHashSet;
-use typst_syntax::{FileId, Span};
+use typst_syntax::{FileId, PreferredCompilerVersion, Span};
 use typst_utils::{LazyHash, Protected};
 
 use crate::diag::{HintedStrResult, SourceDiagnostic, SourceResult, StrResult, bail};
@@ -31,7 +31,8 @@ pub struct Engine<'a> {
     /// A pure sink for warnings, delayed errors, and spans under inspection.
     pub sink: TrackedMut<'a, Sink>,
     /// The route the engine took during compilation. This is used to detect
-    /// cyclic imports and excessive nesting.
+    /// cyclic imports and excessive nesting. This is also used to access the
+    /// preferred compiler version for the root in which the engine is used.
     pub route: Route<'a>,
 }
 
@@ -266,6 +267,9 @@ pub struct Route<'a> {
     /// This is set if this route segment was inserted through the start of a
     /// module evaluation.
     id: Option<FileId>,
+    /// The preferred compiler version at this point in the route. This should
+    /// for all route segments for which the file id is the same.
+    preferred_version: PreferredCompilerVersion,
     /// This is set whenever we enter a function, nested layout, or are applying
     /// a show rule. The length of this segment plus the lengths of all `outer`
     /// route segments make up the length of the route. If the length of the
@@ -285,6 +289,7 @@ impl<'a> Route<'a> {
     pub fn root() -> Self {
         Self {
             id: None,
+            preferred_version: PreferredCompilerVersion::current(),
             outer: None,
             len: 0,
             upper: AtomicUsize::new(0),
@@ -296,14 +301,20 @@ impl<'a> Route<'a> {
         Route {
             outer: Some(outer),
             id: None,
+            preferred_version: outer.preferred_version(),
             len: 1,
             upper: AtomicUsize::new(usize::MAX),
         }
     }
 
-    /// Attach a file id to the route segment.
-    pub fn with_id(self, id: FileId) -> Self {
-        Self { id: Some(id), ..self }
+    /// Attach a file id and associated preferred compiler version to the route
+    /// segment.
+    pub fn with_id(
+        self,
+        id: FileId,
+        preferred_version: PreferredCompilerVersion,
+    ) -> Self {
+        Self { id: Some(id), preferred_version, ..self }
     }
 
     /// Set the length of the route segment to zero.
@@ -426,6 +437,11 @@ impl<'a> Route<'a> {
             None => true,
         }
     }
+
+    /// Returns the preferred compiler version within this route segment.
+    pub fn preferred_version(&self) -> PreferredCompilerVersion {
+        self.preferred_version
+    }
 }
 
 impl Default for Route<'_> {
@@ -439,6 +455,7 @@ impl Clone for Route<'_> {
         Self {
             outer: self.outer,
             id: self.id,
+            preferred_version: self.preferred_version,
             len: self.len,
             upper: AtomicUsize::new(self.upper.load(Ordering::Relaxed)),
         }

--- a/crates/typst-library/src/lib.rs
+++ b/crates/typst-library/src/lib.rs
@@ -29,7 +29,7 @@ pub mod visualize;
 use std::ops::{Deref, Range};
 
 use serde::{Deserialize, Serialize};
-use typst_syntax::{DiagSpan, DiagSpanKind, FileId, Source};
+use typst_syntax::{DiagSpan, DiagSpanKind, FileId, Source, PreferredCompilerVersion, VirtualRoot};
 use typst_utils::{LazyHash, SmallBitSet};
 
 use crate::diag::FileResult;
@@ -79,6 +79,12 @@ pub trait World: Send + Sync {
     /// an existing [`Source`] through [`Bytes::from_string`].
     fn file(&self, id: FileId) -> FileResult<Bytes>;
 
+    /// Try to return the preferred compiler version for the given root.
+    fn preferred_version(
+        &self,
+        root: &VirtualRoot,
+    ) -> FileResult<PreferredCompilerVersion>;
+
     /// Try to access the font with the given index in the font book.
     ///
     /// Note that the index is not guaranteed to be in bounds of the font book
@@ -118,6 +124,13 @@ macro_rules! world_impl {
 
             fn file(&self, id: FileId) -> FileResult<Bytes> {
                 self.deref().file(id)
+            }
+
+            fn preferred_version(
+                &self,
+                root: &VirtualRoot,
+            ) -> FileResult<PreferredCompilerVersion> {
+                self.deref().preferred_version(root)
             }
 
             fn font(&self, index: usize) -> Option<Font> {

--- a/crates/typst-syntax/src/lib.rs
+++ b/crates/typst-syntax/src/lib.rs
@@ -25,6 +25,7 @@ pub use self::lines::Lines;
 pub use self::node::{
     Diagnosis, LinkedChildren, LinkedNode, Side, SyntaxDiagnostic, SyntaxNode,
 };
+pub use self::package::PreferredCompilerVersion;
 pub use self::parser::{parse, parse_code, parse_math};
 pub use self::path::{
     FileId, PathError, RealizeError, RootedPath, VirtualPath, VirtualRoot,

--- a/crates/typst-syntax/src/package.rs
+++ b/crates/typst-syntax/src/package.rs
@@ -130,9 +130,9 @@ pub struct PackageInfo {
     /// package is useful.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub disciplines: Vec<EcoString>,
-    /// The minimum required compiler version for the package.
+    /// The compiler version(s) for the package.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub compiler: Option<VersionBound>,
+    pub compiler: Option<CompilerVersion>,
     /// An array of globs specifying files that should not be part of the
     /// published bundle.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -140,6 +140,26 @@ pub struct PackageInfo {
     /// All parsed but unknown fields, this can be used for validation.
     #[serde(flatten, skip_serializing)]
     pub unknown_fields: UnknownFields,
+}
+
+/// The `package.compiler` key in the manifest.
+///
+/// This may be represented as a version directly, or as a table of two
+/// versions.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CompilerVersion {
+    /// The minimum required version of the compiler for a package.
+    Minimum(VersionBound),
+
+    /// A compound version bound containing the minimum required and preferred version.
+    Compatibility {
+        /// The minimum required version of the compiler for a package.
+        minimum: VersionBound,
+
+        /// The preferred version of the compiler for a package.
+        preferred: PreferredCompilerVersion,
+    },
 }
 
 impl PackageManifest {
@@ -169,9 +189,31 @@ impl PackageManifest {
             ));
         }
 
-        if let Some(required) = self.package.compiler {
+        if let Some(compiler_version) = self.package.compiler.as_ref() {
+            let required = match compiler_version {
+                CompilerVersion::Minimum(minimum) => minimum,
+                CompilerVersion::Compatibility { minimum, preferred } => {
+                    // NOTE: We don't use PackageVersion here because we don't
+                    // know which patch version best represents the preferred
+                    // bound and want to avoid confusing diagnostics.
+                    if !(minimum.major < preferred.major
+                        || (minimum.major == preferred.major
+                            && minimum
+                                .minor
+                                .is_some_and(|minimum| minimum <= preferred.minor)))
+                    {
+                        return Err(eco_format!(
+                            "package requires Typst {minimum} or newer, but \
+                             prefers Typst {preferred}, which is lower"
+                        ));
+                    }
+
+                    minimum
+                }
+            };
+
             let current = PackageVersion::compiler();
-            if !current.matches_ge(&required) {
+            if !current.matches_ge(required) {
                 return Err(eco_format!(
                     "package requires Typst {required} or newer \
                      (current version is {current})"
@@ -217,6 +259,16 @@ impl PackageInfo {
             license: None,
             repository: None,
             unknown_fields: BTreeMap::new(),
+        }
+    }
+}
+
+impl CompilerVersion {
+    /// The minimum required compiler version.
+    pub fn minimum(&self) -> VersionBound {
+        match self {
+            CompilerVersion::Minimum(minimum)
+            | CompilerVersion::Compatibility { minimum, .. } => *minimum,
         }
     }
 }
@@ -482,11 +534,11 @@ impl<'de> Deserialize<'de> for PackageVersion {
 /// A version bound for compatibility specification.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct VersionBound {
-    /// The bounds's major version.
+    /// The bound's major version.
     pub major: u32,
-    /// The bounds's minor version.
+    /// The bound's minor version.
     pub minor: Option<u32>,
-    /// The bounds's patch version. Can only be present if minor is too.
+    /// The bound's patch version. Can only be present if minor is too.
     pub patch: Option<u32>,
 }
 
@@ -549,6 +601,95 @@ impl<'de> Deserialize<'de> for VersionBound {
     }
 }
 
+/// A version bound for compatibility specification.
+///
+/// This always refers to the latest supported patch version because
+/// patch versions.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct PreferredCompilerVersion {
+    /// The bound's major version.
+    pub major: u32,
+    /// The bound's minor version.
+    pub minor: u32,
+}
+
+impl PreferredCompilerVersion {
+    /// Creates a preferred version for the current compiler version.
+    pub fn current() -> Self {
+        let compiler = typst_utils::version();
+        Self { major: compiler.major(), minor: compiler.minor() }
+    }
+}
+
+impl PreferredCompilerVersion {
+    /// Whether this version should support string interpolation.
+    pub fn string_interpolation(&self) -> bool {
+        *self >= Self { major: 0, minor: 15 }
+    }
+}
+
+impl Default for PreferredCompilerVersion {
+    fn default() -> Self {
+        Self::current()
+    }
+}
+
+impl FromStr for PreferredCompilerVersion {
+    type Err = EcoString;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut parts = s.split('.');
+        let mut next = |kind| {
+            if let Some(part) = parts.next() {
+                part.parse::<u32>().map(Some).map_err(|_| {
+                    eco_format!("`{part}` is not a valid {kind} version bound")
+                })
+            } else {
+                Ok(None)
+            }
+        };
+
+        let major = next("major")?.ok_or_else(|| {
+            eco_format!("preferred version bound is missing major version")
+        })?;
+        let minor = next("minor")?.ok_or_else(|| {
+            eco_format!("preferred version bound is missing a minor version")
+        })?;
+        if let Some(rest) = parts.next() {
+            Err(eco_format!(
+                "preferred version bound has unexpected third component: `{rest}`"
+            ))?;
+        }
+
+        Ok(Self { major, minor })
+    }
+}
+
+impl Debug for PreferredCompilerVersion {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl Display for PreferredCompilerVersion {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}.{}", self.major, self.minor)
+    }
+}
+
+impl Serialize for PreferredCompilerVersion {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for PreferredCompilerVersion {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let string = EcoString::deserialize(d)?;
+        string.parse().map_err(serde::de::Error::custom)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
@@ -589,6 +730,73 @@ mod tests {
                     PackageVersion { major: 0, minor: 1, patch: 0 },
                     "src/lib.typ"
                 ),
+                template: None,
+                tool: ToolInfo { sections: BTreeMap::new() },
+                unknown_fields: BTreeMap::new(),
+            })
+        );
+    }
+
+    #[test]
+    fn compiler_inline_version() {
+        assert_eq!(
+            toml::from_str::<PackageManifest>(
+                r#"
+                [package]
+                name = "package"
+                version = "0.1.0"
+                entrypoint = "src/lib.typ"
+                compiler = "0.14.0"
+            "#
+            ),
+            Ok(PackageManifest {
+                package: PackageInfo {
+                    compiler: Some(CompilerVersion::Minimum(VersionBound {
+                        major: 0,
+                        minor: Some(14),
+                        patch: Some(0),
+                    })),
+                    ..PackageInfo::new(
+                        "package",
+                        PackageVersion { major: 0, minor: 1, patch: 0 },
+                        "src/lib.typ"
+                    )
+                },
+                template: None,
+                tool: ToolInfo { sections: BTreeMap::new() },
+                unknown_fields: BTreeMap::new(),
+            })
+        );
+    }
+
+    #[test]
+    fn compiler_compatibility_vesion() {
+        assert_eq!(
+            toml::from_str::<PackageManifest>(
+                r#"
+                [package]
+                name = "package"
+                version = "0.1.0"
+                entrypoint = "src/lib.typ"
+                compiler = { minimum = "0.14.0", preferred = "0.13" }
+            "#
+            ),
+            Ok(PackageManifest {
+                package: PackageInfo {
+                    compiler: Some(CompilerVersion::Compatibility {
+                        minimum: VersionBound {
+                            major: 0,
+                            minor: Some(14),
+                            patch: Some(0),
+                        },
+                        preferred: PreferredCompilerVersion { major: 0, minor: 13 },
+                    }),
+                    ..PackageInfo::new(
+                        "package",
+                        PackageVersion { major: 0, minor: 1, patch: 0 },
+                        "src/lib.typ"
+                    )
+                },
                 template: None,
                 tool: ToolInfo { sections: BTreeMap::new() },
                 unknown_fields: BTreeMap::new(),

--- a/crates/typst-syntax/src/package.rs
+++ b/crates/typst-syntax/src/package.rs
@@ -130,9 +130,9 @@ pub struct PackageInfo {
     /// package is useful.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub disciplines: Vec<EcoString>,
-    /// The minimum required compiler version for the package.
+    /// The compiler version(s) for the package.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub compiler: Option<VersionBound>,
+    pub compiler: Option<CompilerVersion>,
     /// An array of globs specifying files that should not be part of the
     /// published bundle.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -140,6 +140,26 @@ pub struct PackageInfo {
     /// All parsed but unknown fields, this can be used for validation.
     #[serde(flatten, skip_serializing)]
     pub unknown_fields: UnknownFields,
+}
+
+/// The `package.compiler` key in the manifest.
+///
+/// This may be represented as a version directly, or as a table of two
+/// versions.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CompilerVersion {
+    /// The minimum required version of the compiler for a package.
+    Minimum(VersionBound),
+
+    /// A compound version bound containing the minimum required and preferred version.
+    Compatibility {
+        /// The minimum required version of the compiler for a package.
+        minimum: VersionBound,
+
+        /// The preferred version of the compiler for a package.
+        preferred: PreferredCompilerVersion,
+    },
 }
 
 impl PackageManifest {
@@ -169,9 +189,31 @@ impl PackageManifest {
             ));
         }
 
-        if let Some(required) = self.package.compiler {
+        if let Some(compiler_version) = self.package.compiler.as_ref() {
+            let required = match compiler_version {
+                CompilerVersion::Minimum(minimum) => minimum,
+                CompilerVersion::Compatibility { minimum, preferred } => {
+                    // NOTE: We don't use PackageVersion here because we don't
+                    // know which patch version best represents the preferred
+                    // bound and want to avoid confusing diagnostics.
+                    if !(minimum.major < preferred.major
+                        || (minimum.major == preferred.major
+                            && minimum
+                                .minor
+                                .is_some_and(|minimum| minimum <= preferred.minor)))
+                    {
+                        return Err(eco_format!(
+                            "package requires Typst {minimum} or newer, but \
+                             prefers Typst {preferred}, which is lower"
+                        ));
+                    }
+
+                    minimum
+                }
+            };
+
             let current = PackageVersion::compiler();
-            if !current.matches_ge(&required) {
+            if !current.matches_ge(required) {
                 return Err(eco_format!(
                     "package requires Typst {required} or newer \
                      (current version is {current})"
@@ -217,6 +259,16 @@ impl PackageInfo {
             license: None,
             repository: None,
             unknown_fields: BTreeMap::new(),
+        }
+    }
+}
+
+impl CompilerVersion {
+    /// The minimum required compiler version.
+    pub fn minimum(&self) -> VersionBound {
+        match self {
+            CompilerVersion::Minimum(minimum)
+            | CompilerVersion::Compatibility { minimum, .. } => *minimum,
         }
     }
 }
@@ -482,11 +534,11 @@ impl<'de> Deserialize<'de> for PackageVersion {
 /// A version bound for compatibility specification.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct VersionBound {
-    /// The bounds's major version.
+    /// The bound's major version.
     pub major: u32,
-    /// The bounds's minor version.
+    /// The bound's minor version.
     pub minor: Option<u32>,
-    /// The bounds's patch version. Can only be present if minor is too.
+    /// The bound's patch version. Can only be present if minor is too.
     pub patch: Option<u32>,
 }
 
@@ -549,6 +601,87 @@ impl<'de> Deserialize<'de> for VersionBound {
     }
 }
 
+/// A version bound for compatibility specification.
+///
+/// This always refers to the latest supported patch version.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct PreferredCompilerVersion {
+    /// The bound's major version.
+    pub major: u32,
+    /// The bound's minor version.
+    pub minor: u32,
+}
+
+impl PreferredCompilerVersion {
+    /// Creates a preferred version for the current compiler version.
+    pub fn current() -> Self {
+        let compiler = typst_utils::version();
+        Self { major: compiler.major(), minor: compiler.minor() }
+    }
+}
+
+impl Default for PreferredCompilerVersion {
+    fn default() -> Self {
+        Self::current()
+    }
+}
+
+impl FromStr for PreferredCompilerVersion {
+    type Err = EcoString;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut parts = s.split('.');
+        let mut next = |kind| {
+            if let Some(part) = parts.next() {
+                part.parse::<u32>().map(Some).map_err(|_| {
+                    eco_format!("`{part}` is not a valid {kind} version bound")
+                })
+            } else {
+                Ok(None)
+            }
+        };
+
+        let major = next("major")?.ok_or_else(|| {
+            eco_format!("preferred version bound is missing major version")
+        })?;
+        let minor = next("minor")?.ok_or_else(|| {
+            eco_format!("preferred version bound is missing a minor version")
+        })?;
+        if let Some(rest) = parts.next() {
+            Err(eco_format!(
+                "preferred version bound has unexpected third component: `{rest}`"
+            ))?;
+        }
+
+        Ok(Self { major, minor })
+    }
+}
+
+impl Debug for PreferredCompilerVersion {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl Display for PreferredCompilerVersion {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}.{}", self.major, self.minor)
+    }
+}
+
+impl Serialize for PreferredCompilerVersion {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for PreferredCompilerVersion {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let string = EcoString::deserialize(d)?;
+        string.parse().map_err(serde::de::Error::custom)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
@@ -593,6 +726,119 @@ mod tests {
                 tool: ToolInfo { sections: BTreeMap::new() },
                 unknown_fields: BTreeMap::new(),
             })
+        );
+    }
+
+    #[test]
+    fn compiler_inline_version() {
+        assert_eq!(
+            toml::from_str::<PackageManifest>(
+                r#"
+                [package]
+                name = "package"
+                version = "0.1.0"
+                entrypoint = "src/lib.typ"
+                compiler = "0.14.0"
+            "#
+            ),
+            Ok(PackageManifest {
+                package: PackageInfo {
+                    compiler: Some(CompilerVersion::Minimum(VersionBound {
+                        major: 0,
+                        minor: Some(14),
+                        patch: Some(0),
+                    })),
+                    ..PackageInfo::new(
+                        "package",
+                        PackageVersion { major: 0, minor: 1, patch: 0 },
+                        "src/lib.typ"
+                    )
+                },
+                template: None,
+                tool: ToolInfo { sections: BTreeMap::new() },
+                unknown_fields: BTreeMap::new(),
+            })
+        );
+    }
+
+    #[test]
+    fn compiler_compatibility_vesion() {
+        assert_eq!(
+            toml::from_str::<PackageManifest>(
+                r#"
+                [package]
+                name = "package"
+                version = "0.1.0"
+                entrypoint = "src/lib.typ"
+                compiler = { minimum = "0.14.0", preferred = "0.13" }
+            "#
+            ),
+            Ok(PackageManifest {
+                package: PackageInfo {
+                    compiler: Some(CompilerVersion::Compatibility {
+                        minimum: VersionBound {
+                            major: 0,
+                            minor: Some(14),
+                            patch: Some(0),
+                        },
+                        preferred: PreferredCompilerVersion { major: 0, minor: 13 },
+                    }),
+                    ..PackageInfo::new(
+                        "package",
+                        PackageVersion { major: 0, minor: 1, patch: 0 },
+                        "src/lib.typ"
+                    )
+                },
+                template: None,
+                tool: ToolInfo { sections: BTreeMap::new() },
+                unknown_fields: BTreeMap::new(),
+            })
+        );
+    }
+
+    #[test]
+    fn validate() {
+        let manifest = toml::from_str::<PackageManifest>(
+            r#"
+                [package]
+                name = "package"
+                version = "0.1.0"
+                entrypoint = "src/lib.typ"
+                compiler = { minimum = "0.14.0", preferred = "0.15" }
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            manifest.validate(&PackageSpec {
+                namespace: "preview".into(),
+                name: "package".into(),
+                version: PackageVersion { major: 0, minor: 1, patch: 0 },
+            }),
+            Ok(()),
+        );
+    }
+
+    #[test]
+    fn validate_compiler_versions_invalid() {
+        let manifest = toml::from_str::<PackageManifest>(
+            r#"
+                [package]
+                name = "package"
+                version = "0.1.0"
+                entrypoint = "src/lib.typ"
+                compiler = { minimum = "0.14.0", preferred = "0.12" }
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            manifest.validate(&PackageSpec {
+                namespace: "preview".into(),
+                name: "package".into(),
+                version: PackageVersion { major: 0, minor: 1, patch: 0 },
+            }),
+            Err("package requires Typst 0.14.0 or newer, but prefers Typst 0.12, which is lower".into()),
         );
     }
 

--- a/crates/typst-syntax/src/path.rs
+++ b/crates/typst-syntax/src/path.rs
@@ -80,6 +80,13 @@ pub enum VirtualRoot {
     Package(PackageSpec),
 }
 
+impl VirtualRoot {
+    /// Joins the given `path` to this root.
+    pub fn join(&self, path: impl AsRef<str>) -> Result<RootedPath, PathError> {
+        VirtualPath::new(path).map(|path| RootedPath::new(self.clone(), path))
+    }
+}
+
 /// The global interner for rooted paths.
 static INTERNER: LazyLock<RwLock<Interner>> = LazyLock::new(|| {
     RwLock::new(Interner { to_id: FxHashMap::default(), from_id: Vec::new() })

--- a/docs/src/example.rs
+++ b/docs/src/example.rs
@@ -16,7 +16,9 @@ use typst::layout::{
     Transform,
 };
 use typst::loading::{DataSource, LoadSource, Loaded};
-use typst::syntax::{FileId, RangeMapper, Source, Span, Spanned};
+use typst::syntax::{
+    FileId, PreferredCompilerVersion, RangeMapper, Source, Span, Spanned, VirtualRoot,
+};
 use typst::text::{Font, FontBook, RawContent, RawElem};
 use typst::visualize::{
     Curve, ImageElem, ImageFormat, PixelEncoding, PixelFormat, RasterFormat,
@@ -291,6 +293,13 @@ impl World for ExampleWorld {
         }
 
         Err(FileError::NotFound(id.vpath().get_without_slash().into()))
+    }
+
+    fn preferred_version(
+        &self,
+        _root: &VirtualRoot,
+    ) -> FileResult<PreferredCompilerVersion> {
+        Ok(PreferredCompilerVersion::default())
     }
 
     fn font(&self, index: usize) -> Option<Font> {

--- a/docs/src/world.rs
+++ b/docs/src/world.rs
@@ -13,7 +13,7 @@ use typst::foundations::{
 use typst::introspection::{EmptyIntrospector, MetadataElem};
 use typst::model::{Destination, EarlyLinkResolver, LinkElem, ResolvedLink};
 use typst::routines::SpanMode;
-use typst::syntax::package::{PackageSpec, PackageVersion};
+use typst::syntax::package::{PackageSpec, PackageVersion, PreferredCompilerVersion};
 use typst::syntax::{
     FileId, RangeMapper, RootedPath, Source, Spanned, SyntaxMode, VirtualPath,
     VirtualRoot,
@@ -105,6 +105,13 @@ impl World for DocWorld {
 
     fn file(&self, id: FileId) -> FileResult<Bytes> {
         self.files.file(id)
+    }
+
+    fn preferred_version(
+        &self,
+        root: &VirtualRoot,
+    ) -> FileResult<PreferredCompilerVersion> {
+        self.files.preferred_version(root)
     }
 
     fn font(&self, index: usize) -> Option<Font> {

--- a/tests/fuzz/src/lib.rs
+++ b/tests/fuzz/src/lib.rs
@@ -1,9 +1,10 @@
 use typst::diag::{FileError, FileResult};
 use typst::foundations::{Bytes, Datetime, Duration};
-use typst::syntax::{FileId, Source};
+use typst::syntax::{FileId, PreferredCompilerVersion, Source};
 use typst::text::{Font, FontBook};
 use typst::utils::LazyHash;
 use typst::{Library, LibraryExt, World};
+use typst_syntax::VirtualRoot;
 
 pub struct FuzzWorld {
     library: LazyHash<Library>,
@@ -49,6 +50,13 @@ impl World for FuzzWorld {
 
     fn file(&self, id: FileId) -> FileResult<Bytes> {
         Err(FileError::NotFound(id.vpath().get_without_slash().into()))
+    }
+
+    fn preferred_version(
+        &self,
+        _root: &VirtualRoot,
+    ) -> FileResult<PreferredCompilerVersion> {
+        Ok(PreferredCompilerVersion::current())
     }
 
     fn font(&self, _: usize) -> Option<Font> {

--- a/tests/packages/compat-minimum-0.1.0/lib.typ
+++ b/tests/packages/compat-minimum-0.1.0/lib.typ
@@ -1,0 +1,2 @@
+#let preferred = compiler-preferred-version()
+#let preferred-deferred = () => compiler-preferred-version()

--- a/tests/packages/compat-minimum-0.1.0/typst.toml
+++ b/tests/packages/compat-minimum-0.1.0/typst.toml
@@ -1,0 +1,5 @@
+[package]
+name = "compat-minimum"
+version = "0.1.0"
+entrypoint = "lib.typ"
+compiler = "0.14.0"

--- a/tests/packages/compat-none-0.1.0/lib.typ
+++ b/tests/packages/compat-none-0.1.0/lib.typ
@@ -1,0 +1,2 @@
+#let preferred = compiler-preferred-version()
+#let preferred-deferred = () => compiler-preferred-version()

--- a/tests/packages/compat-none-0.1.0/typst.toml
+++ b/tests/packages/compat-none-0.1.0/typst.toml
@@ -1,0 +1,4 @@
+[package]
+name = "compat-none"
+version = "0.1.0"
+entrypoint = "lib.typ"

--- a/tests/packages/compat-preferred-0.1.0/lib.typ
+++ b/tests/packages/compat-preferred-0.1.0/lib.typ
@@ -1,0 +1,2 @@
+#let preferred = compiler-preferred-version()
+#let preferred-deferred = () => compiler-preferred-version()

--- a/tests/packages/compat-preferred-0.1.0/typst.toml
+++ b/tests/packages/compat-preferred-0.1.0/typst.toml
@@ -1,0 +1,6 @@
+[package]
+name = "compat-preferred"
+version = "0.1.0"
+entrypoint = "lib.typ"
+compiler.minimum = "0.14.0"
+compiler.preferred = "0.15"

--- a/tests/src/collect.rs
+++ b/tests/src/collect.rs
@@ -9,7 +9,7 @@ use ecow::EcoString;
 use rustc_hash::{FxHashMap, FxHashSet};
 use typst::foundations::Target;
 use typst_pdf::PdfStandard;
-use typst_syntax::{is_id_continue, is_ident, is_newline};
+use typst_syntax::{PreferredCompilerVersion, is_id_continue, is_ident, is_newline};
 use unscanny::Scanner;
 
 use crate::notes::{TestBody, parse_test_body};
@@ -101,6 +101,7 @@ pub struct Attrs {
     /// to increase it. This can for example happen due to cross-platform
     /// differences in float and SIMD handling.
     pub tolerance: Option<u8>,
+    pub compat: PreferredCompilerVersion,
     /// The test stages that are either directly specified or are implied by a
     /// test attribute. If not specified otherwise by the `--stages` flag a
     /// reference output will be generated.
@@ -689,6 +690,7 @@ impl<'a> Parser<'a> {
         let mut flags = AttrFlags::empty();
         let mut pdf_standard = Vec::new();
         let mut tolerance = None;
+        let mut compat = None;
 
         while !self.s.eat_if("---") {
             let attr_name = self.s.eat_while(is_id_continue);
@@ -737,6 +739,16 @@ impl<'a> Parser<'a> {
                         _ => self.error("expected integer for `tolerance`"),
                     }
                 }
+                "compat" => {
+                    let Some(param) = attr_params.take() else {
+                        self.error("expected parameter for `compat`");
+                        continue;
+                    };
+                    match param.parse::<PreferredCompilerVersion>() {
+                        Ok(value) => compat = Some(value),
+                        _ => self.error("expected integer for `compat`"),
+                    }
+                }
                 "html" => self.set_attr(attr_name, &mut stages, TestStages::HTML),
                 "bundle" => self.set_attr(attr_name, &mut stages, TestStages::BUNDLE),
                 "large" => self.set_attr(attr_name, &mut flags, AttrFlags::LARGE),
@@ -778,6 +790,7 @@ impl<'a> Parser<'a> {
             pdf_standard,
             stages,
             tolerance,
+            compat: compat.unwrap_or_default(),
         }
     }
 

--- a/tests/src/run.rs
+++ b/tests/src/run.rs
@@ -122,7 +122,7 @@ impl UnexpectedEmpty {
 impl<'a> Runner<'a> {
     /// Create a new test runner.
     fn new(hashes: &'a [RwLock<HashedRefs>], test: &'a mut Test) -> Self {
-        let world = TestWorld::new(test.body.source.clone());
+        let world = TestWorld::new(test.body.source.clone(), test.attrs.compat);
         Self {
             hashes,
             test,

--- a/tests/src/world.rs
+++ b/tests/src/world.rs
@@ -21,7 +21,7 @@ use typst::{Features, Library, LibraryExt, World};
 use typst_kit::datetime::Time;
 use typst_kit::files::{FileLoader, FileStore};
 use typst_layout::layout_fragment;
-use typst_syntax::package::PackageSpec;
+use typst_syntax::package::{PackageSpec, PreferredCompilerVersion};
 use typst_syntax::{RootedPath, VirtualPath, VirtualRoot};
 use unscanny::Scanner;
 
@@ -72,6 +72,13 @@ impl World for TestWorld {
         } else {
             self.base.files.file(id)
         }
+    }
+
+    fn preferred_version(
+        &self,
+        _root: &VirtualRoot,
+    ) -> FileResult<PreferredCompilerVersion> {
+        Ok(PreferredCompilerVersion::default())
     }
 
     fn font(&self, index: usize) -> Option<Font> {

--- a/tests/src/world.rs
+++ b/tests/src/world.rs
@@ -8,7 +8,7 @@ use typst::diag::{At, FileError, FileResult, SourceResult, StrResult, bail};
 use typst::engine::Engine;
 use typst::foundations::{
     Array, Bytes, Content, Context, Datetime, Duration, IntoValue, NativeElement,
-    NoneValue, Packed, Repr, Smart, StyleChain, Value, elem, func,
+    NoneValue, Packed, Repr, Smart, StyleChain, Value, Version, elem, func,
 };
 use typst::introspection::Locator;
 use typst::layout::{Abs, BlockElem, Fragment, Margin, PageElem, Regions};
@@ -21,7 +21,7 @@ use typst::{Features, Library, LibraryExt, World};
 use typst_kit::datetime::Time;
 use typst_kit::files::{FileLoader, FileStore};
 use typst_layout::layout_fragment;
-use typst_syntax::package::PackageSpec;
+use typst_syntax::package::{PackageSpec, PreferredCompilerVersion};
 use typst_syntax::{RootedPath, VirtualPath, VirtualRoot};
 use unscanny::Scanner;
 
@@ -30,6 +30,7 @@ use unscanny::Scanner;
 pub struct TestWorld {
     main: Source,
     base: &'static TestBase,
+    prefered_version: PreferredCompilerVersion,
 }
 
 impl TestWorld {
@@ -37,10 +38,11 @@ impl TestWorld {
     ///
     /// This is cheap because the shared base for all test runs is lazily
     /// initialized just once.
-    pub fn new(source: Source) -> Self {
+    pub fn new(source: Source, prefered_version: PreferredCompilerVersion) -> Self {
         Self {
             main: source,
             base: singleton!(TestBase, TestBase::default()),
+            prefered_version,
         }
     }
 }
@@ -71,6 +73,17 @@ impl World for TestWorld {
             Ok(Bytes::from_string(self.main.clone()))
         } else {
             self.base.files.file(id)
+        }
+    }
+
+    fn preferred_version(
+        &self,
+        root: &VirtualRoot,
+    ) -> FileResult<PreferredCompilerVersion> {
+        if root == self.main.id().root() {
+            Ok(self.prefered_version)
+        } else {
+            self.base.files.preferred_version(root)
         }
     }
 
@@ -174,6 +187,8 @@ fn library() -> Library {
     let mut lib = Library::builder().with_features(Features::all()).build();
 
     // Hook up helpers into the global scope.
+    lib.global.scope_mut().define_func::<compiler_preferred_version>();
+    lib.global.scope_mut().define_func::<compiler_current_version>();
     lib.global.scope_mut().define_func::<test>();
     lib.global.scope_mut().define_func::<test_repr>();
     lib.global.scope_mut().define_func::<print>();
@@ -196,6 +211,24 @@ fn library() -> Library {
     lib.styles.set(TextElem::size, TextSize(Abs::pt(10.0).into()));
 
     lib
+}
+
+#[func]
+fn compiler_preferred_version(engine: &mut Engine) -> StrResult<Version> {
+    let preferred = engine.route.preferred_version();
+    let mut version = Version::new();
+    version.push(preferred.major);
+    version.push(preferred.minor);
+    Ok(version)
+}
+
+#[func]
+fn compiler_current_version() -> StrResult<Version> {
+    let preferred = PreferredCompilerVersion::current();
+    let mut version = Version::new();
+    version.push(preferred.major);
+    version.push(preferred.minor);
+    Ok(version)
 }
 
 #[func]

--- a/tests/suite/scripting/closure.typ
+++ b/tests/suite/scripting/closure.typ
@@ -26,6 +26,13 @@
   test(h(2), 5)
 }
 
+--- closure-compat eval ---
+// The closure from the package receives the same preferred version as the
+// package. Use an explicit version here to ensure we're not accidentally
+// using the current one for both.
+#import "@test/compat-preferred:0.1.0": preferred, preferred-deferred
+#test(preferred, preferred-deferred())
+
 --- closure-capture-from-popped-stack-frame eval ---
 // Capture environment.
 #{

--- a/tests/suite/scripting/import.typ
+++ b/tests/suite/scripting/import.typ
@@ -435,6 +435,22 @@ This is never reached.
 #import "@test/adder:0.1.0": add
 #test(add(2, 8), 10)
 
+--- import-from-package-no-compat eval ---
+// Test import with no compatibility. If none is given the current one is used.
+#import "@test/compat-none:0.1.0": preferred
+#test(preferred, compiler-current-version())
+
+--- import-from-package-implicit-compat eval ---
+// Test import with implicit compatibility. If only a minimum is given the
+// minimum is used as preferred too.
+#import "@test/compat-minimum:0.1.0": preferred
+#test(preferred, version(0, 14))
+
+--- import-from-package-explicit-compat eval ---
+// Test import with explicit compatibility.
+#import "@test/compat-preferred:0.1.0": preferred
+#test(preferred, version(0, 15))
+
 --- import-from-package-required-compiler-version eval ---
 // Test too high required compiler version.
 // Error: 9-29 package requires Typst 1.0.0 or newer (current version is VERSION)


### PR DESCRIPTION
While this has currently no effect, it allows packages to already set a preferred compiler version before any breaking changes are introduced. This is integral for initial adoption of the compatibility feature, as introducing it with the breaking change would constitute a chicken and egg problem.

Consider a package targeting Typst 0.14, if Typst introduced a breaking change and the new manifest format in 0.15, then the package could not set the preferred compiler version to 0.14 without breaking itself for 0.14 also.

This would make it effectively a 0.15.0 targeting package without being able to use the new feature.