### PR TITLE
Extend IDE functionality to user-defined functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3162,6 +3162,7 @@ dependencies = [
  "comemo",
  "csv",
  "ecow",
+ "either",
  "flate2",
  "fontdb",
  "glidesort",

--- a/crates/typst-html/src/typed.rs
+++ b/crates/typst-html/src/typed.rs
@@ -15,7 +15,7 @@ use typst_library::diag::{At, Hint, HintedStrResult, SourceResult, bail};
 use typst_library::engine::Engine;
 use typst_library::foundations::{
     Args, Array, AutoValue, CastInfo, Content, Context, Datetime, Dict, Duration,
-    FromValue, IntoValue, NativeFuncData, NativeFuncPtr, NoneValue, ParamInfo,
+    FromValue, IntoValue, NativeFuncData, NativeFuncPtr, NativeParamInfo, NoneValue,
     PositiveF64, Reflect, Scope, Str, Type, Value,
 };
 use typst_library::layout::{Axes, Axis, Dir, Length};
@@ -68,10 +68,10 @@ fn create_func_data(
 }
 
 /// Creates parameter signature metadata for an element.
-fn create_param_info(element: &'static data::ElemInfo) -> Vec<ParamInfo> {
+fn create_param_info(element: &'static data::ElemInfo) -> Vec<NativeParamInfo> {
     let mut params = vec![];
     for attr in element.attributes() {
-        params.push(ParamInfo {
+        params.push(NativeParamInfo {
             name: attr.name,
             docs: attr.docs,
             input: AttrType::convert(attr.ty).input(),
@@ -86,7 +86,7 @@ fn create_param_info(element: &'static data::ElemInfo) -> Vec<ParamInfo> {
     let tag = HtmlTag::constant(element.name);
     if !tag::is_void(tag) {
         let raw = tag::is_raw(tag);
-        params.push(ParamInfo {
+        params.push(NativeParamInfo {
             name: "body",
             docs: if raw {
                 "The text content of the HTML element."

--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -19,9 +19,9 @@ use typst::visualize::Color;
 use typst::{AsDocument, Document};
 use unscanny::Scanner;
 
-use crate::utils::{
-    check_value_recursively, globals, plain_docs_sentence, summarize_font_family,
-};
+use crate::analyze::analyze_expr_with_fallback;
+use crate::docs::{find_param_docs, find_value_docs};
+use crate::utils::{check_value_recursively, globals, summarize_font_family};
 use crate::{IdeWorld, analyze_expr, analyze_import, analyze_labels, named_items};
 
 /// Autocomplete a cursor position in a source file.
@@ -427,10 +427,8 @@ fn field_access_completions(
     // those which have a `self` parameter.
     for (name, binding) in scopes.flat_map(|scope| scope.iter()) {
         let Ok(func) = binding.read().clone().cast::<Func>() else { continue };
-        if func
-            .params()
-            .and_then(|params| params.first())
-            .is_some_and(|param| param.name == "self")
+        if let Some(param) = func.params().next()
+            && param.name() == Some("self")
         {
             ctx.call_completion(name.clone(), binding.read());
         }
@@ -615,10 +613,7 @@ fn set_rule_completions(ctx: &mut CompletionContext) {
     ctx.scope_completions(true, |value| {
         matches!(
             value,
-            Value::Func(func) if func.params()
-                .unwrap_or_default()
-                .iter()
-                .any(|param| param.settable),
+            Value::Func(func) if func.params().any(|param| param.settable())
         )
     });
 }
@@ -684,7 +679,9 @@ fn complete_params(ctx: &mut CompletionContext) -> bool {
             ast::Expr::FuncCall(call) => Some(call.callee()),
             ast::Expr::SetRule(set) => Some(set.target()),
             _ => None,
-        } {
+        }
+        && let Some(callee) = grand.find(callee.span())
+    {
         (callee, set, args, parent)
     } else {
         return false;
@@ -712,7 +709,7 @@ fn complete_params(ctx: &mut CompletionContext) -> bool {
             ctx.from = ctx.cursor.min(next.offset());
         }
 
-        named_param_value_completions(ctx, callee, &param);
+        named_param_value_completions(ctx, &callee, &param);
         return true;
     }
 
@@ -726,7 +723,7 @@ fn complete_params(ctx: &mut CompletionContext) -> bool {
             ctx.from = ctx.cursor.min(next.offset());
         }
 
-        param_completions(ctx, callee, set, args, args_linked);
+        param_completions(ctx, &callee, set, args, args_linked);
         return true;
     }
 
@@ -736,13 +733,13 @@ fn complete_params(ctx: &mut CompletionContext) -> bool {
 /// Add completions for the parameters of a function.
 fn param_completions<'a>(
     ctx: &mut CompletionContext<'a>,
-    callee: ast::Expr<'a>,
+    callee: &LinkedNode<'a>,
     set: bool,
     args: ast::Args<'a>,
-    args_linked: &'a LinkedNode<'a>,
+    args_linked: &LinkedNode<'a>,
 ) {
-    let Some(func) = resolve_global_callee(ctx, callee) else { return };
-    let Some(params) = func.params() else { return };
+    let Some(value) = analyze_expr_with_fallback(ctx.world, callee) else { return };
+    let Ok(func) = value.cast::<Func>() else { return };
 
     // Determine which arguments are already present.
     let mut existing_positional = 0;
@@ -763,36 +760,38 @@ fn param_completions<'a>(
     }
 
     let mut skipped_positional = 0;
-    for param in params {
-        if set && !param.settable {
+    for param in func.params() {
+        if set && !param.settable() {
             continue;
         }
 
-        if param.positional {
-            if skipped_positional < existing_positional && !param.variadic {
+        if param.positional() {
+            if skipped_positional < existing_positional && !param.variadic() {
                 skipped_positional += 1;
                 continue;
             }
 
-            param_value_completions(ctx, func, param);
+            param_value_completions(ctx, &func, &param);
         }
 
-        if param.named {
-            if existing_named.contains(&param.name) {
+        if let Some(name) = param.name()
+            && param.named()
+        {
+            if existing_named.contains(name) {
                 continue;
             }
 
-            let apply = if param.name == "caption" {
-                eco_format!("{}: [${{}}]", param.name)
+            let apply = if param.name() == Some("caption") {
+                eco_format!("{name}: [${{}}]")
             } else {
-                eco_format!("{}: ${{}}", param.name)
+                eco_format!("{name}: ${{}}")
             };
 
             ctx.completions.push(Completion {
                 kind: CompletionKind::Param,
-                label: param.name.into(),
+                label: name.into(),
                 apply: Some(apply),
-                detail: Some(plain_docs_sentence(param.docs)),
+                detail: find_param_docs(ctx.world, &param).map(|docs| docs.summary()),
             });
         }
     }
@@ -805,16 +804,18 @@ fn param_completions<'a>(
 /// Add completions for the values of a named function parameter.
 fn named_param_value_completions<'a>(
     ctx: &mut CompletionContext<'a>,
-    callee: ast::Expr<'a>,
+    callee: &LinkedNode,
     name: &str,
 ) {
-    let Some(func) = resolve_global_callee(ctx, callee) else { return };
+    let Some(value) = analyze_expr_with_fallback(ctx.world, callee) else { return };
+    let Ok(func) = value.cast::<Func>() else { return };
+
     let Some(param) = func.param(name) else { return };
-    if !param.named {
+    if !param.named() {
         return;
     }
 
-    param_value_completions(ctx, func, param);
+    param_value_completions(ctx, &func, &param);
 
     if ctx.before.ends_with(':') {
         ctx.enrich(" ", "");
@@ -825,23 +826,25 @@ fn named_param_value_completions<'a>(
 fn param_value_completions<'a>(
     ctx: &mut CompletionContext<'a>,
     func: &Func,
-    param: &'a ParamInfo,
+    param: &ParamInfo,
 ) {
-    if param.name == "font" {
+    if param.name() == Some("font") {
         ctx.font_completions();
     } else if let Some(extensions) = path_completion(func, param) {
         ctx.file_completions_with_extensions(extensions);
-    } else if func.name() == Some("figure") && param.name == "body" {
+    } else if func.name() == Some("figure") && param.name() == Some("body") {
         ctx.snippet_completion("image", "image(\"${}\"),", "An image in a figure.");
         ctx.snippet_completion("table", "table(\n  ${}\n),", "A table in a figure.");
     }
 
-    ctx.cast_completions(&param.input);
+    if let ParamInfo::Native(param) = param {
+        ctx.cast_completions(&param.input);
+    }
 }
 
 /// Returns which file extensions to complete for the given parameter if any.
 fn path_completion(func: &Func, param: &ParamInfo) -> Option<&'static [&'static str]> {
-    Some(match (func.name(), param.name) {
+    Some(match (func.name(), param.name().unwrap_or_default()) {
         (Some("image"), "source") => {
             &["png", "jpg", "jpeg", "gif", "svg", "svgz", "webp", "pdf"]
         }
@@ -862,29 +865,6 @@ fn path_completion(func: &Func, param: &ParamInfo) -> Option<&'static [&'static 
         (None, "path") => &[],
         _ => return None,
     })
-}
-
-/// Resolve a callee expression to a global function.
-fn resolve_global_callee<'a>(
-    ctx: &CompletionContext<'a>,
-    callee: ast::Expr<'a>,
-) -> Option<&'a Func> {
-    let globals = globals(ctx.world, ctx.leaf);
-    let value = match callee {
-        ast::Expr::Ident(ident) => globals.get(&ident)?.read(),
-        ast::Expr::FieldAccess(access) => match access.target() {
-            ast::Expr::Ident(target) => {
-                globals.get(&target)?.read().scope()?.get(&access.field())?.read()
-            }
-            _ => return None,
-        },
-        _ => return None,
-    };
-
-    match value {
-        Value::Func(func) => Some(func),
-        _ => None,
-    }
 }
 
 /// Complete in code mode.
@@ -1348,8 +1328,9 @@ impl<'a> CompletionContext<'a> {
 
         let detail = detail.map(Into::into).or_else(|| match value {
             Value::Symbol(_) => None,
-            Value::Func(func) => func.docs().map(plain_docs_sentence),
-            Value::Type(ty) => Some(plain_docs_sentence(ty.docs())),
+            Value::Func(_) | Value::Type(_) => {
+                find_value_docs(self.world, value).map(|docs| docs.summary())
+            }
             v => {
                 let repr = v.repr();
                 (repr.as_str() != label).then_some(repr)
@@ -1392,7 +1373,7 @@ impl<'a> CompletionContext<'a> {
     }
 
     /// Add completions for a castable.
-    fn cast_completions(&mut self, cast: &'a CastInfo) {
+    fn cast_completions(&mut self, cast: &CastInfo) {
         // Prevent duplicate completions from appearing.
         if !self.seen_casts.insert(typst::utils::hash128(cast)) {
             return;
@@ -1535,10 +1516,9 @@ enum BracketMode {
 
 impl BracketMode {
     fn of(func: &Func) -> Self {
-        if func
-            .params()
-            .is_some_and(|params| params.iter().all(|param| param.name == "self"))
-        {
+        // If we have no parameters or only the self one, it's friendlier to put
+        // the cursor after the method call.
+        if func.params().all(|param| param.name() == Some("self")) {
             return Self::RoundAfter;
         }
 
@@ -1580,8 +1560,7 @@ mod tests {
         fn must_be_empty(&self) -> &Self;
         fn must_include<'a>(&self, includes: impl IntoIterator<Item = &'a str>) -> &Self;
         fn must_exclude<'a>(&self, excludes: impl IntoIterator<Item = &'a str>) -> &Self;
-        fn must_apply<'a>(&self, label: &str, apply: impl Into<Option<&'a str>>)
-        -> &Self;
+        fn at(&self, label: &str) -> &Completion;
     }
 
     impl ResponseExt for Response {
@@ -1631,16 +1610,29 @@ mod tests {
         }
 
         #[track_caller]
-        fn must_apply<'a>(
-            &self,
-            label: &str,
-            apply: impl Into<Option<&'a str>>,
-        ) -> &Self {
-            let Some(completion) = self.completions().iter().find(|c| c.label == label)
-            else {
-                panic!("found no completion for {label:?}");
-            };
-            assert_eq!(completion.apply.as_deref(), apply.into());
+        fn at(&self, label: &str) -> &Completion {
+            self.completions()
+                .iter()
+                .find(|c| c.label == label)
+                .unwrap_or_else(|| panic!("found no completion for {label:?}"))
+        }
+    }
+
+    trait CompletionExt {
+        fn must_apply_as<'a>(&self, apply: impl Into<Option<&'a str>>) -> &Self;
+        fn must_have_detail<'a>(&self, detail: impl Into<Option<&'a str>>) -> &Self;
+    }
+
+    impl CompletionExt for Completion {
+        #[track_caller]
+        fn must_apply_as<'a>(&self, apply: impl Into<Option<&'a str>>) -> &Self {
+            assert_eq!(self.apply.as_deref(), apply.into());
+            self
+        }
+
+        #[track_caller]
+        fn must_have_detail<'a>(&self, detail: impl Into<Option<&'a str>>) -> &Self {
+            assert_eq!(self.detail.as_deref(), detail.into());
             self
         }
     }
@@ -1768,14 +1760,14 @@ mod tests {
     /// on the function and existing parens.
     #[test]
     fn test_autocomplete_bracket_mode() {
-        test("#", 1).must_apply("list", "list(${})");
-        test("#", 1).must_apply("linebreak", "linebreak()${}");
-        test("#", 1).must_apply("strong", "strong[${}]");
-        test("#", 1).must_apply("footnote", "footnote[${}]");
-        test("#", 1).must_apply("figure", "figure(\n  ${}\n)");
-        test("#", 1).must_apply("table", "table(\n  ${}\n)");
-        test("#()", 1).must_apply("list", None);
-        test("#[]", 1).must_apply("strong", None);
+        test("#", 1).at("list").must_apply_as("list(${})");
+        test("#", 1).at("linebreak").must_apply_as("linebreak()${}");
+        test("#", 1).at("strong").must_apply_as("strong[${}]");
+        test("#", 1).at("footnote").must_apply_as("footnote[${}]");
+        test("#", 1).at("figure").must_apply_as("figure(\n  ${}\n)");
+        test("#", 1).at("table").must_apply_as("table(\n  ${}\n)");
+        test("#()", 1).at("list").must_apply_as(None);
+        test("#[]", 1).at("strong").must_apply_as(None);
     }
 
     /// Test that we only complete positional parameters if they aren't
@@ -1851,11 +1843,11 @@ mod tests {
 
     #[test]
     fn test_autocomplete_figure_snippets() {
-        test("#figure()", -2)
-            .must_apply("image", "image(\"${}\"),")
-            .must_apply("table", "table(\n  ${}\n),");
+        let res = test("#figure()", -2);
+        res.at("image").must_apply_as("image(\"${}\"),");
+        res.at("table").must_apply_as("table(\n  ${}\n),");
 
-        test("#figure(cap)", -2).must_apply("caption", "caption: [${}]");
+        test("#figure(cap)", -2).at("caption").must_apply_as("caption: [${}]");
     }
 
     #[test]
@@ -1997,5 +1989,24 @@ mod tests {
         // At destructuring rename pattern source
         test(document, 24).must_be_empty();
         test_implicit(document, 24).must_be_empty();
+    }
+
+    #[test]
+    fn test_autocomplete_user_function() {
+        let world = TestWorld::new("#import \"lib.typ\"\n#lib.")
+            .with_source("lib.typ", crate::tests::EXAMPLE_CLOSURE);
+        let res = test(&world, -1);
+        res.must_include(["foo"]);
+        res.at("foo").must_have_detail("A useful function.");
+    }
+
+    #[test]
+    fn test_autocomplete_user_function_params() {
+        let world = TestWorld::new("#import \"lib.typ\": *\n#foo()")
+            .with_source("lib.typ", crate::tests::EXAMPLE_CLOSURE);
+        let res = test(&world, -2);
+        res.must_include(["forest", "tree"]);
+        res.at("forest").must_have_detail("More trees.");
+        res.at("tree").must_have_detail("Tree with three slashes.");
     }
 }

--- a/crates/typst-ide/src/docs.rs
+++ b/crates/typst-ide/src/docs.rs
@@ -1,0 +1,171 @@
+use std::ops::Deref;
+
+use ecow::EcoString;
+use typst::foundations::{ParamInfo, Value};
+use typst::syntax::{LinkedNode, SyntaxKind, ast};
+
+use crate::IdeWorld;
+
+/// Tries to find documentation for an arbitrary value.
+pub fn find_value_docs(world: &dyn IdeWorld, value: &Value) -> Option<Docs> {
+    if let Some(docs) = value.docs() {
+        return Some(Docs::Native(docs));
+    }
+
+    // Try to find doc comment before a function definition.
+    if let Value::Func(func) = value
+        && let span = func.span()
+        && let Some(id) = span.id()
+        && let Ok(source) = world.source(id)
+        && let Some(args) = source.find(span)
+        && let Some(parent) = args.parent()
+        && parent.kind() == SyntaxKind::Closure
+        && let Some(grand) = parent.parent()
+        && grand.kind() == SyntaxKind::LetBinding
+        && let Some(docs) = Docs::collect_doc_comment(grand.clone())
+    {
+        return Some(docs);
+    }
+
+    None
+}
+
+/// Tries to determine documentation for a parameter.
+pub fn find_param_docs(world: &dyn IdeWorld, param: &ParamInfo) -> Option<Docs> {
+    match param {
+        ParamInfo::Native(param) => Some(Docs::Native(param.docs)),
+        ParamInfo::Closure(param) => {
+            // Try to find doc comment before parameter.
+            if let Some(id) = param.span.id()
+                && let Ok(source) = world.source(id)
+                && let Some(node) = source.find(param.span)
+                && let Some(docs) = Docs::collect_doc_comment(node.clone())
+            {
+                return Some(docs);
+            }
+            None
+        }
+        ParamInfo::Plugin => None,
+    }
+}
+
+/// Documentation for something.
+pub enum Docs {
+    Native(&'static str),
+    Comment(EcoString),
+}
+
+impl Docs {
+    /// Tries to collect the contents of a doc comment before the given node.
+    ///
+    /// Important: This is a pragmatic function that deals with doc comments that
+    /// are currently in use in the ecosystem. It's solely used for best-effort IDE
+    /// functionality.
+    ///
+    /// The presence of this function in typst/typst has *zero* implications on
+    /// standardization of any kind of doc comment format at the language level!
+    pub fn collect_doc_comment(node: LinkedNode) -> Option<Docs> {
+        let mut lines = Vec::new();
+
+        let mut current = node;
+        while let Some(prev) = current.prev_sibling_with_trivia() {
+            if let Some(comment) = prev.get().cast::<ast::LineComment>() {
+                // Triple slash doc comments are pretty common in the ecosystem, so
+                // we strip that extra slash.
+                let text = comment.text();
+                lines.push(text.strip_prefix('/').unwrap_or(text));
+            } else if let Some(comment) = prev.get().cast::<ast::BlockComment>() {
+                lines.push(comment.text());
+            } else if !matches!(prev.kind(), SyntaxKind::Space | SyntaxKind::Hash) {
+                break;
+            }
+            current = prev;
+        }
+
+        if lines.is_empty() {
+            return None;
+        }
+
+        let mut output = EcoString::new();
+        for line in lines.iter().rev() {
+            // Remove up to one leading space for each line.
+            output.push_str(line.strip_prefix(' ').unwrap_or(line));
+            output.push('\n');
+        }
+        output.pop();
+
+        Some(Self::Comment(output))
+    }
+
+    /// Extract the first sentence of plain text of a piece of documentation,
+    /// removing Markdown formatting.
+    ///
+    /// For doc comments, it's unclear whether they contain plain text,
+    /// Markdown, or Typst, but this is okay-ish for now.
+    pub fn summary(&self) -> EcoString {
+        let paragraph = self.split("\n\n").next().unwrap_or_default();
+        let mut s = unscanny::Scanner::new(paragraph);
+        let mut output = EcoString::new();
+        let mut link = false;
+        while let Some(c) = s.eat() {
+            match c {
+                '`' => {
+                    let mut raw = s.eat_until('`');
+                    if (raw.starts_with('{') && raw.ends_with('}'))
+                        || (raw.starts_with('[') && raw.ends_with(']'))
+                    {
+                        raw = &raw[1..raw.len() - 1];
+                    }
+
+                    s.eat();
+                    output.push('`');
+                    output.push_str(raw);
+                    output.push('`');
+                }
+                '[' => link = true,
+                ']' if link => {
+                    if s.eat_if('(') {
+                        s.eat_until(')');
+                        s.eat();
+                    } else if s.eat_if('[') {
+                        s.eat_until(']');
+                        s.eat();
+                    }
+                    link = false
+                }
+                '*' | '_' => {}
+                '.' => {
+                    output.push('.');
+                    // Avoid stopping on things like `See foo.bar.` or `e.g.`.
+                    if (s.done() || s.at(char::is_whitespace)) && s.scout(-3) != Some('.')
+                    {
+                        break;
+                    }
+                }
+                _ => output.push(c),
+            }
+        }
+
+        output
+    }
+}
+
+impl Deref for Docs {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Native(s) => s,
+            Self::Comment(s) => s,
+        }
+    }
+}
+
+impl From<Docs> for EcoString {
+    fn from(docs: Docs) -> Self {
+        match docs {
+            Docs::Native(s) => s.into(),
+            Docs::Comment(s) => s,
+        }
+    }
+}

--- a/crates/typst-ide/src/lib.rs
+++ b/crates/typst-ide/src/lib.rs
@@ -3,6 +3,7 @@
 mod analyze;
 mod complete;
 mod definition;
+mod docs;
 mod jump;
 mod matchers;
 mod tooltip;

--- a/crates/typst-ide/src/tests.rs
+++ b/crates/typst-ide/src/tests.rs
@@ -242,3 +242,19 @@ fn cursor(source: &Source, cursor: isize) -> usize {
         cursor as usize
     }
 }
+
+/// A test function that is used in autocomplete & tooltip tests.
+pub const EXAMPLE_CLOSURE: &str = "
+// A *useful* function.
+//
+// With extra text.
+#let foo(
+    wood,
+    /// Tree with three slashes.
+    tree: 1,
+    // More *trees*.
+    //
+    // More information, $1+2$.
+    forest: rgb(\"#123\"),
+) = (wood * tree, forest)
+";

--- a/crates/typst-ide/src/utils.rs
+++ b/crates/typst-ide/src/utils.rs
@@ -32,51 +32,6 @@ where
     f(&mut engine)
 }
 
-/// Extract the first sentence of plain text of a piece of documentation.
-///
-/// Removes Markdown formatting.
-pub fn plain_docs_sentence(docs: &str) -> EcoString {
-    let mut s = unscanny::Scanner::new(docs);
-    let mut output = EcoString::new();
-    let mut link = false;
-    while let Some(c) = s.eat() {
-        match c {
-            '`' => {
-                let mut raw = s.eat_until('`');
-                if (raw.starts_with('{') && raw.ends_with('}'))
-                    || (raw.starts_with('[') && raw.ends_with(']'))
-                {
-                    raw = &raw[1..raw.len() - 1];
-                }
-
-                s.eat();
-                output.push('`');
-                output.push_str(raw);
-                output.push('`');
-            }
-            '[' => link = true,
-            ']' if link => {
-                if s.eat_if('(') {
-                    s.eat_until(')');
-                    s.eat();
-                } else if s.eat_if('[') {
-                    s.eat_until(']');
-                    s.eat();
-                }
-                link = false
-            }
-            '*' | '_' => {}
-            '.' => {
-                output.push('.');
-                break;
-            }
-            _ => output.push(c),
-        }
-    }
-
-    output
-}
-
 /// Create a short description of a font family.
 pub fn summarize_font_family(mut variants: Vec<&FontInfo>) -> EcoString {
     variants.sort_by_key(|info| info.variant);

--- a/crates/typst-library/Cargo.toml
+++ b/crates/typst-library/Cargo.toml
@@ -28,6 +28,7 @@ codex = { workspace = true }
 comemo = { workspace = true }
 csv = { workspace = true }
 ecow = { workspace = true }
+either = { workspace = true }
 flate2 = { workspace = true }
 fontdb = { workspace = true }
 glidesort = { workspace = true }

--- a/crates/typst-library/src/foundations/content/element.rs
+++ b/crates/typst-library/src/foundations/content/element.rs
@@ -11,7 +11,7 @@ use typst_utils::Static;
 use crate::diag::SourceResult;
 use crate::engine::Engine;
 use crate::foundations::{
-    Args, Content, ContentVtable, FieldAccessError, Func, ParamInfo, Repr, Scope,
+    Args, Content, ContentVtable, FieldAccessError, Func, NativeParamInfo, Repr, Scope,
     Selector, StyleChain, Styles, Value, cast,
 };
 use crate::text::{Lang, Region};
@@ -99,13 +99,13 @@ impl Element {
     }
 
     /// Details about the element's fields.
-    pub fn params(&self) -> &'static [ParamInfo] {
+    pub fn params(&self) -> &'static [NativeParamInfo] {
         (self.vtable().store)().params.get_or_init(|| {
             self.vtable()
                 .fields
                 .iter()
                 .filter(|field| !field.synthesized)
-                .map(|field| ParamInfo {
+                .map(|field| NativeParamInfo {
                     name: field.name,
                     docs: field.docs,
                     input: (field.input)(),
@@ -193,7 +193,7 @@ cast! {
 #[derive(Default)]
 pub struct LazyElementStore {
     pub scope: OnceLock<Scope>,
-    pub params: OnceLock<Vec<ParamInfo>>,
+    pub params: OnceLock<Vec<NativeParamInfo>>,
 }
 
 impl LazyElementStore {

--- a/crates/typst-library/src/math/accent.rs
+++ b/crates/typst-library/src/math/accent.rs
@@ -11,7 +11,7 @@ use icu_provider_blob::BlobDataProvider;
 use crate::engine::Engine;
 use crate::foundations::{
     Args, CastInfo, Content, Context, Func, IntoValue, NativeElement, NativeFuncData,
-    NativeFuncPtr, ParamInfo, Reflect, Scope, Str, SymbolElem, Type, cast, elem,
+    NativeFuncPtr, NativeParamInfo, Reflect, Scope, Str, SymbolElem, Type, cast, elem,
 };
 use crate::layout::{Em, Length, Rel};
 use crate::math::Mathy;
@@ -209,9 +209,9 @@ fn create_accent_func_data(accent: char, bump: &'static Bump) -> NativeFuncData 
 }
 
 /// Creates parameter signature metadata for an accent function.
-fn create_accent_param_info() -> Vec<ParamInfo> {
+fn create_accent_param_info() -> Vec<NativeParamInfo> {
     vec![
-        ParamInfo {
+        NativeParamInfo {
             name: "base",
             docs: "The base to which the accent is applied.",
             input: Content::input(),
@@ -222,7 +222,7 @@ fn create_accent_param_info() -> Vec<ParamInfo> {
             required: true,
             settable: false,
         },
-        ParamInfo {
+        NativeParamInfo {
             name: "size",
             docs: "The size of the accent, relative to the width of the base.",
             input: Rel::<Length>::input(),
@@ -233,7 +233,7 @@ fn create_accent_param_info() -> Vec<ParamInfo> {
             required: false,
             settable: false,
         },
-        ParamInfo {
+        NativeParamInfo {
             name: "dotless",
             docs: "Whether to remove the dot on top of lowercase i and j when adding a top accent.",
             input: bool::input(),

--- a/crates/typst-library/src/math/lr.rs
+++ b/crates/typst-library/src/math/lr.rs
@@ -7,8 +7,8 @@ use comemo::Tracked;
 use crate::engine::Engine;
 use crate::foundations::{
     Args, CastInfo, Content, Context, Func, IntoValue, NativeElement, NativeFunc,
-    NativeFuncData, NativeFuncPtr, ParamInfo, Reflect, Scope, SymbolElem, Type, elem,
-    func,
+    NativeFuncData, NativeFuncPtr, NativeParamInfo, Reflect, Scope, SymbolElem, Type,
+    elem, func,
 };
 use crate::layout::{Em, Length, Rel};
 use crate::math::Mathy;
@@ -231,9 +231,9 @@ fn create_lr_func_data(left: char, right: char, bump: &'static Bump) -> NativeFu
 }
 
 /// Creates parameter signature metadata for an L/R function.
-fn create_lr_param_info() -> Vec<ParamInfo> {
+fn create_lr_param_info() -> Vec<NativeParamInfo> {
     vec![
-        ParamInfo {
+        NativeParamInfo {
             name: "size",
             docs: "\
             The size of the brackets, relative to the height of the wrapped content.\n\
@@ -247,7 +247,7 @@ fn create_lr_param_info() -> Vec<ParamInfo> {
             required: false,
             settable: false,
         },
-        ParamInfo {
+        NativeParamInfo {
             name: "body",
             docs: "The expression to wrap.",
             input: Content::input(),

--- a/crates/typst-macros/src/func.rs
+++ b/crates/typst-macros/src/func.rs
@@ -412,7 +412,7 @@ fn create_param_info(param: &Param) -> TokenStream {
         }
     }));
     quote! {
-        #foundations::ParamInfo {
+        #foundations::NativeParamInfo {
             name: #name,
             docs: #docs,
             input: <#ty as #foundations::Reflect>::input(),

--- a/crates/typst-syntax/src/ast.rs
+++ b/crates/typst-syntax/src/ast.rs
@@ -184,6 +184,34 @@ macro_rules! node {
 }
 
 node! {
+    /// A line comment: `// ...`.
+    struct LineComment
+}
+
+impl<'a> LineComment<'a> {
+    /// The contents of the line comment.
+    pub fn text(&self) -> &'a str {
+        let text = self.0.text();
+        text.strip_prefix("//").unwrap_or(text)
+    }
+}
+
+node! {
+    /// A block comment: `/* ... */`.
+    struct BlockComment
+}
+
+impl<'a> BlockComment<'a> {
+    /// The contents of the block comment.
+    pub fn text(&self) -> &'a str {
+        let text = self.0.text();
+        text.strip_prefix("/*")
+            .and_then(|text| text.strip_suffix("*/"))
+            .unwrap_or(text)
+    }
+}
+
+node! {
     /// The syntactical root capable of representing a full parsed document.
     struct Markup
 }

--- a/crates/typst-syntax/src/node.rs
+++ b/crates/typst-syntax/src/node.rs
@@ -770,6 +770,16 @@ impl LinkedNode<'_> {
         None
     }
 
+    /// Get the first previous sibling node, including potential trivia.
+    pub fn prev_sibling_with_trivia(&self) -> Option<Self> {
+        let parent = self.parent.as_ref()?;
+        let children = parent.node.children().as_slice();
+        let (index, node) = children[..self.index].iter().enumerate().next_back()?;
+        let offset = self.offset - node.len();
+        let parent = Some(parent.clone());
+        Some(Self { node, parent, index, offset })
+    }
+
     /// Get the next non-trivia sibling node.
     pub fn next_sibling(&self) -> Option<Self> {
         let parent = self.parent.as_ref()?;
@@ -783,6 +793,16 @@ impl LinkedNode<'_> {
             offset += node.len();
         }
         None
+    }
+
+    /// Get the next sibling node, including potential trivia.
+    pub fn next_sibling_with_trivia(&self) -> Option<Self> {
+        let parent = self.parent.as_ref()?;
+        let children = parent.node.children();
+        let (index, node) = children.enumerate().nth(self.index + 1)?;
+        let offset = self.offset + self.len();
+        let parent = Some(parent.clone());
+        Some(Self { node, parent, index, offset })
     }
 
     /// Get the kind of this node's parent.


### PR DESCRIPTION
Extends `typst-ide` with autocompletion & tooltips for parameters of user-defined function. 

This is probably the most important Tinymist feature that's so far been missing in `typst-ide`.