### PR TITLE
Fix table cell show rules in HTML

### DIFF
--- a/crates/typst-html/src/rules.rs
+++ b/crates/typst-html/src/rules.rs
@@ -63,6 +63,7 @@ pub fn register(rules: &mut NativeRuleMap) {
     rules.register(Html, CSL_LIGHT_RULE);
     rules.register(Html, CSL_INDENT_RULE);
     rules.register(Html, TABLE_RULE);
+    rules.register(Html, TABLE_CELL_RULE);
 
     // Text.
     rules.register(Html, SUB_RULE);
@@ -694,11 +695,13 @@ fn show_cell(tag: HtmlTag, cell: &Cell, styles: StyleChain) -> Content {
         attrs.push(attr::rowspan, rowspan);
     }
     HtmlElem::new(tag)
-        .with_body(Some(cell.body.clone()))
+        .with_body(Some(cell.clone().pack()))
         .with_attrs(attrs)
         .pack()
         .spanned(cell.span())
 }
+
+const TABLE_CELL_RULE: ShowFn<TableCell> = |elem, _, _| Ok(elem.body.clone());
 
 const SUB_RULE: ShowFn<SubElem> =
     |elem, _, _| Ok(HtmlElem::new(tag::sub).with_body(Some(elem.body.clone())).pack());

--- a/tests/ref/html/issue-7751-table-cell-show-rules.html
+++ b/tests/ref/html/issue-7751-table-cell-show-rules.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body>
+    <table>
+      <thead>
+        <tr>
+          <th>0</th>
+          <th>1</th>
+          <th>2</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>0</td>
+          <td>1</td>
+          <td>2</td>
+        </tr>
+      </tbody>
+      <tfoot>
+        <tr>
+          <td>0</td>
+          <td>1</td>
+          <td>2</td>
+        </tr>
+      </tfoot>
+    </table>
+  </body>
+</html>

--- a/tests/suite/layout/grid/html.typ
+++ b/tests/suite/layout/grid/html.typ
@@ -181,3 +181,28 @@
     [Ending], [Table],
   ),
 )
+
+--- issue-7751-table-cell-show-rules html ---
+#show table.cell.where(x: 0): [0]
+#show table.cell.where(x: 1): [1]
+#show table.cell.where(x: 2): [2]
+
+#table(
+  columns: 3,
+  rows: 3,
+
+  table.header(
+    [Text], [Text], [Text],
+    table.hline(stroke: red)
+  ),
+
+  [Text],
+  [Text],
+  [Text],
+
+  table.footer(
+    [Text],
+    [Text],
+    [Text],
+  ),
+)


### PR DESCRIPTION
Fixes #7751

Table cells are now correctly `show`n in HTML. We were previously placing their bodies instead of the cells themselves, stopping show rules from running. That has been corrected.

