### PR TITLE
Fix doc comment on `--open-report` and reorder before `--no-report` 

### DIFF
--- a/tests/src/args.rs
+++ b/tests/src/args.rs
@@ -53,12 +53,12 @@ pub struct CliArguments {
     /// How many threads to spawn when running the tests.
     #[arg(short = 'j', long)]
     pub num_threads: Option<usize>,
+    /// Open the generated HTML test report in a browser when finished.
+    #[arg(long)]
+    pub open_report: bool,
     /// Don't generate a HTML test report.
     #[arg(long)]
     no_report: bool,
-    /// Don't generate a HTML test report.
-    #[arg(long)]
-    pub open_report: bool,
     /// The git base revision against which the tests will be run.
     ///
     /// If none is specified, it's compared against the current working tree.


### PR DESCRIPTION
A small thing that seems to have slipped through.

For the ordering, I figure this way is more useful and a bit easier to understand.
