### PR TITLE
Remove a `.clone()` and add a comment on eval tests

### DIFF
--- a/tests/src/run.rs
+++ b/tests/src/run.rs
@@ -151,10 +151,13 @@ impl<'a> Runner<'a> {
             log!(into: self.result.infos, "tree: {:#?}", self.test.source.root());
         }
 
+        // Unconditionally eval the document to check for empty/non-empty
+        // content. This result is cached, so calling compile below won't
+        // duplicate any work.
         if let Some(content) = self.eval() {
             if self.test.attrs.parsed_stages().contains(TestStages::EVAL) {
                 if !output::is_empty_content(&content) {
-                    self.unexpected_non_empty.eval(content.clone());
+                    self.unexpected_non_empty.eval(content);
                 }
             } else if output::is_empty_content(&content) {
                 self.unexpected_empty.eval();


### PR DESCRIPTION
These changes were non-conflicting and easy to update together.

I added the comment because I had to convince myself of it by reading a good bit of surrounding code. Lmk if it's too much.

