### PR TITLE
Prevent stack overflow in list grouping with linebreak

### DIFF
--- a/tests/suite/styling/show.typ
+++ b/tests/suite/styling/show.typ
@@ -278,3 +278,13 @@ I am *strong*, I am _emphasized_, and I am #[special<special>].
 Hello
 
 World
+
+--- issue-7797-list-grouping-linebreak paged ---
+// Error: 7:1-7:6 maximum grouping depth exceeded
+#show list: it => {
+  for item in it.children {
+    [#item\ ]
+  }
+}
+
+- One


### PR DESCRIPTION
Fixes #7797

# 1. Summary

Add a recursion-depth guard around grouping finishers so show-rule feedback loops fail with the existing “maximum grouping depth exceeded” error instead of crashing. Add a regression test for the list + linebreak cycle.

# 2. Problem

A `#show list` rule that re-emits list items can feed list grouping back into itself. When the output includes a linebreak, this becomes an unbounded recursion that crashes the CLI with a stack overflow.

# 3. Reproduction

### Step 1. Create input.typ file:

```typ
#show list: it => {
  for item in it.children {
    [#item\ ]
  }
}

- One
```

### Step 2. Run the CLI:

```bash
./target/debug/typst compile tmp/input.typ tmp/input.pdf
```

Logs (before fix):

```
thread 'main' (608235) has overflowed its stack
fatal runtime error: stack overflow, aborting
Aborted (core dumped)
```

# 4. Solution

Introduce a small grouping recursion counter in realization and guard the grouping finisher call. If recursion exceeds the existing 512 threshold, bail with the same “maximum grouping depth exceeded” error. This mirrors the existing grouping guardrails and avoids stack overflow without changing normal grouping behavior.

# 5. Tests

- Added test `issue-7797-list-grouping-linebreak paged`
- Verified all passed with no regressions.

```bash
cargo testit -p tests/suite/styling/show.typ
```
