### PR TITLE
Add reference to `array.to-dict` in `dictionary` constructor docs

### DIFF
--- a/crates/typst-library/src/foundations/dict.rs
+++ b/crates/typst-library/src/foundations/dict.rs
@@ -176,7 +176,7 @@ impl Dict {
     /// Note that this function is only intended for conversion of a
     /// dictionary-like value to a dictionary, not for creation of a dictionary
     /// from individual pairs. Use the dictionary syntax `(key: value)` instead.
-    /// Also see [`array.to-dict`].
+    /// Also see [`array.to-dict`] for converting arrays to dictionaries.
     ///
     /// ```example
     /// #dictionary(sys).at("version")


### PR DESCRIPTION
The `dictionary` docs currently have no references to `array.to-dict`, which is unfortunate for someone trying to convert an `array` to a `dictionary` for the first time.

I added the reference to the `dictionary` constructor docs, since to me the most likely pipeline for finding it would be trying `dictionary(..pairs)`, and on getting an error looking at the `dictionary` constructor docs, where you would find this new hint.

I did not add a reference to the overall docs since I did not see a clean place to fit it in, and unless you are specifically trying to convert an `array` to a `dictionary` (not sure how common that is) it would not be helpful to mention there.