### PR TITLE
Mark test references as `linguist-vendored`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 * text=auto eol=lf
+tests/ref/** linguist-vendored
+NOTICE linguist-vendored


### PR DESCRIPTION
This [excludes them from stats](https://github.com/github-linguist/linguist/blob/main/docs/overrides.md#vendored-code). I've also considered `linguist-generated`, but that also auto-collapses them in diffs, which would be annoying. Vendored seems fine semantically. I've also included NOTICE, which literally contains vendored license texts.