### PR TITLE
Prevent stack overflow in list grouping with linebreak

### DIFF
--- a/tests/suite/styling/show.typ
+++ b/tests/suite/styling/show.typ
@@ -278,3 +278,13 @@ I am *strong*, I am _emphasized_, and I am #[special<special>].
 Hello
 
 World
+
+--- issue-7797-list-grouping-linebreak paged ---
+// Error: 7:1-7:6 maximum grouping depth exceeded
+#show list: it => {
+  for item in it.children {
+    [#item\ ]
+  }
+}
+
+- One


### PR DESCRIPTION
Fixes #7797

I was able to reproduce the exact bug locally and noticed that the stack overflow crash was caused by unbounded grouping recursion. To resolve the crash, I added a recursion-depth guard to grouping finishers so the existing “maximum grouping depth exceeded” error is raised instead.