### PR TITLE
Convert diagnostic tests to use the eval target

### DIFF
--- a/tests/suite/foundations/arguments.typ
+++ b/tests/suite/foundations/arguments.typ
@@ -14,12 +14,12 @@
 #test(args.at(2), 3)
 #test(args.at("a"), 2)
 
---- arguments-at-invalid-index paged ---
+--- arguments-at-invalid-index eval ---
 #let args = arguments(0, 1, a: 2, 3)
 // Error: 2-12 arguments do not contain key 4 and no default value was specified
 #args.at(4)
 
---- arguments-at-invalid-name paged ---
+--- arguments-at-invalid-name eval ---
 #let args = arguments(0, 1, a: 2, 3)
 // Error: 2-14 arguments do not contain key "b" and no default value was specified
 #args.at("b")
@@ -39,7 +39,7 @@
 #test(arguments(1, a: 2, b: 3, 4).filter(calc.even), arguments(a: 2, 4))
 #test(arguments(h: 7, e: 3, l: 2, o: 5, 1).filter(x => x < 5), arguments(e: 3, l: 2, 1))
 
---- arguments-filter-error paged ---
+--- arguments-filter-error eval ---
 // Test that errors in the predicate are reported properly.
 // Error: 29-34 cannot subtract integer from string
 #arguments("a").filter(x => x - 2)
@@ -49,7 +49,7 @@
 #test(arguments().map(x => x * 2), arguments())
 #test(arguments(2, a: 3).map(x => x * 2), arguments(4, a: 6))
 
---- arguments-map-error paged ---
+--- arguments-map-error eval ---
 // Test that errors in the function are reported properly.
 // Error: 26-31 cannot subtract integer from string
 #arguments("a").map(x => x - 2)

--- a/tests/suite/foundations/array.typ
+++ b/tests/suite/foundations/array.typ
@@ -20,35 +20,35 @@
     , rgb("002")
     ,)
 
---- array-bad-token paged ---
+--- array-bad-token eval ---
 // Error: 4-6 unexpected end of block comment
 // Hint: 4-6 consider escaping the `*` with a backslash or opening the block comment with `/*`
 #(1*/2)
 
---- array-bad-number-suffix paged ---
+--- array-bad-number-suffix eval ---
 // Error: 6-8 invalid number suffix: u
 #(1, 1u 2)
 
---- array-leading-comma paged ---
+--- array-leading-comma eval ---
 // Error: 3-4 unexpected comma
 #(,1)
 
---- array-incomplete-pair paged ---
+--- array-incomplete-pair eval ---
 // Missing expression makes named pair incomplete, making this an empty array.
 // Error: 5 expected expression
 #(a:)
 
---- array-named-pair paged ---
+--- array-named-pair eval ---
 // Named pair after this is already identified as an array.
 // Error: 6-10 expected expression, found named pair
 #(1, b: 2)
 
---- array-keyed-pair paged ---
+--- array-keyed-pair eval ---
 // Keyed pair after this is already identified as an array.
 // Error: 6-14 expected expression, found keyed pair
 #(1, "key": 2)
 
---- array-bad-conversion-from-string paged ---
+--- array-bad-conversion-from-string eval ---
 // Error: 8-15 expected array, bytes, or version, found string
 #array("hello")
 
@@ -61,7 +61,7 @@
   test((..none), ())
 }
 
---- spread-dict-into-array paged ---
+--- spread-dict-into-array eval ---
 // Error: 9-17 cannot spread dictionary into array
 #(1, 2, ..(a: 1))
 
@@ -87,16 +87,16 @@
   test(array, (7, 16, 3))
 }
 
---- array-at-out-of-bounds paged ---
+--- array-at-out-of-bounds eval ---
 // Test rvalue out of bounds.
 // Error: 2-17 array index out of bounds (index: 5, len: 3) and no default value was specified
 #(1, 2, 3).at(5)
 
---- array-at-out-of-bounds-negative paged ---
+--- array-at-out-of-bounds-negative eval ---
 // Error: 2-18 array index out of bounds (index: -4, len: 3) and no default value was specified
 #(1, 2, 3).at(-4)
 
---- array-at-out-of-bounds-lvalue paged ---
+--- array-at-out-of-bounds-lvalue eval ---
 // Test lvalue out of bounds.
 #{
   let array = (1, 2, 3)
@@ -134,29 +134,29 @@
 #test(range(5, 2, step: -1), (5, 4, 3))
 #test(range(10, 0, step: -3), (10, 7, 4, 1))
 
---- array-range-end-missing paged ---
+--- array-range-end-missing eval ---
 // Error: 2-9 missing argument: end
 #range()
 
---- array-range-float-invalid paged ---
+--- array-range-float-invalid eval ---
 // Error: 11-14 expected integer, found float
 #range(1, 2.0)
 
---- array-range-bad-step-type paged ---
+--- array-range-bad-step-type eval ---
 // Error: 17-22 expected integer, found string
 #range(4, step: "one")
 
---- array-range-step-zero paged ---
+--- array-range-step-zero eval ---
 // Error: 18-19 number must not be zero
 #range(10, step: 0)
 
---- array-bad-method-lvalue paged ---
+--- array-bad-method-lvalue eval ---
 // Test bad lvalue.
 // Error: 2:3-2:14 cannot mutate a temporary value
 #let array = (1, 2, 3)
 #(array.len() = 4)
 
---- array-unknown-method-lvalue paged ---
+--- array-unknown-method-lvalue eval ---
 // Test bad lvalue.
 // Error: 2:9-2:13 type array has no method `yolo`
 #let array = (1, 2, 3)
@@ -184,11 +184,11 @@
 #test((1, 2).last(default: 99), 2)
 #test(().last(default: 99), 99)
 
---- array-first-empty paged ---
+--- array-first-empty eval ---
 // Error: 2-12 array is empty
 #().first()
 
---- array-last-empty paged ---
+--- array-last-empty eval ---
 // Error: 2-11 array is empty
 #().last()
 
@@ -212,7 +212,7 @@
   test(array, (0, 2, 3, 4, 5))
 }
 
---- array-insert-missing-index paged ---
+--- array-insert-missing-index eval ---
 // Error: 2:2-2:18 missing argument: index
 #let numbers = ()
 #numbers.insert()
@@ -230,19 +230,19 @@
 #test((1, 2, 3).slice(-3, 2), (1, 2))
 #test("ABCD".split("").slice(1, -1).join("-"), "A-B-C-D")
 
---- array-slice-count-end paged ---
+--- array-slice-count-end eval ---
 // Error: 2-33 `end` and `count` are mutually exclusive
 #(1, 2, 3).slice(0, 1, count: 2)
 
---- array-slice-out-of-bounds paged ---
+--- array-slice-out-of-bounds eval ---
 // Error: 2-30 array index out of bounds (index: 12, len: 10)
 #range(10).slice(9, count: 3)
 
---- array-slice-out-of-bounds-from-back paged ---
+--- array-slice-out-of-bounds-from-back eval ---
 // Error: 2-31 array index out of bounds (index: 12, len: 10)
 #range(10).slice(-2, count: 4)
 
---- array-slice-out-of-bounds-negative paged ---
+--- array-slice-out-of-bounds-negative eval ---
 // Error: 2-24 array index out of bounds (index: -4, len: 3)
 #(1, 2, 3).slice(0, -4)
 
@@ -258,7 +258,7 @@
 #test((1, 2, 3, 4).filter(calc.even), (2, 4))
 #test((7, 3, 2, 5, 1).filter(x => x < 5), (3, 2, 1))
 
---- array-filter-error paged ---
+--- array-filter-error eval ---
 // Test that errors in the predicate are reported properly.
 // Error: 21-26 cannot subtract integer from string
 #("a",).filter(x => x - 2)
@@ -268,7 +268,7 @@
 #test(().map(x => x * 2), ())
 #test((2, 3).map(x => x * 2), (4, 6))
 
---- array-map-error paged ---
+--- array-map-error eval ---
 // Test that errors in the function are reported properly.
 // Error: 18-23 cannot subtract integer from string
 #("a",).map(x => x - 2)
@@ -278,7 +278,7 @@
 #test(().fold("hi", grid), "hi")
 #test((1, 2, 3, 4).fold(0, (s, x) => s + x), 10)
 
---- array-fold-closure-without-params paged ---
+--- array-fold-closure-without-params eval ---
 // Error: 20-22 unexpected argument
 #(1, 2, 3).fold(0, () => none)
 
@@ -288,7 +288,7 @@
 #test(().sum(default: []), [])
 #test((1, 2, 3).sum(), 6)
 
---- array-sum-empty paged ---
+--- array-sum-empty eval ---
 // Error: 2-10 cannot calculate sum of empty array with no default
 #().sum()
 
@@ -299,7 +299,7 @@
 #test(([ab], 3).product(), [ab]*3)
 #test((1, 2, 3).product(), 6)
 
---- array-product-empty paged ---
+--- array-product-empty eval ---
 // Error: 2-14 cannot calculate product of empty array with no default
 #().product()
 
@@ -319,11 +319,11 @@
 #test(("hello",).join(default: "EMPTY", ", "), "hello")
 #test(("hello", "world").join(default: "EMPTY", ", "), "hello, world")
 
---- array-join-bad-values paged ---
+--- array-join-bad-values eval ---
 // Error: 2-22 cannot join boolean with boolean
 #(true, false).join()
 
---- array-join-bad-separator paged ---
+--- array-join-bad-separator eval ---
 // Error: 2-20 cannot join string with integer
 #("a", "b").join(1)
 
@@ -350,11 +350,11 @@
 #test((1, 2, 3, 4, 5, 6).chunks(3, exact: true), ((1, 2, 3), (4, 5, 6)))
 #test((1, 2, 3, 4, 5, 6, 7, 8).chunks(3, exact: true), ((1, 2, 3), (4, 5, 6)))
 
---- array-chunks-size-zero paged ---
+--- array-chunks-size-zero eval ---
 // Error: 19-20 number must be positive
 #(1, 2, 3).chunks(0)
 
---- array-chunks-size-negative paged ---
+--- array-chunks-size-negative eval ---
 // Error: 19-21 number must be positive
 #(1, 2, 3).chunks(-5)
 
@@ -365,11 +365,11 @@
 #test((1, 2, 3, 4, 5).windows(3), ((1, 2, 3), (2, 3, 4), (3, 4, 5)))
 #test((1, 2, 3, 4, 5, 6, 7, 8).windows(5), ((1, 2, 3, 4, 5), (2, 3, 4, 5, 6), (3, 4, 5, 6, 7), (4, 5, 6, 7, 8)))
 
---- array-windows-size-zero paged ---
+--- array-windows-size-zero eval ---
 // Error: 20-21 number must be positive
 #(1, 2, 3).windows(0)
 
---- array-windows-size-negative paged ---
+--- array-windows-size-negative eval ---
 // Error: 20-22 number must be positive
 #(1, 2, 3).windows(-5)
 
@@ -387,11 +387,11 @@
 #test(("I", "the", "hi", "text").sorted(by: (x, y) => x.len() < y.len()), ("I", "hi", "the", "text"))
 #test(("I", "the", "hi", "text").sorted(key: x => x.len(), by: (x, y) => y < x), ("text", "the", "hi", "I"))
 
---- array-sorted-invalid-by-function paged ---
+--- array-sorted-invalid-by-function eval ---
 // Error: 2-39 expected boolean from `by` function, got string
 #(1, 2, 3).sorted(by: (_, _) => "hmm")
 
---- array-sorted-key-function-positional-1 paged ---
+--- array-sorted-key-function-positional-1 eval ---
 // Error: 12-18 unexpected argument
 #().sorted(x => x)
 
@@ -411,11 +411,11 @@
 #test((1, 2, 3).zip(), ((1,), (2,), (3,)))
 #test(array.zip(()), ())
 
---- array-zip-exact-error paged ---
+--- array-zip-exact-error eval ---
 // Error: 13-22 second array has different length (3) from first array (2)
 #(1, 2).zip((1, 2, 3), exact: true)
 
---- array-zip-exact-multi-error paged ---
+--- array-zip-exact-multi-error eval ---
 // Error: 13-22 array has different length (3) from first array (2)
 // Error: 24-36 array has different length (4) from first array (2)
 #(1, 2).zip((1, 2, 3), (1, 2, 3, 4), exact: true)
@@ -451,82 +451,82 @@
 #test((("a", 1), ("b", 2), ("c", 3)).to-dict(), (a: 1, b: 2, c: 3))
 #test((("a", 1), ("b", 2), ("c", 3), ("b", 4)).to-dict(), (a: 1, b: 4, c: 3))
 
---- array-to-dict-bad-item-type paged ---
+--- array-to-dict-bad-item-type eval ---
 // Error: 2-16 expected (str, any) pairs, found integer
 #(1,).to-dict()
 
---- array-to-dict-bad-pair-length-1 paged ---
+--- array-to-dict-bad-pair-length-1 eval ---
 // Error: 2-19 expected pairs of length 2, found length 1
 #((1,),).to-dict()
 
---- array-to-dict-bad-pair-length-3 paged ---
+--- array-to-dict-bad-pair-length-3 eval ---
 // Error: 2-26 expected pairs of length 2, found length 3
 #(("key",1,2),).to-dict()
 
---- array-to-dict-bad-key-type paged ---
+--- array-to-dict-bad-key-type eval ---
 // Error: 2-21 expected key of type str, found integer
 #((1, 2),).to-dict()
 
---- array-zip-positional-and-named-argument paged ---
+--- array-zip-positional-and-named-argument eval ---
 // Error: 13-30 unexpected argument: val
 #().zip((), val: "applicable")
 
---- array-sorted-bad-key paged ---
+--- array-sorted-bad-key eval ---
 // Error: 32-37 cannot divide by zero
 #(1, 2, 0, 3).sorted(key: x => 5 / x)
 
---- array-sorted-underdetermined-with-key paged ---
+--- array-sorted-underdetermined-with-key eval ---
 // Error: 2-40 cannot compare content and content
 // Hint: 2-40 consider defining the comparison with `by` or choosing a different `key`
 #((1, []), (1, [])).sorted(key: a => a)
 
---- array-sorted-uncomparable paged ---
+--- array-sorted-uncomparable eval ---
 // Error: 2-26 cannot compare content and content
 // Hint: 2-26 consider choosing a `key` or defining the comparison with `by`
 #([Hi], [There]).sorted()
 
---- array-sorted-uncomparable-lengths paged ---
+--- array-sorted-uncomparable-lengths eval ---
 // Error: 2-26 cannot compare 3em with 2pt
 // Hint: 2-26 consider choosing a `key` or defining the comparison with `by`
 #(1pt, 2pt, 3em).sorted()
 
---- array-sorted-key-function-positional-2 paged ---
+--- array-sorted-key-function-positional-2 eval ---
 // Error: 42-52 unexpected argument
 #((k: "a", v: 2), (k: "b", v: 1)).sorted(it => it.v)
 
---- issue-3014-mix-array-dictionary paged ---
+--- issue-3014-mix-array-dictionary eval ---
 // Error: 8-17 expected expression, found named pair
 #(box, fill: red)
 
---- issue-3154-array-first-empty paged ---
+--- issue-3154-array-first-empty eval ---
 #{
   let array = ()
   // Error: 3-16 array is empty
   array.first()
 }
 
---- issue-3154-array-first-mutable-empty paged ---
+--- issue-3154-array-first-mutable-empty eval ---
 #{
   let array = ()
   // Error: 3-16 array is empty
   array.first() = 9
 }
 
---- issue-3154-array-last-empty paged ---
+--- issue-3154-array-last-empty eval ---
 #{
   let array = ()
   // Error: 3-15 array is empty
   array.last()
 }
 
---- issue-3154-array-last-mutable-empty paged ---
+--- issue-3154-array-last-mutable-empty eval ---
 #{
   let array = ()
   // Error: 3-15 array is empty
   array.last() = 9
 }
 
---- issue-3154-array-at-out-of-bounds paged ---
+--- issue-3154-array-at-out-of-bounds eval ---
 #{
   let array = (1,)
   // Error: 3-14 array index out of bounds (index: 1, len: 1) and no default value was specified
@@ -539,25 +539,25 @@
   test(array.at(1, default: 0), 0)
 }
 
---- issue-3154-array-at-out-of-bounds-mutable paged ---
+--- issue-3154-array-at-out-of-bounds-mutable eval ---
 #{
   let array = (1,)
   // Error: 3-14 array index out of bounds (index: 1, len: 1)
   array.at(1) = 9
 }
 
---- issue-3154-array-at-out-of-bounds-mutable-default paged ---
+--- issue-3154-array-at-out-of-bounds-mutable-default eval ---
 #{
   let array = (1,)
   // Error: 3-26 array index out of bounds (index: 1, len: 1)
   array.at(1, default: 0) = 9
 }
 
---- array-unopened paged ---
+--- array-unopened eval ---
 // Error: 2-3 unclosed delimiter
 #{)}
 
---- array-unclosed paged ---
+--- array-unclosed eval ---
 // Error: 3-4 unclosed delimiter
 #{(}
 
@@ -566,15 +566,15 @@
 #test(().reduce(grid), none)
 #test((1, 2, 3, 4).reduce((s, x) => s + x), 10)
 
---- array-reduce-missing-reducer paged ---
+--- array-reduce-missing-reducer eval ---
 // Error: 2-13 missing argument: reducer
 #().reduce()
 
---- array-reduce-unexpected-argument paged ---
+--- array-reduce-unexpected-argument eval ---
 // Error: 19-21 unexpected argument
 #(1, 2, 3).reduce(() => none)
 
---- issue-6285-crashed-with-sorting-non-total-order paged ---
+--- issue-6285-crashed-with-sorting-non-total-order eval ---
 // Error: 2-66 cannot compare none and string
 // Hint: 2-66 consider choosing a `key` or defining the comparison with `by`
 #(("a", "b", "c", "d", "e", "z") * 3 + ("c", none, "a")).sorted()

--- a/tests/suite/foundations/assert.typ
+++ b/tests/suite/foundations/assert.typ
@@ -1,34 +1,34 @@
---- assert-fail paged ---
+--- assert-fail eval ---
 // Test failing assertions.
 // Error: 2-16 assertion failed
 #assert(1 == 2)
 
---- assert-fail-message paged ---
+--- assert-fail-message eval ---
 // Test failing assertions.
 // Error: 2-51 assertion failed: two is smaller than one
 #assert(2 < 1, message: "two is smaller than one")
 
---- assert-bad-type paged ---
+--- assert-bad-type eval ---
 // Test failing assertions.
 // Error: 9-15 expected boolean, found string
 #assert("true")
 
---- assert-eq-fail paged ---
+--- assert-eq-fail eval ---
 // Test failing assertions.
 // Error: 2-19 equality assertion failed: value 10 was not equal to 11
 #assert.eq(10, 11)
 
---- assert-eq-fail-message paged ---
+--- assert-eq-fail-message eval ---
 // Test failing assertions.
 // Error: 2-55 equality assertion failed: 10 and 12 are not equal
 #assert.eq(10, 12, message: "10 and 12 are not equal")
 
---- assert-ne-fail paged ---
+--- assert-ne-fail eval ---
 // Test failing assertions.
 // Error: 2-19 inequality assertion failed: value 11 was equal to 11
 #assert.ne(11, 11)
 
---- assert-ne-fail-message paged ---
+--- assert-ne-fail-message eval ---
 // Test failing assertions.
 // Error: 2-57 inequality assertion failed: must be different from 11
 #assert.ne(11, 11, message: "must be different from 11")

--- a/tests/suite/foundations/bytes.typ
+++ b/tests/suite/foundations/bytes.typ
@@ -26,7 +26,7 @@
   bytes("World")
 }), "Hello World")
 
---- bytes-bad-conversion-from-dict paged ---
+--- bytes-bad-conversion-from-dict eval ---
 // Error: 8-14 expected string, array, or bytes, found dictionary
 #bytes((a: 1))
 

--- a/tests/suite/foundations/calc.typ
+++ b/tests/suite/foundations/calc.typ
@@ -34,7 +34,7 @@
 #test(calc.abs(decimal("4932.493249324932")), decimal("4932.493249324932"))
 #test(calc.abs(decimal("-12402.593295932041")), decimal("12402.593295932041"))
 
---- calc-abs-bad-type paged ---
+--- calc-abs-bad-type eval ---
 // Error: 11-22 expected integer, float, length, angle, ratio, fraction, or decimal, found string
 #calc.abs("no number")
 
@@ -64,15 +64,15 @@
 #test(calc.rem(int("-9223372036854775808"), -1), 0)
 #test(calc.rem(float("-9223372036854775808"), -1.0), 0.0)
 
---- calc-rem-divisor-zero-1 paged ---
+--- calc-rem-divisor-zero-1 eval ---
 // Error: 14-15 divisor must not be zero
 #calc.rem(5, 0)
 
---- calc-rem-divisor-zero-2 paged ---
+--- calc-rem-divisor-zero-2 eval ---
 // Error: 16-19 divisor must not be zero
 #calc.rem(3.0, 0.0)
 
---- calc-rem-divisor-zero-3 paged ---
+--- calc-rem-divisor-zero-3 eval ---
 // Error: 27-39 divisor must not be zero
 #calc.rem(decimal("4.0"), decimal("0"))
 
@@ -89,19 +89,19 @@
 #test(calc.div-euclid(decimal("-7"), decimal("-3")), decimal("3"))
 #test(calc.div-euclid(decimal("2.5"), decimal("2")), decimal("1"))
 
---- calc-div-euclid-divisor-zero-1 paged ---
+--- calc-div-euclid-divisor-zero-1 eval ---
 // Error: 21-22 divisor must not be zero
 #calc.div-euclid(5, 0)
 
---- calc-div-euclid-divisor-zero-2 paged ---
+--- calc-div-euclid-divisor-zero-2 eval ---
 // Error: 23-26 divisor must not be zero
 #calc.div-euclid(3.0, 0.0)
 
---- calc-div-euclid-divisor-zero-3 paged ---
+--- calc-div-euclid-divisor-zero-3 eval ---
 // Error: 35-50 divisor must not be zero
 #calc.div-euclid(decimal("3.00"), decimal("0.00"))
 
---- calc-div-euclid-too-large paged ---
+--- calc-div-euclid-too-large eval ---
 // Error: 2-50 the result is too large
 #calc.div-euclid(int("-9223372036854775808"), -1)
 
@@ -122,15 +122,15 @@
 #test(calc.rem-euclid(int("-9223372036854775808"), -1), 0)
 #test(calc.rem-euclid(float("-9223372036854775808"), -1.0), 0.0)
 
---- calc-rem-euclid-divisor-zero-1 paged ---
+--- calc-rem-euclid-divisor-zero-1 eval ---
 // Error: 21-22 divisor must not be zero
 #calc.rem-euclid(5, 0)
 
---- calc-rem-euclid-divisor-zero-2 paged ---
+--- calc-rem-euclid-divisor-zero-2 eval ---
 // Error: 23-26 divisor must not be zero
 #calc.rem-euclid(3.0, 0.0)
 
---- calc-rem-euclid-divisor-zero-3 paged ---
+--- calc-rem-euclid-divisor-zero-3 eval ---
 // Error: 35-50 divisor must not be zero
 #calc.rem-euclid(decimal("3.00"), decimal("0.00"))
 
@@ -150,19 +150,19 @@
 #test(calc.quo(decimal("9"), decimal("4.5")), 2)
 #test(calc.quo(decimal("-9"), decimal("4.1")), -3)
 
---- calc-quo-divisor-zero-1 paged ---
+--- calc-quo-divisor-zero-1 eval ---
 // Error: 14-15 divisor must not be zero
 #calc.quo(5, 0)
 
---- calc-quo-divisor-zero-2 paged ---
+--- calc-quo-divisor-zero-2 eval ---
 // Error: 16-19 divisor must not be zero
 #calc.quo(3.0, 0.0)
 
---- calc-quo-divisor-zero-3 paged ---
+--- calc-quo-divisor-zero-3 eval ---
 // Error: 27-41 divisor must not be zero
 #calc.quo(decimal("4.0"), decimal("0.0"))
 
---- calc-quo-too-large paged ---
+--- calc-quo-too-large eval ---
 // Error: 2-43 the result is too large
 #calc.quo(int("-9223372036854775808"), -1)
 
@@ -214,43 +214,43 @@
 #test(128.bit-rshift(12345, logical: true), 0)
 #test((-7).bit-rshift(12345, logical: true), 0)
 
---- calc-bit-shift-too-large paged ---
+--- calc-bit-shift-too-large eval ---
 // Error: 2-18 the result is too large
 #1.bit-lshift(64)
 
---- calc-bit-lshift-negative paged ---
+--- calc-bit-lshift-negative eval ---
 // Error: 15-17 number must be at least zero
 #1.bit-lshift(-1)
 
---- calc-bit-rshift-negative paged ---
+--- calc-bit-rshift-negative eval ---
 // Error: 15-17 number must be at least zero
 #1.bit-rshift(-1)
 
---- calc-pow-zero-to-power-of-zero paged ---
+--- calc-pow-zero-to-power-of-zero eval ---
 // Error: 2-16 zero to the power of zero is undefined
 #calc.pow(0, 0)
 
---- calc-pow-exponent-too-large paged ---
+--- calc-pow-exponent-too-large eval ---
 // Error: 14-31 exponent is too large
 #calc.pow(2, 10000000000000000)
 
---- calc-pow-too-large paged ---
+--- calc-pow-too-large eval ---
 // Error: 2-25 the result is too large
 #calc.pow(2, 2147483647)
 
---- calc-pow-too-large-decimal paged ---
+--- calc-pow-too-large-decimal eval ---
 // Error: 2-56 the result is too large
 #calc.pow(decimal("2222222222222222222222222222"), 100)
 
---- calc-pow-bad-exponent paged ---
+--- calc-pow-bad-exponent eval ---
 // Error: 14-36 exponent may not be infinite, subnormal, or NaN
 #calc.pow(2, calc.pow(2.0, 10000.0))
 
---- calc-pow-not-real paged ---
+--- calc-pow-not-real eval ---
 // Error: 2-19 the result is not a real number
 #calc.pow(-1, 0.5)
 
---- calc-sqrt-not-real paged ---
+--- calc-sqrt-not-real eval ---
 // Error: 12-14 cannot take square root of negative number
 #calc.sqrt(-1)
 
@@ -262,23 +262,23 @@
 // 100^(-1/2) = (100^(1/2))^-1 = 1/sqrt(100)
 #test(calc.root(100.0, -2), 0.1)
 
---- calc-root-zeroth paged ---
+--- calc-root-zeroth eval ---
 // Error: 17-18 cannot take the 0th root of a number
 #calc.root(1.0, 0)
 
---- calc-root-negative-even paged ---
+--- calc-root-negative-even eval ---
 // Error: 24-25 negative numbers do not have a real nth root when n is even
 #test(calc.root(-27.0, 4), -3.0)
 
---- calc-log-negative paged ---
+--- calc-log-negative eval ---
 // Error: 11-13 value must be strictly positive
 #calc.log(-1)
 
---- calc-log-bad-base paged ---
+--- calc-log-bad-base eval ---
 // Error: 20-21 base may not be zero, NaN, infinite, or subnormal
 #calc.log(1, base: 0)
 
---- calc-log-not-real paged ---
+--- calc-log-not-real eval ---
 // Error: 2-24 the result is not a real number
 #calc.log(10, base: -1)
 
@@ -287,7 +287,7 @@
 #test(calc.fact(0), 1)
 #test(calc.fact(5), 120)
 
---- calc-fact-too-large paged ---
+--- calc-fact-too-large eval ---
 // Error: 2-15 the result is too large
 #calc.fact(21)
 
@@ -298,7 +298,7 @@
 #test(calc.perm(5, 5), 120)
 #test(calc.perm(5, 6), 0)
 
---- calc-perm-too-large paged ---
+--- calc-perm-too-large eval ---
 // Error: 2-19 the result is too large
 #calc.perm(21, 21)
 
@@ -320,7 +320,7 @@
 #test(calc.gcd(0, 0), 0)
 #test(calc.gcd(7, 0), 7)
 
---- calc-gcd-too-large paged ---
+--- calc-gcd-too-large eval ---
 // Error: 2-43 the result is too large
 #calc.gcd(int("-9223372036854775808"), -1)
 
@@ -334,7 +334,7 @@
 #test(calc.lcm(0, 0), 0)
 #test(calc.lcm(8, 0), 0)
 
---- calc-lcm-too-large paged ---
+--- calc-lcm-too-large eval ---
 // Error: 2-41 the result is too large
 #calc.lcm(15486487489457, 4874879896543)
 
@@ -342,11 +342,11 @@
 #test(calc.round(decimal("9223372036854775809.5")), decimal("9223372036854775810"))
 #test(calc.round(9223372036854775809.5), 9223372036854775810.0)
 
---- calc-floor-float-larger-than-max-int paged ---
+--- calc-floor-float-larger-than-max-int eval ---
 // Error: 2-35 the result is too large
 #calc.floor(9223372036854775809.5)
 
---- calc-floor-decimal-larger-than-max-int paged ---
+--- calc-floor-decimal-larger-than-max-int eval ---
 // Error: 2-46 the result is too large
 #calc.floor(decimal("9223372036854775809.5"))
 
@@ -354,43 +354,43 @@
 #test(calc.round(decimal("-9223372036854775809.5")), decimal("-9223372036854775810"))
 #test(calc.round(-9223372036854775809.5), -9223372036854775810.0)
 
---- calc-floor-float-smaller-than-min-int paged ---
+--- calc-floor-float-smaller-than-min-int eval ---
 // Error: 2-36 the result is too large
 #calc.floor(-9223372036854775809.5)
 
---- calc-floor-decimal-smaller-than-min-int paged ---
+--- calc-floor-decimal-smaller-than-min-int eval ---
 // Error: 2-47 the result is too large
 #calc.floor(decimal("-9223372036854775809.5"))
 
---- calc-round-int-too-large paged ---
+--- calc-round-int-too-large eval ---
 // Error: 2-45 the result is too large
 #calc.round(9223372036854775807, digits: -1)
 
---- calc-round-int-negative-too-large paged ---
+--- calc-round-int-negative-too-large eval ---
 // Error: 2-46 the result is too large
 #calc.round(-9223372036854775807, digits: -1)
 
---- calc-round-decimal-too-large paged ---
+--- calc-round-decimal-too-large eval ---
 // Error: 2-66 the result is too large
 #calc.round(decimal("79228162514264337593543950335"), digits: -1)
 
---- calc-round-decimal-negative-too-large paged ---
+--- calc-round-decimal-negative-too-large eval ---
 // Error: 2-67 the result is too large
 #calc.round(decimal("-79228162514264337593543950335"), digits: -1)
 
---- calc-min-nothing paged ---
+--- calc-min-nothing eval ---
 // Error: 2-12 expected at least one value
 #calc.min()
 
---- calc-min-uncomparable paged ---
+--- calc-min-uncomparable eval ---
 // Error: 14-18 cannot compare string and integer
 #calc.min(1, "hi")
 
---- calc-max-uncomparable paged ---
+--- calc-max-uncomparable eval ---
 // Error: 16-19 cannot compare 1pt with 1em
 #calc.max(1em, 1pt)
 
---- calc-clamp-decimal-float paged ---
+--- calc-clamp-decimal-float eval ---
 // Error: 2-37 cannot apply this operation to a decimal and a float
 // Hint: 2-37 if loss of precision is acceptable, explicitly cast the decimal to a float with `float(value)`
 #calc.clamp(decimal("10"), 5.5, 6.6)
@@ -403,11 +403,11 @@
 #test(calc.norm(p: 3, 1, -2), calc.pow(9, 1/3))
 #test(calc.norm(p: calc.inf, 1, -2), 2.0)
 
---- calc-norm-negative-p paged ---
+--- calc-norm-negative-p eval ---
 // Error: 15-17 p must be greater than zero
 #calc.norm(p: -1, 1)
 
---- calc-norm-expected-float paged ---
+--- calc-norm-expected-float eval ---
 // Error: 12-15 expected float, found ratio
 #calc.norm(10%)
 

--- a/tests/suite/foundations/content.typ
+++ b/tests/suite/foundations/content.typ
@@ -22,7 +22,7 @@
 #test([a].fields(), (text: "a"))
 #test([a *b*].fields(),  (children: ([a], [ ], strong[b])))
 
---- content-fields-mutable-invalid paged ---
+--- content-fields-mutable-invalid eval ---
 #{
   let object = [hi]
   // Error: 3-9 cannot mutate fields on content
@@ -123,14 +123,14 @@
 
 = Hello, world! <my-label>
 
---- content-fields-unset paged ---
+--- content-fields-unset eval ---
 // Error: 10-15 field "block" in raw is not known at this point
 #raw("").block
 
---- content-fields-unset-no-default paged ---
+--- content-fields-unset-no-default eval ---
 // Error: 2-21 field "block" in raw is not known at this point and no default was specified
 #raw("").at("block")
 
---- content-try-to-access-internal-field paged ---
+--- content-try-to-access-internal-field eval ---
 // Error: 9-15 hide does not have field "hidden"
 #hide[].hidden

--- a/tests/suite/foundations/context.typ
+++ b/tests/suite/foundations/context.typ
@@ -6,7 +6,7 @@
 #test(c.children.first().func(), (context none).func())
 #test(c.children.last(), [.])
 
---- context-element-constructor-forbidden paged ---
+--- context-element-constructor-forbidden eval ---
 // Test that manual construction is forbidden.
 // Error: 2-25 cannot be constructed manually
 #(context none).func()()

--- a/tests/suite/foundations/datetime.typ
+++ b/tests/suite/foundations/datetime.typ
@@ -1,14 +1,14 @@
---- datetime-constructor-empty paged ---
+--- datetime-constructor-empty eval ---
 // Error: 2-12 at least one of date or time must be fully specified
 // Hint: 2-12 add the `hour`, `minute`, and `second` arguments to get a valid time
 // Hint: 2-12 add the `year`, `month`, and `day` arguments to get a valid date
 #datetime()
 
---- datetime-constructor-time-invalid paged ---
+--- datetime-constructor-time-invalid eval ---
 // Error: 2-42 time is invalid
 #datetime(hour: 25, minute: 0, second: 0)
 
---- datetime-constructor-date-invalid paged ---
+--- datetime-constructor-date-invalid eval ---
 // Error: 2-41 date is invalid
 #datetime(year: 2000, month: 2, day: 30)
 
@@ -74,42 +74,42 @@
 #test(datetime(day: 1, month: 3, year: 2001).ordinal(), 31 + 28 + 1);
 #test(datetime(day: 31, month: 12, year: 2001).ordinal(), 365);
 
---- datetime-incomplete-time-1 paged ---
+--- datetime-incomplete-time-1 eval ---
 // Error: 2-34 time is incomplete
 // Hint: 2-34 add the `hour` argument to get a valid time
 #datetime(minute: 14, second: 30)
 
---- datetime-incomplete-time-2 paged ---
+--- datetime-incomplete-time-2 eval ---
 // Error: 2-20 time is incomplete
 // Hint: 2-20 add the `minute` and `second` arguments to get a valid time
 #datetime(hour: 14)
 
---- datetime-incomplete-date-1 paged ---
+--- datetime-incomplete-date-1 eval ---
 // Error: 2-31 date is incomplete
 // Hint: 2-31 add the `month` argument to get a valid date
 #datetime(year: 2014, day: 30)
 
---- datetime-incomplete-date-2 paged ---
+--- datetime-incomplete-date-2 eval ---
 // Error: 2-20 date is incomplete
 // Hint: 2-20 add the `year` and `day` arguments to get a valid date
 #datetime(month: 5)
 
---- datetime-display-missing-closing-bracket paged ---
+--- datetime-display-missing-closing-bracket eval ---
 // Error: 27-34 missing closing bracket for bracket at index 0
 #datetime.today().display("[year")
 
---- datetime-display-invalid-component paged ---
+--- datetime-display-invalid-component eval ---
 // Error: 27-38 invalid component name 'nothing' at index 1
 #datetime.today().display("[nothing]")
 
---- datetime-display-invalid-modifier paged ---
+--- datetime-display-invalid-modifier eval ---
 // Error: 27-50 invalid modifier 'wrong' at index 6
 #datetime.today().display("[year wrong:last_two]")
 
---- datetime-display-expected-component paged ---
+--- datetime-display-expected-component eval ---
 // Error: 27-33 expected component name at index 2
 #datetime.today().display("  []")
 
---- datetime-display-insufficient-information paged ---
+--- datetime-display-insufficient-information eval ---
 // Error: 2-36 failed to format datetime (insufficient information)
 #datetime.today().display("[hour]")

--- a/tests/suite/foundations/decimal.typ
+++ b/tests/suite/foundations/decimal.typ
@@ -8,11 +8,11 @@
 #test(decimal(true), decimal("1.0"))
 #test(type(decimal(10)), decimal)
 
---- decimal-constructor-bad-type paged ---
+--- decimal-constructor-bad-type eval ---
 // Error: 10-17 expected decimal, integer, boolean, float, or string, found type
 #decimal(decimal)
 
---- decimal-constructor-bad-value paged ---
+--- decimal-constructor-bad-value eval ---
 // Error: 10-17 invalid decimal: 1.2.3
 #decimal("1.2.3")
 
@@ -21,15 +21,15 @@
 // Hint: 18-25 use a string in the decimal constructor to avoid loss of precision: `decimal("1.32523")`
 #let _ = decimal(1.32523)
 
---- decimal-constructor-float-inf paged ---
+--- decimal-constructor-float-inf eval ---
 // Error: 10-19 float is not a valid decimal: float.inf
 #decimal(float.inf)
 
---- decimal-constructor-float-negative-inf paged ---
+--- decimal-constructor-float-negative-inf eval ---
 // Error: 10-20 float is not a valid decimal: -float.inf
 #decimal(-float.inf)
 
---- decimal-constructor-float-nan paged ---
+--- decimal-constructor-float-nan eval ---
 // Error: 10-19 float is not a valid decimal: float.nan
 #decimal(float.nan)
 
@@ -78,11 +78,11 @@
 #calc.round(decimal("-3.9191919191919191919191919195"), digits: 4) \
 #calc.round(decimal("5.0000000000"), digits: 4)
 
---- decimal-expected-float-error paged ---
+--- decimal-expected-float-error eval ---
 // Error: 11-25 expected integer, float, or angle, found decimal
 // Hint: 11-25 if loss of precision is acceptable, explicitly cast the decimal to a float with `float(value)`
 #calc.sin(decimal("1.1"))
 
---- decimal-expected-integer-error paged ---
+--- decimal-expected-integer-error eval ---
 // Error: 11-25 expected integer, found decimal
 #calc.odd(decimal("1.1"))

--- a/tests/suite/foundations/dict.typ
+++ b/tests/suite/foundations/dict.typ
@@ -23,29 +23,29 @@
   test(world, "world")
 }
 
---- dict-missing-field paged ---
+--- dict-missing-field eval ---
 // Error: 6-13 dictionary does not contain key "invalid"
 #(:).invalid
 
---- dict-bad-key paged ---
+--- dict-bad-key eval ---
 // Error: 3-7 expected string, found boolean
 // Error: 16-18 expected string, found integer
 #(true: false, 42: 3)
 
---- dict-duplicate-key paged ---
+--- dict-duplicate-key eval ---
 // Error: 24-29 duplicate key: first
 #(first: 1, second: 2, first: 3)
 
---- dict-duplicate-key-stringy paged ---
+--- dict-duplicate-key-stringy eval ---
 // Error: 17-20 duplicate key: a
 #(a: 1, "b": 2, "a": 3)
 
---- dict-bad-expression paged ---
+--- dict-bad-expression eval ---
 // Simple expression after already being identified as a dictionary.
 // Error: 9-10 expected named or keyed pair, found identifier
 #(a: 1, b)
 
---- dict-leading-colon paged ---
+--- dict-leading-colon eval ---
 // Identified as dictionary due to initial colon.
 // The boolean key is allowed for now since it will only cause an error at the evaluation stage.
 // Error: 4-5 expected named or keyed pair, found integer
@@ -61,7 +61,7 @@
   test((..(a: 1), b: 2), (a: 1, b: 2))
 }
 
---- spread-array-into-dict paged ---
+--- spread-array-into-dict eval ---
 // Error: 3-11 cannot spread array into dictionary
 #(..(1, 2), a: 1)
 
@@ -78,7 +78,7 @@
   test(dict.state.err, false)
 }
 
---- dict-at-missing-key paged ---
+--- dict-at-missing-key eval ---
 // Test rvalue missing key.
 #{
   let dict = (a: 1, b: 2)
@@ -113,7 +113,7 @@
   test(dict.remove("c", default: 3), 3)
 }
 
---- dict-missing-lvalue paged ---
+--- dict-missing-lvalue eval ---
 // Missing lvalue is not automatically none-initialized.
 #{
   let dict = (:)
@@ -173,11 +173,11 @@
   test(dict.keys(), ("a", "b", "c", "d"))
 }
 
---- dict-temporary-lvalue paged ---
+--- dict-temporary-lvalue eval ---
 // Error: 3-15 cannot mutate a temporary value
 #((key: "val").other = "some")
 
---- dict-function-item-not-a-method paged ---
+--- dict-function-item-not-a-method eval ---
 #{
   let dict = (
     call-me: () => 1,
@@ -187,7 +187,7 @@
   dict.call-me()
 }
 
---- dict-item-missing-method paged ---
+--- dict-item-missing-method eval ---
 #{
   let dict = (
     nonfunc: 1
@@ -215,7 +215,7 @@
 #test((a: 0, b: 1, c: 2).filter(v => v != 0), (b: 1, c: 2))
 #test((a: 0, b: 1, c: 2).filter(calc.even), (a: 0, c: 2))
 
---- dict-filter-error paged ---
+--- dict-filter-error eval ---
 // Test that errors in the predicate are reported properly.
 // Error: 23-28 cannot subtract integer from string
 #(a: "a").filter(v => v - 2)
@@ -225,24 +225,24 @@
 #test(().map(x => x * 2), ())
 #test((a: 2, b: 3).map(x => x * 2), (a: 4, b: 6))
 
---- dict-map-error paged ---
+--- dict-map-error eval ---
 // Test that errors in the function are reported properly.
 // Error: 20-25 cannot subtract integer from string
 #(a: "a").map(v => v - 2)
 
---- issue-1338-dictionary-underscore paged ---
+--- issue-1338-dictionary-underscore eval ---
 #let foo = "foo"
 #let bar = "bar"
 // Error: 8-9 expected expression, found underscore
 // Error: 16-17 expected expression, found underscore
 #(foo: _, bar: _)
 
---- issue-1342-dictionary-bare-expressions paged ---
+--- issue-1342-dictionary-bare-expressions eval ---
 // Error: 5-8 expected named or keyed pair, found identifier
 // Error: 10-13 expected named or keyed pair, found identifier
 #(: foo, bar)
 
---- issue-3154-dict-at-not-contained paged ---
+--- issue-3154-dict-at-not-contained eval ---
 #{
   let dict = (a: 1)
   // Error: 3-15 dictionary does not contain key "b" and no default value was specified
@@ -255,7 +255,7 @@
   test(dict.at("b", default: 0), 0)
 }
 
---- issue-3154-dict-at-missing-mutable paged ---
+--- issue-3154-dict-at-missing-mutable eval ---
 #{
   let dict = (a: 1)
   // Error: 3-15 dictionary does not contain key "b"
@@ -263,7 +263,7 @@
   dict.at("b") = 9
 }
 
---- issue-3154-dict-at-missing-mutable-default paged ---
+--- issue-3154-dict-at-missing-mutable-default eval ---
 #{
   let dict = (a: 1)
   // Error: 3-27 dictionary does not contain key "b"
@@ -271,7 +271,7 @@
   dict.at("b", default: 0) = 9
 }
 
---- issue-3154-dict-syntax-missing paged ---
+--- issue-3154-dict-syntax-missing eval ---
 #{
   let dict = (a: 1)
   // Error: 8-9 dictionary does not contain key "b"
@@ -285,7 +285,7 @@
   test(dict, (a: 1, b: 9))
 }
 
---- issue-3154-dict-syntax-missing-add-assign paged ---
+--- issue-3154-dict-syntax-missing-add-assign eval ---
 #{
   let dict = (a: 1)
   // Error: 3-9 dictionary does not contain key "b"
@@ -293,20 +293,20 @@
   dict.b += 9
 }
 
---- issue-3232-dict-unexpected-keys-sides paged ---
+--- issue-3232-dict-unexpected-keys-sides eval ---
 // Confusing "expected relative length or dictionary, found dictionary"
 // Error: 16-58 unexpected keys "unexpected" and "unexpected-too"
 #block(outset: (unexpected: 0.5em, unexpected-too: 0.2em), [Hi])
 
---- issue-3232-dict-unexpected-keys-corners paged ---
+--- issue-3232-dict-unexpected-keys-corners eval ---
 // Error: 14-56 unexpected keys "unexpected" and "unexpected-too"
 #box(radius: (unexpected: 0.5em, unexpected-too: 0.5em), [Hi])
 
---- issue-3232-dict-unexpected-key-sides paged ---
+--- issue-3232-dict-unexpected-key-sides eval ---
 // Error: 16-49 unexpected key "unexpected", valid keys are "left", "top", "right", "bottom", "x", "y", and "rest"
 #block(outset: (unexpected: 0.2em, right: 0.5em), [Hi]) // The 1st key is unexpected
 
---- issue-3232-dict-unexpected-key-corners paged ---
+--- issue-3232-dict-unexpected-key-corners eval ---
 // Error: 14-50 unexpected key "unexpected", valid keys are "top-left", "top-right", "bottom-right", "bottom-left", "left", "top", "right", "bottom", and "rest"
 #box(radius: (top-left: 0.5em, unexpected: 0.5em), [Hi]) // The 2nd key is unexpected
 

--- a/tests/suite/foundations/eval.typ
+++ b/tests/suite/foundations/eval.typ
@@ -10,7 +10,7 @@
 #eval("_Hello" + " World!_", mode: "markup") \
 #eval("RR_1^NN", mode: "math", scope: (RR: math.NN, NN: math.RR))
 
---- eval-syntax-error-1 paged ---
+--- eval-syntax-error-1 eval ---
 // Error: 7-12 expected pattern
 #eval("let")
 
@@ -23,11 +23,11 @@ Interacting
 Blue #move(dy: -0.15em)[🌊]
 ```
 
---- eval-runtime-error paged ---
+--- eval-runtime-error eval ---
 // Error: 7-17 cannot continue outside of loop
 #eval("continue")
 
---- eval-syntax-error-2 paged ---
+--- eval-syntax-error-2 eval ---
 // Error: 7-12 expected semicolon or line break
 #eval("1 2")
 

--- a/tests/suite/foundations/float.typ
+++ b/tests/suite/foundations/float.typ
@@ -12,11 +12,11 @@
 #test(float(decimal("-79228162514264337593543950335")), -79228162514264340000000000000.0)
 #test(type(float(10)), float)
 
---- float-constructor-bad-type paged ---
+--- float-constructor-bad-type eval ---
 // Error: 8-13 expected float, boolean, integer, decimal, ratio, or string, found type
 #float(float)
 
---- float-constructor-bad-value paged ---
+--- float-constructor-bad-value eval ---
 // Error: 8-15 invalid float: 1.2.3
 #float("1.2.3")
 
@@ -58,7 +58,7 @@
 #test(2.5.to-bytes(size: 4), bytes((0, 0, 32, 64)))
 #test(2.5.to-bytes(size: 4, endian: "big"), bytes((64, 32, 0, 0)))
 
---- float-from-bytes-bad-length paged ---
+--- float-from-bytes-bad-length eval ---
 // Error: 2-54 bytes must have a length of 4 or 8
 #float.from-bytes(bytes((0, 0, 0, 0, 0, 0, 0, 1, 0)))
 
@@ -96,7 +96,7 @@
 #(-float.inf) \
 #float.nan
 
---- float-syntax-edge-cases paged ---
+--- float-syntax-edge-cases eval ---
 // Test float syntax edge cases and which spans of text are highlighted. Valid
 // items are those not annotated with an error comment since syntax is handled
 // at parse time.

--- a/tests/suite/foundations/int.typ
+++ b/tests/suite/foundations/int.typ
@@ -4,11 +4,11 @@
 #test(0b1101, 13)
 #test(0xA + 0xa, 0x14)
 
---- int-base-binary-invalid paged ---
+--- int-base-binary-invalid eval ---
 // Error: 2-7 invalid binary number: 0b123
 #0b123
 
---- int-base-hex-invalid paged ---
+--- int-base-hex-invalid eval ---
 // Error: 2-8 invalid hexadecimal number: 0x123z
 #0x123z
 
@@ -32,63 +32,63 @@
 #test(int(decimal("92492.193848921")), 92492)
 #test(int(decimal("-224.342211")), -224)
 
---- int-constructor-bad-type paged ---
+--- int-constructor-bad-type eval ---
 // Error: 6-10 expected integer, boolean, float, decimal, or string, found length
 #int(10pt)
 
---- int-constructor-str-empty paged ---
+--- int-constructor-str-empty eval ---
 // Error: 6-8 string must not be empty
 #int("")
 
---- int-constructor-str-empty-based paged ---
+--- int-constructor-str-empty-based eval ---
 // Error: 6-8 string must not be empty
 #int("", base: 16)
 
---- int-constructor-bad-value paged ---
+--- int-constructor-bad-value eval ---
 // Error: 6-12 string contains invalid digits
 #int("nope")
 
---- int-constructor-bad-value-based paged ---
+--- int-constructor-bad-value-based eval ---
 // Error: 6-11 string contains invalid digits for a base 3 integer
 #int("123", base: 3)
 
---- int-constructor-base-with-non-string paged ---
+--- int-constructor-base-with-non-string eval ---
 // Error: 16-18 base is only supported for strings
 #int(40, base: 16)
 
---- int-constructor-str-small-base paged ---
+--- int-constructor-str-small-base eval ---
 // Error: 17-18 base must be between 2 and 36
 #int("0", base: 1)
 
---- int-constructor-str-large-base paged ---
+--- int-constructor-str-large-base eval ---
 // Error: 17-19 base must be between 2 and 36
 #int("0", base: 42)
 
---- int-constructor-str-too-large paged ---
+--- int-constructor-str-too-large eval ---
 // Error: 6-27 integer value is too large
 // Hint: 6-27 value does not fit into a signed 64-bit integer
 // Hint: 6-27 try using a floating point number
 #int("9223372036854775808")
 
---- int-constructor-str-too-small paged ---
+--- int-constructor-str-too-small eval ---
 // Error: 6-28 integer value is too small
 // Hint: 6-28 value does not fit into a signed 64-bit integer
 // Hint: 6-28 try using a floating point number
 #int("-9223372036854775809")
 
---- int-constructor-float-too-large paged ---
+--- int-constructor-float-too-large eval ---
 // Error: 6-27 number too large
 #int(9223372036854775809.5)
 
---- int-constructor-float-too-large-min paged ---
+--- int-constructor-float-too-large-min eval ---
 // Error: 6-28 number too large
 #int(-9223372036854775809.5)
 
---- int-constructor-decimal-too-large paged ---
+--- int-constructor-decimal-too-large eval ---
 // Error: 6-38 number too large
 #int(decimal("9223372036854775809.5"))
 
---- int-constructor-decimal-too-large-min paged ---
+--- int-constructor-decimal-too-large-min eval ---
 // Error: 6-39 number too large
 #int(decimal("-9223372036854775809.5"))
 
@@ -114,7 +114,7 @@
 #test(int.from-bytes(1000.to-bytes(endian: "little", size: 5), endian: "little", signed: true), 1000)
 #test(int.from-bytes(1000.to-bytes(endian: "little", size: 5), endian: "little", signed: false), 1000)
 
---- int-from-and-to-bytes-too-many paged ---
+--- int-from-and-to-bytes-too-many eval ---
 // Error: 2-34 too many bytes to convert to a 64 bit number
 #int.from-bytes(bytes((0,) * 16))
 
@@ -182,6 +182,6 @@
 #test(type(x), int)
 #test(int(x), x)
 
---- number-invalid-suffix paged ---
+--- number-invalid-suffix eval ---
 // Error: 2-4 invalid number suffix: u
 #1u

--- a/tests/suite/foundations/label.typ
+++ b/tests/suite/foundations/label.typ
@@ -61,7 +61,7 @@ _Visible_
 #test(str(label("hey")), "hey")
 #test(str([Hmm<hey>].label), "hey")
 
---- label-in-code-mode-hint paged ---
+--- label-in-code-mode-hint eval ---
 // Error: 7-7 expected semicolon or line break
 // Hint: 7-7 labels can only be applied in markup mode
 // Hint: 7-7 try wrapping your code in a markup block (`[ ]`)
@@ -89,10 +89,10 @@ _Visible_
 // Warning: 1-4 label `<a>` is not attached to anything
 <a>
 
---- label-non-existent-error paged ---
+--- label-non-existent-error eval ---
 // Error: 5-10 sequence does not have field "label"
 #[].label
 
---- label-empty paged ---
+--- label-empty eval ---
 // Error: 23-32 label name must not be empty
 = Something to label #label("")

--- a/tests/suite/foundations/panic.typ
+++ b/tests/suite/foundations/panic.typ
@@ -1,14 +1,14 @@
---- panic paged ---
+--- panic eval ---
 // Test panic.
 // Error: 2-9 panicked
 #panic()
 
---- panic-with-int paged ---
+--- panic-with-int eval ---
 // Test panic.
 // Error: 2-12 panicked with: 123
 #panic(123)
 
---- panic-with-str paged ---
+--- panic-with-str eval ---
 // Test panic.
 // Error: 2-24 panicked with: "this is wrong"
 #panic("this is wrong")

--- a/tests/suite/foundations/path.typ
+++ b/tests/suite/foundations/path.typ
@@ -4,13 +4,13 @@
   "path(\"/tests/suite/foundations/hi/there.txt\")",
 )
 
---- path-escapes paged ---
+--- path-escapes eval ---
 // Error: 7-29 path `"../../../../file.txt"` would escape the project root
 // Hint: 7-29 cannot access files outside of the project sandbox
 // Hint: 7-29 you can adjust the project root with the `--root` argument
 #read("../../../../file.txt")
 
---- path-backslash paged ---
+--- path-backslash eval ---
 // Error: 7-21 path must not contain a backslash
 // Hint: 7-21 use forward slashes instead: `"to/file.txt"`
 // Hint: 7-21 in earlier Typst versions, backslashes indicated path separators on Windows

--- a/tests/suite/foundations/plugin.typ
+++ b/tests/suite/foundations/plugin.typ
@@ -40,38 +40,38 @@
 #test(hello == world, false)
 #test(hello == hello2, true)
 
---- plugin-wrong-number-of-arguments paged ---
+--- plugin-wrong-number-of-arguments eval ---
 #let p = plugin("/assets/plugins/hello.wasm")
 
 // Error: 2-20 plugin function takes 0 arguments, but 1 was given
 #p.hello(bytes(""))
 
---- plugin-wrong-argument-type paged ---
+--- plugin-wrong-argument-type eval ---
 #let p = plugin("/assets/plugins/hello.wasm")
 
 // Error: 10-14 expected bytes, found boolean
 // Error: 27-29 expected bytes, found integer
 #p.hello(true, bytes(()), 10)
 
---- plugin-error paged ---
+--- plugin-error eval ---
 #let p = plugin("/assets/plugins/hello.wasm")
 
 // Error: 2-17 plugin errored with: This is an `Err`
 #p.returns_err()
 
---- plugin-panic paged ---
+--- plugin-panic eval ---
 #let p = plugin("/assets/plugins/hello.wasm")
 
 // Error: 2-16 plugin panicked: wasm `unreachable` instruction executed
 #p.will_panic()
 
---- plugin-out-of-bounds-read paged ---
+--- plugin-out-of-bounds-read eval ---
 #let p = plugin("/assets/plugins/plugin-oob.wasm")
 
 // Error: 2-14 plugin tried to read out of bounds: pointer 0x40000000 is out of bounds for read of length 1
 #p.read_oob()
 
---- plugin-out-of-bounds-write paged ---
+--- plugin-out-of-bounds-write eval ---
 #let p = plugin("/assets/plugins/plugin-oob.wasm")
 
 // Error: 2-27 plugin tried to write out of bounds: pointer 0x40000000 is out of bounds for write of length 3

--- a/tests/suite/foundations/std.typ
+++ b/tests/suite/foundations/std.typ
@@ -13,12 +13,12 @@
 #let grid = "oh no!"
 #test(my-grid.func(), std.grid)
 
---- std-shadowing paged ---
+--- std-shadowing eval ---
 #let std = 5
 // Error: 6-10 cannot access fields on type integer
 #std.grid
 
---- std-mutation paged ---
+--- std-mutation eval ---
 // Error: 3-6 cannot mutate a constant: std
 #(std = 10)
 

--- a/tests/suite/foundations/str.typ
+++ b/tests/suite/foundations/str.typ
@@ -53,24 +53,24 @@
 #test(str(-0987654321), "−987654321")
 #test(str(4 - 8), "−4")
 
---- str-constructor-bad-type paged ---
+--- str-constructor-bad-type eval ---
 // Error: 6-8 expected integer, float, decimal, version, bytes, label, type, or string, found content
 #str([])
 
---- str-constructor-bad-base paged ---
+--- str-constructor-bad-base eval ---
 // Error: 17-19 base must be between 2 and 36
 #str(123, base: 99)
 
---- str-constructor-unary paged ---
+--- str-constructor-unary eval ---
 // Error: 17-18 base must be between 2 and 36
 // Hint: 17-18 generate a unary representation with `"1" * 999`
 #str(999, base: 1)
 
---- str-constructor-unsupported-base paged ---
+--- str-constructor-unsupported-base eval ---
 // Error: 18-19 base is only supported for integers
 #str(1.23, base: 2)
 
---- str-constructor-unsupported-base-ten paged ---
+--- str-constructor-unsupported-base-ten eval ---
 // Error: 18-20 base is only supported for integers
 #str(1.23, base: 10)
 
@@ -79,19 +79,19 @@
 #test(str.from-unicode(97), "a")
 #test(str.to-unicode("a"), 97)
 
---- str-from-unicode-bad-type paged ---
+--- str-from-unicode-bad-type eval ---
 // Error: 19-22 expected integer, found content
 #str.from-unicode([a])
 
---- str-to-unicode-bad-type paged ---
+--- str-to-unicode-bad-type eval ---
 // Error: 17-21 expected exactly one character
 #str.to-unicode("ab")
 
---- str-from-unicode-negative paged ---
+--- str-from-unicode-negative eval ---
 // Error: 19-21 number must be at least zero
 #str.from-unicode(-1)
 
---- str-from-unicode-bad-value paged ---
+--- str-from-unicode-bad-value eval ---
 // Error: 2-28 0x110000 is not a valid codepoint
 #str.from-unicode(0x110000) // 0x10ffff is the highest valid code point
 
@@ -117,11 +117,11 @@
 #test("hey".last(default: "d"), "y")
 #test("".last(default: "d"), "d")
 
---- string-first-empty paged ---
+--- string-first-empty eval ---
 // Error: 2-12 string is empty
 #"".first()
 
---- string-last-empty paged ---
+--- string-last-empty eval ---
 // Error: 2-11 string is empty
 #"".last()
 
@@ -137,11 +137,11 @@
 // Test `at`'s 'default' parameter.
 #test("z", "Hello".at(5, default: "z"))
 
---- string-at-not-a-char-boundary paged ---
+--- string-at-not-a-char-boundary eval ---
 // Error: 2-14 string index 2 is not a character boundary
 #"🏳️‍🌈".at(2)
 
---- string-at-out-of-bounds paged ---
+--- string-at-out-of-bounds eval ---
 // Error: 2-15 no default value was specified and string index out of bounds (index: 5, len: 5)
 #"Hello".at(5)
 
@@ -157,11 +157,11 @@
 #test("x🏡yz".slice(-2, count: 2), "yz")
 #test("x🏡yz".slice(-7, count: 7), "x🏡yz")
 
---- string-slice-count-end paged ---
+--- string-slice-count-end eval ---
 // Error: 2-29 `end` and `count` are mutually exclusive
 #"abc".slice(0, 1, count: 2)
 
---- string-slice-not-a-char-boundary paged ---
+--- string-slice-not-a-char-boundary eval ---
 // Error: 2-21 string index -1 is not a character boundary
 #"🏳️‍🌈".slice(0, -1)
 
@@ -287,11 +287,11 @@
 }), "hello world")
 #test("aaa".replace("a", m => str(m.captures.len())), "000")
 
---- string-replace-function-bad-type paged ---
+--- string-replace-function-bad-type eval ---
 // Error: 23-24 expected string, found integer
 #"123".replace("123", m => 1)
 
---- string-replace-bad-type paged ---
+--- string-replace-bad-type eval ---
 // Error: 23-32 expected string or function, found array
 #"123".replace("123", (1, 2, 3))
 
@@ -338,7 +338,7 @@
 #test("abc12306".trim(regex("\\d"), at: end), "abc")
 #test("whole".trim(regex("whole"), at: end), "")
 
---- string-trim-at-bad-alignment paged ---
+--- string-trim-at-bad-alignment eval ---
 // Error: 17-21 expected either `start` or `end`
 #"abc".trim(at: left)
 
@@ -369,6 +369,6 @@
 #test("abc".rev(), "cba")
 #test("ax̂e".rev(), "ex̂a")
 
---- string-unclosed paged ---
+--- string-unclosed eval ---
 // Error: 1:2-2:1 unclosed string
 #"hello\"

--- a/tests/suite/foundations/type.typ
+++ b/tests/suite/foundations/type.typ
@@ -3,16 +3,16 @@
 #test(type(ltr), direction)
 #test(type(10 / 3), float)
 
---- issue-3110-type-constructor paged ---
+--- issue-3110-type-constructor eval ---
 // Let the error message report the type name.
 // Error: 2-9 type content does not have a constructor
 #content()
 
---- issue-3110-associated-field paged ---
+--- issue-3110-associated-field eval ---
 // Error: 6-12 type integer does not contain field `MAXVAL`
 #int.MAXVAL
 
---- issue-3110-associated-function paged ---
+--- issue-3110-associated-function eval ---
 // Error: 6-18 type string does not contain field `from-unïcode`
 #str.from-unïcode(97)
 

--- a/tests/suite/foundations/version.typ
+++ b/tests/suite/foundations/version.typ
@@ -21,7 +21,7 @@
 #test(version(0), version(0, 0))
 #test(version(1, 2), version(1, 2, 0, 0, 0, 0))
 
---- version-at paged ---
+--- version-at eval ---
 // Test `version.at`.
 
 // Non-negative index in bounds

--- a/tests/suite/introspection/counter.typ
+++ b/tests/suite/introspection/counter.typ
@@ -195,7 +195,7 @@ $ 1 + 2 $ <eq>
 #counter(figure.where(kind: image)).update(n => n + 3)
 #figure(caption: [Four 'D's], kind: image, supplement: "Figure")[_DDDD!_]
 
---- counter-at-no-context paged ---
+--- counter-at-no-context eval ---
 // Test `counter.at` outside of context.
 // Error: 2-28 can only be used when context is known
 // Hint: 2-28 try wrapping this in a `context` expression

--- a/tests/suite/introspection/state.typ
+++ b/tests/suite/introspection/state.typ
@@ -47,7 +47,7 @@ Was: #context {
 #trait[Fear]
 #trait[Anger]
 
---- state-at-no-context paged ---
+--- state-at-no-context eval ---
 // Test `state.at` outside of context.
 // Error: 2-26 can only be used when context is known
 // Hint: 2-26 try wrapping this in a `context` expression

--- a/tests/suite/layout/align.typ
+++ b/tests/suite/layout/align.typ
@@ -124,15 +124,15 @@ To the right! Where the sunlight peeks behind the mountain.
 #test((bottom + end).inv(), (start + top))
 #test((horizon + center).inv(), (center + horizon))
 
---- alignment-add-two-horizontal paged ---
+--- alignment-add-two-horizontal eval ---
 // Error: 8-22 cannot add two horizontal alignments
 #align(center + right, [A])
 
---- alignment-add-two-vertical paged ---
+--- alignment-add-two-vertical eval ---
 // Error: 8-20 cannot add two vertical alignments
 #align(top + bottom, [A])
 
---- alignment-add-vertical-and-2d paged ---
+--- alignment-add-vertical-and-2d eval ---
 // Error: 8-30 cannot add a vertical and a 2D alignment
 #align(top + (bottom + right), [A])
 

--- a/tests/suite/layout/columns.typ
+++ b/tests/suite/layout/columns.typ
@@ -99,7 +99,7 @@ second column.
 
 This is a normal page. Very normal.
 
---- columns-zero paged ---
+--- columns-zero eval ---
 // Test a page with zero columns.
 // Error: 49-50 number must be positive
 #set page(height: auto, width: 7.05cm, columns: 0)

--- a/tests/suite/layout/dir.typ
+++ b/tests/suite/layout/dir.typ
@@ -4,7 +4,7 @@
 #test(direction.from(top), ttb)
 #test(direction.from(bottom), btt)
 
---- dir-from-invalid paged ---
+--- dir-from-invalid eval ---
 // Error: 17-23 cannot convert this alignment to a side
 #direction.from(center)
 
@@ -14,7 +14,7 @@
 #test(direction.to(top), btt)
 #test(direction.to(bottom), ttb)
 
---- dir-to-invalid paged ---
+--- dir-to-invalid eval ---
 // Error: 15-21 cannot convert this alignment to a side
 #direction.to(center)
 

--- a/tests/suite/layout/grid/cell.typ
+++ b/tests/suite/layout/grid/cell.typ
@@ -127,7 +127,7 @@
   )
 }
 
---- table-cell-in-grid paged ---
+--- table-cell-in-grid eval ---
 // Error: 7-19 cannot use `table.cell` as a grid cell
 // Hint: 7-19 use `grid.cell` instead
 #grid(table.cell[])

--- a/tests/suite/layout/grid/footers.typ
+++ b/tests/suite/layout/grid/footers.typ
@@ -182,7 +182,7 @@
   grid.footer([b]),
 )
 
---- table-footer-in-grid paged ---
+--- table-footer-in-grid eval ---
 // Error: 3:3-3:20 cannot use `table.footer` as a grid footer
 // Hint: 3:3-3:20 use `grid.footer` instead
 #grid(
@@ -190,7 +190,7 @@
   table.footer([a]),
 )
 
---- grid-footer-in-table paged ---
+--- grid-footer-in-table eval ---
 // Error: 3:3-3:19 cannot use `grid.footer` as a table footer
 // Hint: 3:3-3:19 use `table.footer` instead
 #table(
@@ -198,51 +198,51 @@
   grid.footer([a]),
 )
 
---- grid-footer-in-grid-header paged ---
+--- grid-footer-in-grid-header eval ---
 // Error: 14-28 cannot place a grid footer within another footer or header
 #grid.header(grid.footer[a])
 
---- table-footer-in-grid-header paged ---
+--- table-footer-in-grid-header eval ---
 // Error: 14-29 cannot place a table footer within another footer or header
 #grid.header(table.footer[a])
 
---- grid-footer-in-table-header paged ---
+--- grid-footer-in-table-header eval ---
 // Error: 15-29 cannot place a grid footer within another footer or header
 #table.header(grid.footer[a])
 
---- table-footer-in-table-header paged ---
+--- table-footer-in-table-header eval ---
 // Error: 15-30 cannot place a table footer within another footer or header
 #table.header(table.footer[a])
 
---- grid-footer-in-grid-footer paged ---
+--- grid-footer-in-grid-footer eval ---
 // Error: 14-28 cannot place a grid footer within another footer or header
 #grid.footer(grid.footer[a])
 
---- table-footer-in-grid-footer paged ---
+--- table-footer-in-grid-footer eval ---
 // Error: 14-29 cannot place a table footer within another footer or header
 #grid.footer(table.footer[a])
 
---- grid-footer-in-table-footer paged ---
+--- grid-footer-in-table-footer eval ---
 // Error: 15-29 cannot place a grid footer within another footer or header
 #table.footer(grid.footer[a])
 
---- table-footer-in-table-footer paged ---
+--- table-footer-in-table-footer eval ---
 // Error: 15-30 cannot place a table footer within another footer or header
 #table.footer(table.footer[a])
 
---- grid-header-in-grid-footer paged ---
+--- grid-header-in-grid-footer eval ---
 // Error: 14-28 cannot place a grid header within another header or footer
 #grid.footer(grid.header[a])
 
---- table-header-in-grid-footer paged ---
+--- table-header-in-grid-footer eval ---
 // Error: 14-29 cannot place a table header within another header or footer
 #grid.footer(table.header[a])
 
---- grid-header-in-table-footer paged ---
+--- grid-header-in-table-footer eval ---
 // Error: 15-29 cannot place a grid header within another header or footer
 #table.footer(grid.header[a])
 
---- table-header-in-table-footer paged ---
+--- table-header-in-table-footer eval ---
 // Error: 15-30 cannot place a table header within another header or footer
 #table.footer(table.header[a])
 

--- a/tests/suite/layout/grid/headers.typ
+++ b/tests/suite/layout/grid/headers.typ
@@ -263,7 +263,7 @@
   [c],
 )
 
---- table-header-in-grid paged ---
+--- table-header-in-grid eval ---
 // Error: 2:3-2:20 cannot use `table.header` as a grid header
 // Hint: 2:3-2:20 use `grid.header` instead
 #grid(
@@ -271,7 +271,7 @@
   [a],
 )
 
---- grid-header-in-table paged ---
+--- grid-header-in-table eval ---
 // Error: 2:3-2:19 cannot use `grid.header` as a table header
 // Hint: 2:3-2:19 use `table.header` instead
 #table(
@@ -279,19 +279,19 @@
   [a],
 )
 
---- grid-header-in-grid-header paged ---
+--- grid-header-in-grid-header eval ---
 // Error: 14-28 cannot place a grid header within another header or footer
 #grid.header(grid.header[a])
 
---- table-header-in-grid-header paged ---
+--- table-header-in-grid-header eval ---
 // Error: 14-29 cannot place a table header within another header or footer
 #grid.header(table.header[a])
 
---- grid-header-in-table-header paged ---
+--- grid-header-in-table-header eval ---
 // Error: 15-29 cannot place a grid header within another header or footer
 #table.header(grid.header[a])
 
---- table-header-in-table-header paged ---
+--- table-header-in-table-header eval ---
 // Error: 15-30 cannot place a table header within another header or footer
 #table.header(table.header[a])
 

--- a/tests/suite/layout/grid/stroke.typ
+++ b/tests/suite/layout/grid/stroke.typ
@@ -384,22 +384,22 @@
   table.vline(x: 3)
 )
 
---- table-hline-in-grid paged ---
+--- table-hline-in-grid eval ---
 // Error: 7-20 cannot use `table.hline` as a grid line
 // Hint: 7-20 use `grid.hline` instead
 #grid(table.hline())
 
---- table-vline-in-grid paged ---
+--- table-vline-in-grid eval ---
 // Error: 7-20 cannot use `table.vline` as a grid line
 // Hint: 7-20 use `grid.vline` instead
 #grid(table.vline())
 
---- grid-hline-in-table paged ---
+--- grid-hline-in-table eval ---
 // Error: 8-20 cannot use `grid.hline` as a table line
 // Hint: 8-20 use `table.hline` instead
 #table(grid.hline())
 
---- grid-vline-in-table paged ---
+--- grid-vline-in-table eval ---
 // Error: 8-20 cannot use `grid.vline` as a table line
 // Hint: 8-20 use `table.vline` instead
 #table(grid.vline())
@@ -422,19 +422,19 @@
   [g], [h], [i],
 )
 
---- grid-hline-position-horizon paged ---
+--- grid-hline-position-horizon eval ---
 // Error: 24-31 expected `top` or `bottom`, found horizon
 #table.hline(position: horizon)
 
---- grid-vline-position-center paged ---
+--- grid-vline-position-center eval ---
 // Error: 24-30 expected `start`, `left`, `right`, or `end`, found center
 #table.vline(position: center)
 
---- grid-hline-position-right paged ---
+--- grid-hline-position-right eval ---
 // Error: 24-29 expected `top` or `bottom`, found right
 #table.hline(position: right)
 
---- grid-vline-position-top paged ---
+--- grid-vline-position-top eval ---
 // Error: 24-27 expected `start`, `left`, `right`, or `end`, found top
 #table.vline(position: top)
 

--- a/tests/suite/layout/inline/bidi.typ
+++ b/tests/suite/layout/inline/bidi.typ
@@ -65,7 +65,7 @@ Lריווח #h(1cm) R
 #show raw: set text(dir:rtl)
 לתכנת בעברית `אם א == ב:`
 
---- bidi-vertical paged ---
+--- bidi-vertical eval ---
 // Test setting a vertical direction.
 // Error: 16-19 text direction must be horizontal
 #set text(dir: ttb)

--- a/tests/suite/layout/inline/hyphenate.typ
+++ b/tests/suite/layout/inline/hyphenate.typ
@@ -159,11 +159,11 @@ Hello-#text(red)[world]
 #set text(costs: (hyphenation: 10000%))
 #sample
 
---- costs-invalid-type paged ---
+--- costs-invalid-type eval ---
 // Error: 18-37 expected ratio, found auto
 #set text(costs: (hyphenation: auto))
 
---- costs-invalid-key paged ---
+--- costs-invalid-key eval ---
 // Error: 18-52 unexpected key "invalid-key", valid keys are "hyphenation", "runt", "widow", and "orphan"
 #set text(costs: (hyphenation: 1%, invalid-key: 3%))
 

--- a/tests/suite/layout/inline/justify.typ
+++ b/tests/suite/layout/inline/justify.typ
@@ -167,26 +167,26 @@ int main() {
   it
 }
 
---- justify-limits-tracking-wrong-type paged ---
+--- justify-limits-tracking-wrong-type eval ---
 // Error: 1:32-4:2 `min` value of `tracking` is invalid (expected length, found ratio)
 #set par(justification-limits: (
   spacing: (min: 100%, max: 100%),
   tracking: (min: 90%, max: 110%),
 ))
 
---- justify-limits-tracking-min-positive paged ---
+--- justify-limits-tracking-min-positive eval ---
 // Error: 32-65 `min` value of `tracking` is invalid (length must be negative or zero)
 #set par(justification-limits: (tracking: (min: 1em, max: -1em)))
 
---- justify-limits-tracking-max-negative paged ---
+--- justify-limits-tracking-max-negative eval ---
 // Error: 32-66 `max` value of `tracking` is invalid (length must be positive or zero)
 #set par(justification-limits: (tracking: (min: -1em, max: -1em)))
 
---- justify-limits-spacing-max-negative paged ---
+--- justify-limits-spacing-max-negative eval ---
 // Error: 32-78 `max` value of `spacing` is invalid (length must be positive or zero)
 #set par(justification-limits: (spacing: (min: 100% - 10pt, max: 120% - 1pt)))
 
---- justify-limits-spacing-ratio-negative paged ---
+--- justify-limits-spacing-ratio-negative eval ---
 // Error: 32-76 `min` value of `spacing` is invalid (ratio must be positive)
 #set par(justification-limits: (spacing: (min: -50% - 1pt, max: 50% + 1pt)))
 

--- a/tests/suite/layout/inline/text.typ
+++ b/tests/suite/layout/inline/text.typ
@@ -48,53 +48,53 @@ waltz vs #text(discretionary-ligatures: true)[waltz]
 #text(features: ("smcp",))[Smcp] \
 fi vs. #text(features: (liga: 0))[No fi]
 
---- text-stylistic-set-bad-type paged ---
+--- text-stylistic-set-bad-type eval ---
 // Error: 26-31 expected none, integer, or array, found boolean
 #set text(stylistic-set: false)
 
---- text-stylistic-set-out-of-bounds paged ---
+--- text-stylistic-set-out-of-bounds eval ---
 // Error: 26-28 stylistic set must be between 1 and 20
 #set text(stylistic-set: 25)
 
---- text-number-type-bad paged ---
+--- text-number-type-bad eval ---
 // Error: 24-25 expected "lining", "old-style", or auto, found integer
 #set text(number-type: 2)
 
---- text-features-bad paged ---
+--- text-features-bad eval ---
 // Error: 21-26 expected array or dictionary, found boolean
 #set text(features: false)
 
---- text-features-non-ascii paged ---
+--- text-features-non-ascii eval ---
 // Error: 21-30 feature tag may contain only printable ASCII characters
 // Hint: 21-30 found invalid cluster `"ƒ"`
 // Hint: 21-30 occurred in tag at index 0 (`"ƒeat"`)
 #set text(features: ("ƒeat",))
 
---- text-features-bad-padding paged ---
+--- text-features-bad-padding eval ---
 // Error: 21-30 spaces may only appear as padding following a feature tag
 // Hint: 21-30 occurred in tag at index 0 (`" tag"`)
 #set text(features: (" tag",))
 
---- text-features-empty-array paged ---
+--- text-features-empty-array eval ---
 // Error: 21-26 feature tag must be one to four characters in length
 // Hint: 21-26 found 0 characters
 // Hint: 21-26 occurred in tag at index 0 (`""`)
 #set text(features: ("",))
 
---- text-features-overlong-dict paged ---
+--- text-features-overlong-dict eval ---
 // Error: 21-41 feature tag must be one to four characters in length
 // Hint: 21-41 found 15 characters
 // Hint: 21-41 occurred in tag at index 0 (`"verylongfeature"`)
 #set text(features: (verylongfeature: 0))
 
---- text-features-array-kv paged ---
+--- text-features-array-kv eval ---
 // Error: 21-32 feature tag must be one to four characters in length
 // Hint: 21-32 found 6 characters
 // Hint: 21-32 occurred in tag at index 0 (`"feat=2"`)
 // Hint: 21-32 to set features with custom values, consider supplying a dictionary
 #set text(features: ("feat=2",))
 
---- text-features-bad-nested-type paged ---
+--- text-features-bad-nested-type eval ---
 // Error: 21-35 expected string, found boolean
 // Hint: 21-35 occurred in tag at index 1 (`false`)
 // Hint: 21-35 to set features with custom values, consider supplying a dictionary

--- a/tests/suite/layout/length.typ
+++ b/tests/suite/layout/length.typ
@@ -46,41 +46,41 @@
   test((10em).to-absolute(), 640pt)
 }
 
---- length-unit-hint paged ---
+--- length-unit-hint eval ---
 // Error: 17-19 expected length, found integer
 // Hint: 17-19 a length needs a unit - did you mean 12pt?
 #set text(size: 12)
 
---- length-ignore-em-pt-hint paged ---
+--- length-ignore-em-pt-hint eval ---
 // Error: 2-21 cannot convert a length with non-zero em units (`-6pt + 10.5em`) to pt
 // Hint: 2-21 use `length.to-absolute()` to resolve its em component (requires context)
 // Hint: 2-21 or use `length.abs.pt()` instead to ignore its em component
 #(10.5em - 6pt).pt()
 
---- length-ignore-em-cm-hint paged ---
+--- length-ignore-em-cm-hint eval ---
 // Error: 2-12 cannot convert a length with non-zero em units (`3em`) to cm
 // Hint: 2-12 use `length.to-absolute()` to resolve its em component (requires context)
 // Hint: 2-12 or use `length.abs.cm()` instead to ignore its em component
 #(3em).cm()
 
---- length-ignore-em-mm-hint paged ---
+--- length-ignore-em-mm-hint eval ---
 // Error: 2-20 cannot convert a length with non-zero em units (`-226.77pt + 93em`) to mm
 // Hint: 2-20 use `length.to-absolute()` to resolve its em component (requires context)
 // Hint: 2-20 or use `length.abs.mm()` instead to ignore its em component
 #(93em - 80mm).mm()
 
---- length-ignore-em-inches-hint paged ---
+--- length-ignore-em-inches-hint eval ---
 // Error: 2-24 cannot convert a length with non-zero em units (`432pt + 4.5em`) to inches
 // Hint: 2-24 use `length.to-absolute()` to resolve its em component (requires context)
 // Hint: 2-24 or use `length.abs.inches()` instead to ignore its em component
 #(4.5em + 6in).inches()
 
---- issue-5519-nondecimal-suffix paged ---
+--- issue-5519-nondecimal-suffix eval ---
 // Error: 2-9 binary numbers cannot have a suffix
 // Hint: 2-9 try using a decimal number: 4pt
 #0b100pt
 
---- nondecimal-suffix-edge-cases paged ---
+--- nondecimal-suffix-edge-cases eval ---
 // Error: 2-7 octal numbers cannot have a suffix
 // Hint: 2-7 try using a decimal number: 50%
 #0o62%
@@ -94,7 +94,7 @@
 #0b0101dag
 
 
---- number-syntax-edge-cases paged ---
+--- number-syntax-edge-cases eval ---
 // Test numeric syntax edge cases with suffixes and which spans of text are
 // highlighted. Valid items are those not annotated with an error comment since
 // syntax is handled at parse time.

--- a/tests/suite/layout/page.typ
+++ b/tests/suite/layout/page.typ
@@ -129,11 +129,11 @@
 #pagebreak()
 #rect(width: 100%)[Right]
 
---- page-margin-left-and-outside paged ---
+--- page-margin-left-and-outside eval ---
 // Error: 19-44 `inside` and `outside` are mutually exclusive with `left` and `right`
 #set page(margin: (left: 1cm, outside: 2cm))
 
---- page-margin-binding-bad paged ---
+--- page-margin-binding-bad eval ---
 // Error: 20-23 must be `left` or `right`
 #set page(binding: top)
 
@@ -177,7 +177,7 @@ Z
 
 #block(width: 100%, height: 100%, fill: aqua.lighten(50%))
 
---- page-number-align-left-horizon paged ---
+--- page-number-align-left-horizon eval ---
 // Error: 25-39 expected `top` or `bottom`, found horizon
 #set page(number-align: left + horizon)
 

--- a/tests/suite/layout/relative.typ
+++ b/tests/suite/layout/relative.typ
@@ -6,11 +6,11 @@
 #test((100% + 2pt - 2pt).length, 0pt)
 #test((56% + 2pt - 56%).ratio, 0%)
 
---- double-percent-embedded paged ---
+--- double-percent-embedded eval ---
 // Test for two percent signs in a row.
 // Error: 2-7 invalid number suffix: %%
 #3.1%%
 
---- double-percent-parens paged ---
+--- double-percent-parens eval ---
 // Error: 3-8 invalid number suffix: %%
 #(3.1%%)

--- a/tests/suite/layout/spacing.typ
+++ b/tests/suite/layout/spacing.typ
@@ -107,7 +107,7 @@ A #h(1fr) B
 #v(1fr, weak: true)
 2
 
---- spacing-missing-amount paged ---
+--- spacing-missing-amount eval ---
 // Missing spacing.
 // Error: 10-13 missing argument: amount
 Totally #h() ignored

--- a/tests/suite/layout/table.typ
+++ b/tests/suite/layout/table.typ
@@ -16,7 +16,7 @@
 --- table-fill-basic paged ---
 #table(columns: 3, stroke: none, fill: green, [A], [B], [C])
 
---- table-fill-bad paged ---
+--- table-fill-bad eval ---
 // Error: 14-19 expected color, gradient, tiling, none, array, or function, found string
 #table(fill: "hey")
 
@@ -321,7 +321,7 @@
   par[C],
 )
 
---- grid-cell-in-table paged ---
+--- grid-cell-in-table eval ---
 // Error: 8-19 cannot use `grid.cell` as a table cell
 // Hint: 8-19 use `table.cell` instead
 #table(grid.cell[])

--- a/tests/suite/loading/csv.typ
+++ b/tests/suite/loading/csv.typ
@@ -17,20 +17,20 @@
 #test(data.at(2).Weight, "150kg")
 #test(data.at(1).Species, "Tiger")
 
---- csv-file-not-found paged ---
+--- csv-file-not-found eval ---
 // Error: 6-16 file not found (searched at tests/suite/loading/nope.csv)
 #csv("nope.csv")
 
---- csv-invalid paged ---
+--- csv-invalid eval ---
 // Error: "/assets/data/bad.csv" 3:1 failed to parse CSV (found 3 instead of 2 fields in line 3)
 #csv("/assets/data/bad.csv")
 
---- csv-invalid-row-type-dict paged ---
+--- csv-invalid-row-type-dict eval ---
 // Test error numbering with dictionary rows.
 // Error: "/assets/data/bad.csv" 3:1 failed to parse CSV (found 3 instead of 2 fields in line 3)
 #csv("/assets/data/bad.csv", row-type: dictionary)
 
---- csv-invalid-delimiter paged ---
+--- csv-invalid-delimiter eval ---
 // Error: 41-51 delimiter must be an ASCII character
 #csv("/assets/data/zoo.csv", delimiter: "\u{2008}")
 

--- a/tests/suite/loading/json.typ
+++ b/tests/suite/loading/json.typ
@@ -9,12 +9,12 @@
 #let data-from-path = json(path("/assets/data/zoo.json"))
 #test(data-from-path, data)
 
---- json-with-bom paged ---
+--- json-with-bom eval ---
 // Error: 7-43 failed to parse JSON (unexpected Byte Order Mark at 1:1)
 // Hint: 7-43 JSON requires UTF-8 without a BOM
 #json(bytes("\u{FEFF}{\"name\": \"BOM\"}"))
 
---- json-invalid paged ---
+--- json-invalid eval ---
 // Error: "/assets/data/bad.json" 3:14 failed to parse JSON (expected value at line 3 column 14)
 #json("/assets/data/bad.json")
 

--- a/tests/suite/loading/read.typ
+++ b/tests/suite/loading/read.typ
@@ -3,15 +3,15 @@
 #let data = read("/assets/text/hello.txt")
 #test(data, "Hello, world!\n")
 
---- read-file-not-found paged ---
+--- read-file-not-found eval ---
 // Error: 18-44 file not found (searched at assets/text/missing.txt)
 #let data = read("/assets/text/missing.txt")
 
---- read-invalid-utf-8 paged ---
+--- read-invalid-utf-8 eval ---
 // Error: 18-40 failed to convert to string (file is not valid UTF-8 in assets/text/bad.txt:1:1)
 #let data = read("/assets/text/bad.txt")
 
---- read-escapes paged ---
+--- read-escapes eval ---
 // Error: 7-29 path `"../../../../file.txt"` would escape the project root
 // Hint: 7-29 cannot access files outside of the project sandbox
 // Hint: 7-29 you can adjust the project root with the `--root` argument
@@ -27,7 +27,7 @@
 // Reads from the project.
 #test(reader.read-it(path("/assets/text/hello.txt")), "Hello, world!\n")
 
---- read-from-project-in-package-fails paged ---
+--- read-from-project-in-package-fails eval ---
 #import "@test/reader:0.1.0"
 
 // Error: "tests/packages/reader-0.1.0/src/lib.typ" 2:24-2:25 file not found (searched at tests/packages/reader-0.1.0/assets/text/hello.txt)

--- a/tests/suite/loading/toml.typ
+++ b/tests/suite/loading/toml.typ
@@ -40,7 +40,7 @@
 #let data-from-path = toml(path("/assets/data/toml-types.toml"))
 #test(data-from-path, data)
 
---- toml-invalid paged ---
+--- toml-invalid eval ---
 // Error: "/assets/data/bad.toml" 1:16-2:1 failed to parse TOML (expected `.`, `=`)
 #toml("/assets/data/bad.toml")
 
@@ -61,7 +61,7 @@
   )
 }
 
---- toml-decode-integer-too-large paged ---
+--- toml-decode-integer-too-large eval ---
 // If an integer cannot be represented losslessly, an error must be thrown.
 // https://toml.io/en/v1.0.0#integer
 
@@ -69,7 +69,7 @@
 // Error: 7-55 failed to parse TOML (number too large to fit in target type at 1:7)
 #toml(bytes("key = " + large-integer.i64-max-plus-one))
 
---- toml-decode-integer-too-small paged ---
+--- toml-decode-integer-too-small eval ---
 #import "edge-case.typ": large-integer
 // Error: 7-56 failed to parse TOML (number too small to fit in target type at 1:7)
 #toml(bytes("key = " + large-integer.i64-min-minus-one))
@@ -83,10 +83,10 @@
   )
 }
 
---- toml-encode-non-table paged ---
+--- toml-encode-non-table eval ---
 // Error: 14-15 expected dictionary, found integer
 #toml.encode(3)
 
---- toml-decode-non-table paged ---
+--- toml-decode-non-table eval ---
 // Error: 7-17 failed to parse TOML (expected `.`, `=` at 1:2)
 #toml(bytes("3"))

--- a/tests/suite/loading/xml.typ
+++ b/tests/suite/loading/xml.typ
@@ -27,7 +27,7 @@
 #let data-from-path = xml(path("/assets/data/hello.xml"))
 #test(data-from-path, data)
 
---- xml-invalid paged ---
+--- xml-invalid eval ---
 // Error: "/assets/data/bad.xml" 3:1 failed to parse XML (found closing tag 'data' instead of 'hello')
 #xml("/assets/data/bad.xml")
 

--- a/tests/suite/loading/yaml.typ
+++ b/tests/suite/loading/yaml.typ
@@ -16,7 +16,7 @@
 #let data-from-path = yaml(path("/assets/data/yaml-types.yaml"))
 #test(data-from-path, data)
 
---- yaml-invalid paged ---
+--- yaml-invalid eval ---
 // Error: "/assets/data/bad.yaml" 2:1 failed to parse YAML (did not find expected ',' or ']' at line 2 column 1, while parsing a flow sequence at line 1 column 18)
 #yaml("/assets/data/bad.yaml")
 

--- a/tests/suite/math/accent.typ
+++ b/tests/suite/math/accent.typ
@@ -95,11 +95,11 @@ $hat(accent(L, \u{0330})), accent(circle(p), \u{0323}),
   macron(accent(caron(accent(A, \u{20ED})), \u{0333})) \
   breve(accent(eta, \u{032E})) = accent(breve(eta), \u{032E})$
 
---- math-accent-string-too-long paged ---
+--- math-accent-string-too-long eval ---
 // Error: 17-21 expected exactly one character
 $ accent(x + y, "..") $
 
---- math-accent-content-too-long paged ---
+--- math-accent-content-too-long eval ---
 // Error: 17-19 expected a single-codepoint symbol
 $ accent(x + y, ..) $
 
@@ -123,7 +123,7 @@ $ accent(x + y, <->) $
 // Ensure that function call works.
 $ arrow.l.r(x + y) $
 
---- issue-7437-math-accent-emoji-presentation paged ---
+--- issue-7437-math-accent-emoji-presentation eval ---
 // Check that we do not normalize an accent character with emoji presentation
 // variation selector to an accent.
 //
@@ -135,7 +135,7 @@ $ arrow.l.r(x + y) $
 // Error: 12-31 expected exactly one character
 $accent(A, std.emoji.arrow.l.r)$
 
---- issue-7437-math-accent-trailing-text paged ---
+--- issue-7437-math-accent-trailing-text eval ---
 // Test that we don't allow extra text after the text variation selector.
 
 // Error: 13-47 expected exactly one character

--- a/tests/suite/math/attach.typ
+++ b/tests/suite/math/attach.typ
@@ -199,7 +199,7 @@ $
 $lr(size: #240%, [x])_0^1, [x]_0^1, \]_0^1, x_0^1, A_0^1$ \
 $n^2, (n + 1)^2, sum_0^1, integral_0^1$
 
---- math-attach-missing-sides paged ---
+--- math-attach-missing-sides eval ---
 // Test attachments that are missing a side.
 // Error: 23-24 unexpected underscore
 $ a _ b (d _) (d'_ ) (_ c) $

--- a/tests/suite/math/call.typ
+++ b/tests/suite/math/call.typ
@@ -8,12 +8,12 @@ $ pi(a,) $
 $ pi(a,b) $
 $ pi(a,b,) $
 
---- math-call-unclosed-func paged ---
+--- math-call-unclosed-func eval ---
 #let func(x) = x
 // Error: 6-7 unclosed delimiter
 $func(a$
 
---- math-call-unclosed-non-func paged ---
+--- math-call-unclosed-non-func eval ---
 // Error: 5-6 unclosed delimiter
 $sin(x$
 
@@ -31,32 +31,32 @@ $ func5(m: a) $
 $ func5(m: sigma : f) $
 $ func5(m: sigma:pi) $
 
---- math-call-named-args-no-expr paged ---
+--- math-call-named-args-no-expr eval ---
 #let func(m: none) = m
 // Error: 10 expected expression
 $ func(m: ) $
 
---- math-call-named-args-duplicate paged ---
+--- math-call-named-args-duplicate eval ---
 #let func(my: none) = my
 // Error: 15-17 duplicate argument: my
 $ func(my: a, my: b) $
 
---- math-call-named-args-shorthand-clash-1 paged ---
+--- math-call-named-args-shorthand-clash-1 eval ---
 #let func(m: none) = m
 // Error: 18-21 unexpected argument
 $func(m: =) func(m:=)$
 
---- math-call-named-args-shorthand-clash-2 paged ---
+--- math-call-named-args-shorthand-clash-2 eval ---
 #let func(m: none) = m
 // Error: 41-45 unexpected argument
 $func(m::) func(m: :=) func(m:: =) func(m::=)$
 
---- math-call-named-single-underscore paged ---
+--- math-call-named-single-underscore eval ---
 #let func(x) = x
 // Error: 8-9 expected identifier, found underscore
 $ func(_: a) $
 
---- math-call-named-single-char-error paged ---
+--- math-call-named-single-char-error eval ---
 #let func(m: none) = m
 // Error: 8-13 unexpected argument
 $ func(m : a) $
@@ -73,22 +73,22 @@ $ func(m : a) $
 #check($args(a-b: a-b)$, "arguments(a-b: sequence([a], [−], [b]))")
 #check($args(a-b)$, "arguments(sequence([a], [−], [b]))")
 
---- math-call-spread-content-error paged ---
+--- math-call-spread-content-error eval ---
 #let args(..body) = body
 // Error: 7-16 cannot spread content
 $args(..(a + b))$
 
---- math-call-spread-multiple-exprs paged ---
+--- math-call-spread-multiple-exprs eval ---
 #let args(..body) = body
 // Error: 7-14 cannot spread content
 $args(..a + b)$
 
---- math-call-spread-unexpected-dots paged ---
+--- math-call-spread-unexpected-dots eval ---
 #let args(..body) = body
 // Error: 8-10 unexpected dots
 $args(#..range(1, 5).chunks(2))$
 
---- math-call-spread-unexpected-binary paged ---
+--- math-call-spread-unexpected-binary eval ---
 // Test spread operators followed by binary math operators with and without
 // right operands. These errors aren't great, but they can be silenced with a
 // space and no one would actually write this.
@@ -125,7 +125,7 @@ $func(...)$
 #check($func(a: #4, ..dict, b: #4)$, (a: 2, b: 4))
 #check($func(a: #4, ..args, b: #4)$, (a: 3, b: 4))
 
---- math-call-named-spread-duplicate paged ---
+--- math-call-named-spread-duplicate eval ---
 // Test duplicate named args with the spread operator.
 // The error should only happen for manually added args.
 #let func(..) = none
@@ -164,7 +164,7 @@ $func(a: #2, ..dict, a: #3)$
 #check($args(a,b,)$, "arguments([a], [b])")
 #check($args(,a,b,,,)$, "arguments([], [a], [b], [], [])")
 
---- math-call-2d-non-func paged ---
+--- math-call-2d-non-func eval ---
 // Error: 6-7 expected content, found array
 // Error: 8-9 expected content, found array
 $ pi(a;b) $
@@ -235,7 +235,7 @@ $ sin( ,/**/x/**/, , /**/y, ,/**/, ) $
 // with whitespace/trivia:
 #check($args( ,/**/x/**/, , /**/y, ,/**/, )$, "arguments([], [x], [], [y], [], [])")
 
---- math-call-value-non-func paged ---
+--- math-call-value-non-func eval ---
 $ sin(1) $
 // Error: 8-9 expected content, found integer
 $ sin(#1) $
@@ -256,7 +256,7 @@ $
   bx(x y)  &&quad  bx(x (y z))  &quad  bx(x y^z) \
 $
 
---- math-call-unknown-var-hint paged ---
+--- math-call-unknown-var-hint eval ---
 // Error: 4-6 unknown variable: ab
 // Hint: 4-6 if you meant to display multiple letters as is, try adding spaces between each letter: `a b`
 // Hint: 4-6 or if you meant to display this as text, try placing it in quotes: `"ab"`
@@ -267,7 +267,7 @@ $ phi(x) $
 $ phi(x, y) $
 $ phi(1,2,,3,) $
 
---- math-call-symbol-named-argument paged ---
+--- math-call-symbol-named-argument eval ---
 // Error: 10-18 unexpected argument: alpha
 $ phi(x, alpha: y) $
 
@@ -286,7 +286,7 @@ $ mat(
    , ,1;
 ) $
 
---- issue-2885-math-var-only-in-global paged ---
+--- issue-2885-math-var-only-in-global eval ---
 // Error: 7-10 unknown variable: rgb
 // Hint: 7-10 `rgb` is not available directly in math, but is in the standard library
 // Hint: 7-10 to access `rgb` in code mode you can add a hash: `#rgb`
@@ -298,13 +298,13 @@ $text(rgb(0, 0, 0), "foo")$
 #let box = "box"
 $ box() $
 
---- math-call-error paged ---
+--- math-call-error eval ---
 // Test the span of errors when calling a function.
 #let func(a, b, c) = {}
 // Error: 3-13 missing argument: c
 $ func(a, b) $
 
---- math-call-error-inside-func paged ---
+--- math-call-error-inside-func eval ---
 // Test whether errors inside function calls produce further errors.
 #let int = int
 $ int(

--- a/tests/suite/math/delimited.typ
+++ b/tests/suite/math/delimited.typ
@@ -195,7 +195,7 @@ $
 --- math-lr-sym-call-size paged ---
 $ bracket.l(x, size: #400%) $
 
---- math-lr-sym-call-extra-arg paged ---
+--- math-lr-sym-call-extra-arg eval ---
 // Error: 16-28 unexpected argument: nope
 $ bracket.l(x, nope: "nope") $
 

--- a/tests/suite/math/equation.typ
+++ b/tests/suite/math/equation.typ
@@ -144,11 +144,11 @@ $ a + b = c $
 #show math.equation: set align(end)
 $ a + b = c $
 
---- math-equation-number-align-center paged ---
+--- math-equation-number-align-center eval ---
 // Error: 52-58 expected `start`, `left`, `right`, or `end`, found center
 #set math.equation(numbering: "(1)", number-align: center)
 
---- math-equation-number-align-center-bottom paged ---
+--- math-equation-number-align-center-bottom eval ---
 // Error: 52-67 expected `start`, `left`, `right`, or `end`, found center
 #set math.equation(numbering: "(1)", number-align: center + bottom)
 

--- a/tests/suite/math/frac.typ
+++ b/tests/suite/math/frac.typ
@@ -20,7 +20,7 @@ $ binom(circle, square) $
 // Test multinomial coefficients.
 $ binom(n, k_1, k_2, k_3) $
 
---- math-binom-missing-lower paged ---
+--- math-binom-missing-lower eval ---
 // Error: 3-13 missing argument: lower
 $ binom(x^2) $
 

--- a/tests/suite/math/mat.typ
+++ b/tests/suite/math/mat.typ
@@ -73,7 +73,7 @@ $ mat(..nums, delim: "|",)
 $ mat(..nums) mat(..nums;) \
   mat(..nums;,) mat(..nums,) $
 
---- math-mat-spread-expected-array-error paged ---
+--- math-mat-spread-expected-array-error eval ---
 #let nums = range(0, 2).map(i => (i, i+1))
 // Error: 15-16 expected array, found content
 $ mat(..nums, 0, 1) $
@@ -186,7 +186,7 @@ $ mat(-1&, 1&, 1&; 1&, -1&, 1&; 1&, 1&, -1&) $
 $ mat(-1&, 1&, 1&; 1, -1, 1; 1, 1, -1) $
 $ mat(&-1, &1, &1; 1, -1, 1; 1, 1, -1) $
 
---- math-mat-bad-comma paged ---
+--- math-mat-bad-comma eval ---
 // This error message is bad.
 // Error: 13-14 expected array, found content
 $ mat(1, 2; 3, 4, delim: "[") $,

--- a/tests/suite/math/symbols.typ
+++ b/tests/suite/math/symbols.typ
@@ -4,12 +4,12 @@
 #let sym = symbol("s", ("basic", "s"))
 #test($sym.basic$, $s$)
 
---- math-symbol-underscore paged ---
+--- math-symbol-underscore eval ---
 #let sym = symbol("s", ("test_underscore", "s"))
 // Error: 6-10 unknown symbol modifier
 $sym.test_underscore$
 
---- math-symbol-dash paged ---
+--- math-symbol-dash eval ---
 #let sym = symbol("s", ("test-dash", "s"))
 // Error: 6-10 unknown symbol modifier
 $sym.test-dash$
@@ -18,12 +18,12 @@ $sym.test-dash$
 #let sym = symbol("s", ("test.basic", "s"))
 #test($sym.test.basic$, $s$)
 
---- math-symbol-double-underscore paged ---
+--- math-symbol-double-underscore eval ---
 #let sym = symbol("s", ("one.test_underscore", "s"))
 // Error: 10-14 unknown symbol modifier
 $sym.one.test_underscore$
 
---- math-symbol-double-dash paged ---
+--- math-symbol-double-dash eval ---
 #let sym = symbol("s", ("one.test-dash", "s"))
 // Error: 10-14 unknown symbol modifier
 $sym.one.test-dash$

--- a/tests/suite/math/syntax.typ
+++ b/tests/suite/math/syntax.typ
@@ -32,6 +32,6 @@ $floor(phi.alt. )$
 // Numbers should parse the same regardless of number of characters.
 $1/2(x)$ vs. $1/10(x)$
 
---- math-unclosed paged ---
+--- math-unclosed eval ---
 // Error: 1-2 unclosed delimiter
 $a

--- a/tests/suite/math/vec.typ
+++ b/tests/suite/math/vec.typ
@@ -26,27 +26,27 @@ $ v = vec(1, 2+3, 4) $
 #set math.vec(delim: "[")
 $ vec(1, 2) $
 
---- math-vec-delim-empty-string paged ---
+--- math-vec-delim-empty-string eval ---
 // Error: 22-24 expected exactly one character
 #set math.vec(delim: "")
 
---- math-vec-delim-not-single-char paged ---
+--- math-vec-delim-not-single-char eval ---
 // Error: 22-39 expected exactly one character
 #set math.vec(delim: "not a delimiter")
 
---- math-vec-delim-invalid-char paged ---
+--- math-vec-delim-invalid-char eval ---
 // Error: 22-25 invalid delimiter: "%"
 #set math.vec(delim: "%")
 
---- math-vec-delim-invalid-symbol paged ---
+--- math-vec-delim-invalid-symbol eval ---
 // Error: 22-33 invalid delimiter: "%"
 #set math.vec(delim: sym.percent)
 
---- math-vec-delim-invalid-opening paged ---
+--- math-vec-delim-invalid-opening eval ---
 // Error: 22-33 invalid delimiter: "%"
 #set math.vec(delim: ("%", none))
 
---- math-vec-delim-invalid-closing paged ---
+--- math-vec-delim-invalid-closing eval ---
 // Error: 22-33 invalid delimiter: "%"
 #set math.vec(delim: (none, "%"))
 

--- a/tests/suite/model/bibliography.typ
+++ b/tests/suite/model/bibliography.typ
@@ -57,7 +57,7 @@ hi:
   bytes(src.text)
 ))
 
---- bibliography-duplicate-key paged ---
+--- bibliography-duplicate-key eval ---
 // Error: 15-65 duplicate bibliography keys: netwok, issue201, arrgh, quark, distress, glacier-melt, tolkien54, DBLP:books/lib/Knuth86a, sharing, restful, mcintosh_anxiety, psychology25
 #bibliography(("/assets/bib/works.bib", "/assets/bib/works.bib"))
 
@@ -101,7 +101,7 @@ hi:
 // Error: 2-62 CSL style "Alphanumeric" is not suitable for bibliographies
 #bibliography("/assets/bib/works.bib", style: "alphanumeric")
 
---- bibliography-empty-key paged ---
+--- bibliography-empty-key eval ---
 #let src = ```yaml
 "":
   type: Book

--- a/tests/suite/model/cite.typ
+++ b/tests/suite/model/cite.typ
@@ -136,13 +136,13 @@ B #cite(<netwok>) #cite(<arrgh>).
 #show bibliography: none
 #bibliography("/assets/bib/works.bib")
 
---- cite-type-error-hint paged ---
+--- cite-type-error-hint eval ---
 // Test hint for cast error from str to label
 // Error: 7-15 expected label, found string
 // Hint: 7-15 use `<netwok>` or `label("netwok")` to create a label
 #cite("netwok")
 
---- cite-type-error-hint-invalid-literal paged ---
+--- cite-type-error-hint-invalid-literal eval ---
 // Test hint for cast error from str to label
 // Error: 7-17 expected label, found string
 // Hint: 7-17 use `label("%@&#*!\\")` to create a label

--- a/tests/suite/model/document.typ
+++ b/tests/suite/model/document.typ
@@ -7,11 +7,11 @@ What's up?
 --- document-set-author-date paged empty ---
 #set document(author: ("A", "B"), date: datetime.today())
 
---- document-date-bad paged ---
+--- document-date-bad eval ---
 // Error: 21-28 expected datetime, none, or auto, found string
 #set document(date: "today")
 
---- document-author-bad paged ---
+--- document-author-bad eval ---
 // Error: 23-29 expected string, found integer
 #set document(author: (123,))
 What's up?
@@ -22,7 +22,7 @@ What's up?
 Hello
 #set document(title: [Hello])
 
---- document-constructor paged ---
+--- document-constructor eval ---
 // Error: 2-12 can only be used in set rules
 #document()
 

--- a/tests/suite/model/emph-strong.typ
+++ b/tests/suite/model/emph-strong.typ
@@ -35,18 +35,18 @@ __
 // Hint: 13-15 using multiple consecutive underscores (e.g. __) has no additional effect
 __not italic__
 
---- emph-unclosed paged ---
+--- emph-unclosed eval ---
 // Error: 6-7 unclosed delimiter
 #box[_Scoped] to body.
 
---- emph-ends-at-parbreak paged ---
+--- emph-ends-at-parbreak eval ---
 // Ends at paragraph break.
 // Error: 1-2 unclosed delimiter
 _Hello
 
 World
 
---- emph-strong-unclosed-nested paged ---
+--- emph-strong-unclosed-nested eval ---
 // Error: 11-12 unclosed delimiter
 // Error: 3-4 unclosed delimiter
 #[_Cannot *be interleaved]

--- a/tests/suite/model/enum.typ
+++ b/tests/suite/model/enum.typ
@@ -130,11 +130,11 @@ a + 0.
 + E
 + F
 
---- enum-numbering-pattern-empty paged ---
+--- enum-numbering-pattern-empty eval ---
 // Error: 22-24 invalid numbering pattern
 #set enum(numbering: "")
 
---- enum-numbering-pattern-invalid paged ---
+--- enum-numbering-pattern-invalid eval ---
 // Error: 22-28 invalid numbering pattern
 #set enum(numbering: "(())")
 

--- a/tests/suite/model/figure.typ
+++ b/tests/suite/model/figure.typ
@@ -226,7 +226,7 @@ We can clearly see that @fig-cylinder and
 --- figure-caption-position paged empty ---
 #set figure.caption(position: top)
 
---- figure-caption-position-bad paged ---
+--- figure-caption-position-bad eval ---
 // Error: 31-38 expected `top` or `bottom`, found horizon
 #set figure.caption(position: horizon)
 

--- a/tests/suite/model/link.typ
+++ b/tests/suite/model/link.typ
@@ -33,7 +33,7 @@ https://example.com/#(((nested))) \
 #[https://example.com/] \
 https://example.com/)
 
---- link-bracket-unbalanced-opening paged ---
+--- link-bracket-unbalanced-opening eval ---
 // Verify that opening brackets without closing brackets throw an error.
 // Error: 1-22 automatic links cannot contain unbalanced brackets, use the `link` function instead
 https://exam(ple.com/
@@ -189,7 +189,7 @@ Text <hey>
 // Error: 2-20 label `<hey>` occurs multiple times in the document
 #link(<hey>)[Nope.]
 
---- link-empty-url paged ---
+--- link-empty-url eval ---
 // Error: 7-9 URL must not be empty
 #link("")[Empty]
 

--- a/tests/suite/model/list.typ
+++ b/tests/suite/model/list.typ
@@ -171,7 +171,7 @@ Not in list
 - Bare hyphen is
 - a bad marker
 
---- list-marker-array-empty paged ---
+--- list-marker-array-empty eval ---
 // Error: 19-21 array must contain at least one marker
 #set list(marker: ())
 

--- a/tests/suite/model/numbering.typ
+++ b/tests/suite/model/numbering.typ
@@ -91,6 +91,6 @@
 #t(pat: "⓵", 1, "⓵")
 #t(pat: "⓵", 10, "⓾")
 
---- numbering-negative paged ---
+--- numbering-negative eval ---
 // Error: 17-19 number must be at least zero
 #numbering("1", -1)

--- a/tests/suite/model/ref.typ
+++ b/tests/suite/model/ref.typ
@@ -92,7 +92,7 @@ Text seen on #ref(<text>, form: "page", supplement: "Page").
 // and not produce a reference to a label with an empty name.
 @
 
---- ref-function-empty-label paged ---
+--- ref-function-empty-label eval ---
 // using ref() should also not be possible
 // Error: 6-7 unexpected less-than operator
 // Error: 7-8 unexpected greater-than operator

--- a/tests/suite/model/terms.typ
+++ b/tests/suite/model/terms.typ
@@ -55,7 +55,7 @@
 Not in list
 /Nope
 
---- terms-missing-colon paged ---
+--- terms-missing-colon eval ---
 // Error: 8 expected colon
 / Hello
 

--- a/tests/suite/pdf/attach.typ
+++ b/tests/suite/pdf/attach.typ
@@ -23,7 +23,7 @@
 --- pdf-attach-zero-bytes paged empty ---
 #pdf.attach("file", bytes(()))
 
---- pdf-attach-invalid-relationship paged ---
+--- pdf-attach-invalid-relationship eval ---
 #pdf.attach(
   "/assets/text/hello.txt",
   // Error: 17-23 expected "source", "data", "alternative", "supplement", or none
@@ -32,7 +32,7 @@
   description: "A test file",
 )
 
---- pdf-attach-invalid-data paged ---
+--- pdf-attach-invalid-data eval ---
 // Error: 39-46 expected bytes, found string
 #pdf.attach("/assets/text/hello.txt", "hello")
 

--- a/tests/suite/scripting/blocks.typ
+++ b/tests/suite/scripting/blocks.typ
@@ -51,7 +51,7 @@
   none
 }, str)
 
---- code-block-join-int-with-content paged ---
+--- code-block-join-int-with-content eval ---
 // Some things can't be joined.
 #{
   [A]
@@ -60,14 +60,14 @@
   [B]
 }
 
---- code-block-scope-in-markup paged ---
+--- code-block-scope-in-markup eval ---
 // Block directly in markup also creates a scope.
 #{ let x = 1 }
 
 // Error: 7-8 unknown variable: x
 #test(x, 1)
 
---- code-block-scope-in-let paged ---
+--- code-block-scope-in-let eval ---
 // Block in expression does create a scope.
 #let a = {
   let b = 1
@@ -79,7 +79,7 @@
 // Error: 3-4 unknown variable: b
 #{b}
 
---- code-block-double-scope paged ---
+--- code-block-double-scope eval ---
 // Double block creates a scope.
 #{{
   import "module.typ": b
@@ -105,17 +105,17 @@
   test(a, "a1")
 }
 
---- code-block-multiple-literals-without-semicolon paged ---
+--- code-block-multiple-literals-without-semicolon eval ---
 // Multiple unseparated expressions in one line.
 // Error: 4 expected semicolon or line break
 #{1 2}
 
---- code-block-multiple-expressions-without-semicolon paged ---
+--- code-block-multiple-expressions-without-semicolon eval ---
 // Error: 13 expected semicolon or line break
 // Error: 23 expected semicolon or line break
 #{let x = -1 let y = 3 x + y}
 
---- code-block-incomplete-expressions paged ---
+--- code-block-incomplete-expressions eval ---
 #{
   // Error: 7-10 expected pattern, found string
   for "v"
@@ -127,20 +127,20 @@
   z
 }
 
---- code-block-unclosed paged ---
+--- code-block-unclosed eval ---
 // Error: 2-3 unclosed delimiter
 #{
 
---- code-block-unopened paged ---
+--- code-block-unopened eval ---
 // Error: 2-3 unexpected closing brace
 #}
 
---- single-right-bracket paged ---
+--- single-right-bracket eval ---
 // Error: 1-2 unexpected closing bracket
 // Hint: 1-2 try using a backslash escape: \]
 ]
 
---- right-bracket-nesting paged ---
+--- right-bracket-nesting eval ---
 [
 = [ Hi ]]
 - how [
@@ -150,11 +150,11 @@
   - error][]
 [[]]
 
---- right-bracket-hash paged ---
+--- right-bracket-hash eval ---
 // Error: 2-3 unexpected closing bracket
 #]
 
---- right-bracket-in-blocks paged ---
+--- right-bracket-in-blocks eval ---
 // Error: 3-4 unclosed delimiter
 // Error: 6-7 unexpected closing bracket
 // Hint: 6-7 try using a backslash escape: \]
@@ -175,7 +175,7 @@
 // Hint: 4-5 try using a backslash escape: \]
 #{{]}}
 
---- content-block-in-markup-scope paged ---
+--- content-block-in-markup-scope eval ---
 // Content blocks also create a scope.
 #[#let x = 1]
 

--- a/tests/suite/scripting/call.typ
+++ b/tests/suite/scripting/call.typ
@@ -39,30 +39,30 @@
   test(adder(2)(5), 7)
 }
 
---- call-bad-type-bool-literal paged ---
+--- call-bad-type-bool-literal eval ---
 // Error: 2-6 expected function, found boolean
 #true()
 
---- call-bad-type-string-var paged ---
+--- call-bad-type-string-var eval ---
 #let x = "x"
 
 // Error: 2-3 expected function, found string
 #x()
 
---- call-shadowed-builtin-function paged ---
+--- call-shadowed-builtin-function eval ---
 #let image = "image"
 
 // Error: 2-7 expected function, found string
 // Hint: 2-7 use `std.image` to access the shadowed standard library function
 #image("image")
 
---- call-bad-type-int-expr paged ---
+--- call-bad-type-int-expr eval ---
 #let f(x) = x
 
 // Error: 2-6 expected function, found integer
 #f(1)(2)
 
---- call-bad-type-content-expr paged ---
+--- call-bad-type-content-expr eval ---
 #let f(x) = x
 
 // Error: 2-6 expected function, found content
@@ -72,42 +72,42 @@
 // Trailing comma.
 #test(1 + 1, 2,)
 
---- call-args-duplicate paged ---
+--- call-args-duplicate eval ---
 // Error: 26-30 duplicate argument: font
 #set text(font: "Arial", font: "Helvetica")
 
---- call-args-bad-positional-as-named paged ---
+--- call-args-bad-positional-as-named eval ---
 // Error: 4-15 the argument `amount` is positional
 // Hint: 4-15 try removing `amount:`
 #h(amount: 0.5)
 
---- call-args-bad-colon paged ---
+--- call-args-bad-colon eval ---
 // Error: 7-8 unexpected colon
 #func(:)
 
---- call-args-bad-token paged ---
+--- call-args-bad-token eval ---
 // Error: 10-12 unexpected end of block comment
 // Hint: 10-12 consider escaping the `*` with a backslash or opening the block comment with `/*`
 #func(a:1*/)
 
---- call-args-missing-comma paged ---
+--- call-args-missing-comma eval ---
 // Error: 8 expected comma
 #func(1 2)
 
---- call-args-bad-name-and-incomplete-pair paged ---
+--- call-args-bad-name-and-incomplete-pair eval ---
 // Error: 7-8 expected identifier, found integer
 // Error: 9 expected expression
 #func(1:)
 
---- call-args-bad-name-int paged ---
+--- call-args-bad-name-int eval ---
 // Error: 7-8 expected identifier, found integer
 #func(1:2)
 
---- call-args-bad-name-string paged ---
+--- call-args-bad-name-string eval ---
 // Error: 7-12 expected identifier, found string
 #func("abc": 2)
 
---- call-args-bad-name-group paged ---
+--- call-args-bad-name-group eval ---
 // Error: 7-10 expected identifier, found group
 #func((x):1)
 
@@ -169,11 +169,11 @@
 #f(..if false {})
 #f(..for x in () [])
 
---- call-args-spread-string-invalid paged ---
+--- call-args-spread-string-invalid eval ---
 // Error: 11-19 cannot spread string
 #calc.min(.."nope")
 
---- call-args-content-block-unclosed paged ---
+--- call-args-content-block-unclosed eval ---
 // Error: 6-7 unclosed delimiter
 #func[`a]`
 
@@ -198,11 +198,11 @@
 #let f( param : v ) = param
 #test(f( param /* ok */ : 2 ), 2)
 
---- call-args-unclosed paged ---
+--- call-args-unclosed eval ---
 // Error: 7-8 unclosed delimiter
 #{func(}
 
---- call-args-unclosed-string paged ---
+--- call-args-unclosed-string eval ---
 // Error: 6-7 unclosed delimiter
 // Error: 1:7-2:1 unclosed string
 #func("]

--- a/tests/suite/scripting/closure.typ
+++ b/tests/suite/scripting/closure.typ
@@ -101,7 +101,7 @@
   test(g()(8), 13)
 }
 
---- closure-bad-capture paged ---
+--- closure-bad-capture eval ---
 // Don't leak environment.
 #{
   // Error: 16-17 unknown variable: x
@@ -110,7 +110,7 @@
   func()
 }
 
---- closure-missing-arg-positional paged ---
+--- closure-missing-arg-positional eval ---
 // Too few arguments.
 #{
   let types(x, y) = "[" + str(type(x)) + ", " + str(type(y)) + "]"
@@ -120,7 +120,7 @@
   test(types("nope"), "[string, none]")
 }
 
---- closure-too-many-args-positional paged ---
+--- closure-too-many-args-positional eval ---
 // Too many arguments.
 #{
   let f(x) = x + 1
@@ -139,7 +139,7 @@
 }
 #f()
 
---- closure-capture-mutate paged ---
+--- closure-capture-mutate eval ---
 #let x = ()
 #let f() = {
   // Error: 3-4 variables from outside the function are read-only and cannot be modified
@@ -147,7 +147,7 @@
 }
 #f()
 
---- closure-named-args-basic paged ---
+--- closure-named-args-basic eval ---
 // Named arguments.
 #{
   let greet(name, birthday: false) = {
@@ -161,7 +161,7 @@
   test(greet("Typst", whatever: 10))
 }
 
---- closure-args-sink paged ---
+--- closure-args-sink eval ---
 // Parameter unpacking.
 #let f((a, b), ..c) = (a, b, c)
 #test(f((1, 2), 3, 4), (1, 2, (3, 4)))
@@ -178,41 +178,41 @@
 // Error: 10-16 expected pattern, found array
 #let f(..(a, b)) = none
 
---- closure-param-duplicate-positional paged ---
+--- closure-param-duplicate-positional eval ---
 // Error: 11-12 duplicate parameter: x
 #let f(x, x) = none
 
---- closure-body-multiple-expressions paged ---
+--- closure-body-multiple-expressions eval ---
 // Error: 21 expected comma
 // Error: 22-23 expected pattern, found integer
 // Error: 24-25 unexpected plus
 // Error: 26-27 expected pattern, found integer
 #let f = (x: () => 1 2 + 3) => 4
 
---- closure-param-duplicate-mixed paged ---
+--- closure-param-duplicate-mixed eval ---
 // Error: 14-15 duplicate parameter: a
 // Error: 23-24 duplicate parameter: b
 // Error: 35-36 duplicate parameter: b
 #let f(a, b, a: none, b: none, c, b) = none
 
---- closure-param-duplicate-spread paged ---
+--- closure-param-duplicate-spread eval ---
 // Error: 13-14 duplicate parameter: a
 #let f(a, ..a) = none
 
---- closure-pattern-bad-string paged ---
+--- closure-pattern-bad-string eval ---
 // Error: 7-14 expected pattern, found string
 #((a, "named": b) => none)
 
---- closure-let-pattern-bad-string paged ---
+--- closure-let-pattern-bad-string eval ---
 // Error: 10-15 expected pattern, found string
 #let foo("key": b) = key
 
---- closure-param-keyword paged ---
+--- closure-param-keyword eval ---
 // Error: 10-14 expected pattern, found `none`
 // Hint: 10-14 keyword `none` is not allowed as an identifier; try `none_` instead
 #let foo(none: b) = key
 
---- closure-param-named-underscore paged ---
+--- closure-param-named-underscore eval ---
 // Error: 10-11 expected identifier, found underscore
 #let foo(_: 3) = none
 

--- a/tests/suite/scripting/destructuring.typ
+++ b/tests/suite/scripting/destructuring.typ
@@ -23,7 +23,7 @@
   test(array, (1, "baz", 3, 4))
 }
 
---- destructuring-dict-bad paged ---
+--- destructuring-dict-bad eval ---
 // Error: 7-10 expected identifier, found group
 // Error: 12-14 expected pattern, found integer
 #let ((a): 10) = "world"
@@ -95,7 +95,7 @@
 #let (..a) = ()
 #test(a, ())
 
---- destructuring-let-array-with-unnamed-sink paged ---
+--- destructuring-let-array-with-unnamed-sink eval ---
 // Destructuring with unnamed sink.
 #let (a, .., b) = (1, 2, 3, 4)
 #test(a, 1)
@@ -122,27 +122,27 @@
 --- destructuring-let-empty-array eval ---
 #let () = ()
 
---- destructuring-let-empty-array-too-many-elements paged ---
+--- destructuring-let-empty-array-too-many-elements eval ---
 // Error: 6-8 too many elements to destructure
 // Hint: 6-8 the provided array has a length of 2, but the pattern expects an empty array
 #let () = (1, 2)
 
---- destructuring-let-array-too-few-elements paged ---
+--- destructuring-let-array-too-few-elements eval ---
 // Error: 6-15 not enough elements to destructure
 // Hint: 6-15 the provided array has a length of 2, but the pattern expects 3 elements
 #let (a, b, c) = (1, 2)
 
---- destructuring-let-array-too-few-elements-with-sink paged ---
+--- destructuring-let-array-too-few-elements-with-sink eval ---
 // Error: 6-20 not enough elements to destructure
 // Hint: 6-20 the provided array has a length of 2, but the pattern expects at least 3 elements
 #let (..a, b, c, d) = (1, 2)
 
---- destructuring-let-array-too-few-elements-with-sink-1-element paged ---
+--- destructuring-let-array-too-few-elements-with-sink-1-element eval ---
 // Error: 6-14 not enough elements to destructure
 // Hint: 6-14 the provided array has a length of 0, but the pattern expects at least 1 element
 #let (..a, b) = ()
 
---- destructuring-let-array-bool-invalid paged ---
+--- destructuring-let-array-bool-invalid eval ---
 // Error: 6-12 cannot destructure boolean
 #let (a, b) = true
 
@@ -183,39 +183,39 @@
 #let ((a, b), (key: c)) = ((1, 2), (key: 3))
 #test((a, b, c), (1, 2, 3))
 
---- destructuring-let-dict-key-string-invalid paged ---
+--- destructuring-let-dict-key-string-invalid eval ---
 // Keyed destructuring is not currently supported.
 // Error: 7-18 expected pattern, found string
 #let ("spacy key": val) = ("spacy key": 123)
 #val
 
---- destructuring-let-dict-key-expr-invalid paged ---
+--- destructuring-let-dict-key-expr-invalid eval ---
 // Keyed destructuring is not currently supported.
 #let x = "spacy key"
 // Error: 7-10 expected identifier, found group
 #let ((x): v) = ("spacy key": 123)
 
---- destructuring-let-array-trailing-placeholders paged ---
+--- destructuring-let-array-trailing-placeholders eval ---
 // Trailing placeholders.
 // Error: 6-21 not enough elements to destructure
 // Hint: 6-21 the provided array has a length of 1, but the pattern expects 5 elements
 #let (a, _, _, _, _) = (1,)
 #test(a, 1)
 
---- destructuring-let-dict-patterns-invalid paged ---
+--- destructuring-let-dict-patterns-invalid eval ---
 // Error: 10-13 expected pattern, found string
 // Error: 18-19 expected pattern, found integer
 #let (a: "a", b: 2) = (a: 1, b: 2)
 
---- destructuring-let-dict-shorthand-missing-key paged ---
+--- destructuring-let-dict-shorthand-missing-key eval ---
 // Error: 10-11 dictionary does not contain key "b"
 #let (a, b) = (a: 1)
 
---- destructuring-let-dict-missing-key paged ---
+--- destructuring-let-dict-missing-key eval ---
 // Error: 10-11 dictionary does not contain key "b"
 #let (a, b: b) = (a: 1)
 
---- destructuring-let-dict-from-array paged ---
+--- destructuring-let-dict-from-array eval ---
 // Error: 7-11 cannot destructure named pattern from an array
 #let (a: a, b) = (1, 2, 3)
 
@@ -301,7 +301,7 @@
 #(((a, b), (key: c)) = ((1, 2), (key: 3)))
 #test((a, b, c), (1, 2, 3))
 
---- destructuring-assign-nested-invalid paged ---
+--- destructuring-assign-nested-invalid eval ---
 #let array = (1, 2, 3)
 // Error: 3-17 cannot destructure string
 #((array.at(1),) = ("hi"))
@@ -328,53 +328,53 @@
 #for (k, v)  in (a: 1, b: 2, c: 3) {}
 #for (.., v) in (a: 1, b: 2, c: 3) {}
 
---- issue-3275-loop-over-content paged ---
+--- issue-3275-loop-over-content eval ---
 // Error: 11-17 cannot loop over content
 #for x in [1, 2] {}
 
---- issue-3275-loop-over-arguments paged ---
+--- issue-3275-loop-over-arguments eval ---
 // Error: 11-25 cannot loop over arguments
 #for _ in arguments("a") {}
 
---- issue-3275-loop-over-integer paged ---
+--- issue-3275-loop-over-integer eval ---
 // Error: 16-21 cannot loop over integer
 #for (x, y) in 12306 {}
 
---- issue-3275-destructuring-loop-over-content paged ---
+--- issue-3275-destructuring-loop-over-content eval ---
 // Error: 16-22 cannot loop over content
 #for (x, y) in [1, 2] {}
 
---- issue-3275-destructuring-loop-over-string paged ---
+--- issue-3275-destructuring-loop-over-string eval ---
 // Error: 6-12 cannot destructure values of string
 #for (x, y) in "foo" {}
 
---- issue-3275-destructuring-loop-over-string-array paged ---
+--- issue-3275-destructuring-loop-over-string-array eval ---
 // Error: 6-12 cannot destructure string
 #for (x, y) in ("foo", "bar") {}
 
---- issue-3275-destructuring-loop-over-bytes paged ---
+--- issue-3275-destructuring-loop-over-bytes eval ---
 // Error: 6-12 cannot destructure values of bytes
 #for (x, y) in bytes("😊") {}
 
---- issue-3275-destructuring-loop-over-bytes-array paged ---
+--- issue-3275-destructuring-loop-over-bytes-array eval ---
 // Error: 6-12 cannot destructure bytes
 #for (x, y) in (bytes((1,2)), bytes((1,2))) {}
 
---- issue-3275-destructuring-loop-over-int-array paged ---
+--- issue-3275-destructuring-loop-over-int-array eval ---
 // Error: 6-12 cannot destructure integer
 #for (x, y) in (1, 2) {}
 
---- issue-3275-destructuring-loop-over-2d-array-1 paged ---
+--- issue-3275-destructuring-loop-over-2d-array-1 eval ---
 // Error: 6-12 not enough elements to destructure
 // Hint: 6-12 the provided array has a length of 1, but the pattern expects 2 elements
 #for (x, y) in ((1,), (2,)) {}
 
---- issue-3275-destructuring-loop-over-2d-array-2 paged ---
+--- issue-3275-destructuring-loop-over-2d-array-2 eval ---
 // Error: 6-12 too many elements to destructure
 // Hint: 6-12 the provided array has a length of 3, but the pattern expects 2 elements
 #for (x, y) in ((1,2,3), (4,5,6)) {}
 
---- issue-4573-destructuring-unclosed-delimiter paged ---
+--- issue-4573-destructuring-unclosed-delimiter eval ---
 // Tests a case where parsing within an incorrectly predicted paren expression
 // (the "outer" assignment) would put the parser in an invalid state when
 // reloading a stored prediction (the "inner" assignment) and cause a panic when

--- a/tests/suite/scripting/field.typ
+++ b/tests/suite/scripting/field.typ
@@ -6,68 +6,68 @@
 #assert.eq
 #assert.ne
 
---- field-normal-function-invalid paged ---
+--- field-normal-function-invalid eval ---
 // Error: 9-16 function `assert` does not contain field `invalid`
 #assert.invalid
 
---- field-elem-function-invalid paged ---
+--- field-elem-function-invalid eval ---
 // Error: 7-14 function `enum` does not contain field `invalid`
 #enum.invalid
 
---- field-elem-function-invalid-call paged ---
+--- field-elem-function-invalid-call eval ---
 // Error: 7-14 function `enum` does not contain field `invalid`
 #enum.invalid()
 
---- field-closure-invalid paged ---
+--- field-closure-invalid eval ---
 // Closures cannot have fields.
 #let f(x) = x
 // Error: 4-11 cannot access fields on user-defined functions
 #f.invalid
 
---- field-bool-invalid paged ---
+--- field-bool-invalid eval ---
 // Error: 8-10 cannot access fields on type boolean
 #false.ok
 
---- field-bool-keyword-invalid paged ---
+--- field-bool-keyword-invalid eval ---
 // Error: 9-13 cannot access fields on type boolean
 #{false.true}
 
---- field-invalid-none paged ---
+--- field-invalid-none eval ---
 #{
   let object = none
   // Error: 3-9 none does not have accessible fields
   object.property = "value"
 }
 
---- field-invalid-int paged ---
+--- field-invalid-int eval ---
 #{
   let object = 10
   // Error: 3-9 integer does not have accessible fields
   object.property = "value"
 }
 
---- field-mutable-invalid-symbol paged ---
+--- field-mutable-invalid-symbol eval ---
 #{
   let object = sym.eq.not
   // Error: 3-9 cannot mutate fields on symbol
   object.property = "value"
 }
 
---- field-mutable-invalid-module paged ---
+--- field-mutable-invalid-module eval ---
 #{
   let object = calc
   // Error: 3-9 cannot mutate fields on module
   object.property = "value"
 }
 
---- field-mutable-invalid-function paged ---
+--- field-mutable-invalid-function eval ---
 #{
   let object = calc.sin
   // Error: 3-9 cannot mutate fields on function
   object.property = "value"
 }
 
---- field-mutable-invalid-stroke paged ---
+--- field-mutable-invalid-stroke eval ---
 #{
   let s = 1pt + red
   // Error: 3-4 fields on stroke are not yet mutable

--- a/tests/suite/scripting/for.typ
+++ b/tests/suite/scripting/for.typ
@@ -76,19 +76,19 @@
 #test(for v in "" [], none)
 #test(type(for v in "1" []), content)
 
---- for-loop-over-bool paged ---
+--- for-loop-over-bool eval ---
 // Uniterable expression.
 // Error: 11-15 cannot loop over boolean
 #for v in true {}
 
---- for-loop-over-string paged ---
+--- for-loop-over-string eval ---
 // Keys and values of strings.
 // Error: 6-12 cannot destructure values of string
 #for (k, v) in "hi" {
   dont-care
 }
 
---- for-loop-destructuring-without-parentheses paged ---
+--- for-loop-destructuring-without-parentheses eval ---
 // Destructuring without parentheses.
 // Error: 7-8 unexpected comma
 // Hint: 7-8 destructuring patterns must be wrapped in parentheses
@@ -96,12 +96,12 @@
   dont-care
 }
 
---- for-loop-destructuring-half paged ---
+--- for-loop-destructuring-half eval ---
 // Error: 7-8 unexpected comma
 // Hint: 7-8 destructuring patterns must be wrapped in parentheses
 #for k, in () {}
 
---- for-loop-incomplete paged ---
+--- for-loop-incomplete eval ---
 // Error: 5 expected pattern
 #for
 

--- a/tests/suite/scripting/get-rule.typ
+++ b/tests/suite/scripting/get-rule.typ
@@ -52,16 +52,16 @@
 // Error: 18-22 function `heading` does not contain field `body`
 #context heading.body
 
---- get-rule-missing-context-no-context paged ---
+--- get-rule-missing-context-no-context eval ---
 // Error: 7-11 can only be used when context is known
 // Hint: 7-11 try wrapping this in a `context` expression
 // Hint: 7-11 the `context` expression should wrap everything that depends on this function
 #text.lang
 
---- get-rule-unknown-field-no-context paged ---
+--- get-rule-unknown-field-no-context eval ---
 // Error: 7-12 function `text` does not contain field `langs`
 #text.langs
 
---- get-rule-inherent-field-no-context paged ---
+--- get-rule-inherent-field-no-context eval ---
 // Error: 10-14 function `heading` does not contain field `body`
 #heading.body

--- a/tests/suite/scripting/if.typ
+++ b/tests/suite/scripting/if.typ
@@ -92,18 +92,18 @@
   test(z, none)
 }
 
---- if-condition-string-invalid paged ---
+--- if-condition-string-invalid eval ---
 // Condition must be boolean.
 // If it isn't, neither branch is evaluated.
 // Error: 5-14 expected boolean, found string
 #if "a" + "b" { nope } else { nope }
 
---- if-condition-invalid-and-wrong-type paged ---
+--- if-condition-invalid-and-wrong-type eval ---
 // Make sure that we don't complain twice.
 // Error: 5-12 cannot add integer and string
 #if 1 + "2" {}
 
---- if-incomplete paged ---
+--- if-incomplete eval ---
 // Error: 4 expected expression
 #if
 

--- a/tests/suite/scripting/import.typ
+++ b/tests/suite/scripting/import.typ
@@ -83,15 +83,15 @@
 #test(c, 2)
 #test(d, 3)
 
---- import-items-parenthesized-invalid paged ---
+--- import-items-parenthesized-invalid eval ---
 // Error: 23-24 unclosed delimiter
 #import "module.typ": (a, b, c
 
---- import-items-parenthesized-invalid-2 paged ---
+--- import-items-parenthesized-invalid-2 eval ---
 // Error: 23-24 unclosed delimiter
 #import "module.typ": (
 
---- import-items-parenthesized-invalid-3 paged ---
+--- import-items-parenthesized-invalid-3 eval ---
 // Error: 23-24 unclosed delimiter
 #import "module.typ": (
   a, b,
@@ -145,34 +145,34 @@
 #test(module.item(1, 2), 3)
 #test(module.push(2), 3)
 
---- import-from-file-bare-invalid paged ---
+--- import-from-file-bare-invalid eval ---
 // Error: 9-33 module name would not be a valid identifier
 // Hint: 9-33 you can rename the import with `as`
 #import "modules/with space.typ"
 
---- import-from-file-bare-dynamic paged ---
+--- import-from-file-bare-dynamic eval ---
 // Error: 9-26 dynamic import requires an explicit name
 // Hint: 9-26 you can name the import with `as`
 #import "mod" + "ule.typ"
 
---- import-from-path-bare paged ---
+--- import-from-path-bare eval ---
 // Error: 9-27 dynamic import requires an explicit name
 // Hint: 9-27 you can name the import with `as`
 #import path("module.typ")
 
---- import-from-str-var-bare paged ---
+--- import-from-str-var-bare eval ---
 #let p = "module.typ"
 // Error: 9-10 dynamic import requires an explicit name
 // Hint: 9-10 you can name the import with `as`
 #import p
 
---- import-from-path-var-bare paged ---
+--- import-from-path-var-bare eval ---
 #let p = path("module.typ")
 // Error: 9-10 dynamic import requires an explicit name
 // Hint: 9-10 you can name the import with `as`
 #import p
 
---- import-from-dict-field-bare paged ---
+--- import-from-dict-field-bare eval ---
 #let d = (p: "module.typ")
 // Error: 9-12 dynamic import requires an explicit name
 // Hint: 9-12 you can name the import with `as`
@@ -222,7 +222,7 @@
 #import asrt: ne as asne
 #asne(1, 2)
 
---- import-from-module-bare paged ---
+--- import-from-module-bare eval ---
 #import "modules/chap1.typ" as mymod
 // Warning: 9-14 this import has no effect
 #import mymod
@@ -239,7 +239,7 @@
 #import module.chap2
 #test(chap2.name, "Peter")
 
---- import-module-item-name-mutating paged ---
+--- import-module-item-name-mutating eval ---
 // Edge case for module access that isn't fixed.
 #import "module.typ"
 
@@ -290,82 +290,82 @@
 #import "modul" + "e.typ" as module
 #test(module.b, 1)
 
---- import-from-closure-invalid paged ---
+--- import-from-closure-invalid eval ---
 // Can't import from closures.
 #let f(x) = x
 // Error: 9-10 cannot import from user-defined functions
 #import f: x
 
---- import-from-closure-renamed-invalid paged ---
+--- import-from-closure-renamed-invalid eval ---
 // Can't import from closures, despite renaming.
 #let f(x) = x
 // Error: 9-10 cannot import from user-defined functions
 #import f as g
 
---- import-from-with-closure-invalid paged ---
+--- import-from-with-closure-invalid eval ---
 // Can't import from closures, despite modifiers.
 #let f(x) = x
 // Error: 9-18 cannot import from user-defined functions
 #import f.with(5): x
 
---- import-from-with-closure-literal-invalid paged ---
+--- import-from-with-closure-literal-invalid eval ---
 // Error: 9-18 cannot import from user-defined functions
 #import () => {5}: x
 
---- import-from-int-invalid paged ---
+--- import-from-int-invalid eval ---
 // Error: 9-10 expected path, module, function, or type, found integer
 #import 5: something
 
---- import-from-int-renamed-invalid paged ---
+--- import-from-int-renamed-invalid eval ---
 // Error: 9-10 expected path, module, function, or type, found integer
 #import 5 as x
 
---- import-from-string-invalid paged ---
+--- import-from-string-invalid eval ---
 // Error: 9-11 failed to load file (is a directory)
 #import "": name
 
---- import-from-string-renamed-invalid paged ---
+--- import-from-string-renamed-invalid eval ---
 // Error: 9-11 failed to load file (is a directory)
 #import "" as x
 
---- import-file-not-found-invalid paged ---
+--- import-file-not-found-invalid eval ---
 // Error: 9-20 file not found (searched at tests/suite/scripting/lib/0.2.1)
 #import "lib/0.2.1"
 
---- import-file-not-found-renamed-invalid paged ---
+--- import-file-not-found-renamed-invalid eval ---
 // Error: 9-20 file not found (searched at tests/suite/scripting/lib/0.2.1)
 #import "lib/0.2.1" as x
 
---- import-file-not-valid-utf-8 paged ---
+--- import-file-not-valid-utf-8 eval ---
 // Some non-text stuff.
 // Error: 9-35 file is not valid UTF-8
 #import "/assets/images/rhino.png"
 
---- import-item-not-found paged ---
+--- import-item-not-found eval ---
 // Unresolved import.
 // Error: 23-35 unresolved import
 #import "module.typ": non_existing
 
---- import-cyclic paged ---
+--- import-cyclic eval ---
 // Cyclic import of this very file.
 // Error: 9-23 cyclic import
 #import "./import.typ"
 
---- import-cyclic-in-other-file paged ---
+--- import-cyclic-in-other-file eval ---
 // Cyclic import in other file.
 // Error: "tests/suite/scripting/modules/cycle2.typ" 2:9-2:21 cyclic import
 #import "./modules/cycle1.typ": *
 
 This is never reached.
 
---- import-renamed-old-name paged ---
+--- import-renamed-old-name eval ---
 // Renaming does not import the old name (without items).
 #import "./modules/chap1.typ" as something
 #test(something.name, "Klaus")
 // Error: 7-12 unknown variable: chap1
 #test(chap1.name, "Klaus")
 
---- import-items-renamed-old-name paged ---
+--- import-items-renamed-old-name eval ---
 // Renaming does not import the old name (with items).
 #import "./modules/chap1.typ" as something: name as other
 #test(other, "Klaus")
@@ -373,57 +373,57 @@ This is never reached.
 // Error: 7-12 unknown variable: chap1
 #test(chap1.b, "Klaus")
 
---- import-nested-invalid-type paged ---
+--- import-nested-invalid-type eval ---
 // Error: 19-21 expected module, function, or type, found float
 #import std: calc.pi.something
 
---- import-incomplete paged ---
+--- import-incomplete eval ---
 // Error: 8 expected expression
 #import
 
---- import-item-string-invalid paged ---
+--- import-item-string-invalid eval ---
 // Error: 26-29 unexpected string
 #import "module.typ": a, "b", c
 
---- import-bad-token paged ---
+--- import-bad-token eval ---
 // Error: 23-24 unexpected equals sign
 #import "module.typ": =
 
---- import-duplicate-comma paged ---
+--- import-duplicate-comma eval ---
 // An additional trailing comma.
 // Error: 31-32 unexpected comma
 #import "module.typ": a, b, c,,
 
---- import-no-colon paged ---
+--- import-no-colon eval ---
 // Error: 2:2 expected semicolon or line break
 #import "module.typ
 "stuff
 
---- import-bad-token-star paged ---
+--- import-bad-token-star eval ---
 // A star in the list.
 // Error: 26-27 unexpected star
 #import "module.typ": a, *, b
 
---- import-item-after-star paged ---
+--- import-item-after-star eval ---
 // An item after a star.
 // Error: 24 expected semicolon or line break
 #import "module.typ": *, a
 
---- import-bad-colon-in-items paged ---
+--- import-bad-colon-in-items eval ---
 // Error: 14-15 unexpected colon
 // Error: 16-17 unexpected integer
 #import "": a: 1
 
---- import-incomplete-nested paged ---
+--- import-incomplete-nested eval ---
 // Error: 15 expected identifier
 #import "": a.
 
---- import-wildcard-in-nested paged ---
+--- import-wildcard-in-nested eval ---
 // Error: 15 expected identifier
 // Error: 15-16 unexpected star
 #import "": a.*
 
---- import-missing-comma paged ---
+--- import-missing-comma eval ---
 // Error: 14 expected comma
 #import "": a b
 
@@ -432,7 +432,7 @@ This is never reached.
 #import "@test/adder:0.1.0"
 #test(adder.add(2, 8), 10)
 
---- import-from-package-dynamic paged ---
+--- import-from-package-dynamic eval ---
 // Error: 9-33 dynamic import requires an explicit name
 // Hint: 9-33 you can name the import with `as`
 #import "@test/" + "adder:0.1.0"
@@ -446,59 +446,59 @@ This is never reached.
 #import "@test/adder:0.1.0": add
 #test(add(2, 8), 10)
 
---- import-from-package-required-compiler-version paged ---
+--- import-from-package-required-compiler-version eval ---
 // Test too high required compiler version.
 // Error: 9-29 package requires Typst 1.0.0 or newer (current version is VERSION)
 #import "@test/future:0.1.0": future
 
---- import-from-package-namespace-invalid-1 paged ---
+--- import-from-package-namespace-invalid-1 eval ---
 // Error: 9-13 `@` is not a valid package namespace
 #import "@@": *
 
---- import-from-package-name-missing-1 paged ---
+--- import-from-package-name-missing-1 eval ---
 // Error: 9-16 package specification is missing name
 #import "@heya": *
 
---- import-from-package-namespace-invalid-2 paged ---
+--- import-from-package-namespace-invalid-2 eval ---
 // Error: 9-15 `123` is not a valid package namespace
 #import "@123": *
 
---- import-from-package-name-missing-2 paged ---
+--- import-from-package-name-missing-2 eval ---
 // Error: 9-17 package specification is missing name
 #import "@test/": *
 
---- import-from-package-version-missing-1 paged ---
+--- import-from-package-version-missing-1 eval ---
 // Error: 9-22 package specification is missing version
 #import "@test/mypkg": *
 
---- import-from-package-name-invalid paged ---
+--- import-from-package-name-invalid eval ---
 // Error: 9-20 `$$$` is not a valid package name
 #import "@test/$$$": *
 
---- import-from-package-version-missing-2 paged ---
+--- import-from-package-version-missing-2 eval ---
 // Error: 9-23 package specification is missing version
 #import "@test/mypkg:": *
 
---- import-from-package-version-missing-minor paged ---
+--- import-from-package-version-missing-minor eval ---
 // Error: 9-24 version number is missing minor version
 #import "@test/mypkg:0": *
 
---- import-from-package-version-major-invalid-1 paged ---
+--- import-from-package-version-major-invalid-1 eval ---
 // Error: 9-29 `latest` is not a valid major version
 #import "@test/mypkg:latest": *
 
---- import-from-package-version-major-invalid-2 paged ---
+--- import-from-package-version-major-invalid-2 eval ---
 // Error: 9-29 `-3` is not a valid major version
 #import "@test/mypkg:-3.0.0": *
 
---- import-from-package-version-missing-patch-1 paged ---
+--- import-from-package-version-missing-patch-1 eval ---
 // Error: 9-26 version number is missing patch version
 #import "@test/mypkg:0.3": *
 
---- import-from-package-version-missing-patch-2 paged ---
+--- import-from-package-version-missing-patch-2 eval ---
 // Error: 9-27 version number is missing patch version
 #import "@test/mypkg:0.3.": *
 
---- import-from-file-package-lookalike paged ---
+--- import-from-file-package-lookalike eval ---
 // Error: 9-28 file not found (searched at tests/suite/scripting/#test/mypkg:1.0.0)
 #import "#test/mypkg:1.0.0": *

--- a/tests/suite/scripting/include.typ
+++ b/tests/suite/scripting/include.typ
@@ -12,7 +12,7 @@
 -- _Intermission_ --
 #chap2
 
---- include-file-not-found paged ---
+--- include-file-not-found eval ---
 #{
   // Error: 19-38 file not found (searched at tests/suite/scripting/modules/chap3.typ)
   let x = include "modules/chap3.typ"
@@ -22,18 +22,18 @@
 #import "modules/chap1.typ": chap2-path
 #include chap2-path
 
---- include-path-like-str-not-found paged ---
+--- include-path-like-str-not-found eval ---
 #import "modules/chap1.typ": chap2-str
 // Error: 10-19 file not found (searched at tests/suite/scripting/chap2.typ)
 #include chap2-str
 
---- include-no-bindings paged ---
+--- include-no-bindings eval ---
 #include "modules/chap1.typ"
 
 // The variables of the file should not appear in this scope.
 // Error: 2-6 unknown variable: name
 #name
 
---- include-semicolon-or-linebreak paged ---
+--- include-semicolon-or-linebreak eval ---
 // Error: 18 expected semicolon or line break
 #include "hi.typ" Hi

--- a/tests/suite/scripting/let.typ
+++ b/tests/suite/scripting/let.typ
@@ -47,12 +47,12 @@ Three
 #let ůñıćóðė = 1
 #test(ůñıćóðė, 1)
 
---- let-binding-keyword-in-markup paged ---
+--- let-binding-keyword-in-markup eval ---
 // Error: 6-8 expected pattern, found keyword `as`
 // Hint: 6-8 keyword `as` is not allowed as an identifier; try `as_` instead
 #let as = 1 + 2
 
---- let-binding-keyword-in-code paged ---
+--- let-binding-keyword-in-code eval ---
 #{
   // Error: 7-9 expected pattern, found keyword `as`
   // Hint: 7-9 keyword `as` is not allowed as an identifier; try `as_` instead
@@ -63,7 +63,7 @@ Three
 // Test parenthesised assignments.
 #let (a) = (1, 2)
 
---- let-incomplete paged ---
+--- let-incomplete eval ---
 // Error: 5 expected pattern
 #let
 
@@ -94,7 +94,7 @@ Three
 // Error: 9-13 expected pattern, found boolean
 #let (..true) = false
 
---- underscore-invalid paged ---
+--- underscore-invalid eval ---
 #let _ = 4
 
 #for _ in range(2) []
@@ -114,45 +114,45 @@ Three
 // Error: 8-9 expected expression, found underscore
 #{ 1 + _ }
 
---- let-function-incomplete paged ---
+--- let-function-incomplete eval ---
 // Error: 13 expected equals sign
 #let func(x)
 
 // Error: 15 expected expression
 #let func(x) =
 
---- let-function-parenthesized paged ---
+--- let-function-parenthesized eval ---
 // This is not yet parsed in the ideal way.
 // Error: 12 expected equals sign
 #let (func)(x)
 
---- let-function-parenthesized-with-init paged ---
+--- let-function-parenthesized-with-init eval ---
 // These errors aren't great.
 // Error: 12 expected equals sign
 // Error: 15-15 expected semicolon or line break
 #let (func)(x) = 3
 
---- let-with-no-init-group paged ---
+--- let-with-no-init-group eval ---
 // This was unintentionally allowed ...
 // Error: 9 expected equals sign
 #let (a)
 
---- let-with-no-init-destructuring paged ---
+--- let-with-no-init-destructuring eval ---
 // ... where this wasn't.
 // Error: 12 expected equals sign
 #let (a, b)
 
---- issue-4027-let-binding-with-keyword-context paged ---
+--- issue-4027-let-binding-with-keyword-context eval ---
 // Error: 6-13 expected pattern, found keyword `context`
 // Hint: 6-13 keyword `context` is not allowed as an identifier; try `context_` instead
 #let context = 5
 
---- issue-4027-let-binding-with-keyword-let paged ---
+--- issue-4027-let-binding-with-keyword-let eval ---
 // Error: 6-9 expected pattern, found keyword `let`
 // Hint: 6-9 keyword `let` is not allowed as an identifier; try `let_` instead
 #let let = 5
 
---- issue-4027-let-binding-with-destructured-keywords paged ---
+--- issue-4027-let-binding-with-destructured-keywords eval ---
 // Error: 7-14 expected pattern, found keyword `context`
 // Hint: 7-14 keyword `context` is not allowed as an identifier; try `context_` instead
 // Error: 21-24 expected pattern, found keyword `let`

--- a/tests/suite/scripting/loop.typ
+++ b/tests/suite/scripting/loop.typ
@@ -63,7 +63,7 @@
 
 #test(x, "a_a1a2a_a4")
 
---- loop-break-outside-of-loop paged ---
+--- loop-break-outside-of-loop eval ---
 // Test break outside of loop.
 #let f() = {
   // Error: 3-8 cannot break outside of loop
@@ -88,13 +88,13 @@
 
 #test(out, "AB")
 
---- loop-continue-outside-of-loop-in-block paged ---
+--- loop-continue-outside-of-loop-in-block eval ---
 // Test continue outside of loop.
 
 // Error: 12-20 cannot continue outside of loop
 #let x = { continue }
 
---- loop-continue-outside-of-loop-in-markup paged ---
+--- loop-continue-outside-of-loop-in-markup eval ---
 // Error: 2-10 cannot continue outside of loop
 #continue
 

--- a/tests/suite/scripting/methods.typ
+++ b/tests/suite/scripting/methods.typ
@@ -25,27 +25,27 @@
   test(rewritten, "Hello!\n This is a sentence!\n And one more!")
 }
 
---- method-unknown paged ---
+--- method-unknown eval ---
 // Error: 2:10-2:13 type array has no method `fun`
 #let numbers = ()
 #numbers.fun()
 
---- method-unknown-but-field-exists paged ---
+--- method-unknown-but-field-exists eval ---
 // Error: 2:4-2:10 element line has no method `stroke`
 // Hint: 2:4-2:10 did you mean to access the field `stroke`?
 #let l = line(stroke: red)
 #l.stroke()
 
---- method-mutate-on-temporary paged ---
+--- method-mutate-on-temporary eval ---
 // Error: 2:2-2:43 cannot mutate a temporary value
 #let numbers = (1, 2, 3)
 #numbers.map(v => v / 2).sorted().map(str).remove(4)
 
---- assign-to-method-invalid paged ---
+--- assign-to-method-invalid eval ---
 // Error: 2:3-2:19 cannot mutate a temporary value
 #let numbers = (1, 2, 3)
 #(numbers.sorted() = 1)
 
---- method-mutate-on-std-constant paged ---
+--- method-mutate-on-std-constant eval ---
 // Error: 2-5 cannot mutate a constant: box
 #box.push(1)

--- a/tests/suite/scripting/ops.typ
+++ b/tests/suite/scripting/ops.typ
@@ -31,7 +31,7 @@
 #test((1, 2) + (3, 4), (1, 2, 3, 4))
 #test((a: 1) + (b: 2, c: 3), (a: 1, b: 2, c: 3))
 
---- ops-add-too-large paged ---
+--- ops-add-too-large eval ---
 // Error: 3-26 value is too large
 #(9223372036854775807 + 1)
 
@@ -145,11 +145,11 @@
 #test(decimal("0.7777777777777777777777777777") / 1000, decimal("0.0007777777777777777777777778"))
 #test(decimal("0.7777777777777777777777777777") * decimal("0.001"), decimal("0.0007777777777777777777777778"))
 
---- ops-add-too-large-decimal paged ---
+--- ops-add-too-large-decimal eval ---
 // Error: 3-47 value is too large
 #(decimal("79228162514264337593543950335") + 1)
 
---- ops-subtract-too-large-decimal paged ---
+--- ops-subtract-too-large-decimal eval ---
 // Error: 3-48 value is too large
 #(decimal("-79228162514264337593543950335") - 1)
 
@@ -267,7 +267,7 @@
 #test("sys" in std, true)
 #test("system" in std, false)
 
---- ops-not-trailing paged ---
+--- ops-not-trailing eval ---
 // Error: 10 expected keyword `in`
 #("a" not)
 
@@ -312,13 +312,13 @@
 #test("a" == "a" and 2 < 3, true)
 #test(not "b" == "b", false)
 
---- ops-precedence-boolean-ops paged ---
+--- ops-precedence-boolean-ops eval ---
 // Assignment binds stronger than boolean operations.
 // Error: 2:3-2:8 cannot mutate a temporary value
 #let x = false
 #(not x = "a")
 
---- ops-precedence-unary paged ---
+--- ops-precedence-unary eval ---
 // Precedence doesn't matter for chained unary operators.
 // Error: 3-12 cannot apply '-' to boolean
 #(-not true)
@@ -327,7 +327,7 @@
 // Not in handles precedence.
 #test(-1 not in (1, 2, 3), true)
 
---- ops-precedence-parentheses paged ---
+--- ops-precedence-parentheses eval ---
 // Parentheses override precedence.
 #test((1), 1)
 #test((1+2)*-3, -9)
@@ -351,100 +351,100 @@
   test(y, "ok")
 }
 
---- ops-unary-minus-missing-expr paged ---
+--- ops-unary-minus-missing-expr eval ---
 // Error: 4 expected expression
 #(-)
 
---- ops-add-missing-rhs paged ---
+--- ops-add-missing-rhs eval ---
 // Error: 10 expected expression
 #test({1+}, 1)
 
---- ops-mul-missing-rhs paged ---
+--- ops-mul-missing-rhs eval ---
 // Error: 10 expected expression
 #test({2*}, 2)
 
---- ops-unary-plus-on-content paged ---
+--- ops-unary-plus-on-content eval ---
 // Error: 3-13 cannot apply unary '+' to content
 #(+([] + []))
 
---- ops-unary-plus-on-string paged ---
+--- ops-unary-plus-on-string eval ---
 // Error: 3-6 cannot apply '-' to string
 #(-"")
 
---- ops-not-on-array paged ---
+--- ops-not-on-array eval ---
 // Error: 3-9 cannot apply 'not' to array
 #(not ())
 
---- ops-compare-relative-length-and-ratio paged ---
+--- ops-compare-relative-length-and-ratio eval ---
 // Error: 3-19 cannot compare relative length and ratio
 #(30% + 1pt <= 40%)
 
---- ops-compare-em-with-abs paged ---
+--- ops-compare-em-with-abs eval ---
 // Error: 3-14 cannot compare 1em with 10pt
 #(1em <= 10pt)
 
---- ops-compare-normal-float-with-nan paged ---
+--- ops-compare-normal-float-with-nan eval ---
 // Error: 3-22 cannot compare 2.2 with float.nan
 #(2.2 <= float("nan"))
 
---- ops-compare-int-and-str paged ---
+--- ops-compare-int-and-str eval ---
 // Error: 3-26 cannot compare integer and string
 #((0, 1, 3) > (0, 1, "a"))
 
---- ops-compare-array-nested-failure paged ---
+--- ops-compare-array-nested-failure eval ---
 // Error: 3-42 cannot compare 3.5 with float.nan
 #((0, "a", 3.5) <= (0, "a", float("nan")))
 
---- ops-divide-by-zero-float paged ---
+--- ops-divide-by-zero-float eval ---
 // Error: 3-12 cannot divide by zero
 #(1.2 / 0.0)
 
---- ops-divide-by-zero-int paged ---
+--- ops-divide-by-zero-int eval ---
 // Error: 3-8 cannot divide by zero
 #(1 / 0)
 
---- ops-divide-by-zero-angle paged ---
+--- ops-divide-by-zero-angle eval ---
 // Error: 3-15 cannot divide by zero
 #(15deg / 0deg)
 
---- ops-binary-arithmetic-error-message paged ---
+--- ops-binary-arithmetic-error-message eval ---
 // Special messages for +, -, * and /.
 // Error: 3-10 cannot add integer and string
 #(1 + "2", 40% - 1)
 
---- add-assign-int-and-str paged ---
+--- add-assign-int-and-str eval ---
 // Error: 15-23 cannot add integer and string
 #{ let x = 1; x += "2" }
 
---- ops-divide-ratio-by-length paged ---
+--- ops-divide-ratio-by-length eval ---
 // Error: 4-13 cannot divide ratio by length
 #( 10% / 5pt )
 
---- ops-divide-em-by-abs paged ---
+--- ops-divide-em-by-abs eval ---
 // Error: 3-12 cannot divide these two lengths
 #(1em / 5pt)
 
---- ops-divide-relative-length-by-ratio paged ---
+--- ops-divide-relative-length-by-ratio eval ---
 // Error: 3-19 cannot divide relative length by ratio
 #((10% + 1pt) / 5%)
 
---- ops-divide-relative-lengths paged ---
+--- ops-divide-relative-lengths eval ---
 // Error: 3-28 cannot divide these two relative lengths
 #((10% + 1pt) / (20% + 1pt))
 
---- ops-subtract-int-from-ratio paged ---
+--- ops-subtract-int-from-ratio eval ---
 // Error: 13-20 cannot subtract integer from ratio
 #((1234567, 40% - 1))
 
---- ops-multiply-int-with-bool paged ---
+--- ops-multiply-int-with-bool eval ---
 // Error: 3-11 cannot multiply integer with boolean
 #(2 * true)
 
---- ops-divide-int-by-length paged ---
+--- ops-divide-int-by-length eval ---
 // Error: 3-11 cannot divide integer by length
 #(3 / 12pt)
 
---- multiply-negative-int-with-str paged ---
+--- multiply-negative-int-with-str eval ---
 // Error: 3-10 number must be at least zero
 #(-1 * "")
 
@@ -460,14 +460,14 @@
 #(x = "some")   #test(x, "some")
 #(x += "thing") #test(x, "something")
 
---- ops-assign-unknown-var-lhs paged ---
+--- ops-assign-unknown-var-lhs eval ---
 #{
   // Error: 3-6 unknown variable: a-1
   // Hint: 3-6 if you meant to use subtraction, try adding spaces around the minus sign: `a - 1`
   a-1 = 2
 }
 
---- ops-assign-unknown-var-rhs paged ---
+--- ops-assign-unknown-var-rhs eval ---
 #{
   let a = 2
   a = 1-a
@@ -478,32 +478,32 @@
   a = a-1
 }
 
---- ops-assign-unknown-parenthesized-variable paged ---
+--- ops-assign-unknown-parenthesized-variable eval ---
 // Error: 4-5 unknown variable: x
 #((x) = "")
 
---- ops-assign-destructuring-unknown-variable paged ---
+--- ops-assign-destructuring-unknown-variable eval ---
 // Error: 4-5 unknown variable: x
 #((x,) = (1,))
 
---- ops-assign-to-temporary paged ---
+--- ops-assign-to-temporary eval ---
 // Error: 3-8 cannot mutate a temporary value
 #(1 + 2 += 3)
 
---- ops-assign-to-invalid-unary-op paged ---
+--- ops-assign-to-invalid-unary-op eval ---
 // Error: 2:3-2:8 cannot apply 'not' to string
 #let x = "Hey"
 #(not x = "a")
 
---- ops-assign-to-invalid-binary-op paged ---
+--- ops-assign-to-invalid-binary-op eval ---
 // Error: 7-8 unknown variable: x
 #(1 + x += 3)
 
---- ops-assign-unknown-variable paged ---
+--- ops-assign-unknown-variable eval ---
 // Error: 3-4 unknown variable: z
 #(z = 1)
 
---- ops-assign-to-std-constant paged ---
+--- ops-assign-to-std-constant eval ---
 // Error: 3-7 cannot mutate a constant: rect
 #(rect = "hi")
 

--- a/tests/suite/scripting/params.typ
+++ b/tests/suite/scripting/params.typ
@@ -1,4 +1,4 @@
---- param-underscore-missing-argument paged ---
+--- param-underscore-missing-argument eval ---
 // Error: 17-20 missing argument: pattern parameter
 #let f(a: 10) = a() + 1
 #f(a: _ => 5)
@@ -17,11 +17,11 @@
 #let f(..) = 2
 #test(f(arg: 1), 2)
 
---- params-sink-bool-invalid paged ---
+--- params-sink-bool-invalid eval ---
 // Error: 10-14 expected pattern, found boolean
 #let f(..true) = none
 
---- params-sink-multiple-invalid paged ---
+--- params-sink-multiple-invalid eval ---
 // Error: 13-16 only one argument sink is allowed
 #let f(..a, ..b) = none
 
@@ -52,7 +52,7 @@
   test(f(15, b: 16, c: 13), (15, 16))
 }
 
---- params-sink-missing-arguments paged ---
+--- params-sink-missing-arguments eval ---
 #{
   let f(..a, b, c, d) = none
 
@@ -64,6 +64,6 @@
 // Test that underscore works in parameter patterns.
 #test((1, 2, 3).zip((1, 2, 3)).map(((_, x)) => x), (1, 2, 3))
 
---- issue-1351-parameter-dictionary paged ---
+--- issue-1351-parameter-dictionary eval ---
 // Error: 17-22 expected pattern, found string
 #let foo((test: "bar")) = {}

--- a/tests/suite/scripting/recursion.typ
+++ b/tests/suite/scripting/recursion.typ
@@ -12,7 +12,7 @@
 
 #test(fib(10), 55)
 
---- recursion-unnamed-invalid paged ---
+--- recursion-unnamed-invalid eval ---
 // Test with unnamed function.
 // Error: 17-18 unknown variable: f
 #let f = (n) => f(n - 1)
@@ -36,7 +36,7 @@
 #let f(x) = if x != none { f(none) } else { "world" }
 #test(f(1), "world")
 
---- recursion-maximum-depth paged ---
+--- recursion-maximum-depth eval ---
 // Error: 15-21 maximum function call depth exceeded
 #let rec(n) = rec(n) + 1
 #rec(1)

--- a/tests/suite/scripting/return.typ
+++ b/tests/suite/scripting/return.typ
@@ -43,7 +43,7 @@
 
 #f[My other figure]
 
---- return-outside-of-function paged ---
+--- return-outside-of-function eval ---
 // Test return outside of function.
 
 #for x in range(5) {
@@ -79,7 +79,7 @@
 
 #test(f(), "nope")
 
---- return-semicolon-or-linebreak paged ---
+--- return-semicolon-or-linebreak eval ---
 // Test rejection of extra value
 #let f() = [
   // Error: 16-16 expected semicolon or line break

--- a/tests/suite/scripting/while.typ
+++ b/tests/suite/scripting/while.typ
@@ -27,21 +27,21 @@
 #let i = 0
 #test(type(while i < 1 [#(i += 1)]), content)
 
---- while-loop-condition-content-invalid paged ---
+--- while-loop-condition-content-invalid eval ---
 // Condition must be boolean.
 // Error: 8-14 expected boolean, found content
 #while [nope] [nope]
 
---- while-loop-condition-always-true paged ---
+--- while-loop-condition-always-true eval ---
 // Error: 8-25 condition is always true
 #while 2 < "hello".len() {}
 
---- while-loop-limit paged ---
+--- while-loop-limit eval ---
 // Error: 2:2-2:24 loop seems to be infinite
 #let i = 1
 #while i > 0 { i += 1 }
 
---- while-loop-incomplete paged ---
+--- while-loop-incomplete eval ---
 // Error: 7 expected expression
 #while
 

--- a/tests/suite/styling/set.typ
+++ b/tests/suite/styling/set.typ
@@ -57,11 +57,11 @@ Hello *#x*
 
 @hello from the @unknown
 
---- set-if-bad-type paged ---
+--- set-if-bad-type eval ---
 // Error: 19-24 expected boolean, found integer
 #set text(red) if 1 + 2
 
---- set-shadowed-builtin paged ---
+--- set-shadowed-builtin eval ---
 #let text = "foo"
 // Error: 6-10 expected function, found string
 // Hint: 6-10 use `std.text` to access the shadowed standard library function
@@ -72,11 +72,11 @@ Hello *#x*
 #set std.text(fill: red)
 #text
 
---- set-in-expr paged ---
+--- set-in-expr eval ---
 // Error: 12-26 set is only allowed directly in code and content blocks
 #{ let x = set text(blue) }
 
---- set-bad-trivia paged ---
+--- set-bad-trivia eval ---
 // Error cases parsing set rules with trivia between the function and args.
 // Error: 10 expected argument list
 #set page

--- a/tests/suite/styling/show-text.typ
+++ b/tests/suite/styling/show-text.typ
@@ -46,16 +46,16 @@ AA (8)
 
 Treeworld, the World of worlds, is a world.
 
---- show-text-empty paged ---
+--- show-text-empty eval ---
 // Test there is no crashing on empty strings
 // Error: 1:7-1:9 text selector is empty
 #show "": []
 
---- show-text-regex-empty paged ---
+--- show-text-regex-empty eval ---
 // Error: 1:7-1:16 regex selector is empty
 #show regex(""): [AA]
 
---- show-text-regex-matches-empty paged ---
+--- show-text-regex-matches-empty eval ---
 // Error: 1:7-1:42 regex matches empty text
 #show regex("(VAR_GLOBAL|END_VAR||BOOL)") : []
 

--- a/tests/suite/styling/show.typ
+++ b/tests/suite/styling/show.typ
@@ -86,11 +86,11 @@ Another text.
 #show text: none
 Hey
 
---- show-selector-not-an-element-function paged ---
+--- show-selector-not-an-element-function eval ---
 // Error: 7-12 only element functions can be used as selectors
 #show upper: it => {}
 
---- show-selector-shadowed-builtin paged ---
+--- show-selector-shadowed-builtin eval ---
 #let heading = 0
 
 // Error: 7-14 expected symbol, string, label, function, regex, or selector, found integer
@@ -102,16 +102,16 @@ Hey
 #show std.heading: it => text(fill: red, it)
 = #heading
 
---- show-bad-replacement-type paged ---
+--- show-bad-replacement-type eval ---
 // Error: 16-20 expected content or function, found integer
 #show heading: 1234
 = Heading
 
---- show-bad-selector-type paged ---
+--- show-bad-selector-type eval ---
 // Error: 7-10 expected symbol, string, label, function, regex, or selector, found color
 #show red: []
 
---- show-selector-in-expression paged ---
+--- show-selector-in-expression eval ---
 // Error: 7-25 show is only allowed directly in code and content blocks
 #(1 + show heading: none)
 
@@ -141,15 +141,15 @@ Forest
 #show: [Shown]
 Ignored
 
---- show-bare-in-expression paged ---
+--- show-bare-in-expression eval ---
 // Error: 4-19 show is only allowed directly in code and content blocks
 #((show: body => 2) * body)
 
---- show-bare-missing-colon-closure paged ---
+--- show-bare-missing-colon-closure eval ---
 // Error: 6 expected colon
 #show it => {}
 
---- show-bare-missing-colon paged ---
+--- show-bare-missing-colon eval ---
 // Error: 6 expected colon
 #show it
 
@@ -254,7 +254,7 @@ the ```rs &mut T``` reference.
 #show selector(strong).or(<special>): highlight
 I am *strong*, I am _emphasized_, and I am #[special<special>].
 
---- show-selector-element-or-text paged ---
+--- show-selector-element-or-text eval ---
 // Ensure that text selector cannot be nested in and/or. That's too complicated,
 // at least for now.
 

--- a/tests/suite/symbols/symbol.typ
+++ b/tests/suite/symbols/symbol.typ
@@ -35,52 +35,52 @@
 #one
 #one.emoji
 
---- symbol-constructor-empty paged ---
+--- symbol-constructor-empty eval ---
 // Error: 2-10 expected at least one variant
 #symbol()
 
---- symbol-constructor-invalid-modifier paged ---
+--- symbol-constructor-invalid-modifier eval ---
 // Error: 2:3-2:24 invalid symbol modifier: " id!"
 #symbol(
   ("invalid. id!", "x")
 )
 
---- symbol-constructor-duplicate-modifier paged ---
+--- symbol-constructor-duplicate-modifier eval ---
 // Error: 2:3-2:31 duplicate modifier within variant: "duplicate"
 // Hint: 2:3-2:31 modifiers are not ordered, so each one may appear only once
 #symbol(
   ("duplicate.duplicate", "x"),
 )
 
---- symbol-constructor-duplicate-default-variant paged ---
+--- symbol-constructor-duplicate-default-variant eval ---
 // Error: 3:3-3:6 duplicate default variant
 #symbol(
   "x",
   "y",
 )
 
---- symbol-constructor-duplicate-empty-variant paged ---
+--- symbol-constructor-duplicate-empty-variant eval ---
 // Error: 3:3-3:12 duplicate default variant
 #symbol(
   ("", "x"),
   ("", "y"),
 )
 
---- symbol-constructor-default-and-empty-variants paged ---
+--- symbol-constructor-default-and-empty-variants eval ---
 // Error: 3:3-3:12 duplicate default variant
 #symbol(
   "x",
   ("", "y"),
 )
 
---- symbol-constructor-duplicate-variant paged ---
+--- symbol-constructor-duplicate-variant eval ---
 // Error: 3:3-3:29 duplicate variant: "duplicate.variant"
 #symbol(
   ("duplicate.variant", "x"),
   ("duplicate.variant", "y"),
 )
 
---- symbol-constructor-duplicate-variant-different-order paged ---
+--- symbol-constructor-duplicate-variant-different-order eval ---
 // Error: 3:3-3:29 duplicate variant: "variant.duplicate"
 // Hint: 3:3-3:29 variants with the same modifiers are identical, regardless of their order
 #symbol(
@@ -88,7 +88,7 @@
   ("variant.duplicate", "y"),
 )
 
---- symbol-constructor-empty-variant-value paged ---
+--- symbol-constructor-empty-variant-value eval ---
 // Error: 2:3-2:5 invalid variant value: ""
 // Hint: 2:3-2:5 variant value must be exactly one grapheme cluster
 // Error: 3:3-3:16 invalid variant value: ""
@@ -98,7 +98,7 @@
   ("empty", "")
 )
 
---- symbol-constructor-multi-cluster-variant-value paged ---
+--- symbol-constructor-multi-cluster-variant-value eval ---
 // Error: 2:3-2:7 invalid variant value: "aa"
 // Hint: 2:3-2:7 variant value must be exactly one grapheme cluster
 // Error: 3:3-3:14 invalid variant value: "bb"
@@ -108,7 +108,7 @@
   ("b", "bb")
 )
 
---- symbol-unknown-modifier paged ---
+--- symbol-unknown-modifier eval ---
 // Error: 13-20 unknown symbol modifier
 #emoji.face.garbage
 

--- a/tests/suite/syntax/backtracking.typ
+++ b/tests/suite/syntax/backtracking.typ
@@ -13,7 +13,7 @@
   test(eval(s)(), 51)
 }
 
---- parser-backtracking-destructuring-assignment paged ---
+--- parser-backtracking-destructuring-assignment eval ---
 #{
   let s = "(x) = 1"
   let pat = "(x: {_}) = 1"

--- a/tests/suite/syntax/code.typ
+++ b/tests/suite/syntax/code.typ
@@ -1,14 +1,14 @@
 // Syntax tests for code mode and embedded code expressions.
 
---- embedded-code-incomplete paged ---
+--- embedded-code-incomplete eval ---
 // Error: 2-2 expected expression
 #
 
---- embedded-code-incomplete-followed-by-text paged ---
+--- embedded-code-incomplete-followed-by-text eval ---
 // Error: 2-2 expected expression
 #  hello
 
---- embedded-code-extra-hash paged ---
+--- embedded-code-extra-hash eval ---
 // The span on the hints isn't great, but it's hard to fix.
 
 // Error: 2-3 the character `#` is not valid in code
@@ -24,7 +24,7 @@
 // Hint: 4-5 try escaping the preceding hash: `\#`
 ####
 
---- embedded-code-invalid-character paged ---
+--- embedded-code-invalid-character eval ---
 // Error: 2-3 the character `&` is not valid in code
 // Hint: 2-3 the preceding hash is causing this to parse in code mode
 // Hint: 2-3 try escaping the preceding hash: `\#`
@@ -34,7 +34,7 @@
 // Hint: 2-3 try escaping the preceding hash: `\#`
 #!
 
---- code-syntax-extra-hash paged ---
+--- code-syntax-extra-hash eval ---
 // Test unneeded hashtags in code mode.
 // Similar tests for markup exist in "syntax/embedded.typ"
 #{
@@ -54,7 +54,7 @@
   ###
 }
 
---- code-syntax-bad-boolean-ops paged ---
+--- code-syntax-bad-boolean-ops eval ---
 // Test writing invalid boolean operators:
 #{
   // Error: 3-5 `&&` is not valid in code

--- a/tests/suite/syntax/comment.typ
+++ b/tests/suite/syntax/comment.typ
@@ -69,7 +69,7 @@ Second part
 ])
 
 
---- comment-block-unclosed paged ---
+--- comment-block-unclosed eval ---
 // End should not appear without start.
 // Error: 7-9 unexpected end of block comment
 // Hint: 7-9 consider escaping the `*` with a backslash or opening the block comment with `/*`

--- a/tests/suite/syntax/depth.typ
+++ b/tests/suite/syntax/depth.typ
@@ -1,4 +1,4 @@
---- parser-depth-exceeded-balanced paged ---
+--- parser-depth-exceeded-balanced eval ---
 #{
   let s = "()"
   let pat = "({})"
@@ -13,12 +13,12 @@
   eval(s)
 }
 
---- parser-depth-exceeded-unbalanced paged ---
+--- parser-depth-exceeded-unbalanced eval ---
 // Error: 7-17 unclosed delimiter
 // Error: 7-17 maximum parsing depth exceeded
 #eval(1024 * "(")
 
---- parser-depth-exceeded-unbalanced-arrow paged ---
+--- parser-depth-exceeded-unbalanced-arrow eval ---
 // https://issues.oss-fuzz.com/issues/42538221
 // Error: 7-20 the character `#` is not valid in code
 // Hint: 7-20 you are already in code mode
@@ -28,7 +28,7 @@
 // Error: 7-20 maximum parsing depth exceeded
 #eval(512 * "#((=>")
 
---- parser-depth-exceeded-unop paged ---
+--- parser-depth-exceeded-unop eval ---
 // https://issues.oss-fuzz.com/issues/415163163
 // Error: 7-17 maximum parsing depth exceeded
 // Error: 7-17 expected expression

--- a/tests/suite/syntax/escape.typ
+++ b/tests/suite/syntax/escape.typ
@@ -25,12 +25,12 @@ let f() , ; : | + - /= == 12 "string"
 // Escaped dot.
 10\. May
 
---- escape-invalid-codepoint paged ---
+--- escape-invalid-codepoint eval ---
 // Unicode codepoint does not exist.
 // Error: 1-11 invalid Unicode codepoint: FFFFFF
 \u{FFFFFF}
 
---- escape-unclosed paged ---
+--- escape-unclosed eval ---
 // Unterminated.
 // Error: 1-6 unclosed Unicode escape sequence
 \u{41[*Bold*]

--- a/tests/suite/syntax/panics.typ
+++ b/tests/suite/syntax/panics.typ
@@ -1,6 +1,6 @@
 // Tests for panics in the parser caused by syntax.
 
---- issue-4571-panic-when-compiling-invalid-file paged ---
+--- issue-4571-panic-when-compiling-invalid-file eval ---
 // Test that trying to parse the following does not result in a panic.
 
 // Error: 1:9-1:10 unclosed delimiter

--- a/tests/suite/syntax/shebang.typ
+++ b/tests/suite/syntax/shebang.typ
@@ -1,6 +1,6 @@
 // Test shebang support.
 
---- shebang paged ---
+--- shebang eval ---
 #!typst compile
 
 // Error: 2-3 the character `!` is not valid in code

--- a/tests/suite/text/case.typ
+++ b/tests/suite/text/case.typ
@@ -18,6 +18,6 @@
 #lower[MY #html.strong[Lower] #symbol("A")] \
 #upper[my #html.strong[Upper] #symbol("a")] \
 
---- upper-bad-type paged ---
+--- upper-bad-type eval ---
 // Error: 8-9 expected string or content, found integer
 #upper(1)

--- a/tests/suite/text/edge.typ
+++ b/tests/suite/text/edge.typ
@@ -28,14 +28,14 @@
 #try(4pt, -2pt)
 #try(1pt + 0.3em, -0.15em)
 
---- text-edge-bad-type paged ---
+--- text-edge-bad-type eval ---
 // Error: 21-23 expected "ascender", "cap-height", "x-height", "baseline", "bounds", or length, found array
 #set text(top-edge: ())
 
---- text-edge-bad-value paged ---
+--- text-edge-bad-value eval ---
 // Error: 24-26 expected "baseline", "descender", "bounds", or length
 #set text(bottom-edge: "")
 
---- text-edge-wrong-edge paged ---
+--- text-edge-wrong-edge eval ---
 // Error: 24-36 expected "baseline", "descender", "bounds", or length
 #set text(bottom-edge: "cap-height")

--- a/tests/suite/text/font.typ
+++ b/tests/suite/text/font.typ
@@ -49,19 +49,19 @@ Emoji: 🐪, 🌋, 🏞
 #text([Text], teal, font: "IBM Plex Serif") \
 #text(forest, font: "New Computer Modern", [Text]) \
 
---- text-bad-argument paged ---
+--- text-bad-argument eval ---
 // Error: 11-16 unexpected argument
 #set text(false)
 
---- text-style-bad paged ---
+--- text-style-bad eval ---
 // Error: 18-24 expected "normal", "italic", or "oblique"
 #set text(style: "bold", weight: "thin")
 
---- text-bad-extra-argument paged ---
+--- text-bad-extra-argument eval ---
 // Error: 23-27 unexpected argument
 #set text(size: 10pt, 12pt)
 
---- text-bad-named-argument paged ---
+--- text-bad-named-argument eval ---
 // Error: 11-31 unexpected argument: something
 #set text(something: "invalid")
 
@@ -172,12 +172,12 @@ The number 123.
 #text(font: "Noto Color Emoji", "🔗⛓‍💥🖥️🔑") \
 #text(font: "Twitter Color Emoji", "🔗⛓‍💥🖥️🔑") \
 
---- text-font-covers-bad-1 paged ---
+--- text-font-covers-bad-1 eval ---
 // Error: 17-59 coverage regex may only use dot, letters, and character classes
 // Hint: 17-59 the regex is applied to each letter individually
 #set text(font: (name: "Ubuntu", covers: regex("20-FFFF")))
 
---- text-font-covers-bad-2 paged ---
+--- text-font-covers-bad-2 eval ---
 // Error: 17-65 coverage regex may only use dot, letters, and character classes
 // Hint: 17-65 the regex is applied to each letter individually
 #set text(font: (name: "Ubuntu", covers: regex("\u{20}-\u{10}")))
@@ -205,6 +205,6 @@ a
 #set text(-10pt)
 Hello
 
---- empty-text-font-array paged ---
+--- empty-text-font-array eval ---
 // Error: 17-19 font fallback list must not be empty
 #set text(font: ())

--- a/tests/suite/text/lang.typ
+++ b/tests/suite/text/lang.typ
@@ -49,27 +49,27 @@
   [Ş ]
 }
 
---- text-script-bad-type paged ---
+--- text-script-bad-type eval ---
 // Error: 19-23 expected string or auto, found none
 #set text(script: none)
 
---- text-script-bad-value paged ---
+--- text-script-bad-value eval ---
 // Error: 19-23 expected three or four letter script code (ISO 15924 or 'math')
 #set text(script: "ab")
 
---- text-lang-bad-type paged ---
+--- text-lang-bad-type eval ---
 // Error: 17-21 expected string, found none
 #set text(lang: none)
 
---- text-lang-bad-value paged ---
+--- text-lang-bad-value eval ---
 // Error: 17-20 expected two or three letter language code (ISO 639-1/2/3)
 #set text(lang: "ӛ")
 
---- text-lang-bad-value-emoji paged ---
+--- text-lang-bad-value-emoji eval ---
 // Error: 17-20 expected two or three letter language code (ISO 639-1/2/3)
 #set text(lang: "😃")
 
---- text-region-bad-value paged ---
+--- text-region-bad-value eval ---
 // Error: 19-24 expected two letter region code (ISO 3166-1 alpha-2)
 #set text(region: "hey")
 
@@ -79,7 +79,7 @@
 #set text(lang: "qaa", region: "aa")
 #outline()
 
---- text-lang-hint-region-parameter paged ---
+--- text-lang-hint-region-parameter eval ---
 // Error: 17-24 expected two or three letter language code (ISO 639-1/2/3)
 // Hint: 17-24 you should leave only "en" in the `lang` parameter and specify "gb" in the `region` parameter
 #set text(lang: "en-gb")

--- a/tests/suite/text/lorem.typ
+++ b/tests/suite/text/lorem.typ
@@ -27,6 +27,6 @@
   }
 }
 
---- lorem-missing-words paged ---
+--- lorem-missing-words eval ---
 // Error: 2-9 missing argument: words
 #lorem()

--- a/tests/suite/text/raw.typ
+++ b/tests/suite/text/raw.typ
@@ -91,7 +91,7 @@ Year	Month	Day
     (* x (factorial (- x 1)))))
 ```
 
---- raw-syntaxes-invalid-sublime-syntax paged ---
+--- raw-syntaxes-invalid-sublime-syntax eval ---
 // Prevent test parser from failing on "^---" line.
 #let sublime-syntax = ```yaml
 %YAML 1.2
@@ -183,7 +183,7 @@ b = 324923
   "#let f(x) = x\n#align(center, line(length: 1em))",
 ))
 
---- raw-align-invalid paged ---
+--- raw-align-invalid eval ---
 // Error: 17-20 expected `start`, `left`, `center`, `right`, or `end`, found top
 #set raw(align: top)
 
@@ -831,7 +831,7 @@ hi:
   What is this?: This is incredible text!
 ```
 
---- raw-unclosed paged ---
+--- raw-unclosed eval ---
 // Test unterminated raw text.
 //
 // Note: This test should be the final one in the file because it messes up

--- a/tests/suite/text/smartquote.typ
+++ b/tests/suite/text/smartquote.typ
@@ -148,15 +148,15 @@ Does not apply across #html.div["block-level] elements".
 #set smartquote(quotes: (single: "a\u{0301}a\u{0301}"))
 "Double and 'Single' Quotes"
 
---- smartquote-custom-bad-string paged ---
+--- smartquote-custom-bad-string eval ---
 // Error: 25-28 expected 2 characters, found 1 character
 #set smartquote(quotes: "'")
 
---- smartquote-custom-bad-array paged ---
+--- smartquote-custom-bad-array eval ---
 // Error: 25-35 expected 2 quotes, found 4 quotes
 #set smartquote(quotes: ("'",) * 4)
 
---- smartquote-custom-bad-dict paged ---
+--- smartquote-custom-bad-dict eval ---
 // Error: 25-45 expected 2 quotes, found 4 quotes
 #set smartquote(quotes: (single: ("'",) * 4))
 

--- a/tests/suite/visualize/circle.typ
+++ b/tests/suite/visualize/circle.typ
@@ -52,7 +52,7 @@ Expanded by height.
   1fr,
 )
 
---- circle-radius-width-and-height paged ---
+--- circle-radius-width-and-height eval ---
 // Radius wins over width and height.
 // Error: 23-34 unexpected argument: width
 #circle(radius: 10pt, width: 50pt, height: 100pt, fill: eastern)

--- a/tests/suite/visualize/color.typ
+++ b/tests/suite/visualize/color.typ
@@ -1,6 +1,6 @@
 // Test color modification methods.
 
---- color-mix paged ---
+--- color-mix eval ---
 // Compare both ways.
 #test-repr(rgb(0%, 30.2%, 70.2%), rgb("004db3"))
 
@@ -185,49 +185,49 @@
 // Test gray color conversion.
 #stack(dir: ltr, rect(fill: luma(0)), rect(fill: luma(80%)))
 
---- color-rgb-out-of-range paged ---
+--- color-rgb-out-of-range eval ---
 // Error for values that are out of range.
 // Error: 11-14 number must be between 0 and 255
 #test(rgb(-30, 15, 50))
 
---- color-rgb-bad-string paged ---
+--- color-rgb-bad-string eval ---
 // Error: 6-11 color string contains non-hexadecimal letters
 #rgb("lol")
 
---- color-rgb-missing-argument-red paged ---
+--- color-rgb-missing-argument-red eval ---
 // Error: 2-7 missing argument: red component
 #rgb()
 
---- color-rgb-missing-argument-blue paged ---
+--- color-rgb-missing-argument-blue eval ---
 // Error: 2-11 missing argument: blue component
 #rgb(0, 1)
 
---- color-rgb-bad-type paged ---
+--- color-rgb-bad-type eval ---
 // Error: 21-26 expected integer or ratio, found boolean
 #rgb(10%, 20%, 30%, false)
 
---- color-luma-unexpected-argument paged ---
+--- color-luma-unexpected-argument eval ---
 // Error: 10-20 unexpected argument: key
 #luma(1, key: "val")
 
---- color-mix-bad-amount-type paged ---
+--- color-mix-bad-amount-type eval ---
 // Error: 12-24 expected float or ratio, found string
 // Error: 26-39 expected float or ratio, found string
 #color.mix((red, "yes"), (green, "no"), (green, 10%))
 
---- color-mix-bad-value paged ---
+--- color-mix-bad-value eval ---
 // Error: 12-23 expected a color or color-weight pair
 #color.mix((red, 1, 2))
 
---- color-mix-bad-space-type paged ---
+--- color-mix-bad-space-type eval ---
 // Error: 31-38 expected `rgb`, `luma`, `cmyk`, `oklab`, `oklch`, `color.linear-rgb`, `color.hsl`, or `color.hsv`, found string
 #color.mix(red, green, space: "cyber")
 
---- color-mix-bad-space-value-1 paged ---
+--- color-mix-bad-space-value-1 eval ---
 // Error: 31-36 expected `rgb`, `luma`, `cmyk`, `oklab`, `oklch`, `color.linear-rgb`, `color.hsl`, or `color.hsv`
 #color.mix(red, green, space: image)
 
---- color-mix-bad-space-value-2 paged ---
+--- color-mix-bad-space-value-2 eval ---
 // Error: 31-41 expected `rgb`, `luma`, `cmyk`, `oklab`, `oklch`, `color.linear-rgb`, `color.hsl`, or `color.hsv`
 #color.mix(red, green, space: calc.round)
 

--- a/tests/suite/visualize/gradient.typ
+++ b/tests/suite/visualize/gradient.typ
@@ -387,7 +387,7 @@
 #set text(fill: gradient.conic(red, blue, angle: 45deg))
 #lorem(30)
 
---- gradient-text-bad-relative paged ---
+--- gradient-text-bad-relative eval ---
 // Make sure they don't work when `relative: "self"`.
 // Hint: 17-61 make sure to set `relative: auto` on your text fill
 // Error: 17-61 gradients and tilings on text must be relative to the parent

--- a/tests/suite/visualize/image.typ
+++ b/tests/suite/visualize/image.typ
@@ -268,7 +268,7 @@ A #box(image("/assets/images/tiger.jpg", height: 1cm, width: 80%)) B
 // width, but rather max out at its natural size.
 #image("/assets/images/f2t.jpg")
 
---- image-file-not-found paged ---
+--- image-file-not-found eval ---
 // Error: 8-29 file not found (searched at tests/suite/visualize/path/does/not/exist)
 #image("path/does/not/exist")
 
@@ -332,7 +332,7 @@ A #box(image("/assets/images/tiger.jpg", height: 1cm, width: 80%)) B
   ),
 )
 
---- image-pixmap-unknown-attribute paged ---
+--- image-pixmap-unknown-attribute eval ---
 #image(
   bytes((0x00, 0x00, 0x00)),
   // Error: 1:11-6:4 unexpected key "stowaway", valid keys are "encoding", "width", and "height"
@@ -344,7 +344,7 @@ A #box(image("/assets/images/tiger.jpg", height: 1cm, width: 80%)) B
   ),
 )
 
---- image-pixmap-but-png-format paged ---
+--- image-pixmap-but-png-format eval ---
 #image(
   bytes((0x00, 0x00, 0x00)),
   // Error: 1:11-5:4 expected "rgb8", "rgba8", "luma8", or "lumaa8"
@@ -355,7 +355,7 @@ A #box(image("/assets/images/tiger.jpg", height: 1cm, width: 80%)) B
   ),
 )
 
---- image-png-but-pixmap-format paged ---
+--- image-png-but-pixmap-format eval ---
 #image(
   read("/assets/images/tiger.jpg", encoding: none),
   // Error: 11-18 expected "png", "jpg", "gif", "webp", dictionary, "svg", "pdf", or auto

--- a/tests/suite/visualize/line.typ
+++ b/tests/suite/visualize/line.typ
@@ -73,22 +73,22 @@
 #v(3pt)
 #line(length: 60pt, stroke: (paint: red, thickness: 1pt, dash: (1pt, 3pt, 9pt)))
 
---- line-stroke-field-typo paged ---
+--- line-stroke-field-typo eval ---
 // Error: 29-56 unexpected key "thicknes", valid keys are "paint", "thickness", "cap", "join", "dash", and "miter-limit"
 #line(length: 60pt, stroke: (paint: red, thicknes: 1pt))
 
---- line-stroke-bad-dash-kind paged ---
+--- line-stroke-bad-dash-kind eval ---
 // Error: 29-55 expected "solid", "dotted", "densely-dotted", "loosely-dotted", "dashed", "densely-dashed", "loosely-dashed", "dash-dotted", "densely-dash-dotted", "loosely-dash-dotted", array, dictionary, none, or auto
 #line(length: 60pt, stroke: (paint: red, dash: "dash"))
 
---- line-bad-point-array paged ---
+--- line-bad-point-array eval ---
 // Test errors.
 
 // Error: 12-19 array must contain exactly two items
 // Hint: 12-19 the first item determines the value for the X axis and the second item the value for the Y axis
 #line(end: (50pt,))
 
---- line-bad-point-component-type paged ---
+--- line-bad-point-component-type eval ---
 // Error: 14-26 expected relative length, found angle
 #line(start: (3deg, 10pt), length: 5cm)
 

--- a/tests/suite/visualize/polygon.typ
+++ b/tests/suite/visualize/polygon.typ
@@ -48,7 +48,7 @@
     (0pt, 20pt), (15pt, 0pt), (0pt, 40pt), (15pt, 45pt)),
 )
 
---- polygon-bad-point-array paged ---
+--- polygon-bad-point-array eval ---
 // Error: 10-17 array must contain exactly two items
 // Hint: 10-17 the first item determines the value for the X axis and the second item the value for the Y axis
 #polygon((50pt,))

--- a/tests/suite/visualize/rect.typ
+++ b/tests/suite/visualize/rect.typ
@@ -70,7 +70,7 @@
   left: (cap: "round", thickness: 5pt),
   top: (cap: "square", thickness: 7pt),
 ))
---- red-stroke-bad-type paged ---
+--- red-stroke-bad-type eval ---
 // Error: 15-21 expected length, color, gradient, tiling, dictionary, stroke, none, or auto, found array
 #rect(stroke: (1, 2))
 
@@ -99,7 +99,7 @@
   ..items,
 )
 
---- rect-radius-bad-key paged ---
+--- rect-radius-bad-key eval ---
 // Error: 15-38 unexpected key "cake", valid keys are "top-left", "top-right", "bottom-right", "bottom-left", "left", "top", "right", "bottom", and "rest"
 #rect(radius: (left: 10pt, cake: 5pt))
 

--- a/tests/suite/visualize/square.typ
+++ b/tests/suite/visualize/square.typ
@@ -33,7 +33,7 @@
   But, soft! what light through yonder window breaks?
 ]
 
---- square-size-width-and-height paged ---
+--- square-size-width-and-height eval ---
 // Size wins over width and height.
 // Error: 09-20 unexpected argument: width
 #square(width: 10cm, height: 20cm, size: 1cm, fill: rgb("eb5278"))
@@ -97,7 +97,7 @@
 #square(height: 150%)
 #square(height: 150%)[Hello there]
 
---- square-size-relative-invalid paged ---
+--- square-size-relative-invalid eval ---
 // Size cannot be relative because we wouldn't know
 // relative to which axis.
 // Error: 15-18 expected length or auto, found ratio

--- a/tests/suite/visualize/tiling.typ
+++ b/tests/suite/visualize/tiling.typ
@@ -60,7 +60,7 @@
   fill: tiling(size: (2pt, 1pt), square(size: 1pt, fill: black))
 )
 
---- tiling-zero-sized paged ---
+--- tiling-zero-sized eval ---
 // Error: 15-52 tile size must be non-zero
 // Hint: 15-52 try setting the size manually
 #line(stroke: tiling(curve(curve.move((1em, 0pt)))))


### PR DESCRIPTION
This converts every test which has an annotated error that occurs only during `eval` to use that target instead of `paged`. This comes out to 709 tests total.

Note that many of the files are already eval-centric, e.g. `array.typ`, but some are more layout-centric with the surrounding tests generally using `paged`, e.g. `grid/footers.typ`. Let me know if we would prefer to have the layout-centric files still used `paged` for local consistency.
