### PR TITLE
Fix type signature of `block.spacing`

### DIFF
--- a/crates/typst-library/src/layout/container.rs
+++ b/crates/typst-library/src/layout/container.rs
@@ -316,8 +316,8 @@ pub struct BlockElem {
     /// A second paragraph.
     /// ```
     #[external]
-    #[default(Em::new(1.2).into())]
-    pub spacing: Spacing,
+    #[default(Smart::Custom(Em::new(1.2).into()))]
+    pub spacing: Smart<Spacing>,
 
     /// The spacing between this block and its predecessor.
     #[parse(


### PR DESCRIPTION
Since the property is `#[external]` and just a shorthand for `above` and `below`, this only affects docs and such. The property already accepts `auto` in practice.