### PR TITLE
Deduplicate errors emitted in the eval test stage

### DIFF
--- a/tests/src/run.rs
+++ b/tests/src/run.rs
@@ -379,16 +379,16 @@ impl<'a> Runner<'a> {
     }
 
     /// Compile a document with the specified target.
+    ///
+    /// Conceptually, this functions takes the evaluated content as input and
+    /// produces a document. In practice it also re-evaluates the sources and
+    /// thus generates duplicate diagnostics for the eval stage, so we filter
+    /// those out.
     fn compile<D: TestDocument>(
         &mut self,
         evaluated: Warned<SourceResult<Content>>,
     ) -> Option<D> {
         let Warned { output, warnings } = typst::compile::<D>(&self.world);
-
-        // Conecptually this functions takes the evaluated content as input and
-        // produces a document. In practice it also re-evaluates the sources and
-        // thus generates duplicate diagnostics for the eval stage, so we filter
-        // those out.
 
         let warnings = eval::deduplicate_with(warnings, &evaluated.warnings);
         for warning in warnings.iter() {


### PR DESCRIPTION
Fixes the issue described in https://github.com/typst/typst/pull/7738#issuecomment-3801883883

Due to the changes in how diagnostics are printed after https://github.com/typst/typst/pull/7820/commits/e1475583f622f10e065854bf5d1eab1d4c6b7c71 this isn't really noticeable, but is conceptually the consisten thing to do and might still improve the printed message in some edge cases.