### PR TITLE
Fix style of disabled filter button in test report

### DIFF
--- a/tests/src/report/report.css
+++ b/tests/src/report/report.css
@@ -584,12 +584,12 @@ label.icon-toggle-button:has(input:checked) {
   color: var(--action-primary-selected);
 }
 
-*:disabled label.icon-toggle-button {
+label.icon-toggle-button:has(input:disabled) {
   background-color: var(--action-secondary-disabled);
   color: var(--text-disabled);
 }
 
-*:disabled label.icon-toggle-button:has(input:checked) {
+label.icon-toggle-button:has(input:disabled:checked) {
   color: var(--action-primary-disabled);
 }
 
@@ -617,11 +617,6 @@ button.icon-button:hover {
 
 button.icon-button:active {
   background-color: var(--action-secondary-active);
-}
-
-*:disabled button.icon-button {
-  background-color: var(--action-secondary-disabled);
-  color: var(--text-disabled);
 }
 
 button.icon-button:disabled {


### PR DESCRIPTION
Correctly display disabled filter buttons:

Before:
<img width="279" height="51" alt="image" src="https://github.com/user-attachments/assets/f14dcbc5-a045-46df-98f0-e75f2a26e18f" />
After:
<img width="279" height="51" alt="image" src="https://github.com/user-attachments/assets/4a1ea418-8e22-4397-b7d3-2c4e048c7e5c" />
