### PR TITLE
Fix unnamed function link in syntax page to point to `#unnamed` anchor

### DIFF
--- a/docs/reference/language/syntax.md
+++ b/docs/reference/language/syntax.md
@@ -115,7 +115,7 @@ a table listing all syntax that is available in code mode:
 | Method call              | `{x.flatten()}`               | [Scripting]($scripting/#methods)   |
 | Function call            | `{min(x, y)}`                 | [Function]($function)              |
 | Argument spreading       | `{min(..nums)}`               | [Arguments]($arguments)            |
-| Unnamed function         | `{(x, y) => x + y}`           | [Function]($function)              |
+| Unnamed function         | `{(x, y) => x + y}`           | [Function]($function/#unnamed)     |
 | Let binding              | `{let x = 1}`                 | [Scripting]($scripting/#bindings)  |
 | Named function           | `{let f(x) = 2 * x}`          | [Function]($function)              |
 | Set rule                 | `{set text(14pt)}`            | [Styling]($styling/#set-rules)     |


### PR DESCRIPTION
Updates the "Unnamed function" link in the syntax reference table to point directly to the `#unnamed` anchor in the function documentation, making navigation more direct for users.

Fixes #7812
