### PR TITLE
Avoid local timezone offset being added for reproducible builds

### DIFF
--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -147,13 +147,21 @@ impl World for SystemWorld {
 
     fn today(&self, offset: Option<Duration>) -> Option<Datetime> {
         let now = match &self.now {
-            Now::Fixed(time) => time,
-            Now::System(time) => time.get_or_init(Utc::now),
+            Now::Fixed(time) => time.fixed_offset(),
+            Now::System(time) => {
+                let now_utc = time.get_or_init(Utc::now);
+                if offset.is_some() {
+                    // Actual offset will be applied later.
+                    now_utc.fixed_offset()
+                } else {
+                    now_utc.with_timezone(&Local).fixed_offset()
+                }
+            }
         };
 
-        // The time with the specified UTC offset, or within the local time zone.
+        // The time with the specified UTC offset.
         let with_offset = match offset {
-            None => now.with_timezone(&Local).fixed_offset(),
+            None => now,
             Some(offset) => {
                 let seconds = offset.seconds().trunc();
                 // Check whether we can convert seconds from f64 to i32


### PR DESCRIPTION
Always use UTC timezone in the CLI implementation of `World::today()` when a fixed date is requested. Only apply the local timezone offset when the date is not fixed, and no offset argument is set.

Mentioned in #7691.