### PR TITLE
Wrap list/enum item labels and bodies in grid cells

### DIFF
--- a/crates/typst-layout/src/lists.rs
+++ b/crates/typst-layout/src/lists.rs
@@ -2,10 +2,14 @@ use comemo::Track;
 use smallvec::smallvec;
 use typst_library::diag::SourceResult;
 use typst_library::engine::Engine;
-use typst_library::foundations::{Content, Context, Depth, Packed, StyleChain};
+use typst_library::foundations::{
+    Content, Context, Depth, NativeElement, Packed, StyleChain,
+};
 use typst_library::introspection::Locator;
 use typst_library::layout::grid::resolve::{Cell, CellGrid};
-use typst_library::layout::{Axes, Fragment, HAlignment, Regions, Sizing, VAlignment};
+use typst_library::layout::{
+    Axes, Fragment, GridCell, HAlignment, Regions, Sizing, VAlignment,
+};
 use typst_library::model::{EnumElem, ListElem, Numbering, ParElem, ParbreakElem};
 use typst_library::pdf::PdfMarkerTag;
 use typst_library::text::TextElem;
@@ -46,9 +50,11 @@ pub fn layout_list(
         let body = body.set(ListElem::depth, Depth(1));
 
         cells.push(Cell::new(Content::empty()));
-        cells.push(Cell::new(PdfMarkerTag::ListItemLabel(marker.clone())));
+        cells.push(Cell::new(
+            GridCell::new(PdfMarkerTag::ListItemLabel(marker.clone())).pack(),
+        ));
         cells.push(Cell::new(Content::empty()));
-        cells.push(Cell::new(PdfMarkerTag::ListItemBody(body)));
+        cells.push(Cell::new(GridCell::new(PdfMarkerTag::ListItemBody(body)).pack()));
     }
 
     let grid = CellGrid::new(
@@ -130,9 +136,10 @@ pub fn layout_enum(
         let body = body.set(EnumElem::parents, smallvec![number]);
 
         cells.push(Cell::new(Content::empty()));
-        cells.push(Cell::new(PdfMarkerTag::ListItemLabel(resolved)));
+        cells
+            .push(Cell::new(GridCell::new(PdfMarkerTag::ListItemLabel(resolved)).pack()));
         cells.push(Cell::new(Content::empty()));
-        cells.push(Cell::new(PdfMarkerTag::ListItemBody(body)));
+        cells.push(Cell::new(GridCell::new(PdfMarkerTag::ListItemBody(body)).pack()));
         number =
             if reversed { number.saturating_sub(1) } else { number.saturating_add(1) };
     }

--- a/tests/ref/pdftags/issue-7789-list-tags-breaking.yml
+++ b/tests/ref/pdftags/issue-7789-list-tags-breaking.yml
@@ -1,0 +1,28 @@
+- Tag: L
+  /ListNumbering: Circle
+  /K:
+    - Tag: LI
+      /K:
+        - Tag: Lbl
+          /K:
+            - Tag: P
+              /K:
+                - Content: page=0 mcid=0
+        - Tag: LBody
+          /K:
+            - Tag: P
+              /K:
+                - Content: page=0 mcid=1
+    - Tag: L
+      /ListNumbering: Circle
+      /K:
+        - Tag: LI
+          /K:
+            - Tag: Lbl
+              /K:
+                - Tag: P
+                  /K:
+                    - Content: page=0 mcid=2
+            - Tag: LBody
+              /K:
+                - Content: page=0 mcid=3

--- a/tests/suite/pdftags/list.typ
+++ b/tests/suite/pdftags/list.typ
@@ -84,3 +84,10 @@
 // happens when tags are broken up, so it's not *that* bad.
 / A #parbreak() A: 1
 / B: 2
+
+
+--- issue-7789-list-tags-breaking pdftags ---
+#set list(marker: [a] + layout(layout_info => box(height: 100em)))
+
+- A
+  - A


### PR DESCRIPTION
Fixes #7789 by wrapping list/enum item labels and bodies in grid cells.

This ensures proper handling of content broken across multiple regions/pages.