### PR TITLE
Make list item labels non-breakable

### DIFF
--- a/crates/typst-layout/src/lists.rs
+++ b/crates/typst-layout/src/lists.rs
@@ -46,7 +46,9 @@ pub fn layout_list(
         let body = body.set(ListElem::depth, Depth(1));
 
         cells.push(Cell::new(Content::empty()));
-        cells.push(Cell::new(PdfMarkerTag::ListItemLabel(marker.clone())));
+        let mut label_cell = Cell::new(PdfMarkerTag::ListItemLabel(marker.clone()));
+        label_cell.breakable = false;
+        cells.push(label_cell);
         cells.push(Cell::new(Content::empty()));
         cells.push(Cell::new(PdfMarkerTag::ListItemBody(body)));
     }
@@ -130,7 +132,9 @@ pub fn layout_enum(
         let body = body.set(EnumElem::parents, smallvec![number]);
 
         cells.push(Cell::new(Content::empty()));
-        cells.push(Cell::new(PdfMarkerTag::ListItemLabel(resolved)));
+        let mut label_cell = Cell::new(PdfMarkerTag::ListItemLabel(resolved));
+        label_cell.breakable = false;
+        cells.push(label_cell);
         cells.push(Cell::new(Content::empty()));
         cells.push(Cell::new(PdfMarkerTag::ListItemBody(body)));
         number =

--- a/tests/ref/pdftags/issue-7789-list-tags-breaking.yml
+++ b/tests/ref/pdftags/issue-7789-list-tags-breaking.yml
@@ -1,0 +1,28 @@
+- Tag: L
+  /ListNumbering: Circle
+  /K:
+    - Tag: LI
+      /K:
+        - Tag: Lbl
+          /K:
+            - Tag: P
+              /K:
+                - Content: page=0 mcid=0
+        - Tag: LBody
+          /K:
+            - Tag: P
+              /K:
+                - Content: page=0 mcid=1
+    - Tag: L
+      /ListNumbering: Circle
+      /K:
+        - Tag: LI
+          /K:
+            - Tag: Lbl
+              /K:
+                - Tag: P
+                  /K:
+                    - Content: page=0 mcid=2
+            - Tag: LBody
+              /K:
+                - Content: page=0 mcid=3

--- a/tests/suite/pdftags/list.typ
+++ b/tests/suite/pdftags/list.typ
@@ -84,3 +84,10 @@
 // happens when tags are broken up, so it's not *that* bad.
 / A #parbreak() A: 1
 / B: 2
+
+
+--- issue-7789-list-tags-breaking pdftags ---
+#set list(marker: [a] + layout(layout_info => box(height: 100em)))
+
+- A
+  - A


### PR DESCRIPTION
Superseedes #7858, Fixes #7789.

Marking the label/marker/numbering cell as non-breakable is a much simpler fix.