### PR TITLE
Add `testit pdftags` subcommand to print the tags of a PDF file

### DIFF
--- a/tests/src/args.rs
+++ b/tests/src/args.rs
@@ -142,6 +142,14 @@ pub enum Command {
     Clean,
     /// Deletes all dangling reference output.
     Undangle,
+    /// Prints the tags from a PDF file.
+    Pdftags(PdftagsCommand),
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct PdftagsCommand {
+    /// The PDF file containing the tags.
+    pub path: PathBuf,
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, ValueEnum)]

--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -22,7 +22,7 @@ use parking_lot::{Mutex, RwLock};
 use rayon::iter::{ParallelBridge, ParallelIterator};
 use rustc_hash::FxHashMap;
 
-use crate::args::{CliArguments, Command};
+use crate::args::{CliArguments, Command, PdftagsCommand};
 use crate::collect::{Test, TestParseErrorKind};
 use crate::logger::{Logger, TestResult};
 use crate::output::{HASH_OUTPUTS, HashedRefs};
@@ -55,6 +55,7 @@ fn main() {
         None => test(),
         Some(Command::Clean) => clean(),
         Some(Command::Undangle) => undangle(),
+        Some(Command::Pdftags(command)) => pdftags(command),
     }
 }
 
@@ -210,6 +211,20 @@ fn undangle() {
                 std::fs::write(path, hashed_refs.to_string()).unwrap();
             }
         }
+    }
+}
+
+fn pdftags(command: &PdftagsCommand) {
+    let bytes = match std::fs::read(&command.path) {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            eprintln!("error: {err}");
+            return;
+        }
+    };
+    match pdftags::format(&bytes) {
+        Ok(tags) => println!("{tags}"),
+        Err(err) => eprintln!("error: {err}"),
     }
 }
 


### PR DESCRIPTION
This allows running `cargo testit pdftags doc.pdf` to print its PDF tags in the same format as the test suite.