### PR TITLE
Improve the precision of `Date`, `Duration` composition

### DIFF
--- a/crates/typst-library/src/foundations/datetime.rs
+++ b/crates/typst-library/src/foundations/datetime.rs
@@ -526,7 +526,13 @@ impl Add<Duration> for Datetime {
         let rhs: time::Duration = rhs.into();
         match self {
             Self::Datetime(datetime) => Self::Datetime(datetime + rhs),
-            Self::Date(date) => Self::Date(date + rhs),
+            Self::Date(date) => {
+                use time::Time;
+                match PrimitiveDateTime::new(date, Time::MIDNIGHT) + rhs {
+                    dt if dt.time() == Time::MIDNIGHT => Self::Date(dt.date()),
+                    dt => Self::Datetime(dt),
+                }
+            }
             Self::Time(time) => Self::Time(time + rhs),
         }
     }
@@ -539,7 +545,13 @@ impl Sub<Duration> for Datetime {
         let rhs: time::Duration = rhs.into();
         match self {
             Self::Datetime(datetime) => Self::Datetime(datetime - rhs),
-            Self::Date(date) => Self::Date(date - rhs),
+            Self::Date(date) => {
+                use time::Time;
+                match PrimitiveDateTime::new(date, Time::MIDNIGHT) - rhs {
+                    dt if dt.time() == Time::MIDNIGHT => Self::Date(dt.date()),
+                    dt => Self::Datetime(dt),
+                }
+            }
             Self::Time(time) => Self::Time(time - rhs),
         }
     }

--- a/tests/suite/foundations/duration.typ
+++ b/tests/suite/foundations/duration.typ
@@ -74,6 +74,21 @@
 #test(datetime(day: 1, month: 2, year: 2000) - b, duration(days: 31))
 #test(datetime(day: 15, month: 1, year: 2000) - b, duration(weeks: 2))
 
+--- issue-7843-date-duration-precision eval ---
+#test(
+  datetime(year: 2030, month: 5, day: 25,            hour:  6, minute:  30, second:  19),
+  datetime(year: 2030, month: 5, day: 25) + duration(hours: 6, minutes: 30, seconds: 19),
+)
+#test(
+  datetime(year: 2030, month: 5, day: 25),
+  datetime(year: 2030, month: 5, day: 26) - duration(hours: 24),
+)
+
+#let some-day = datetime(year: 2000, month: 6, day: 5)
+#let two-hours = duration(hours: 2)
+#test(some-day + 100 * two-hours, range(100).fold(some-day, (d, _) => d + two-hours))
+#test(some-day - 100 * two-hours, range(100).fold(some-day, (d, _) => d - two-hours))
+
 --- duration-multiply-with-number eval ---
 // Test multiplying and dividing durations with numbers.
 #test(duration(minutes: 10) * 6, duration(hours: 1))


### PR DESCRIPTION
Resolves #7843 by upcasting `Date` to a `PrimitiveDateTime` during composition with `Duration`

<details>
<summary>outdated (see discussion below)</summary>

This caused two existing tests in `tests/suite/foundations/datetime.typ` to change; I _believe_ those would be considered improvements.
</details>

I also explored unconditionally producing a full `Datetime` instead of checking if a `Date` suffices, but that touched more existing tests and I do like how Typst generally doesn't give unnecessary precision on user-facing stuff.