### PR TITLE
Fix "us-executive" paper size

### DIFF
--- a/crates/typst-library/src/layout/page.rs
+++ b/crates/typst-library/src/layout/page.rs
@@ -969,7 +969,7 @@ papers! {
     (US_LETTER:         215.9,  279.4, "us-letter")
     (US_LEGAL:          215.9,  355.6, "us-legal")
     (US_TABLOID:        279.4,  431.8, "us-tabloid")
-    (US_EXECUTIVE:      184.15,  266.7, "us-executive")
+    (US_EXECUTIVE:      184.15, 266.7, "us-executive")
     (US_FOOLSCAP_FOLIO: 215.9,  342.9, "us-foolscap-folio")
     (US_STATEMENT:      139.7,  215.9, "us-statement")
     (US_LEDGER:         431.8,  279.4, "us-ledger")


### PR DESCRIPTION
Changed "us-executive" width from 84.15 to 184.15. I believe this was a typo. Dimensions (7.25 x 10.5 inches) are confirmed by this IBM page: https://www.ibm.com/docs/en/cmofi/7.6.0?topic=reference-paper-sizes-dimensions