### PR TITLE
typst-pdf: Attach known image types without compression

### DIFF
--- a/crates/typst-pdf/src/attach.rs
+++ b/crates/typst-pdf/src/attach.rs
@@ -113,7 +113,7 @@ fn should_compress(data: &[u8]) -> Option<bool> {
             | "image/heif"
             | "image/avif"
             | "image/jxl"
-            | "image/vnd.djvu" => None,
+            | "image/vnd.djvu" => Some(false),
             _ => None,
         },
         infer::MatcherType::Text => None,


### PR DESCRIPTION
Most of the image files already have the data compressed, so sprinkling deflate on top of it won't do much besides making it take longer to compile the document.

Initially, #6256 had it right, but then it got flipped during [refactoring]. I believe it wasn't intentional, hence my PR. :^)
(interesting that clippy doesn't catch equal match cases)

[refactoring]: https://github.com/typst/typst/pull/6256/changes/cd659bf460e820ac1c2eadacd34e007d135294d8#diff-2615574cce919d378aeda60ca1604075f0665af57065a39286a0e363578eae78L107-R107