### PR TITLE
Ensure lorem produces exact word count by skipping hyphens

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -20,8 +20,10 @@ The MIT License applies to:
   based on the `TokenSet` from rust-analyzer
   (https://github.com/rust-lang/rust-analyzer/blob/master/crates/parser/src/token_set.rs)
 
-* The lorem ipsum generator in `crates/typst-library/src/text/lorem.rs` which
-  is based on the `lipsum` crate (https://github.com/mgeisler/lipsum)
+* The Lorem Ipsum generator in `crates/typst-library/src/text/lorem.rs` which
+  is based on the `lipsum` crate
+  (https://github.com/mgeisler/lipsum/blob/0.9.1/src/lib.rs)
+  Copyright (c) 2017 Martin Geisler
 
 The MIT License (MIT)
 

--- a/crates/typst-library/src/text/lorem.rs
+++ b/crates/typst-library/src/text/lorem.rs
@@ -1,5 +1,6 @@
 use std::sync::LazyLock;
 
+use ecow::EcoString;
 use lipsum::{LIBER_PRIMUS, LOREM_IPSUM, MarkovChain};
 
 use crate::foundations::{Str, func};
@@ -24,22 +25,21 @@ pub fn lorem(
     /// The length of the blind text in words.
     words: usize,
 ) -> Str {
-    generate_lorem(words).into()
+    lorem_impl(words).into()
 }
 
-/// Generate `n` words of lorem ipsum text, treating `--` as a non-word
+/// Generates `n` words of Lorem Ipsum text, treating `--` as a non-word
 /// separator that is replaced with an en-dash (`–`).
 ///
 /// This reimplements the joining logic from lipsum's private `join_words`
 /// function, but skips `--` entries in the Markov chain output without
 /// counting them toward the requested word count.
-fn generate_lorem(n: usize) -> String {
-    // Ported from https://github.com/mgeisler/lipsum/blob/0.9.1/src/lib.rs
-    // MIT License
-    // Copyright (c) 2017 Martin Geisler
+fn lorem_impl(n: usize) -> EcoString {
+    // Based on the `lipsum` crate (MIT).
+    // Copyright (c) 2017 Martin Geisler.
     // See NOTICE for full attribution.
     if n == 0 {
-        return String::new();
+        return EcoString::new();
     }
 
     static LOREM_CHAIN: LazyLock<MarkovChain<'static>> = LazyLock::new(|| {
@@ -55,7 +55,7 @@ fn generate_lorem(n: usize) -> String {
     // Punctuation characters which end a sentence.
     const PUNCTUATION: [char; 3] = ['.', '!', '?'];
 
-    let mut sentence = String::new();
+    let mut sentence = EcoString::new();
     let mut word_count = 0;
     let mut needs_cap = false;
 

--- a/tests/suite/text/lorem.typ
+++ b/tests/suite/text/lorem.typ
@@ -37,4 +37,3 @@
 #test(count(193), 193)
 #test(count(194), 194)
 #test(count(195), 195)
-


### PR DESCRIPTION
close #6186

This issue was initially marked as an upstream problem, but the author of lipsum suggested using `MarkovChain::iter`. 
Therefore, this PR adds a custom implementation to Typst that takes the word count into account.

```typ
#import "@preview/wordometer:0.1.4": word-count

#word-count(total => [
  #lorem(193) \
  #[`#lorem(193)`: *#total.words words*] <no-wc>
], exclude: <no-wc>)

#word-count(total => [
  #lorem(194) \
  #[`#lorem(194)`: *#total.words words*] <no-wc>
], exclude: <no-wc>)

#word-count(total => [
  #lorem(195) \
  #[`#lorem(195)`: *#total.words words*] <no-wc>
], exclude: <no-wc>)
```

<img width="1191" height="1684" alt="image" src="https://github.com/user-attachments/assets/ccbcf2dc-03bc-4f74-8ad3-e691be18f4e9" />
