### PR TITLE
Add mise installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Typst's CLI is available from different sources:
   - build and run the [Typst flake](https://github.com/typst/typst-flake) with
     `nix run github:typst/typst-flake -- --version`.
 
+- mise users can install Typst with `mise use -g typst`.
+
 - Docker users can run a prebuilt image with
   `docker run ghcr.io/typst/typst:latest --help`.
 


### PR DESCRIPTION
[mise](https://mise.jdx.dev/) is a tool manager that has recently gained widespread use. Like Nix or Docker, it enables reproducible builds by pinning specific versions on a per-project basis. Furthermore, mise makes it easy to integrate with the Typst ecosystem (such as Tinymist and typstyle), as well as with external tools for data acquisition and processing. 

Many popular tools in recent years provide installation instructions using mise. Therefore, I think it's helpful to mention mise in the README.