### PR TITLE
feat: merge strokes

### DIFF
--- a/crates/typst-library/src/foundations/ops.rs
+++ b/crates/typst-library/src/foundations/ops.rs
@@ -7,7 +7,7 @@ use typst_utils::Numeric;
 
 use crate::diag::{HintedStrResult, StrResult, bail};
 use crate::foundations::{
-    Datetime, IntoValue, Regex, Repr, SymbolElem, Value, format_str,
+    Datetime, Fold, IntoValue, Regex, Repr, SymbolElem, Value, format_str,
 };
 use crate::layout::{Alignment, Length, Rel};
 use crate::text::TextElem;
@@ -162,6 +162,12 @@ pub fn add(lhs: Value, rhs: Value) -> HintedStrResult<Value> {
                 (a.downcast::<Alignment>(), b.downcast::<Alignment>())
             {
                 return Ok((a + b)?.into_value());
+            }
+
+            // Strokes can be merged using the Fold trait.
+            // The right-hand stroke overrides the left-hand stroke's properties.
+            if let (Some(a), Some(b)) = (a.downcast::<Stroke>(), b.downcast::<Stroke>()) {
+                return Ok(b.clone().fold(a.clone()).into_value());
             }
 
             mismatch!("cannot add {} and {}", a, b);

--- a/tests/suite/visualize/stroke.typ
+++ b/tests/suite/visualize/stroke.typ
@@ -19,6 +19,42 @@
 // Error: 9-21 unexpected key "foo", valid keys are "paint", "thickness", "cap", "join", "dash", and "miter-limit"
 #stroke((foo: "bar"))
 
+--- stroke-addition eval ---
+// Test stroke addition (merging).
+// Regression test for issue #7839.
+#let s1 = stroke(black + 0.5pt)
+#let s2 = stroke(paint: red, dash: "dashed")
+#let merged = s1 + s2
+
+// Right-hand side overrides left-hand side
+#test(merged.paint, red)
+#test(merged.thickness, 0.5pt)
+#test(merged.dash, (array: (3pt, 3pt), phase: 0pt))
+
+// Order matters
+#let s3 = stroke(paint: blue, thickness: 2pt)
+#let s4 = stroke(paint: green, dash: "dotted")
+#test((s3 + s4).paint, green)
+#test((s3 + s4).thickness, 2pt)
+#test((s4 + s3).paint, blue)
+#test((s4 + s3).thickness, 2pt)
+
+// Multiple additions
+#let base = stroke(paint: purple)
+#let t = stroke(thickness: 3pt)
+#let d = stroke(dash: "dash-dotted")
+#let combined = base + t + d
+#test(combined.paint, purple)
+#test(combined.thickness, 3pt)
+#test(combined.dash, (array: (3pt, 2pt, "dot", 2pt), phase: 0pt))
+
+// Auto values don't override custom values
+#let custom = stroke(paint: orange, thickness: 5pt)
+#let auto-stroke = stroke(paint: auto, thickness: auto)
+#let result = custom + auto-stroke
+#test(result.paint, orange)
+#test(result.thickness, 5pt)
+
 --- stroke-fields-simple eval ---
 // Test stroke fields for simple strokes.
 #test((1em + blue).paint, blue)


### PR DESCRIPTION
# Add stroke merging/addition capability

## Problem

Users could not merge `Stroke` objects using the `+` operator, which made it difficult to build configuration systems where default stroke settings can be overridden by user-specified properties.

**Example that failed before this PR:**
```typst
#let default = stroke(black + 0.5pt)
#let user = stroke(paint: red, dash: "dashed")
#let merged = default + user  // Error: cannot add stroke and stroke
```

The desired behavior is to merge the stroke properties, with the right-hand side overriding the left-hand side where specified, resulting in:
```typst
stroke(paint: red, thickness: 0.5pt, dash: "dashed")
```

## Use Case

This feature is particularly useful for package authors who want to provide configurable styling:

1. Define default stroke settings (e.g., `stroke(black + 0.5pt)`)
2. Allow users to override specific properties (e.g., `stroke(paint: red, dash: "dashed")`)
3. Merge them to get a stroke with both default and user-specified properties

## Solution

Added support for stroke addition in the `add` function (`crates/typst-library/src/foundations/ops.rs`) by leveraging the existing `Fold` trait implementation that `Stroke` already has.

**Fixes #7839**