### PR TITLE
Replace deprecated symbols in docs

### DIFF
--- a/docs/guides/guide-for-latex-users.md
+++ b/docs/guides/guide-for-latex-users.md
@@ -531,7 +531,7 @@ Numbers and single characters are displayed verbatim, while multiple consecutive
 (non-number) characters will be interpreted as Typst variables.
 
 Typst pre-defines a lot of useful variables in math mode. All Greek (`alpha`,
-`beta`, ...) and some Hebrew letters (`alef`, `bet`, ...) are available through
+`beta`, ...) and some Hebrew letters (`aleph`, `beth`, ...) are available through
 their name. Some symbols are additionally available through shorthands, such as
 `<=`, `>=`, and `->`.
 


### PR DESCRIPTION
Closes #7841.

I went through the docs of this awesome project and searched for deprecated symbols.
Only the [Guide for LaTeX Users](https://github.com/typst/typst/blob/main/docs/guides/guide-for-latex-users.md) mentions deprecated symbols `alef` and `bet` which should be updated to `aleph` and `beth` respectively.