### PR TITLE
Fix stack overflow in list grouping with linebreak (#7797)

### DIFF
--- a/tests/suite/styling/show.typ
+++ b/tests/suite/styling/show.typ
@@ -278,3 +278,13 @@ I am *strong*, I am _emphasized_, and I am #[special<special>].
 Hello
 
 World
+
+--- issue-7797-list-grouping-linebreak paged ---
+// Error: 7:1-7:6 maximum grouping depth exceeded
+#show list: it => {
+  for item in it.children {
+    [#item\ ]
+  }
+}
+
+- One


### PR DESCRIPTION
Fixes #7797.

When a show rule on `list` produces content containing a linebreak (`\`),
the grouping finisher triggers new grouping which calls the finisher again,
leading to unbounded recursion and a stack overflow.

This adds a recursion-depth counter (`grouping_depth`) to the realization
state. The counter is incremented each time a grouping finisher is entered
and decremented when it returns. If it exceeds `MAX_GROUPING_DEPTH` (512),
the existing "maximum grouping depth exceeded" error is raised instead of
crashing.

Concrete changes:
- Added `grouping_depth` field to `State`.
- Introduced `with_grouping_depth()` helper that wraps finisher calls with
  the depth guard.
- Extracted the magic number `512` into a `MAX_GROUPING_DEPTH` constant.
- Added a regression test reproducing the issue.