### PR TITLE
A few tiny docs prose updates

### DIFF
--- a/docs/content/reference/language/scripting.typ
+++ b/docs/content/reference/language/scripting.typ
@@ -108,7 +108,7 @@ Destructuring also works in argument lists of functions ...
 ```
 
 = Conditionals <conditionals>
-With a conditional, you can display or compute different things depending on whether some condition is fulfilled. Typst supports `{if}`, `{else if}` and `{else}` expressions. When the condition evaluates to `{true}`, the conditional yields the value resulting from the if's body, otherwise yields the value resulting from the else's body.
+With a conditional, you can display or compute different things depending on whether some condition is fulfilled. Typst supports `{if}`, `{else if}` and `{else}` expressions. When the condition evaluates to `{true}`, the conditional yields the value resulting from the if's body. Otherwise, it yields the value resulting from the else's body.
 
 ```example
 #if 1 < 2 [

--- a/docs/content/reference/language/scripting.typ
+++ b/docs/content/reference/language/scripting.typ
@@ -51,7 +51,7 @@ It explains #name.
 Sum is #my-add(2, 3).
 ```
 
-Let bindings can also be used to destructure @array[arrays] and @dictionary[dictionaries]. In this case, the left-hand side of the assignment should mirror an array or dictionary. The `..` operator can be used once in the pattern to collect the remainder of the array's or dictionary's items.
+Let bindings can also be used to destructure @array[arrays] and @dictionary[dictionaries]. In this case, the structure of the left-hand side of the assignment should mirror the array or dictionary: With bindings corresponding by position for arrays and by key name for dictionaries. The `..` operator can be used once in the pattern to collect the remainder of the array's or the dictionary's items.
 
 ```example
 #let (x, y) = (1, 2)

--- a/docs/content/reference/language/styling.typ
+++ b/docs/content/reference/language/styling.typ
@@ -22,7 +22,7 @@ With set rules, you can style
 your document.
 ```
 
-A top level set rule stays in effect until the end of the file. When nested inside of a block, it is only in effect until the end of that block. With a block, you can thus restrict the effect of a rule to a particular segment of your document. Below, we use a content block to scope the list styling to one particular list.
+A top level set rule stays in effect until the end of the file. When nested inside of a code or content block, it is only in effect until the end of that block. With a block, you can thus restrict the effect of a rule to a particular segment of your document. Below, we use a content block to scope the list styling to one particular list.
 
 ```example
 This list is affected: #[


### PR DESCRIPTION
These are a couple of tiny unimportant wording changes and typos. Feel free to close if undesired.

When reading through the documentation, I was unclear as to why the special ternary `set expr if bool` syntax was needed, as I didn't realize "block" referred to both content and code blocks when talking about how `set` scopes within its block. The docs *are* correct about this of course, since an unqualified "block" refers to the both, but this just spells it out.

Similarly, while an example of destructuring is given for both arrays and dictionaries, their difference (in that arrays are structural and dictionaries are by-key) is not discussed in the prose.