### PR TITLE
Add link to web app in tutorial

### DIFF
--- a/docs/tutorial/1-writing.md
+++ b/docs/tutorial/1-writing.md
@@ -5,9 +5,9 @@ description: Typst's tutorial.
 # Writing in Typst
 Let's get started! Suppose you got assigned to write a technical report for
 university. It will contain prose, maths, headings, and figures. To get started,
-you create a new project on the Typst app. You'll be taken to the editor where
-you see two panels: A source panel where you compose your document and a
-preview panel where you see the rendered document.
+[open Typst Playground](https://typst.app/play/) and create a new project.
+You'll be taken to the editor where you see two panels: A source panel where you
+compose your document and a preview panel where you see the rendered document.
 
 ![Typst app screenshot](1-writing-app.png)
 

--- a/docs/tutorial/welcome.md
+++ b/docs/tutorial/welcome.md
@@ -9,10 +9,12 @@ introduce more advanced features. This tutorial does not assume prior knowledge
 of Typst, other markup languages, or programming. We do assume that you know how
 to edit a text file.
 
-The best way to start is to sign up to the Typst app for free and follow along
-with the steps below. The app gives you instant preview, syntax highlighting and
-helpful autocompletions. Alternatively, you can follow along in your local text
-editor with the [open-source CLI](https://github.com/typst/typst).
+The best way to start is to [open Typst Playground](https://typst.app/play/) and
+then follow along with the steps below. If you want to save your work you can
+sign up for free once the app is open. The app gives you instant preview,
+syntax highlighting, and helpful autocompletions. Alternatively, you can follow
+along in your local text editor with the
+[open-source CLI](https://github.com/typst/typst).
 
 ## When to use Typst { #when-typst }
 Before we get started, let's check what Typst is and when to use it. Typst is a


### PR DESCRIPTION
close #7587

This PR adds a link to the web app at the top of the tutorial documentation.

The issue suggested linking to either the Playground or the sign up page. I agree with choosing the Playground, as it allows users to start writing immediately and smoothly create an account later if they want to.