### PR TITLE
Update wasm-minimal-protocol links in docs

### DIFF
--- a/crates/typst-library/src/foundations/plugin.rs
+++ b/crates/typst-library/src/foundations/plugin.rs
@@ -83,7 +83,7 @@ use crate::loading::{DataSource, Load};
 /// their only option (e.g. emscripten), which allows printing, reading files,
 /// etc. This ABI will not directly work with Typst. You will either need to
 /// compile to a different target or [stub all
-/// functions](https://github.com/astrale-sharp/wasm-minimal-protocol/tree/master/crates/wasi-stub).
+/// functions](https://github.com/typst-community/wasm-minimal-protocol/tree/main/crates/wasi-stub).
 ///
 /// # Protocol
 /// To be used as a plugin, a WebAssembly module must conform to the following
@@ -139,13 +139,12 @@ use crate::loading::{DataSource, Load};
 ///
 /// # Resources
 /// For more resources, check out the [wasm-minimal-protocol
-/// repository](https://github.com/astrale-sharp/wasm-minimal-protocol). It
+/// repository](https://github.com/typst-community/wasm-minimal-protocol). It
 /// contains:
 ///
 /// - A list of example plugin implementations and a test runner for these
 ///   examples
-/// - Wrappers to help you write your plugin in Rust (Zig wrapper in
-///   development)
+/// - Wrappers to help you write your plugin in Rust
 /// - A stubber for WASI
 #[func(scope)]
 pub fn plugin(


### PR DESCRIPTION
The repo was [transferred](https://github.com/orgs/typst-community/discussions/35) from https://github.com/astrale-sharp/ to https://github.com/typst-community/ and the default branch was renamed from `master` to `main`.
GitHub redirects the old URLs nicely, but it's still better to use the new URLs.

I also delete the sentence  _Zig wrapper in development_. It was added by laurmaedje on 2023-08-21 in 70538ec in #1555. I don't know who was developing it nor whether the development had ever finished, but I'm pretty sure that no one is developing it now.
People on [Discord](https://discord.com/channels/1054443721975922748/1054443722592497796/1477216951376941137) has not heard of anyone developing this either.