### PR TITLE
Expose local timezone offset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2993,6 +2993,7 @@ dependencies = [
  "sigpipe",
  "tar",
  "tempfile",
+ "time",
  "toml",
  "typst",
  "typst-dev-assets",

--- a/crates/typst-cli/Cargo.toml
+++ b/crates/typst-cli/Cargo.toml
@@ -28,6 +28,7 @@ typst-svg = { workspace = true }
 typst-timing = { workspace = true }
 typst-utils = { workspace = true }
 chrono = { workspace = true }
+time = { workspace = true }
 clap = { workspace = true, features = ["string"] }
 clap_complete = { workspace = true }
 codespan-reporting = { workspace = true }

--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -5,6 +5,7 @@ use std::sync::{LazyLock, OnceLock};
 
 use chrono::{DateTime, Datelike, FixedOffset, Local, Utc};
 use ecow::{EcoString, eco_format};
+use time::Duration as TimeDuration;
 use typst::diag::{FileError, FileResult};
 use typst::foundations::{Bytes, Datetime, Dict, Duration, IntoValue, Repr};
 use typst::syntax::{
@@ -118,6 +119,25 @@ impl SystemWorld {
     pub fn scan_fonts(&mut self) {
         LazyLock::force(&self.fonts);
     }
+
+    /// Return the current datetime, optionally shifted to local zone.
+    ///
+    /// `use_local` determines whether to convert the underlying UTC instant
+    /// into the local timezone before returning.
+    fn now_with_offset(&self, use_local: bool) -> chrono::DateTime<FixedOffset> {
+        match &self.now {
+            Now::Fixed(time) => time.fixed_offset(),
+            Now::System(time) => {
+                let now_utc = time.get_or_init(Utc::now);
+                if use_local {
+                    now_utc.with_timezone(&Local).fixed_offset()
+                } else {
+                    // Actual offset will be applied later.
+                    now_utc.fixed_offset()
+                }
+            }
+        }
+    }
 }
 
 impl World for SystemWorld {
@@ -146,18 +166,7 @@ impl World for SystemWorld {
     }
 
     fn today(&self, offset: Option<Duration>) -> Option<Datetime> {
-        let now = match &self.now {
-            Now::Fixed(time) => time.fixed_offset(),
-            Now::System(time) => {
-                let now_utc = time.get_or_init(Utc::now);
-                if offset.is_some() {
-                    // Actual offset will be applied later.
-                    now_utc.fixed_offset()
-                } else {
-                    now_utc.with_timezone(&Local).fixed_offset()
-                }
-            }
-        };
+        let now = self.now_with_offset(offset.is_none());
 
         // The time with the specified UTC offset.
         let with_offset = match offset {
@@ -180,6 +189,12 @@ impl World for SystemWorld {
             with_offset.month().try_into().ok()?,
             with_offset.day().try_into().ok()?,
         )
+    }
+
+    fn local_offset(&self) -> Option<Duration> {
+        let dt = self.now_with_offset(true);
+        let secs = dt.offset().local_minus_utc();
+        Some(Duration::from(TimeDuration::seconds(i64::from(secs))))
     }
 }
 

--- a/crates/typst-library/src/foundations/datetime.rs
+++ b/crates/typst-library/src/foundations/datetime.rs
@@ -375,6 +375,19 @@ impl Datetime {
         Ok(engine.world.today(offset).ok_or("unable to get the current date")?)
     }
 
+    /// Return the local timezone offset relative to UTC.
+    ///
+    /// The value is expressed as a duration where positive for zones east of
+    /// UTC and negative for zones west of UTC. The offset may include minutes
+    /// or seconds to correctly handle non-hourly timezones.
+    #[func]
+    pub fn local_offset(engine: &mut Engine) -> StrResult<Duration> {
+        engine
+            .world
+            .local_offset()
+            .ok_or("unable to determine local timezone offset".into())
+    }
+
     /// Displays the datetime in a specified format.
     ///
     /// Depending on whether you have defined just a date, a time or both, the

--- a/crates/typst-library/src/lib.rs
+++ b/crates/typst-library/src/lib.rs
@@ -95,6 +95,19 @@ pub trait World: Send + Sync {
     /// If this function returns `None`, Typst's `datetime` function will
     /// return an error.
     fn today(&self, offset: Option<Duration>) -> Option<Datetime>;
+
+    /// Get the local timezone offset from UTC.
+    ///
+    /// This value is used when Typst's `datetime.today` function is invoked
+    /// with `offset: auto`. It is positive for zones east of UTC and negative
+    /// for zones west of UTC. The offset may include minutes or seconds to
+    /// correctly handle non-hourly timezones.
+    ///
+    /// If the world cannot determine the offset, it should return `None`.
+    /// The default implementation simply returns zero (UTC).
+    fn local_offset(&self) -> Option<Duration> {
+        Some(Duration::from(time::Duration::ZERO))
+    }
 }
 
 macro_rules! world_impl {

--- a/tests/suite/foundations/datetime.typ
+++ b/tests/suite/foundations/datetime.typ
@@ -69,6 +69,10 @@
 #test(datetime.today(offset: -14).display(), "1969-12-31")
 #test(datetime.today(offset: duration(hours: 5, minutes: 45)).display(), "1970-01-01")
 
+#let local-offset = datetime.local-offset()
+#test(type(local-offset), duration)
+#test(datetime.today(offset: local-offset).display(), "1970-01-01")
+
 --- datetime-ordinal eval ---
 // Test date methods.
 #test(datetime(day: 1, month: 1, year: 2000).ordinal(), 1);


### PR DESCRIPTION
close #7112

This pull request introduces `datetime.local-offset` to retrieve the local timezone offset. 

Since the underlying logic for this feature already existed internally for `datetime.today`, the implementation has been refactored to share the same processing.

```typ
#set page(height: auto)

#let metadata = toml(bytes("createdAt = 2026-03-01T00:00:00Z"))

/ UTC: #metadata.createdAt.display()
/ Local: #(metadata.createdAt + datetime.local-offset()).display()
```

<img width="1191" height="327" alt="image" src="https://github.com/user-attachments/assets/0cfe6493-6b2a-406c-a3da-ee0f1f7ffa17" />

As a side note, while working on this, I noticed that `toml()` doesn't resolve timezones.