### PR TITLE
Improve error when function receives too many compiler-generated args

### DIFF
--- a/crates/typst-library/src/foundations/args.rs
+++ b/crates/typst-library/src/foundations/args.rs
@@ -251,6 +251,18 @@ impl Args {
     /// argument.
     pub fn finish(self) -> SourceResult<()> {
         if let Some(arg) = self.items.first() {
+            // When the argument's span matches the args span, it means the
+            // argument was compiler-generated and has no real source location
+            // (its span defaulted to the function's span). In this case,
+            // produce a more descriptive error message instead of the
+            // confusing "unexpected argument" pointing at the function.
+            if arg.span == self.span {
+                bail!(
+                    arg.span,
+                    "function received more arguments than it expected";
+                    hint: "consider adding an argument sink to capture them"
+                )
+            }
             match &arg.name {
                 Some(name) => bail!(arg.span, "unexpected argument: {name}"),
                 _ => bail!(arg.span, "unexpected argument"),

--- a/tests/suite/foundations/array.typ
+++ b/tests/suite/foundations/array.typ
@@ -279,8 +279,14 @@
 #test((1, 2, 3, 4).fold(0, (s, x) => s + x), 10)
 
 --- array-fold-closure-without-params eval ---
-// Error: 20-22 unexpected argument
+// Error: 20-22 function received more arguments than it expected
+// Hint: 20-22 consider adding an argument sink to capture them
 #(1, 2, 3).fold(0, () => none)
+
+--- array-fold-too-few-params eval ---
+// Error: 20-23 function received more arguments than it expected
+// Hint: 20-23 consider adding an argument sink to capture them
+#(1, 2, 3).fold(0, (x) => x)
 
 --- array-sum eval ---
 // Test the `sum` method.
@@ -571,7 +577,8 @@
 #().reduce()
 
 --- array-reduce-unexpected-argument eval ---
-// Error: 19-21 unexpected argument
+// Error: 19-21 function received more arguments than it expected
+// Hint: 19-21 consider adding an argument sink to capture them
 #(1, 2, 3).reduce(() => none)
 
 --- issue-6285-crashed-with-sorting-non-total-order eval ---


### PR DESCRIPTION
Closes #2102

When `fold`, `reduce`, or similar higher-order functions call a closure internally, they pass arguments via `Args::new(func_span, values)`. This means every compiler-generated argument gets the same span as the function itself. If the closure doesn't accept enough parameters, `finish()` reports "unexpected argument" pointing at the function definition — which is confusing, since the user never wrote an extra argument.

The fix detects this case by checking `arg.span == self.span` in `finish()`. When the spans match, it means the argument was compiler-generated (created by `Args::new` with the function's span as fallback), so we emit a more descriptive error:

> function received more arguments than it expected
> hint: consider adding an argument sink to capture them

For user-written arguments (where `arg.span` points to the actual source location), behavior is unchanged.

Updated the existing `fold`/`reduce` tests and added a new test case for closures with too few parameters.