### PR TITLE
Fix wording in visualize accessibility note

### DIFF
--- a/docs/reference/library/visualize.md
+++ b/docs/reference/library/visualize.md
@@ -10,7 +10,7 @@ All shapes and paths drawn by Typst are automatically marked as
 [artifacts]($pdf.artifact) to make them invisible to Assistive Technology (AT)
 during PDF export. However, their contents (if any) remain accessible.
 
-If you are using the functions in this module to create an illustration with
+If you are using the functions in this category to create an illustration with
 semantic meaning, make it accessible by wrapping it in a [`figure`] function
 call. Use its [`alt` parameter]($figure.alt) to provide an
 [alternative description]($guides/accessibility/#textual-representations).


### PR DESCRIPTION
In the accessibility section of `visualize.md`, I changed `model` to `module` in the sentence:

`If you are using the functions in this model`

In this context, the sentence appears to refer to where the functions belong, so `module` seemed more appropriate, and I thought `model` might be a typo.  
If `model` was intentional here, that is my misunderstanding, and I am happy for this PR to be closed.

This is a wording-only change and does not affect functionality or behavior.