### PR TITLE
Prevent line ending issues with PDF tags tests on Windows

### DIFF
--- a/tests/src/output.rs
+++ b/tests/src/output.rs
@@ -385,7 +385,9 @@ impl FileOutputType for Pdftags {
     }
 
     fn matches(old: &[u8], new: &Self::Live) -> bool {
-        old == new.as_bytes()
+        // We don't use `old == new.as_bytes()` to prevent issues with
+        // inconsistent line endings.
+        str::from_utf8(old).is_ok_and(|old| old.lines().eq(new.lines()))
     }
 }
 


### PR DESCRIPTION
When checking out the repo on Windows, Git automatically changes line ending in the test refs to CRLF. But the test runner generates LF line endings for PDF tags. This PR makes it so that line endings are not taken into account when comparing PDF tags.

Somehow, the problem does not happen with HTML tests. I think this is because the HTML test refs use the system line ending. Maybe we should do that as well for PDF tags tests instead of changing the comparison function.

cc. @saecki