### PR TITLE
Retain test report artifacts longer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
             tests/store/pdftags
             tests/store/html
           compression-level: 9
-          retention-days: 30
+          retention-days: 7
 
       - name: Upload test report
         # When the CI passes, only upload one test report, since all should be the same.
@@ -85,7 +85,6 @@ jobs:
           name: tests-report-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.bits }}
           path: tests/store/report.html
           compression-level: 9
-          retention-days: 30
 
   checks:
     name: Check clippy, formatting, and documentation


### PR DESCRIPTION
The previous 3 `retention-days` where a bit to short of a time frame to review the PR.
This also avoids uploading the same exact test report 3 times, when the CI passes.