### PR TITLE
docs: list countable elements in `counter` documentation

### DIFF
--- a/crates/typst-library/src/introspection/counter.rs
+++ b/crates/typst-library/src/introspection/counter.rs
@@ -31,6 +31,27 @@ use crate::routines::Routines;
 /// headings, figures, and more. Moreover, you can define custom counters for
 /// other things you want to count.
 ///
+/// # Countable elements { #countable }
+/// You can create a counter for any
+/// [locatable]($location/#locatable) element by passing the element
+/// function to `counter`. The following elements have _built-in_
+/// counters that are automatically stepped when the element appears:
+///
+/// - [`page`]: Stepped at each pagebreak.
+/// - [`heading`]: Stepped before each heading (with multi-level support).
+/// - [`figure`]: Stepped before each figure.
+/// - [`equation`]($math.equation): Stepped before each equation (when
+///   numbering is enabled).
+/// - [`footnote`]: Stepped before each footnote.
+///
+/// Beyond these, you can also create a counter for any other locatable
+/// element. For instance, `{counter(table)}` or `{counter(image)}` will
+/// give you a counter that you can [`step`]($counter.step) and
+/// [`display`]($counter.display) manually.
+///
+/// See the documentation on [locatable elements]($location/#locatable) for
+/// the full list of elements that can be used with `counter`.
+///
 /// Since counters change throughout the course of the document, their current
 /// value is _contextual._ It is recommended to read the chapter on [context]
 /// before continuing here.


### PR DESCRIPTION
## Summary

Closes #2728.

Adds a "Countable elements" section to the `counter` type documentation that:

- Lists the five elements with **built-in counters** that are automatically stepped: `page`, `heading`, `figure`, `equation`, and `footnote`
- Notes that any other [locatable element]($location/#locatable) can be used with `counter` for manual counting (e.g., `counter(table)`, `counter(image)`)
- Cross-references the existing "Locatable elements" section in the `location` docs for the full list

This addresses the user confusion described in the issue: the docs previously said "pages, headings, figures, and more" without specifying what "more" includes.

## AI Assistance Disclosure

This PR was written with the assistance of Claude Code (Claude Opus). The locatable elements were identified by searching the codebase for `#[elem(..., Locatable, ...)]` annotations, and the documentation was drafted with AI assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)