### PR TITLE
Document how to get the ISO week year

### DIFF
--- a/crates/typst-library/src/foundations/datetime.rs
+++ b/crates/typst-library/src/foundations/datetime.rs
@@ -130,8 +130,8 @@ use crate::foundations::{
 ///   - `padding`: Can be either `zero`, `space` or `none`. Specifies how the
 ///     second is padded.
 ///
-/// See https://time-rs.github.io/book/api/format-description.html for the
-/// complete list of supported syntax.
+/// [See here](https://time-rs.github.io/book/api/format-description.html#components)
+/// for more details on the supported syntax.
 ///
 /// Keep in mind that not always all components can be used. For example, if you
 /// create a new datetime with `{datetime(year: 2023, month: 10, day: 13)}`, it


### PR DESCRIPTION
I believe it is useful as https://typst.app/docs/reference/foundations/datetime/#format specifies how to get the ISO week number of an ISO week date but the year documentation doesn't help on how to get the ISO week year counterpart.

My personal use case is that I format my timesheets to PDF before sending them to my freelance contract broker and I need/want to put the ISO week year along the ISO week in the title: `= Timesheet #start.display("[year base:iso_week]/[week_number padding:none]")`. And without the feature being documented, I was left in the dark before browsing the time rust crate.

closes #7927