### PR TITLE
Use em length for default footnote entry separator line thickness

### DIFF
--- a/crates/typst-library/src/model/footnote.rs
+++ b/crates/typst-library/src/model/footnote.rs
@@ -13,7 +13,7 @@ use crate::foundations::{
 use crate::introspection::{
     Count, Counter, CounterUpdate, Locatable, Location, QueryLabelIntrospection, Tagged,
 };
-use crate::layout::{Abs, Em, Length, Ratio};
+use crate::layout::{Em, Length, Ratio};
 use crate::model::{DirectLinkElem, Numbering, NumberingPattern, ParElem};
 use crate::text::{LocalName, SuperElem, TextElem, TextSize};
 use crate::visualize::{LineElem, Stroke};
@@ -247,7 +247,7 @@ pub struct FootnoteEntry {
         LineElem::new()
             .with_length(Ratio::new(0.3).into())
             .with_stroke(Stroke {
-                thickness: Smart::Custom(Abs::pt(0.5).into()),
+                thickness: Smart::Custom(Em::new(0.05).into()),
                 ..Default::default()
             })
             .pack()


### PR DESCRIPTION
This makes the footnote separator line thickness relative to the text size to prevent the line from being too thick for documents with small font size and too thin for documents with large font size. `clearance`, `gap`, and `indent` already use ems. This is the last parameter of `footnote` and `footnote.entry` to use an absolute length.

Note that those ems are relative to the outer text size, not the text size within `footnote.entry` (i.e., `show footnote.entry: set text(size: ..)` does not affect the thickness of the line, but `set text(size: ..)` does).

Related to: https://github.com/typst/typst/pull/7241.