### PR TITLE
Improve wording in doc of math function call syntax

### DIFF
--- a/docs/reference/library/math.md
+++ b/docs/reference/library/math.md
@@ -47,8 +47,8 @@ Math mode supports special function calls without the hash prefix. In these
 - Within them, Typst is still in "math mode". Thus, you can write math directly
   into them, but need to use hash syntax to pass code expressions (except for
   strings, which are available in the math syntax).
-- They support positional and named arguments, as well as argument spreading.
-- They don't support trailing content blocks.
+- They support positional and named arguments, as well as argument spreading,
+  but don't support trailing content blocks.
 - They provide additional syntax for 2-dimensional argument lists. The semicolon
   (`;`) merges preceding arguments separated by commas into an array argument.
 


### PR DESCRIPTION
A very minor fix, but I think the current wording might suggest that "They support positional and named arguments, as well as argument spreading" is special for math and not true for code mode.