### PR TITLE
Fix missing file autocompletions for `read` function

### DIFF
--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -859,6 +859,7 @@ fn path_completion(func: &Func, param: &ParamInfo) -> Option<&'static [&'static 
         (Some("cite"), "style") => &["csl"],
         (Some("raw"), "syntaxes") => &["sublime-syntax"],
         (Some("raw"), "theme") => &["tmtheme"],
+        (Some("read"), "path") => &[],
         (Some("embed"), "path") => &[],
         (Some("attach"), "path") if *func == typst::pdf::AttachElem::ELEM => &[],
         (None, "path") => &[],
@@ -1816,6 +1817,7 @@ mod tests {
             .with_source("content/c.typ", "#include \"\"")
             .with_source("content/d.typ", "#pdf.attach(\"\")")
             .with_source("content/e.typ", "#math.attach(\"\")")
+            .with_source("content/f.typ", "#read(\"\")")
             .with_asset_at("assets/tiger.jpg", "tiger.jpg")
             .with_asset_at("assets/rhino.png", "rhino.png")
             .with_asset_at("data/example.csv", "example.csv");
@@ -1838,6 +1840,10 @@ mod tests {
             .must_include([q!("../assets/tiger.jpg"), q!("../data/example.csv")]);
 
         test(&world, ("content/e.typ", -2)).must_exclude([q!("data/example.csv")]);
+
+        // `read` should offer completions for all file types.
+        test(&world, ("content/f.typ", -2))
+            .must_include([q!("../assets/tiger.jpg"), q!("../data/example.csv")]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds the missing `(Some("read"), "path") => &[]` entry to the `path_completion` function in `crates/typst-ide/src/complete.rs`
- This restores file path autocompletions when typing inside `#read("")`, which regressed when the `read` function's first parameter was renamed from `source` to `path`
- Adds a corresponding test case to `test_autocomplete_file_path`

## Context

Fixes #7859.

The `path_completion` function maps `(function_name, parameter_name)` pairs to file extension filters for IDE autocompletion. When the `read` function's parameter was renamed from `source` to `path`, the completion mapping was not updated. Functions like `embed` and `attach` that also use `"path"` as their parameter name have explicit entries, but `read` was missing one.

The empty slice `&[]` means "suggest all file types", which is the correct behavior for `read` since it can read any file.

## Test plan

- [x] Added test case: `#read("")` now offers completions for all file types (images, CSVs, etc.)
- [ ] Verify `cargo test -p typst-ide test_autocomplete_file_path` passes (requires rustc >= 1.89)

Generated with [Claude Code](https://claude.com/claude-code)