### PR TITLE
Clarify that `"page"` form references require a page numbering

### DIFF
--- a/crates/typst-library/src/model/reference.rs
+++ b/crates/typst-library/src/model/reference.rs
@@ -44,7 +44,8 @@ use crate::text::TextElem;
 /// page number at its location. You can use the
 /// [page's supplement]($page.supplement) to modify the text before the page
 /// number. Unlike a `{"normal"}` reference, the label can be attached to any
-/// element.
+/// element as long as the corresponding [page's numbering]($page.numbering) is
+/// set.
 ///
 /// # Example
 /// ```example


### PR DESCRIPTION
Even though we do emit a hint, it was noted by caltorix [on discord](https://discord.com/channels/1054443721975922748/1088371919725793360/1483780845352259585) that it wouldn't hurt to mention in the docs as well.