### PR TITLE
More compact diagnostic tracebacks

### DIFF
--- a/crates/typst-cli/tests/smoke.rs
+++ b/crates/typst-cli/tests/smoke.rs
@@ -196,6 +196,41 @@ fn test_network_access_hint() {
     output.stderr.must_contain("hint: network access is not supported");
 }
 
+#[test]
+fn test_tracepoints() {
+    let project = tempfs();
+    let main = project.write(
+        "main.typ",
+        r#"#show strong: _ => include "chap" + "ter1.typ"
+           *Slightly unusual
+            strong text*"#,
+    );
+    project.write(
+        "chapter1.typ",
+        r#"#import "system.typ": my-figure
+           #my-figure(
+             "tigers.jpg"
+           )"#,
+    );
+    project.write("system.typ", "#let my-figure(p) = image(p)");
+    let output = exec().arg("compile").arg(&main).must_fail();
+    output
+        .stderr
+        .must_contain("while calling `my-figure` at")
+        .must_contain("chapter1.typ:2:12")
+        .must_contain("my-figure(…)");
+    output
+        .stderr
+        .must_contain("while including `chapter1.typ` at")
+        .must_contain("main.typ:1:19")
+        .must_contain(r#"include "chap" + "ter1.typ""#);
+    output
+        .stderr
+        .must_contain("while showing strong element at")
+        .must_contain("main.typ:2:11")
+        .must_contain("*Slightly unusual…*");
+}
+
 /// Executes a command with the Typst CLI.
 fn exec() -> Command {
     Command::new(env!("CARGO_BIN_EXE_typst"))

--- a/crates/typst-eval/src/import.rs
+++ b/crates/typst-eval/src/import.rs
@@ -31,12 +31,21 @@ impl Eval for ast::ModuleImport<'_> {
             Value::Type(_) => {}
             Value::Module(_) => {}
             Value::Str(path) => {
-                source = Value::Module(import(&mut vm.engine, path, source_span)?);
+                source = Value::Module(import(&mut vm.engine, path, source_span).trace(
+                    vm.engine.world,
+                    || Tracepoint::Import(path.clone().into()),
+                    self.span(),
+                )?);
                 replaced_source = true;
             }
             v if RootedPath::castable(v) => {
                 let id = v.clone().cast::<RootedPath>().at(source_span)?.intern();
-                source = Value::Module(import_file(&mut vm.engine, id, source_span)?);
+                source =
+                    Value::Module(import_file(&mut vm.engine, id, source_span).trace(
+                        vm.engine.world,
+                        || Tracepoint::Import(id.get().vpath().get_with_slash().into()),
+                        self.span(),
+                    )?);
                 replaced_source = true;
             }
             v => {
@@ -176,16 +185,24 @@ impl Eval for ast::ModuleInclude<'_> {
     type Output = Content;
 
     fn eval(self, vm: &mut Vm) -> SourceResult<Self::Output> {
-        let span = self.source().span();
+        let source_span = self.source().span();
         let source = self.source().eval(vm)?;
         let module = match source {
-            Value::Str(path) => import(&mut vm.engine, &path, span)?,
+            Value::Str(path) => import(&mut vm.engine, &path, source_span).trace(
+                vm.engine.world,
+                || Tracepoint::Include(path.clone().into()),
+                self.span(),
+            )?,
             Value::Module(module) => module,
             v if RootedPath::castable(&v) => {
-                let id = v.cast::<RootedPath>().at(span)?.intern();
-                import_file(&mut vm.engine, id, span)?
+                let id = v.cast::<RootedPath>().at(source_span)?.intern();
+                import_file(&mut vm.engine, id, source_span).trace(
+                    vm.engine.world,
+                    || Tracepoint::Include(id.get().vpath().get_with_slash().into()),
+                    self.span(),
+                )?
             }
-            v => bail!(span, "expected path or module, found {}", v.ty()),
+            v => bail!(source_span, "expected path or module, found {}", v.ty()),
         };
         Ok(module.content())
     }
@@ -217,7 +234,6 @@ fn import_file(engine: &mut Engine, id: FileId, span: Span) -> SourceResult<Modu
     }
 
     // Evaluate the file.
-    let point = || Tracepoint::Import;
     eval(
         engine.routines,
         engine.world,
@@ -226,7 +242,6 @@ fn import_file(engine: &mut Engine, id: FileId, span: Span) -> SourceResult<Modu
         engine.route.track(),
         &source,
     )
-    .trace(engine.world, point, span)
 }
 
 /// Import an external package.

--- a/crates/typst-kit/src/diagnostics.rs
+++ b/crates/typst-kit/src/diagnostics.rs
@@ -7,12 +7,13 @@ use std::io;
 use std::ops::Range;
 
 use codespan_reporting::diagnostic::{Diagnostic, Label};
+use codespan_reporting::files::Files;
 use codespan_reporting::term;
 use ecow::eco_format;
-use term::termcolor::WriteColor;
+use termcolor::{Color, ColorSpec, WriteColor};
 use typst_library::World;
-use typst_library::diag::{FileError, Severity, SourceDiagnostic};
-use typst_syntax::{FileId, Lines, Source, Span};
+use typst_library::diag::{FileError, Severity, SourceDiagnostic, Tracepoint};
+use typst_syntax::{FileId, Lines, Source, Span, Spanned};
 
 type CodespanResult<T> = Result<T, CodespanError>;
 type CodespanError = codespan_reporting::files::Error;
@@ -66,7 +67,13 @@ pub fn emit<'a>(
                 .collect(),
         )
         .with_labels(
-            label(&mut files, diagnostic.span)
+            diagnostic
+                .span
+                .id()
+                .and_then(|id| {
+                    let range = files.range(diagnostic.span)?;
+                    Some(Label::primary(id, range))
+                })
                 .into_iter()
                 .chain(diagnostic.hints.iter().filter_map(|hint| {
                     let id = hint.span.id()?;
@@ -79,22 +86,62 @@ pub fn emit<'a>(
         term::emit(dest, &config, &files, &diag)?;
 
         // Stacktrace-like helper diagnostics.
+        let mut traced = false;
         for point in &diagnostic.trace {
-            let message = point.v.to_string();
-            let help = Diagnostic::help()
-                .with_message(message)
-                .with_labels(label(&mut files, point.span).into_iter().collect());
+            emit_trace(dest, &mut files, point)?;
+            traced = true;
+        }
 
-            term::emit(dest, &config, &files, &help)?;
+        if traced {
+            writeln!(dest)?;
         }
     }
 
     Ok(())
 }
 
-/// Create a label for a span.
-fn label(files: &mut WorldFiles, span: Span) -> Option<Label<FileId>> {
-    Some(Label::primary(span.id()?, files.range(span)?))
+/// Emits a tracepoint.
+fn emit_trace(
+    dest: &mut dyn WriteColor,
+    files: &mut WorldFiles,
+    point: &Spanned<Tracepoint>,
+) -> Result<(), codespan_reporting::files::Error> {
+    let Some(id) = point.span.id() else { return Ok(()) };
+    let Some(range) = files.range(point.span) else { return Ok(()) };
+    let lines = files.lines(id)?;
+
+    let name = files.name(id)?;
+    let line_index = files.line_index(id, range.start)?;
+    let line = files.line_number(id, line_index)?;
+    let column = files.column_number(id, line_index, range.start)?;
+    let text = &lines.text()[range];
+
+    // Displays what kind of tracepoint we have and where.
+    write!(dest, "  {} at ", point.v)?;
+    dest.set_color(ColorSpec::new().set_underline(true))?;
+    write!(dest, "{name}:{line}:{column}")?;
+    dest.reset()?;
+    writeln!(dest)?;
+
+    // Displays the context in the source in a single line.
+    let mut lines = text.lines();
+    write!(dest, "    ")?;
+    dest.set_color(ColorSpec::new().set_fg(Some(Color::Ansi256(248))))?;
+    if let Some(first) = lines.next() {
+        write!(dest, "{first}")?;
+    }
+    if let Some(last) = lines.next_back()
+        && let Some(last_char) = last.chars().next_back()
+        && !last_char.is_whitespace()
+    {
+        // If the traced source text is multi-line, try to display it
+        // with inner ellipses followed by the last character.
+        write!(dest, "…{last_char}")?;
+    }
+    dest.reset()?;
+    writeln!(dest)?;
+
+    Ok(())
 }
 
 /// Provides file contents and metadata to `codespan-reporting`.
@@ -133,7 +180,7 @@ impl WorldFiles<'_> {
     }
 }
 
-impl<'a> codespan_reporting::files::Files<'a> for WorldFiles<'_> {
+impl<'a> Files<'a> for WorldFiles<'_> {
     type FileId = FileId;
     type Name = String;
     type Source = Lines<String>;

--- a/crates/typst-library/src/diag.rs
+++ b/crates/typst-library/src/diag.rs
@@ -380,24 +380,19 @@ pub enum Tracepoint {
     /// A show rule application.
     Show(EcoString),
     /// A module import.
-    Import,
+    Import(EcoString),
+    /// A module include.
+    Include(EcoString),
 }
 
 impl Display for Tracepoint {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
-            Tracepoint::Call(Some(name)) => {
-                write!(f, "error occurred in this call of function `{name}`")
-            }
-            Tracepoint::Call(None) => {
-                write!(f, "error occurred in this function call")
-            }
-            Tracepoint::Show(name) => {
-                write!(f, "error occurred while applying show rule to this {name}")
-            }
-            Tracepoint::Import => {
-                write!(f, "error occurred while importing this module")
-            }
+            Tracepoint::Call(Some(name)) => write!(f, "while calling `{name}`"),
+            Tracepoint::Call(None) => write!(f, "while calling function"),
+            Tracepoint::Show(name) => write!(f, "while showing {name} element"),
+            Tracepoint::Import(name) => write!(f, "while importing `{name}`"),
+            Tracepoint::Include(name) => write!(f, "while including `{name}`"),
         }
     }
 }


### PR DESCRIPTION
## Description

This PR changes how diagnostic tracebacks are rendered. The current tracebacks are very verbose, making it hard to see the forest for the trees. This is especially bad when you have multiple diagnostics with traces, where there isn't a clear visual hierarchy, with color being basically the only indicator of tracepoints being conceptually nested.

The refreshed diagnostic style is more compact and focuses on what's essential. It display what kind of tracepoint it is (function call, show rule, import, include) with some details (function name, shown element, import/include path) and then underlined the path at which the tracepoint happened. Directly below, it shows only the first line of the relevant source. If there are multiple lines, it shows the last character and an ellipsis in between.

## Example

It's best to just take a look.

### Source
```typ
// main.typ
#show strong: _ => include "chap" + "ter1.typ"
*Slightly unusual
 strong text*

// chapter1.typ
#import "system.typ": my-figure
#my-figure(
  "tigers.jpg"
)

// system.typ
#let my-figure(p) = image(p)
```

### New output
<img width="829" height="483" alt="The new output, see description above for details" src="https://github.com/user-attachments/assets/62b85ca0-01db-469a-91c9-64de766b8154" />

### Old output
<img width="829" height="738" alt="The old output, see description above for details" src="https://github.com/user-attachments/assets/bf3fa29b-fc25-4bca-8790-aa612bf18126" />

