### PR TITLE
Infer CSS and JS mime types based on extension in watch server

### DIFF
--- a/crates/typst-kit/src/server.rs
+++ b/crates/typst-kit/src/server.rs
@@ -196,6 +196,8 @@ fn select_mime_type(path: &str, buf: &[u8]) -> Option<&'static str> {
         Some("pdf") => Some("application/pdf"),
         Some("png") => Some("image/png"),
         Some("svg") => Some("image/svg+xml"),
+        Some("css") => Some("text/css"),
+        Some("js") => Some("text/javascript"),
         _ => infer::get(buf).map(|ty| ty.mime_type()),
     }
 }


### PR DESCRIPTION
Not really a scalable solution, but these two are very important and a better long-term solution needn't block them.

The `infer` crate is good for binary formats, but not so much for text formats. There is [`mime_guess`](https://github.com/abonander/mime_guess), but I haven't checked whether it would be good for us.

Note that this only affects the live reload server, not the actual output. This is also why I don't really want to add a mime field to the `asset` function: We wouldn't have a clean way to export it, so it would only really help for the watch server, and might actually make things more confusing why things suddenly stop working once an exported bundle is deployed on a real web server.