### PR TITLE
Ignore query parameters in watch server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3163,6 +3163,7 @@ dependencies = [
  "typst-timing",
  "typst-utils",
  "ureq",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,7 @@ unicode-script = "0.5"
 unicode-segmentation = "1"
 unscanny = "0.1"
 ureq = { version = "2", default-features = false, features = ["native-tls", "gzip", "json"] }
+url = "2.5"
 usvg = { version = "0.45", default-features = false, features = ["text"] }
 utf8_iter = "1.0.4"
 walkdir = "2"

--- a/crates/typst-kit/Cargo.toml
+++ b/crates/typst-kit/Cargo.toml
@@ -35,6 +35,7 @@ serde_json = { workspace = true }
 tar = { workspace = true, optional = true }
 tiny_http = { workspace = true, optional = true }
 ureq = { workspace = true, optional = true }
+url = { workspace = true }
 
 # Explicitly depend on OpenSSL if applicable, so that we can add the
 # `openssl/vendored` feature to it if `vendor-openssl` is enabled.

--- a/crates/typst-kit/src/server.rs
+++ b/crates/typst-kit/src/server.rs
@@ -115,17 +115,22 @@ fn start_server(port: Option<u16>) -> StrResult<(SocketAddr, tiny_http::Server)>
 
 /// Handles a request.
 fn handle(req: Request, reload: bool, bucket: &Arc<RouterBucket>) -> io::Result<()> {
-    let path = req.url();
+    let base = url::Url::parse("http://localhost").unwrap();
+    let Ok(url) = base.join(req.url()) else {
+        return req.respond(Response::empty(StatusCode(400)));
+    };
+
+    let path = url.path();
     if path == "/__events" {
         return handle_events(req, bucket.clone());
     }
 
     let fs = bucket.get();
-    if let Some(body) = fs(path) {
-        handle_body(req, reload, body)
-    } else {
-        req.respond(Response::new_empty(StatusCode(404)))
-    }
+    let Some(body) = fs(path) else {
+        return req.respond(Response::empty(StatusCode(404)));
+    };
+
+    handle_body(req, reload, body)
 }
 
 /// Handles for the `/` route. Serves the compiled HTML.


### PR DESCRIPTION
So that when these happen to be populated, we don't get stray 404s.