### PR TITLE
fix: handle empty string in --font-path gracefully

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -468,6 +468,7 @@ pub struct FontArgs {
         env = "TYPST_FONT_PATHS",
         value_name = "DIR",
         value_delimiter = ENV_PATH_SEP,
+        value_parser = font_path_value_parser(),
     )]
     pub font_paths: Vec<PathBuf>,
 
@@ -768,6 +769,14 @@ fn parse_page_number(value: &str) -> Result<NonZeroUsize, &'static str> {
     } else {
         NonZeroUsize::from_str(value).map_err(|_| "not a valid page number")
     }
+}
+
+/// The clap value parser used by `FontArgs.font_paths`.
+///
+/// Unlike the default `PathBufValueParser`, this accepts empty strings so that
+/// `--font-path ""` and `TYPST_FONT_PATHS=""` don't produce an error.
+fn font_path_value_parser() -> impl TypedValueParser<Value = PathBuf> {
+    clap::builder::OsStringValueParser::new().map(PathBuf::from)
 }
 
 /// The clap value parser used by `SharedArgs.input`

--- a/crates/typst-cli/src/fonts.rs
+++ b/crates/typst-cli/src/fonts.rs
@@ -46,7 +46,9 @@ pub fn discover_fonts(args: &FontArgs) -> FontStore {
     }
 
     for path in &args.font_paths {
-        fonts.extend(fonts::scan(path));
+        if !path.as_os_str().is_empty() {
+            fonts.extend(fonts::scan(path));
+        }
     }
 
     fonts

--- a/crates/typst-cli/tests/smoke.rs
+++ b/crates/typst-cli/tests/smoke.rs
@@ -66,6 +66,11 @@ fn test_fonts_path() {
 }
 
 #[test]
+fn test_fonts_empty_path() {
+    exec().arg("fonts").arg("--font-path").arg("").must_succeed();
+}
+
+#[test]
 fn test_info() {
     let output = exec().arg("info").must_succeed();
     output.stderr.must_start_with("Version");


### PR DESCRIPTION
Fixes #6183

## Summary

Passing an empty string via `--font-path ""` or `TYPST_FONT_PATHS=""` currently errors with "a value is required..." because clap's default `PathBufValueParser` (which delegates to `OsStringValueParser`) rejects empty `OsStr` values.

This adds a small custom `FontPathParser` that accepts any `OsStr` input (including empty) and converts it to `PathBuf`. Empty paths are then filtered out before font scanning so they don't cause unnecessary directory lookups.

## Changes

- **`crates/typst-cli/src/args.rs`**: Add `FontPathParser` implementing `TypedValueParser<Value = PathBuf>` that accepts empty strings. Use it for the `font_paths` field.
- **`crates/typst-cli/src/fonts.rs`**: Skip empty paths in the font discovery loop.
- **`crates/typst-cli/tests/smoke.rs`**: Add `test_fonts_empty_path` covering both `--font-path ""` and `TYPST_FONT_PATHS=""`.