### PR TITLE
Fix error when annotated test column is out-of-range

### DIFF
--- a/crates/typst-syntax/src/lines.rs
+++ b/crates/typst-syntax/src/lines.rs
@@ -126,7 +126,8 @@ impl<T: AsRef<str>> Lines<T> {
         Some(start..end)
     }
 
-    /// Return the byte index of the given (line, column) pair.
+    /// Return the byte index of the given (line, column) pair, or `None` if
+    /// either is out-of-range.
     ///
     /// The column defines the number of characters to go beyond the start of
     /// the line.
@@ -136,10 +137,10 @@ impl<T: AsRef<str>> Lines<T> {
         column_idx: usize,
     ) -> Option<usize> {
         let range = self.line_to_range(line_idx)?;
-        let line = self.text().get(range.clone())?;
+        let line = &self.text()[range.clone()];
         let mut chars = line.chars();
         for _ in 0..column_idx {
-            chars.next();
+            chars.next()?;
         }
         Some(range.start + (line.len() - chars.as_str().len()))
     }


### PR DESCRIPTION
This fixes an oversight in `Lines::line_column_to_byte` that would return `Some` even when the column index was out of the range for its line. This caused the `else` case I wrote in `tests/src/notes.rs:387` for an invalid column index to never actually trigger.

Now, if you write an annotation like `// Error: 1-500 message`, the test runner will actually fail when collecting tests instead of treating this as a valid annotation range.

In the function I also replaced the call to `self.text().get(range.clone())?` with indexing because this could only fail if the range from `line_to_range` was invalid, but that range was already checked by the question mark on `self.line_to_range(line_idx)?`
