### PR TITLE
Move single line test annotations to their annotated line

### DIFF
--- a/tests/suite/foundations/array.typ
+++ b/tests/suite/foundations/array.typ
@@ -152,14 +152,14 @@
 
 --- array-bad-method-lvalue eval ---
 // Test bad lvalue.
-// Error: 2:3-2:14 cannot mutate a temporary value
 #let array = (1, 2, 3)
+// Error: 3-14 cannot mutate a temporary value
 #(array.len() = 4)
 
 --- array-unknown-method-lvalue eval ---
 // Test bad lvalue.
-// Error: 2:9-2:13 type array has no method `yolo`
 #let array = (1, 2, 3)
+// Error: 9-13 type array has no method `yolo`
 #(array.yolo() = 4)
 
 --- array-negative-indices eval ---
@@ -213,8 +213,8 @@
 }
 
 --- array-insert-missing-index eval ---
-// Error: 2:2-2:18 missing argument: index
 #let numbers = ()
+// Error: 2-18 missing argument: index
 #numbers.insert()
 
 --- array-slice eval ---

--- a/tests/suite/layout/grid/colspan.typ
+++ b/tests/suite/layout/grid/colspan.typ
@@ -73,19 +73,19 @@
 )
 
 --- grid-colspan-out-of-bounds paged ---
-// Error: 3:8-3:32 cell's colspan would cause it to exceed the available column(s)
-// Hint: 3:8-3:32 try placing the cell in another position or reducing its colspan
 #grid(
   columns: 3,
+  // Error: 8-32 cell's colspan would cause it to exceed the available column(s)
+  // Hint: 8-32 try placing the cell in another position or reducing its colspan
   [a], grid.cell(colspan: 3)[b]
 )
 
 --- grid-colspan-overlap paged ---
-// Error: 4:8-4:32 cell would span a previously placed cell at column 2, row 0
-// Hint: 4:8-4:32 try specifying your cells in a different order or reducing the cell's rowspan or colspan
 #grid(
   columns: 3,
   grid.cell(x: 2, y: 0)[x],
+  // Error: 8-32 cell would span a previously placed cell at column 2, row 0
+  // Hint: 8-32 try specifying your cells in a different order or reducing the cell's rowspan or colspan
   [a], grid.cell(colspan: 2)[b]
 )
 

--- a/tests/suite/layout/grid/footers.typ
+++ b/tests/suite/layout/grid/footers.typ
@@ -141,16 +141,16 @@
 )
 
 --- grid-footer-not-at-last-row paged ---
-// Error: 2:3-2:19 footer must end at the last row
 #grid(
+  // Error: 3-19 footer must end at the last row
   grid.footer([a]),
   [b],
 )
 
 --- grid-footer-not-at-last-row-two-columns paged ---
-// Error: 3:3-3:19 footer must end at the last row
 #grid(
   columns: 2,
+  // Error: 3-19 footer must end at the last row
   grid.footer([a]),
   [b],
 )
@@ -175,26 +175,26 @@
 )
 
 --- grid-footer-multiple paged ---
-// Error: 4:3-4:19 cannot have more than one footer
 #grid(
   [a],
   grid.footer([a]),
+  // Error: 3-19 cannot have more than one footer
   grid.footer([b]),
 )
 
 --- table-footer-in-grid eval ---
-// Error: 3:3-3:20 cannot use `table.footer` as a grid footer
-// Hint: 3:3-3:20 use `grid.footer` instead
 #grid(
   [a],
+  // Error: 3-20 cannot use `table.footer` as a grid footer
+  // Hint: 3-20 use `grid.footer` instead
   table.footer([a]),
 )
 
 --- grid-footer-in-table eval ---
-// Error: 3:3-3:19 cannot use `grid.footer` as a table footer
-// Hint: 3:3-3:19 use `table.footer` instead
 #table(
   [a],
+  // Error: 3-19 cannot use `grid.footer` as a table footer
+  // Hint: 3-19 use `table.footer` instead
   grid.footer([a]),
 )
 

--- a/tests/suite/layout/grid/headers.typ
+++ b/tests/suite/layout/grid/headers.typ
@@ -264,17 +264,17 @@
 )
 
 --- table-header-in-grid eval ---
-// Error: 2:3-2:20 cannot use `table.header` as a grid header
-// Hint: 2:3-2:20 use `grid.header` instead
 #grid(
+  // Error: 3-20 cannot use `table.header` as a grid header
+  // Hint: 3-20 use `grid.header` instead
   table.header([a]),
   [a],
 )
 
 --- grid-header-in-table eval ---
-// Error: 2:3-2:19 cannot use `grid.header` as a table header
-// Hint: 2:3-2:19 use `table.header` instead
 #table(
+  // Error: 3-19 cannot use `grid.header` as a table header
+  // Hint: 3-19 use `table.header` instead
   grid.header([a]),
   [a],
 )

--- a/tests/suite/layout/grid/positioning.typ
+++ b/tests/suite/layout/grid/positioning.typ
@@ -53,18 +53,18 @@
 )
 
 --- grid-cell-position-collide paged ---
-// Error: 3:3-3:42 attempted to place a second cell at column 0, row 0
-// Hint: 3:3-3:42 try specifying your cells in a different order
 #grid(
   [A],
+  // Error: 3-42 attempted to place a second cell at column 0, row 0
+  // Hint: 3-42 try specifying your cells in a different order
   grid.cell(x: 0, y: 0)[This shall error]
 )
 
 --- table-cell-position-collide paged ---
-// Error: 3:3-3:43 attempted to place a second cell at column 0, row 0
-// Hint: 3:3-3:43 try specifying your cells in a different order
 #table(
   [A],
+  // Error: 3-43 attempted to place a second cell at column 0, row 0
+  // Hint: 3-43 try specifying your cells in a different order
   table.cell(x: 0, y: 0)[This shall error]
 )
 
@@ -76,10 +76,10 @@
 )
 
 --- grid-cell-position-x-out-of-bounds paged ---
-// Error: 4:3-4:36 cell could not be placed at invalid column 2
 #grid(
   columns: 2,
   [A],
+  // Error: 3-36 cell could not be placed at invalid column 2
   grid.cell(x: 2)[This shall error]
 )
 
@@ -106,20 +106,20 @@
 )
 
 --- grid-cell-position-partial-collide paged ---
-// Error: 4:3-4:21 cell could not be placed in row 0 because it was full
-// Hint: 4:3-4:21 try specifying your cells in a different order
 #grid(
   columns: 2,
   [A], [B],
+  // Error: 3-21 cell could not be placed in row 0 because it was full
+  // Hint: 3-21 try specifying your cells in a different order
   grid.cell(y: 0)[C]
 )
 
 --- table-cell-position-partial-collide paged ---
-// Error: 4:3-4:22 cell could not be placed in row 0 because it was full
-// Hint: 4:3-4:22 try specifying your cells in a different order
 #table(
   columns: 2,
   [A], [B],
+  // Error: 3-22 cell could not be placed in row 0 because it was full
+  // Hint: 3-22 try specifying your cells in a different order
   table.cell(y: 0)[C]
 )
 

--- a/tests/suite/layout/grid/rtl.typ
+++ b/tests/suite/layout/grid/rtl.typ
@@ -131,10 +131,10 @@
 )
 
 --- grid-rtl-vline-out-of-bounds paged ---
-// Error: 3:8-3:34 cannot place vertical line at the 'end' position of the end border (x = 1)
-// Hint: 3:8-3:34 set the line's position to 'start' or place it at a smaller 'x' index
 #set text(dir: rtl)
 #grid(
+  // Error: 8-34 cannot place vertical line at the 'end' position of the end border (x = 1)
+  // Hint: 8-34 set the line's position to 'start' or place it at a smaller 'x' index
   [a], grid.vline(position: left)
 )
 

--- a/tests/suite/layout/grid/stroke.typ
+++ b/tests/suite/layout/grid/stroke.typ
@@ -264,14 +264,14 @@
 )
 
 --- grid-stroke-hline-position-bad paged ---
-// Error: 7:3-7:32 cannot place horizontal line at the 'bottom' position of the bottom border (y = 2)
-// Hint: 7:3-7:32 set the line's position to 'top' or place it at a smaller 'y' index
 #table(
   columns: 2,
   [a], [b],
   [c], [d],
   table.hline(stroke: aqua),
   table.hline(position: top),
+  // Error: 3-32 cannot place horizontal line at the 'bottom' position of the bottom border (y = 2)
+  // Hint: 3-32 set the line's position to 'top' or place it at a smaller 'y' index
   table.hline(position: bottom)
 )
 
@@ -315,8 +315,6 @@
 )
 
 --- grid-stroke-hline-position-bottom-out-of-bounds paged ---
-// Error: 8:3-8:32 cannot place horizontal line at the 'bottom' position of the bottom border (y = 2)
-// Hint: 8:3-8:32 set the line's position to 'top' or place it at a smaller 'y' index
 #table(
   columns: 2,
   gutter: 3pt,
@@ -324,63 +322,65 @@
   [c], [d], table.vline(stroke: red),
   table.hline(stroke: aqua),
   table.hline(position: top),
+  // Error: 3-32 cannot place horizontal line at the 'bottom' position of the bottom border (y = 2)
+  // Hint: 3-32 set the line's position to 'top' or place it at a smaller 'y' index
   table.hline(position: bottom)
 )
 
 --- grid-stroke-vline-position-bottom-out-of-bounds paged ---
-// Error: 6:3-6:28 cannot place vertical line at the 'end' position of the end border (x = 2)
-// Hint: 6:3-6:28 set the line's position to 'start' or place it at a smaller 'x' index
 #grid(
   columns: 2,
   [a], [b],
   grid.vline(stroke: aqua),
   grid.vline(position: start),
+  // Error: 3-28 cannot place vertical line at the 'end' position of the end border (x = 2)
+  // Hint: 3-28 set the line's position to 'start' or place it at a smaller 'x' index
   grid.vline(position: end)
 )
 
 --- grid-stroke-vline-position-bottom-out-of-bounds-gutter paged ---
-// Error: 7:3-7:28 cannot place vertical line at the 'end' position of the end border (x = 2)
-// Hint: 7:3-7:28 set the line's position to 'start' or place it at a smaller 'x' index
 #grid(
   columns: 2,
   gutter: 3pt,
   [a], [b],
   grid.vline(stroke: aqua),
   grid.vline(position: start),
+  // Error: 3-28 cannot place vertical line at the 'end' position of the end border (x = 2)
+  // Hint: 3-28 set the line's position to 'start' or place it at a smaller 'x' index
   grid.vline(position: end)
 )
 
 --- grid-stroke-hline-out-of-bounds paged ---
-// Error: 4:3-4:19 cannot place horizontal line at invalid row 3
 #grid(
   [a],
   [b],
+  // Error: 3-19 cannot place horizontal line at invalid row 3
   grid.hline(y: 3)
 )
 
 --- grid-stroke-hline-out-of-bounds-gutter paged ---
-// Error: 5:3-5:19 cannot place horizontal line at invalid row 3
 #grid(
   gutter: 3pt,
   [a],
   [b],
+  // Error: 3-19 cannot place horizontal line at invalid row 3
   grid.hline(y: 3)
 )
 
 --- grid-stroke-vline-out-of-bounds paged ---
-// Error: 4:3-4:20 cannot place vertical line at invalid column 3
 #table(
   columns: 2,
   [a], [b],
+  // Error: 3-20 cannot place vertical line at invalid column 3
   table.vline(x: 3)
 )
 
 --- grid-stroke-vline-out-of-bounds-gutter paged ---
-// Error: 5:3-5:20 cannot place vertical line at invalid column 3
 #table(
   columns: 2,
   gutter: 3pt,
   [a], [b],
+  // Error: 3-20 cannot place vertical line at invalid column 3
   table.vline(x: 3)
 )
 
@@ -405,17 +405,17 @@
 #table(grid.vline())
 
 --- grid-hline-end-before-start-1 paged ---
-// Error: 3:3-3:31 line cannot end before it starts
 #grid(
   columns: 3,
+  // Error: 3-31 line cannot end before it starts
   grid.hline(start: 2, end: 1),
   [a], [b], [c],
 )
 
 --- grid-hline-end-before-start-2 paged ---
-// Error: 3:3-3:32 line cannot end before it starts
 #table(
   columns: 3,
+  // Error: 3-32 line cannot end before it starts
   table.vline(start: 2, end: 1),
   [a], [b], [c],
   [d], [e], [f],

--- a/tests/suite/layout/page.typ
+++ b/tests/suite/layout/page.typ
@@ -233,8 +233,8 @@ Z
 --- page-numbering-hint paged ---
 = Heading <intro>
 
-// Error: 1:21-1:47 cannot reference without page numbering
-// Hint: 1:21-1:47 you can enable page numbering with `#set page(numbering: "1")`
+// Error: 21-47 cannot reference without page numbering
+// Hint: 21-47 you can enable page numbering with `#set page(numbering: "1")`
 Can not be used as #ref(<intro>, form: "page")
 
 --- page-suppress-headers-and-footers paged ---

--- a/tests/suite/layout/repeat.typ
+++ b/tests/suite/layout/repeat.typ
@@ -39,8 +39,8 @@ A#box(width: 1fr, repeat(rect(width: 6em, height: 0.7em)))B
 ريجين#box(width: 1fr, repeat(rect(width: 4em, height: 0.7em)))سون
 
 --- repeat-unrestricted paged ---
-// Error: 2:2-2:13 repeat with no size restrictions
 #set page(width: auto)
+// Error: 2-13 repeat with no size restrictions
 #repeat(".")
 
 --- repeat-gap paged ---

--- a/tests/suite/model/heading.typ
+++ b/tests/suite/model/heading.typ
@@ -129,8 +129,8 @@ Not in heading
 --- heading-numbering-hint paged ---
 = Heading <intro>
 
-// Error: 1:19-1:25 cannot reference heading without numbering
-// Hint: 1:19-1:25 you can enable heading numbering with `#set heading(numbering: "1.")`
+// Error: 19-25 cannot reference heading without numbering
+// Hint: 19-25 you can enable heading numbering with `#set heading(numbering: "1.")`
 Cannot be used as @intro
 
 --- heading-par paged ---

--- a/tests/suite/pdftags/heading.typ
+++ b/tests/suite/pdftags/heading.typ
@@ -8,9 +8,9 @@
 == Level 2
 
 --- heading-tags-non-consecutive-levels pdftags pdfstandard(ua-1) ---
-// Error: 2:1-2:12 PDF/UA-1 error: skipped from heading level 1 to 3
-// Hint: 2:1-2:12 heading levels must be consecutive
 = Level 1
+// Error: 1-12 PDF/UA-1 error: skipped from heading level 1 to 3
+// Hint: 1-12 heading levels must be consecutive
 === Level 3
 
 --- heading-tags-complex pdftags pdfstandard(ua-1) ---

--- a/tests/suite/pdftags/link.typ
+++ b/tests/suite/pdftags/link.typ
@@ -23,25 +23,25 @@ A random location <somewhere>
 #context link(here().position())[somewhere]
 
 --- link-tags-link-in-artifact pdftags pdfstandard(ua-1) ---
-// Error: 2:4-2:42 PDF/UA-1 error: PDF artifacts may not contain links
-// Hint: 2:4-2:42 references, citations, and footnotes are also considered links in PDF
 #pdf.artifact[
+  // Error: 4-42 PDF/UA-1 error: PDF artifacts may not contain links
+  // Hint: 4-42 references, citations, and footnotes are also considered links in PDF
   #link("https://github.com/typst/typst")
 ]
 
 --- link-tags-reference-in-artifact pdftags pdfstandard(ua-1) ---
-// Error: 4:3-4:11 PDF/UA-1 error: PDF artifacts may not contain links
-// Hint: 4:3-4:11 references, citations, and footnotes are also considered links in PDF
 #set heading(numbering: "1.")
 = Heading <heading>
 #pdf.artifact[
+  // Error: 3-11 PDF/UA-1 error: PDF artifacts may not contain links
+  // Hint: 3-11 references, citations, and footnotes are also considered links in PDF
   @heading
 ]
 
 --- link-tags-citation-in-artifact pdftags pdfstandard(ua-1) ---
-// Error: 2:3-2:10 PDF/UA-1 error: PDF artifacts may not contain links
-// Hint: 2:3-2:10 references, citations, and footnotes are also considered links in PDF
 #pdf.artifact[
+  // Error: 3-10 PDF/UA-1 error: PDF artifacts may not contain links
+  // Hint: 3-10 references, citations, and footnotes are also considered links in PDF
   @netwok
 ]
 #show bibliography: none

--- a/tests/suite/pdftags/query.typ
+++ b/tests/suite/pdftags/query.typ
@@ -23,8 +23,8 @@
 #context query(<placed>).join()
 
 --- query-tags-ambiguous-parent-footnote-error pdftags pdfstandard(ua-1) ---
-// Error: 1:2-1:21 PDF/UA-1 error: ambiguous logical parent
-// Hint: 1:2-1:21 please report this as a bug
+// Error: 2-21 PDF/UA-1 error: ambiguous logical parent
+// Hint: 2-21 please report this as a bug
 #footnote[something] <note>
 
 #context query(<note>).join()

--- a/tests/suite/pdftags/table.typ
+++ b/tests/suite/pdftags/table.typ
@@ -68,10 +68,10 @@
 )
 
 --- table-tags-show-rule-error pdftags pdfstandard(ua-1) ---
-// Error: 2:2-2:30 PDF/UA-1 error: invalid table (Table) structure
-// Hint: 2:2-2:30 table (Table) may not contain raw text (Code)
-// Hint: 2:2-2:30 this is probably caused by a show rule
 #set table(columns: (10pt, auto))
+// Error: 2-30 PDF/UA-1 error: invalid table (Table) structure
+// Hint: 2-30 table (Table) may not contain raw text (Code)
+// Hint: 2-30 this is probably caused by a show rule
 #show table: it => it.columns
 #table[A][B][C][D]
 
@@ -100,10 +100,10 @@
 )
 
 --- table-tags-citation-in-repeated-header pdftags pdfstandard(ua-1) ---
-// Error: 3:16-3:23 PDF/UA-1 error: PDF artifacts may not contain links
-// Hint: 3:16-3:23 references, citations, and footnotes are also considered links in PDF
 #set page(height: 60pt)
 #table(
+  // Error: 16-23 PDF/UA-1 error: PDF artifacts may not contain links
+  // Hint: 16-23 references, citations, and footnotes are also considered links in PDF
   table.header[@netwok],
   [A],
   [A],
@@ -113,8 +113,8 @@
 #bibliography("/assets/bib/works.bib")
 
 --- table-tags-private-table-summary eval pdfstandard(ua-1) ---
-// Error: 2:3-2:18 unexpected argument: summary
 #table(
+  // Error: 3-18 unexpected argument: summary
   summary: "nope",
   [A],
 )

--- a/tests/suite/scripting/methods.typ
+++ b/tests/suite/scripting/methods.typ
@@ -26,24 +26,24 @@
 }
 
 --- method-unknown eval ---
-// Error: 2:10-2:13 type array has no method `fun`
 #let numbers = ()
+// Error: 10-13 type array has no method `fun`
 #numbers.fun()
 
 --- method-unknown-but-field-exists eval ---
-// Error: 2:4-2:10 element line has no method `stroke`
-// Hint: 2:4-2:10 did you mean to access the field `stroke`?
 #let l = line(stroke: red)
+// Error: 4-10 element line has no method `stroke`
+// Hint: 4-10 did you mean to access the field `stroke`?
 #l.stroke()
 
 --- method-mutate-on-temporary eval ---
-// Error: 2:2-2:43 cannot mutate a temporary value
 #let numbers = (1, 2, 3)
+// Error: 2-43 cannot mutate a temporary value
 #numbers.map(v => v / 2).sorted().map(str).remove(4)
 
 --- assign-to-method-invalid eval ---
-// Error: 2:3-2:19 cannot mutate a temporary value
 #let numbers = (1, 2, 3)
+// Error: 3-19 cannot mutate a temporary value
 #(numbers.sorted() = 1)
 
 --- method-mutate-on-std-constant eval ---

--- a/tests/suite/scripting/ops.typ
+++ b/tests/suite/scripting/ops.typ
@@ -314,8 +314,8 @@
 
 --- ops-precedence-boolean-ops eval ---
 // Assignment binds stronger than boolean operations.
-// Error: 2:3-2:8 cannot mutate a temporary value
 #let x = false
+// Error: 3-8 cannot mutate a temporary value
 #(not x = "a")
 
 --- ops-precedence-unary eval ---
@@ -491,8 +491,8 @@
 #(1 + 2 += 3)
 
 --- ops-assign-to-invalid-unary-op eval ---
-// Error: 2:3-2:8 cannot apply 'not' to string
 #let x = "Hey"
+// Error: 3-8 cannot apply 'not' to string
 #(not x = "a")
 
 --- ops-assign-to-invalid-binary-op eval ---

--- a/tests/suite/scripting/while.typ
+++ b/tests/suite/scripting/while.typ
@@ -37,8 +37,8 @@
 #while 2 < "hello".len() {}
 
 --- while-loop-limit eval ---
-// Error: 2:2-2:24 loop seems to be infinite
 #let i = 1
+// Error: 2-24 loop seems to be infinite
 #while i > 0 { i += 1 }
 
 --- while-loop-incomplete eval ---

--- a/tests/suite/styling/show-text.typ
+++ b/tests/suite/styling/show-text.typ
@@ -48,15 +48,15 @@ Treeworld, the World of worlds, is a world.
 
 --- show-text-empty eval ---
 // Test there is no crashing on empty strings
-// Error: 1:7-1:9 text selector is empty
+// Error: 7-9 text selector is empty
 #show "": []
 
 --- show-text-regex-empty eval ---
-// Error: 1:7-1:16 regex selector is empty
+// Error: 7-16 regex selector is empty
 #show regex(""): [AA]
 
 --- show-text-regex-matches-empty eval ---
-// Error: 1:7-1:42 regex matches empty text
+// Error: 7-42 regex matches empty text
 #show regex("(VAR_GLOBAL|END_VAR||BOOL)") : []
 
 --- show-text-regex-character-class paged ---

--- a/tests/suite/symbols/symbol.typ
+++ b/tests/suite/symbols/symbol.typ
@@ -40,71 +40,71 @@
 #symbol()
 
 --- symbol-constructor-invalid-modifier eval ---
-// Error: 2:3-2:24 invalid symbol modifier: " id!"
 #symbol(
+// Error: 3-24 invalid symbol modifier: " id!"
   ("invalid. id!", "x")
 )
 
 --- symbol-constructor-duplicate-modifier eval ---
-// Error: 2:3-2:31 duplicate modifier within variant: "duplicate"
-// Hint: 2:3-2:31 modifiers are not ordered, so each one may appear only once
 #symbol(
+  // Error: 3-31 duplicate modifier within variant: "duplicate"
+  // Hint: 3-31 modifiers are not ordered, so each one may appear only once
   ("duplicate.duplicate", "x"),
 )
 
 --- symbol-constructor-duplicate-default-variant eval ---
-// Error: 3:3-3:6 duplicate default variant
 #symbol(
   "x",
+  // Error: 3-6 duplicate default variant
   "y",
 )
 
 --- symbol-constructor-duplicate-empty-variant eval ---
-// Error: 3:3-3:12 duplicate default variant
 #symbol(
   ("", "x"),
+  // Error: 3-12 duplicate default variant
   ("", "y"),
 )
 
 --- symbol-constructor-default-and-empty-variants eval ---
-// Error: 3:3-3:12 duplicate default variant
 #symbol(
   "x",
+  // Error: 3-12 duplicate default variant
   ("", "y"),
 )
 
 --- symbol-constructor-duplicate-variant eval ---
-// Error: 3:3-3:29 duplicate variant: "duplicate.variant"
 #symbol(
   ("duplicate.variant", "x"),
+  // Error: 3-29 duplicate variant: "duplicate.variant"
   ("duplicate.variant", "y"),
 )
 
 --- symbol-constructor-duplicate-variant-different-order eval ---
-// Error: 3:3-3:29 duplicate variant: "variant.duplicate"
-// Hint: 3:3-3:29 variants with the same modifiers are identical, regardless of their order
 #symbol(
   ("duplicate.variant", "x"),
+  // Error: 3-29 duplicate variant: "variant.duplicate"
+  // Hint: 3-29 variants with the same modifiers are identical, regardless of their order
   ("variant.duplicate", "y"),
 )
 
 --- symbol-constructor-empty-variant-value eval ---
-// Error: 2:3-2:5 invalid variant value: ""
-// Hint: 2:3-2:5 variant value must be exactly one grapheme cluster
-// Error: 3:3-3:16 invalid variant value: ""
-// Hint: 3:3-3:16 variant value must be exactly one grapheme cluster
 #symbol(
+  // Error: 3-5 invalid variant value: ""
+  // Hint: 3-5 variant value must be exactly one grapheme cluster
   "",
+  // Error: 3-16 invalid variant value: ""
+  // Hint: 3-16 variant value must be exactly one grapheme cluster
   ("empty", "")
 )
 
 --- symbol-constructor-multi-cluster-variant-value eval ---
-// Error: 2:3-2:7 invalid variant value: "aa"
-// Hint: 2:3-2:7 variant value must be exactly one grapheme cluster
-// Error: 3:3-3:14 invalid variant value: "bb"
-// Hint: 3:3-3:14 variant value must be exactly one grapheme cluster
 #symbol(
+  // Error: 3-7 invalid variant value: "aa"
+  // Hint: 3-7 variant value must be exactly one grapheme cluster
   "aa",
+  // Error: 3-14 invalid variant value: "bb"
+  // Hint: 3-14 variant value must be exactly one grapheme cluster
   ("b", "bb")
 )
 

--- a/tests/suite/syntax/panics.typ
+++ b/tests/suite/syntax/panics.typ
@@ -3,24 +3,24 @@
 --- issue-4571-panic-when-compiling-invalid-file eval ---
 // Test that trying to parse the following does not result in a panic.
 
-// Error: 1:9-1:10 unclosed delimiter
-// Error: 1:22 expected pattern
-// Error: 1:23-1:24 unexpected star
-// Error: 2:1-2:2 the character `#` is not valid in code
-// Hint: 2:1-2:2 you are already in code mode
-// Hint: 2:1-2:2 try removing the `#`
-// Error: 2:2-2:8 expected pattern, found keyword `import`
-// Hint: 2:2-2:8 keyword `import` is not allowed as an identifier; try `import_` instead
-// Error: 2:9-2:20 expected identifier, found string
-// Error: 3:1-3:2 the character `#` is not valid in code
-// Hint: 3:1-3:2 you are already in code mode
-// Hint: 3:1-3:2 try removing the `#`
-// Error: 3:2-3:5 expected pattern, found keyword `let`
-// Hint: 3:2-3:5 keyword `let` is not allowed as an identifier; try `let_` instead
-// Error: 4:3-4:4 unexpected equals sign
-// Error: 4:5-4:6 unclosed delimiter
-// Error: 4:6 expected equals sign
+// Error: 9-10 unclosed delimiter
+// Error: 22 expected pattern
+// Error: 23-24 unexpected star
 #import (hntle-clues: *
+// Error: 1-2 the character `#` is not valid in code
+// Hint: 1-2 you are already in code mode
+// Hint: 1-2 try removing the `#`
+// Error: 2-8 expected pattern, found keyword `import`
+// Hint: 2-8 keyword `import` is not allowed as an identifier; try `import_` instead
+// Error: 9-20 expected identifier, found string
 #import "/util.typ": qrlink
+// Error: 1-2 the character `#` is not valid in code
+// Hint: 1-2 you are already in code mode
+// Hint: 1-2 try removing the `#`
+// Error: 2-5 expected pattern, found keyword `let`
+// Hint: 2-5 keyword `let` is not allowed as an identifier; try `let_` instead
 #let auton(
+// Error: 3-4 unexpected equals sign
+// Error: 5-6 unclosed delimiter
+// Error: 6 expected equals sign
 ) = {


### PR DESCRIPTION
This PR moves every test annotation that used the `<line>:<col>-<line>:<col>` range notation but only annotated a single line to instead use the `<col>-<col>` notation by moving them to just before the line they're annotating.

This matches the output of annotations added with `--update` and should increase the consistency of annotations across the test suite.