### PR TITLE
Fix inconsistent environment variable checks in `typst info`

### DIFF
--- a/crates/typst-cli/src/info.rs
+++ b/crates/typst-cli/src/info.rs
@@ -415,7 +415,7 @@ fn parse_bool(cmd: &Command, val: &str, key: &'static str) -> Option<bool> {
         Ok(bool) => Some(bool),
         Err(_) => {
             crate::print_error(&format!(
-                "invalid value `{val}` for `{key}`. expected `true` or `false`."
+                "invalid value `{val}` for `{key}`, expected `true` or `false`."
             ))
             .map_err(|e| eco_format!("{e}"))
             .expect("failed to print error");


### PR DESCRIPTION
<!--
Thanks for your interest in landing a change in Typst! Before opening the PR, please review our contribution guidelines: https://github.com/typst/typst/blob/main/CONTRIBUTING.md

In particular, please keep in mind that we do not accept contributions implemented by an AI model. We would also ask you to refrain from using AI to write your pull request description. Summarizing your work helps organizing your thoughts as much as it helps us with seeing the human thought process behind a particular change.
-->
Fixes: #7980

By using `FalseyValueParser` for parsing FontArgs, environment variable checks are consistent between info, compile and watch commands.

Please let me know if any documentation needs to be changed to reflect this fix. Thanks :grin: 