### PR TITLE
docs: list all countable elements in counter constructor documentation

### DIFF
--- a/crates/typst-library/src/introspection/counter.rs
+++ b/crates/typst-library/src/introspection/counter.rs
@@ -29,18 +29,9 @@ use crate::routines::Routines;
 /// Counts through pages, elements, and more.
 ///
 /// With the counter function, you can access and modify counters for pages,
-/// headings, figures, equations, and footnotes. These are the built-in
-/// elements that have automatic counting support:
-///
-/// - [`page`]: page counter
-/// - [`heading`]: heading / section counter (supports multiple levels)
-/// - [`figure`]: figure counter (with automatic numbering via `figure.caption`)
-/// - [`math.equation`]: equation counter
-/// - [`footnote`]: footnote counter
-///
-/// Beyond these, you can pass any [locatable]($location/#locatable)
-/// element or [label] to count its occurrences. You can also define
-/// fully custom counters using a string key.
+/// headings, figures, equations, and more. You can also create fully custom
+/// counters using a string key, or pass any [locatable]($location/#locatable)
+/// element or [label] to count its occurrences.
 ///
 /// Since counters change throughout the course of the document, their current
 /// value is _contextual._ It is recommended to read the chapter on [context]
@@ -358,6 +349,15 @@ impl Counter {
         ///   - provide a [`where`]($function.where) selector:
         ///     counts a type of element with specific fields,
         ///   - provide a [`{<label>}`]($label): counts elements with that label.
+        ///
+        /// The following built-in elements have automatic counting support
+        /// (their counter is stepped at each occurrence):
+        /// - [`page`]: page counter
+        /// - [`heading`]: heading / section counter (supports multiple levels)
+        /// - [`figure`]: figure counter (with automatic numbering via
+        ///   `figure.caption`)
+        /// - [`math.equation`]: equation counter
+        /// - [`footnote`]: footnote counter
         key: CounterKey,
     ) -> Counter {
         Self::new(key)

--- a/crates/typst-library/src/introspection/counter.rs
+++ b/crates/typst-library/src/introspection/counter.rs
@@ -29,8 +29,18 @@ use crate::routines::Routines;
 /// Counts through pages, elements, and more.
 ///
 /// With the counter function, you can access and modify counters for pages,
-/// headings, figures, and more. Moreover, you can define custom counters for
-/// other things you want to count.
+/// headings, figures, equations, and footnotes. These are the built-in
+/// elements that have automatic counting support:
+///
+/// - [`page`]: page counter
+/// - [`heading`]: heading / section counter (supports multiple levels)
+/// - [`figure`]: figure counter (with automatic numbering via `figure.caption`)
+/// - [`math.equation`]: equation counter
+/// - [`footnote`]: footnote counter
+///
+/// Beyond these, you can pass any [locatable]($location/#locatable)
+/// element or [label] to count its occurrences. You can also define
+/// fully custom counters using a string key.
 ///
 /// Since counters change throughout the course of the document, their current
 /// value is _contextual._ It is recommended to read the chapter on [context]


### PR DESCRIPTION
Closes #2728

The `counter` documentation said "pages, headings, figures, and more" without specifying what "more" means. This explicitly lists all built-in elements with automatic counting support:

- `page`
- `heading` (supports multiple levels)
- `figure` (with automatic numbering)
- `math.equation`
- `footnote`

Also clarifies that any locatable element, label, or string key can be used.