### PR TITLE
Fix typo in list docs

### DIFF
--- a/crates/typst-library/src/model/list.rs
+++ b/crates/typst-library/src/model/list.rs
@@ -37,7 +37,7 @@ use crate::text::TextElem;
 /// ```
 ///
 /// # Syntax
-/// This functions also has dedicated syntax: Start a line with a hyphen,
+/// This function also has dedicated syntax: Start a line with a hyphen,
 /// followed by a space to create a list item. A list item can contain multiple
 /// paragraphs and other block-level content. All content that is indented
 /// more than an item's marker becomes part of that item.


### PR DESCRIPTION
Fixes a typo in the documentation of List.