### PR TITLE
Fix SimSun-ExtB being incorrectly merged with SimSun

### DIFF
--- a/crates/typst-library/src/text/font/exceptions.rs
+++ b/crates/typst-library/src/text/font/exceptions.rs
@@ -327,6 +327,10 @@ static EXCEPTION_MAP: phf::Map<&'static str, Exception> = phf::phf_map! {
         .family("Latin Modern Sans 12"),
     "LMSans17-Oblique" => Exception::new()
         .family("Latin Modern Sans 17"),
+    // SimSun-ExtB is a CJK Extension B font, not an "ExtraBold" variant of
+    // SimSun. Without this exception, `typographic_family()` strips the "ExtB"
+    // suffix and merges it with SimSun, causing wrong font selection.
+    "SimSun-ExtB" => Exception::new().family("SimSun-ExtB"),
     // STKaiti is a set of Kai fonts. Their weight values need to be corrected
     // according to their PostScript names.
     "STKaitiSC-Regular" => Exception::new().weight(400),


### PR DESCRIPTION
`typographic_family()` strips the suffix "ExtB" from "SimSun-ExtB", treating it as an "ExtraBold" style variant. This incorrectly merges SimSun-ExtB (a CJK  Unified Ideographs Extension B supplementary font covering U+20000–U+2A6DF)   with SimSun (the standard font covering the CJK basic block U+4E00–U+9FFF) into a single family. Since both register as Normal/400 variants,        book.select() may non-deterministically pick SimSun-ExtB, which lacks basic CJK characters, causing fallback to an unrelated system font.

The fix adds a family exception for SimSun-ExtB, consistent with similar entries for Archivo Narrow, Noto Sans Display, etc.
                                                                                
Closes #6205 