### PR TITLE
Add `cargo testit open-report` command

### DIFF
--- a/tests/src/args.rs
+++ b/tests/src/args.rs
@@ -144,6 +144,8 @@ pub enum Command {
     Undangle,
     /// Prints the tags from a PDF file.
     Pdftags(PdftagsCommand),
+    /// Open the last generated HTML test report in a browser.
+    OpenReport,
 }
 
 #[derive(Debug, Clone, Parser)]

--- a/tests/src/logger.rs
+++ b/tests/src/logger.rs
@@ -204,10 +204,7 @@ impl Logger {
             prompt_regen = report::write(reports).unwrap_or(false);
 
             if ARGS.open_report {
-                let res = open::that("tests/store/report.html");
-                if let Err(err) = res {
-                    eprintln!("failed to open `tests/store/report.html`: {err}");
-                }
+                crate::open_report();
             }
         }
 

--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -56,6 +56,7 @@ fn main() {
         Some(Command::Clean) => clean(),
         Some(Command::Undangle) => undangle(),
         Some(Command::Pdftags(command)) => pdftags(command),
+        Some(Command::OpenReport) => open_report(),
     }
 }
 
@@ -225,6 +226,13 @@ fn pdftags(command: &PdftagsCommand) {
     match pdftags::format(&bytes) {
         Ok(tags) => println!("{tags}"),
         Err(err) => eprintln!("error: {err}"),
+    }
+}
+
+fn open_report() {
+    let res = open::that("tests/store/report.html");
+    if let Err(err) = res {
+        eprintln!("failed to open `tests/store/report.html`: {err}");
     }
 }
 


### PR DESCRIPTION
This allows opening the last generated `report.html` without rerunning tests.