### PR TITLE
 Warn on inconsistent equation spacing, e.g. `$x $` or `$ x$`

### DIFF
--- a/crates/typst-eval/src/math.rs
+++ b/crates/typst-eval/src/math.rs
@@ -1,5 +1,5 @@
 use ecow::eco_format;
-use typst_library::diag::{At, SourceResult};
+use typst_library::diag::{At, SourceResult, warning};
 use typst_library::foundations::{Content, NativeElement, Symbol, SymbolElem, Value};
 use typst_library::math::{
     AlignPointElem, AttachElem, EquationElem, FracElem, LrElem, PrimesElem, RootElem,
@@ -14,7 +14,23 @@ impl Eval for ast::Equation<'_> {
 
     fn eval(self, vm: &mut Vm) -> SourceResult<Self::Output> {
         let body = self.body().eval(vm)?;
-        let block = self.block();
+        let block = match self.block() {
+            ast::EquationBlock::Consistent { block } => block,
+            ast::EquationBlock::Inconsistent => {
+                vm.engine.sink.warn(warning!(
+                    self.span(),
+                    "inconsistent spacing next to opening and closing dollar signs";
+                    hint: "a block-level equation requires whitespace both after the \
+                           opening dollar sign and before the closing dollar sign";
+                    hint: "an inline equation should not have whitespace on either side";
+                    hint: "this is being treated as an inline equation";
+                ));
+                // We treat inconsistently spaced equations as inline since one
+                // of the sides didn't have a space. This avoids shifting the
+                // layout when writing `$a + $` before typing `b`.
+                false
+            }
+        };
         Ok(EquationElem::new(body).with_block(block).pack())
     }
 }

--- a/crates/typst-syntax/src/ast.rs
+++ b/crates/typst-syntax/src/ast.rs
@@ -863,8 +863,9 @@ impl<'a> Equation<'a> {
         self.0.cast_first()
     }
 
-    /// Whether the equation should be displayed as a separate block.
-    pub fn block(self) -> bool {
+    /// Whether the equation should be displayed as block-level or inline based
+    /// on the whitespace inside the dollar signs.
+    pub fn block(self) -> EquationBlock {
         // The parser likes to group adjacent trivia, so if the equation's body
         // is an empty `Math` node, e.g. in `$ /**/ $`, the CST will look like:
         // `Eqn [ Math(<empty>) Space(" ") BlockComment("/**/") Space(" ") ]`.
@@ -881,19 +882,32 @@ impl<'a> Equation<'a> {
                     // inside the dollar signs. We treat this as a block if that
                     // node is whitespace with multiple chars or is a newline.
                     // `parse::<char>` is `Ok` when there was exactly one char.
-                    return back.kind() == SyntaxKind::Space
+                    let block = back.kind() == SyntaxKind::Space
                         && back.text().parse::<char>().map_or(true, is_newline);
+                    return EquationBlock::Consistent { block };
                 }
             }
             [_ldollar, front, .., back, _rdollar] => (front, back),
-            _ => return false,
+            _ => return EquationBlock::Consistent { block: false },
         };
 
         let front_space = front.kind() == SyntaxKind::Space;
         let back_space = back.kind() == SyntaxKind::Space;
 
-        front_space && back_space
+        if front_space == back_space {
+            EquationBlock::Consistent { block: front_space }
+        } else {
+            EquationBlock::Inconsistent
+        }
     }
+}
+
+/// The spacing around an equation, and whether it should be displayed as
+/// block-level or inline. Inconsistent spacing should be treated as inline.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum EquationBlock {
+    Consistent { block: bool },
+    Inconsistent,
 }
 
 node! {

--- a/tests/suite/math/delimited.typ
+++ b/tests/suite/math/delimited.typ
@@ -8,7 +8,7 @@ $f(x/2) < zeta(c^2 + abs(a + b/2))$
 
 --- math-lr-unmatched paged ---
 // Test unmatched.
-$[1,2[ = [1,2) != zeta\(x/2\) $
+$[1,2[ = [1,2) != zeta\(x/2\)$
 
 --- math-lr-call paged ---
 // Test manual matching.

--- a/tests/suite/math/equation.typ
+++ b/tests/suite/math/equation.typ
@@ -27,8 +27,17 @@ $.block)
 
 // If either side lacks whitespace, we have an inline equation.
 #assert(not $x$.block)
+// And we warn if the sides are inconsistent:
+// Warning: 1:13-2:2 inconsistent spacing next to opening and closing dollar signs
+// Hint: 1:13-2:2 a block-level equation requires whitespace both after the opening dollar sign and before the closing dollar sign
+// Hint: 1:13-2:2 an inline equation should not have whitespace on either side
+// Hint: 1:13-2:2 this is being treated as an inline equation
 #assert(not $x
 $.block)
+// Warning: 1:13-2:3 inconsistent spacing next to opening and closing dollar signs
+// Hint: 1:13-2:3 a block-level equation requires whitespace both after the opening dollar sign and before the closing dollar sign
+// Hint: 1:13-2:3 an inline equation should not have whitespace on either side
+// Hint: 1:13-2:3 this is being treated as an inline equation
 #assert(not $
 x$.block)
 
@@ -38,11 +47,24 @@ x$.block)
 
 y$.block)
 
-// And inline comments _do_ interrupt the block status.
+// Comments _do_ interrupt the block status.
 #assert($ /**/ $.block)
+#assert(not $/**/ /**/ /**/$.block)
+// Warning: 13-20 inconsistent spacing next to opening and closing dollar signs
+// Hint: 13-20 a block-level equation requires whitespace both after the opening dollar sign and before the closing dollar sign
+// Hint: 13-20 an inline equation should not have whitespace on either side
+// Hint: 13-20 this is being treated as an inline equation
 #assert(not $/**/ $.block)
+// Warning: 13-20 inconsistent spacing next to opening and closing dollar signs
+// Hint: 13-20 a block-level equation requires whitespace both after the opening dollar sign and before the closing dollar sign
+// Hint: 13-20 an inline equation should not have whitespace on either side
+// Hint: 13-20 this is being treated as an inline equation
 #assert(not $ /**/$.block)
-#assert(not $/**/
+// Warning: 1:13-2:2 inconsistent spacing next to opening and closing dollar signs
+// Hint: 1:13-2:2 a block-level equation requires whitespace both after the opening dollar sign and before the closing dollar sign
+// Hint: 1:13-2:2 an inline equation should not have whitespace on either side
+// Hint: 1:13-2:2 this is being treated as an inline equation
+#assert(not $//
 $.block)
 
 --- math-equation-block-syntax-unicode eval ---
@@ -64,7 +86,15 @@ $.block)
   }
   for non-space in non-spaces {
     assert(eval("$" + space + non-space + space + "$.block"))
+    // Warning: 17-56 inconsistent spacing next to opening and closing dollar signs
+    // Hint: 17-56 a block-level equation requires whitespace both after the opening dollar sign and before the closing dollar sign
+    // Hint: 17-56 an inline equation should not have whitespace on either side
+    // Hint: 17-56 this is being treated as an inline equation
     assert(eval("not $" + space + non-space + "$.block"))
+    // Warning: 17-56 inconsistent spacing next to opening and closing dollar signs
+    // Hint: 17-56 a block-level equation requires whitespace both after the opening dollar sign and before the closing dollar sign
+    // Hint: 17-56 an inline equation should not have whitespace on either side
+    // Hint: 17-56 this is being treated as an inline equation
     assert(eval("not $" + non-space + space + "$.block"))
   }
 }
@@ -76,7 +106,15 @@ $.block)
   }
   for non-space in non-spaces {
     assert(eval("$" + newline + non-space + newline + "$.block"))
+    // Warning: 17-58 inconsistent spacing next to opening and closing dollar signs
+    // Hint: 17-58 a block-level equation requires whitespace both after the opening dollar sign and before the closing dollar sign
+    // Hint: 17-58 an inline equation should not have whitespace on either side
+    // Hint: 17-58 this is being treated as an inline equation
     assert(eval("not $" + newline + non-space + "$.block"))
+    // Warning: 17-58 inconsistent spacing next to opening and closing dollar signs
+    // Hint: 17-58 a block-level equation requires whitespace both after the opening dollar sign and before the closing dollar sign
+    // Hint: 17-58 an inline equation should not have whitespace on either side
+    // Hint: 17-58 this is being treated as an inline equation
     assert(eval("not $" + non-space + newline + "$.block"))
   }
 }

--- a/tests/suite/math/interactions.typ
+++ b/tests/suite/math/interactions.typ
@@ -219,7 +219,7 @@ $ width A^width A^A^width $
 // Ideally the heights would match the actual height of the sums.
 #let sum = $sum^2$
 #let height(x) = context measure(x).height
-$sum = height(sum) $
+$sum = height(sum)$
 $ sum != height(sum) $
 
 --- math-size-math-content-3 paged ---

--- a/tests/suite/math/multiline.typ
+++ b/tests/suite/math/multiline.typ
@@ -157,7 +157,13 @@ Multiple trailing line breaks.
 --- math-linebreaking-trailing-linebreak paged ---
 // A single linebreak at the end still counts as one line.
 #let hrule(x) = box(line(length: x))
+// Warning: 13-31 inconsistent spacing next to opening and closing dollar signs
+// Hint: 13-31 a block-level equation requires whitespace both after the opening dollar sign and before the closing dollar sign
+// Hint: 13-31 an inline equation should not have whitespace on either side
+// Hint: 13-31 this is being treated as an inline equation
 #hrule(60pt)$e^(pi i)+1 = 0\ $
+// We could remove the warning by using `#linebreak()` or `#[\ ]`, but it's
+// questionable whether inline equations with a linebreak at the end are useful.
 
 --- math-linebreaking-in-box paged ---
 // Inline, in a box, doesn't linebreak.

--- a/tests/suite/math/stretch.typ
+++ b/tests/suite/math/stretch.typ
@@ -186,7 +186,7 @@ $ stretch(=, size: #2em) \
 #let base = math.stretch($=$, size: 4em)
 $ stretch(base, size: #50%) $
 
-#let base = $stretch(=, size: #4em) $
+#let base = $stretch(=, size: #4em)$
 $ stretch(base, size: #50%) $
 
 --- math-stretch-attach-nested-equation paged ---


### PR DESCRIPTION
**Part of the Math Syntax Refactor**
This PR is part of the exhaustive math syntax refactor. It should be considered exploratory, and not necessarily a final decision, even if merged to the `math-syntax` branch. Non-specific feedback for this change should go in one of its related issues.

---

The first commit is what I hope is an actually clean refactoring of `Equation::block` (see discussions in #7741), via matching on the structure of the children slice.

The second commit adds a warning when equations have inconsistent spacing around their dollar signs, such as `$x $` or `$x $`. We only warn if the _presence_ of whitespace differs, not based on the content of that whitespace, so `$ x\n$` is still fine. It also fixes a few instances of inconsistent spacing in the tests.

One test that was more interesting is `math-linebreaking-trailing-linebreak`, which has a linebreak at the end of an inline equation. This is an interesting edge case because the backslash for the linebreak needs to be followed by whitespace (or it would be a character escape), so linebreak syntax just cannot be used at the end of inline equations without triggering this warning. We could remove the warning by using `#linebreak()` or `#[\ ]`, but it's questionable whether ending an inline equation with a linebreak is useful at all, so I left it with the warning and added a comment explaining this.

A choice that could differ is which span we warn on. Currently we target for the entire equation, which will noisily underline the whole thing in yellow in most editors, but we could choose to instead only target the first/last dollar sign(s). However, we do want users to notice the warning, so I'm fine with it being noisy.

I'm also open to changing the wording. I think it's currently OK, but could likely be better.

### Rationale

This was mentioned in #6430 at the very end of [this comment](https://github.com/typst/typst/issues/6430#issuecomment-3907959175), but I'll expand on the rationale a bit.

We don't want to _error_ on inconsistent spacing because we expect it to be common when initially typing an equation and you want to see the live preview without needing to have correct spacing just yet. However, we recognize that Typst's dollar sign syntax is unfamiliar, and it can be common for users to accidentally create inline equations when they intended to have a block. So we give a (pretty loud) warning that explains the syntax and hopefully gets users clarify their intent.
