### PR TITLE
Update `error!` macros to allow spanned hints as: `hint[span]: "..."`

### DIFF
--- a/crates/typst-bundle/src/lib.rs
+++ b/crates/typst-bundle/src/lib.rs
@@ -13,14 +13,12 @@ use std::collections::hash_map::Entry;
 use std::sync::Arc;
 
 use comemo::{Tracked, TrackedMut};
-use ecow::{EcoString, EcoVec, eco_format};
+use ecow::{EcoString, EcoVec};
 use indexmap::IndexMap;
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use typst_html::HtmlDocument;
 use typst_layout::PagedDocument;
-use typst_library::diag::{
-    At, CollectCombinedResult, SourceDiagnostic, SourceResult, bail, error,
-};
+use typst_library::diag::{At, CollectCombinedResult, SourceResult, bail, error};
 use typst_library::engine::{Engine, Route, Sink, Traced};
 use typst_library::foundations::{
     Bytes, Content, Output, Packed, StyleChain, Target, TargetElem,
@@ -267,20 +265,13 @@ fn collect<'a>(
                 entry.insert(elem.span());
             }
             Entry::Occupied(entry) => {
-                errors.push(
-                    SourceDiagnostic::error(
-                        elem.span(),
-                        eco_format!(
-                            "path `{}` occurs multiple times in the bundle",
-                            path.get_without_slash()
-                        ),
-                    )
-                    .with_hint(eco_format!(
-                        "{} paths must be unique in the bundle",
-                        elem.func().name(),
-                    ))
-                    .with_spanned_hint("path is already in use here", *entry.get()),
-                );
+                errors.push(error!(
+                    elem.span(), "path `{}` occurs multiple times in the bundle",
+                    path.get_without_slash();
+                    hint: "{} paths must be unique in the bundle",
+                    elem.func().name();
+                    hint[*entry.get()]: "path is already in use here";
+                ));
             }
         }
     }

--- a/crates/typst-cli/src/query.rs
+++ b/crates/typst-cli/src/query.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 use comemo::Track;
 use ecow::{EcoString, eco_format};
 use typst::World;
-use typst::diag::{HintedStrResult, SourceDiagnostic, StrResult, Warned, bail};
+use typst::diag::{HintedStrResult, SourceDiagnostic, StrResult, Warned, bail, warning};
 use typst::engine::Sink;
 use typst::foundations::{
     Content, Context, IntoValue, LocatableSelector, Output, Repr, Scope,
@@ -148,9 +148,9 @@ fn deprecation_warning(command: &QueryCommand) -> SourceDiagnostic {
         Input::Stdin => eco_format!("typst eval {query}"),
     };
 
-    SourceDiagnostic::warning(
+    warning!(
         Span::detached(),
-        "the `typst query` subcommand is deprecated",
+        "the `typst query` subcommand is deprecated";
+        hint: "use `{eval_command}` instead";
     )
-    .with_hint(eco_format!("use `{}` instead", eval_command))
 }

--- a/crates/typst-eval/src/call.rs
+++ b/crates/typst-eval/src/call.rs
@@ -503,37 +503,21 @@ fn unparse_math_args(
                 let name = callee.to_untyped().clone().into_text();
                 let fixed =
                     named.to_untyped().clone().into_text().replacen(":", "\\:", 1);
-                errors.push(
-                    error!(
-                        named.span(),
-                        "named-argument syntax can only be used with functions"
-                    )
-                    .with_spanned_hint(
-                        eco_format!("`{name}` is not a function"),
-                        callee.span(),
-                    )
-                    .with_hint(eco_format!(
-                        "to render the colon as text, escape it: `{fixed}`"
-                    )),
-                );
+                errors.push(error!(
+                    named.span(), "named-argument syntax can only be used with functions";
+                    hint[callee.span()]: "`{name}` is not a function";
+                    hint: "to render the colon as text, escape it: `{fixed}`";
+                ));
             }
             ast::MathArgItem::Arg(ast::Arg::Spread(spread)) => {
                 let name = callee.to_untyped().clone().into_text();
                 let fixed =
                     spread.to_untyped().clone().into_text().replacen("..", ".. ", 1);
-                errors.push(
-                    error!(
-                        spread.span(),
-                        "spread-argument syntax can only be used with functions"
-                    )
-                    .with_spanned_hint(
-                        eco_format!("`{name}` is not a function"),
-                        callee.span(),
-                    )
-                    .with_hint(eco_format!(
-                        "to render the dots as text, add a space: `{fixed}`"
-                    )),
-                );
+                errors.push(error!(
+                    spread.span(), "spread-argument syntax can only be used with functions";
+                    hint[callee.span()]: "`{name}` is not a function";
+                    hint: "to render the dots as text, add a space: `{fixed}`";
+                ));
             }
         }
     }

--- a/crates/typst-library/src/diag.rs
+++ b/crates/typst-library/src/diag.rs
@@ -35,7 +35,7 @@ use crate::{World, WorldExt};
 /// bail!(
 ///     span, "returning a {} error", "formatted";
 ///     hint: "with multiple hints";
-///     hint: "the hints can have {} too", "formatting";
+///     hint[hint_span]: "hints can have custom spans and {}", "formatting";
 /// ); // SourceResult
 /// ```
 #[macro_export]
@@ -80,7 +80,7 @@ macro_rules! __bail {
 /// error!(
 ///     span, "an error with a {} message", "formatted";
 ///     hint: "with multiple hints";
-///     hint: "the hints can have {} too", "formatting";
+///     hint[hint_span]: "hints can have custom spans and {}", "formatting";
 /// ); // SourceDiagnostic
 /// ```
 #[macro_export]
@@ -103,15 +103,30 @@ macro_rules! __error {
     };
 
     // For `error!(span, ...)`
+    // Hints may include a span inside brackets: `hint[span_expr]: "msg"`.
     (
         $span:expr, $fmt:literal $(, $arg:expr)* $(,)?
-        $(; hint: $hint:literal $(, $hint_arg:expr)*)*
+        $(; hint $([$hint_span:expr])? : $hint:literal $(, $hint_arg:expr)*)*
         $(;)?
-    ) => {
-        $crate::diag::SourceDiagnostic::error(
+    ) => {{
+        #[allow(unused_mut)]
+        let mut err = $crate::diag::SourceDiagnostic::error(
             $span,
             $crate::diag::eco_format!($fmt $(, $arg)*)
-        ) $(.with_hint($crate::diag::eco_format!($hint $(, $hint_arg)*)))*
+        );
+        // We use a recursive macro for hints to allow for optional spans.
+        $($crate::diag::error!(hint$([$hint_span])?: err, $hint $(, $hint_arg)*);)*
+        err
+    }};
+
+    // Internal recursive macro for adding hints with/without spans. Note that
+    // recursive macros must generate full expressions, so we can't use
+    // `.with_hint()` or `.with_spanned_hint()`.
+    (hint: $err:ident, $hint:literal $(, $hint_arg:expr)*) => {
+        $err.hint($crate::diag::eco_format!($hint $(, $hint_arg)*))
+    };
+    (hint[$hint_span:expr]: $err:ident, $hint:literal $(, $hint_arg:expr)*) => {
+        $err.spanned_hint($crate::diag::eco_format!($hint $(, $hint_arg)*), $hint_span)
     };
 }
 
@@ -130,7 +145,7 @@ macro_rules! __error {
 /// warning!(
 ///     span, "warning with a {} message", "formatted";
 ///     hint: "with multiple hints";
-///     hint: "the hints can have {} too", "formatting";
+///     hint[hint_span]: "hints can have custom spans and {}", "formatting";
 /// );
 /// ```
 #[macro_export]
@@ -138,14 +153,18 @@ macro_rules! __error {
 macro_rules! __warning {
     (
         $span:expr, $fmt:literal $(, $arg:expr)* $(,)?
-        $(; hint: $hint:literal $(, $hint_arg:expr)*)*
+        $(; hint $([$hint_span:expr])? : $hint:literal $(, $hint_arg:expr)*)*
         $(;)?
-    ) => {
-        $crate::diag::SourceDiagnostic::warning(
+    ) => {{
+        #[allow(unused_mut)]
+        let mut warning = $crate::diag::SourceDiagnostic::warning(
             $span,
             $crate::diag::eco_format!($fmt $(, $arg)*)
-        ) $(.with_hint($crate::diag::eco_format!($hint $(, $hint_arg)*)))*
-    };
+        );
+        // We use a recursive macro for hints to allow for optional spans.
+        $($crate::diag::error!(hint$([$hint_span])?: warning, $hint $(, $hint_arg)*);)*
+        warning
+    }};
 }
 
 #[rustfmt::skip]


### PR DESCRIPTION
This adds syntax to the `error!`, `bail!`, and `warning!` macros for spanned hints.

I had to reconfigure the macro internals a bit to allow for a recursive macro call --- moving from `.with_hint()` taking the diagnostic by value to mutating the diagnostic --- but the result should be the same.

I also updated the three cases of manual calls that were able to use the spanned hint macro plus a single warning that didn't need the new syntax, but could still use the `warning!` macro.