### PR TITLE
Fix test `--update` for multiline annotations and messages

### DIFF
--- a/tests/src/notes.rs
+++ b/tests/src/notes.rs
@@ -254,7 +254,8 @@ impl Note {
             seen: stage,
             kind,
             range,
-            message,
+            // Annotated messages must be a single line.
+            message: message.replace("\n", "\\n"),
         }
     }
 }
@@ -476,6 +477,10 @@ fn parse_note_start(s: &mut Scanner) -> Option<NoteKind> {
 }
 
 /// Parses an annotation in a test, continuing from `parse_note_start`.
+///
+/// Messages must be a single line, but can annotate multiline errors by writing
+/// `\n`, as we convert newlines in the emitted message to `\n` before
+/// comparing.
 fn parse_note(
     pos: FilePos,
     annotated_line: usize,
@@ -487,11 +492,12 @@ fn parse_note(
 
     let range = parse_note_range(s, annotated_line, source)?;
 
+    // Using `VERSION` as a placeholder for the current version lets us avoid
+    // updating certain messages on every release.
     let message = s
         .after()
         .trim()
-        .replace("VERSION", &format!("{}", PackageVersion::compiler()))
-        .replace("\\n", "\n");
+        .replace("VERSION", &format!("{}", PackageVersion::compiler()));
 
     Ok(Note {
         status: NoteStatus::Annotated { pos },
@@ -509,6 +515,9 @@ fn expect_space_after(s: &mut Scanner, thing: &str) -> StrResult<()> {
 
 /// Parse the range of an annotation, either internal to this test or external
 /// at the given path.
+///
+/// External ranges include the path in quotes before the line/col positions.
+/// Ex: `// Error: "/path/to/file.typ" <line>:<col>-<line>:<col> message`
 fn parse_note_range(
     s: &mut Scanner,
     annotated_line: usize,

--- a/tests/suite/foundations/panic.typ
+++ b/tests/suite/foundations/panic.typ
@@ -1,14 +1,28 @@
---- panic eval ---
-// Test panic.
+// Test the panic function.
+
+--- panic-empty eval ---
+// Test panic with no args.
 // Error: 2-9 panicked
 #panic()
 
---- panic-with-int eval ---
-// Test panic.
+--- panic-int eval ---
+// We can panic with a random value.
 // Error: 2-12 panicked with: 123
 #panic(123)
 
---- panic-with-str eval ---
-// Test panic.
+--- panic-str eval ---
+// But usually we panic with an error message.
 // Error: 2-24 panicked with: "this is wrong"
 #panic("this is wrong")
+
+--- panic-multiline eval ---
+// Test panic with a multiline string.
+// Error: 1:2-2:7 panicked with: "oops\noops\noops"
+#panic("oops\noops
+oops")
+
+--- panic-raw-newline eval ---
+// Test panic with raw text containing escaped and normal newlines.
+// Error: 1:2-2:5 panicked with: raw(text: "\\n\n\\n", block: false)
+#panic(`\n
+\n`)


### PR DESCRIPTION
I'm submitting this as one PR because the three commits are relatively related and each is small. It's also a bit hard to test `--update` for the third commit without the second.

### 1. Emit external annotations at the start of tests

This was a simple oversight that was just wrong. We should never compare external annotation line numbers to test line numbers.

Luckily, this was an easy fix because we already sort external annotations before internal annotations and emitting them in a different branch puts them before any internal annotations.

### 2. Write multiline ranges relative to the annotated line (not the start of the test)

This fixes a bug with `--update` that I ran into while testing the next fix.

The bug is that when parsing annotation ranges (e.g. `<line>:<col>-<line>:<col>`), we read line numbers in ranges as relative to the line after the annotation in the test (ignoring other annotation lines), but we internally store line numbers relative to the start of the test, and we don't convert back when writing out multiline ranges with  `--update`. I didn't catch this earlier because I only tested updates to multline annotations that came at the start of the test (where both line numbers are the same).

The fix is simple: when using `--update`, we still emit multiline annotations just before the line they annotate, but we set the start line to zero (and adjust the end line) so that the line numbers are relative to the annotated line.

And while I previously [discussed on Discord](https://discord.com/channels/1054443721975922748/1217423226410373240/1486107447138582558) that I would prefer to use line numbers relative to the start of the test instead, I have changed my mind after reading the responses and considering it a bit more.

### 3. Escape emitted (not annotated) newlines in error messages

Closes #7949

I finally looked at #7949 in-depth and found that both problems in it can be resolved by leaving `\n` in the annotated messages unchanged, and instead replacing newlines with `\n` in the emitted messages.

The implementation is simply removing `.replace("\\n", "\n")` when loading the annotated messages and adding `.replace("\n", "\\n")` when storing the emitted messages. This does make it so we no longer distinguish between newlines and `\n` in emitted messages, but for many cases (e.g. panics), we actually print the fully escaped `\\n` in the message instead of printing strings directly, which removes the main ambiguity I would anticipate.

An alternative fix would be to do proper backslash escaping of the annotated messages, or creating some kind of multiline annotation syntax for real newlines. But given that the above only requires changing two lines, I'm inclined to just do the simple fix.

I updated the `panic` tests to flex this behavior, and you can check that `--update` replaces the new messages if you remove them.
