### PR TITLE
Fix incremental parsing of unclosed strings

### DIFF
--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -572,13 +572,7 @@ fn embedded_code_expr(p: &mut Parser) {
         }
 
         let stmt = p.at_set(set::STMT);
-        let at = p.at_set(set::ATOMIC_CODE_EXPR);
         code_expr_prec(p, true, 0);
-
-        // Consume error for things like `#12p` or `#"abc\"`.#
-        if !at {
-            p.unexpected();
-        }
 
         // Note: 2d math arguments rely on the `directly_at` check.
         let semi = (stmt || p.directly_at(SyntaxKind::Semicolon))
@@ -592,7 +586,7 @@ fn embedded_code_expr(p: &mut Parser) {
 
 /// Parses a single code expression.
 fn code_expr(p: &mut Parser) {
-    code_expr_prec(p, false, 0)
+    code_expr_prec(p, false, 0);
 }
 
 /// Parses a code expression with at least the given precedence.
@@ -722,6 +716,9 @@ fn code_primary(p: &mut Parser, atomic: bool) {
         | SyntaxKind::Numeric
         | SyntaxKind::Str
         | SyntaxKind::Label => p.eat(),
+
+        // Consume erroneous tokens for things like `#12p`, `#]`, or `#"abc\"`.
+        _ if atomic => p.unexpected(),
 
         _ => p.expected("expression"),
     }
@@ -1984,9 +1981,24 @@ impl Parser<'_> {
         }
     }
 
-    /// Produce an error that the given `thing` was expected.
+    /// Produce an error that the given `thing` was expected. If the parser is
+    /// at an erroneous token, this will instead eat that token and continue.
     fn expected(&mut self, thing: &str) {
-        if !self.after_error() {
+        if self.token.kind.is_error() {
+            // If we encounter an erroneous token when something was expected,
+            // we need to actually consume the token. If we don't, and we then
+            // proceed to exit our current lexing mode, future incremental
+            // reparsing could fail to lex the token in the correct mode.
+            //
+            // Example: When parsing an unclosed string in `#import "str`,
+            // we need to make sure the string is lexed as code, because if
+            // it were lexed as markup, a future insert of a closing quote
+            // would only be adjacent to markup text, and wouldn't lex as a
+            // string when reparsing, causing a difference between the full
+            // parse and the incremental parse.
+            self.trim_errors();
+            self.eat();
+        } else if !self.after_error() {
             self.expected_at(self.before_trivia(), thing);
         }
     }

--- a/crates/typst-syntax/src/reparser.rs
+++ b/crates/typst-syntax/src/reparser.rs
@@ -242,79 +242,154 @@ mod tests {
 
     use crate::{Source, Span, parse};
 
-    #[track_caller]
-    fn test(prev: &str, range: Range<usize>, with: &str, incremental: bool) {
-        let mut source = Source::detached(prev);
-        let prev = source.root().clone();
-        let range = source.edit(range, with);
-        let mut found = source.root().clone();
-        let mut expected = parse(source.text());
-        found.synthesize(Span::detached());
-        expected.synthesize(Span::detached());
-        if found != expected {
-            eprintln!("source:   {:?}", source.text());
-            eprintln!("previous: {prev:#?}");
-            eprintln!("expected: {expected:#?}");
-            eprintln!("found:    {found:#?}");
-            panic!("test failed");
-        }
-        if incremental {
-            assert_ne!(source.text().len(), range.len(), "should have been incremental");
-        } else {
-            assert_eq!(
-                source.text().len(),
-                range.len(),
-                "shouldn't have been incremental"
-            );
+    /// How to replace text in the test string.
+    enum Edit {
+        /// Insert at the end.
+        End,
+        /// Insert at an index.
+        At(usize),
+        /// Replace the given range.
+        Range(Range<usize>),
+        /// Replace the first match in the original.
+        Match(&'static str),
+        /// Replace at the index after the first match of this string.
+        After(&'static str),
+    }
+
+    impl Edit {
+        #[track_caller]
+        fn into_range(self, text: &str) -> Range<usize> {
+            match self {
+                Self::End => text.len()..text.len(),
+                Self::At(index) => {
+                    assert!(text.len() >= index, "index is out of bounds");
+                    index..index
+                }
+                Self::Range(range) => {
+                    assert!(text.len() >= range.end, "range is out of bounds");
+                    range
+                }
+                Self::Match(pat) => {
+                    let start = text.find(pat).expect("pattern must exist in original");
+                    start..start + pat.len()
+                }
+                Self::After(pat) => {
+                    let start = text.find(pat).expect("pattern must exist in original");
+                    let end = start + pat.len();
+                    end..end
+                }
+            }
         }
     }
 
+    /// What kind of reparsing happened.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum Reparse<'a> {
+        /// The whole text was reparsed.
+        All,
+        /// The text was parsed incrementally matching this string.
+        Incr(&'a str),
+    }
+
+    #[track_caller]
+    fn test(text: &str, edit: Edit, with: &str, expected: Reparse) {
+        let mut source = Source::detached(text);
+        let orig_tree = source.root().clone();
+        // `Source::edit()` is the public interface for reparsing.
+        let replaced_range = source.edit(edit.into_range(text), with);
+        let mut reparsed_tree = source.root().clone();
+        let mut normal_parse = parse(source.text());
+        reparsed_tree.synthesize(Span::detached());
+        normal_parse.synthesize(Span::detached());
+        if reparsed_tree != normal_parse {
+            eprintln!("Original source text: {text:?}");
+            eprintln!("Original tree:\n{orig_tree:#?}");
+            eprintln!("New source text: {:?}", source.text());
+            eprintln!("Reparsed tree:\n{reparsed_tree:#?}");
+            eprintln!("Normal parse tree:\n{normal_parse:#?}");
+            panic!("Reparsed tree did not match normal parse");
+        }
+        let actual = if replaced_range == (0..source.text().len()) {
+            Reparse::All
+        } else {
+            Reparse::Incr(&source.text()[replaced_range])
+        };
+        assert_eq!(actual, expected);
+    }
+
+    /// Basic tests for the reparsing algorithm and the testing framework.
+    #[test]
+    fn test_reparse_basic() {
+        use Reparse::*;
+        // Replace everything with something else:
+        test("some content", Edit::Match("some content"), "do it", All);
+        test("some content", Edit::Range(0..12), "", All);
+        test("", Edit::At(0), "do it", All);
+        test("", Edit::End, "do it", All);
+        // Add something at the end:
+        test("some content", Edit::After("some content"), " do it", All);
+    }
+
+    /// Test incremental reparsing of markup expressions.
     #[test]
     fn test_reparse_markup() {
-        test("abc~def~gh~", 5..6, "+", true);
-        test("~~~~~~~", 3..4, "A", true);
-        test("abc~~", 1..2, "", true);
-        test("#var. hello", 5..6, " ", false);
-        test("#var;hello", 9..10, "a", false);
-        test("https:/world", 7..7, "/", false);
-        test("hello  world", 7..12, "walkers", false);
-        test("some content", 0..12, "", false);
-        test("", 0..0, "do it", false);
-        test("a d e", 1..3, " b c d", false);
-        test("~*~*~", 2..2, "*", false);
-        test("::1\n2. a\n3", 7..7, "4", true);
-        test("* #{1+2} *", 6..7, "3", true);
-        test("#{(0, 1, 2)}", 6..7, "11pt", true);
-        test("\n= A heading", 4..4, "n evocative", false);
-        test("#call() abc~d", 7..7, "[]", true);
-        test("a your thing a", 6..7, "a", false);
-        test("#grid(columns: (auto, 1fr, 40%))", 16..20, "4pt", false);
-        test("abc\n= a heading\njoke", 3..4, "\nmore\n\n", true);
-        test("#show f: a => b..", 16..16, "c", false);
-        test("#for", 4..4, "//", false);
-        test("a\n#let \nb", 7..7, "i", true);
-        test(r"#{{let x = z}; a = 1} b", 7..7, "//", false);
-        test(r#"a ```typst hello```"#, 16..17, "", false);
-        test("a{b}c", 1..1, "#", false);
-        test("a#{b}c", 1..2, "", false);
+        use Reparse::*;
+        // Tilde is useful because it always creates a distinct token, whereas
+        // spaces may join with adjacent text as one token.
+        test("abc~def~gh~", Edit::Range(5..6), "+", Incr("abc~d+f~"));
+        test("~~~~~~~", Edit::Range(3..4), "A", Incr("~~~A~~"));
+        test("abc~~", Edit::Match("b"), "", Incr("ac~"));
+        test("#var. hello", Edit::Match(" "), " ", All);
+        test("#var;hello", Edit::Range(9..10), "a", All);
+        test("https:/world", Edit::After("/"), "/", All);
+        test("hello  world", Edit::Match("world"), "walkers", All);
+        test("a d e", Edit::Match(" d"), " b c d", All);
+        test("~*~*~", Edit::At(2), "*", All);
+        test("::1\n2. a\n3", Edit::After(" "), "4", Incr("1\n2. 4a\n"));
+        test("* #{1+2} *", Edit::Match("2"), "3", Incr("{1+3}"));
+        test("#{(0, 1, 2)}", Edit::Match("1"), "11pt", Incr("{(0, 11pt, 2)}"));
+        test("\n= A heading", Edit::After("A"), "n evocative", All);
+        test("#call() abc~d", Edit::After("()"), "[]", Incr("#call()[] abc"));
+        test("a your thing a", Edit::Range(6..7), "a", All);
+        test("#grid(columns: (auto, 1fr, 40%))", Edit::Match("auto"), "4pt", All);
+        test(
+            "abc\n= a head\njoke",
+            Edit::Match("\n"),
+            "\nmore\n\n",
+            Incr("abc\nmore\n\n= a head\n"),
+        );
+        test("#show f: a => b..", Edit::End, "c", All);
+        test("#for", Edit::End, "//", All);
+        test("a\n#let \nb", Edit::At(7), "i", Incr("#let i\nb"));
+        test("#{{let x = z}; a = 1} b", Edit::At(7), "//", All);
+        test("a ```typst hello```", Edit::Range(16..17), "", All);
+        test("a{b}c", Edit::At(1), "#", All);
+        test("a#{b}c", Edit::Match("#"), "", All);
     }
 
+    /// Test incremental reparsing of code and content blocks.
     #[test]
     fn test_reparse_block() {
-        test("Hello #{ x + 1 }!", 9..10, "abc", true);
-        test("A#{}!", 3..3, "\"", false);
-        test("#{ [= x] }!", 5..5, "=", true);
-        test("#[[]]", 3..3, "\\", true);
-        test("#[[ab]]", 4..5, "\\", true);
-        test("#{}}", 2..2, "{", false);
-        test("A: #[BC]", 6..6, "{", true);
-        test("A: #[BC]", 6..6, "#{", true);
-        test("A: #[BC]", 6..6, "#{}", true);
-        test("#{\"ab\"}A", 5..5, "c", true);
-        test("#{\"ab\"}A", 5..6, "c", false);
-        test("a#[]b", 3..3, "#{", true);
-        test("a#{call(); abc}b", 8..8, "[]", true);
-        test("a #while x {\n g(x) \n}  b", 12..12, "//", true);
-        test("a#[]b", 3..3, "[hey]", true);
+        use Reparse::*;
+        test("Hello #{ x + 1 }!", Edit::Match("x"), "abc", Incr("{ abc + 1 }"));
+        test("A#{}!", Edit::After("{"), "\"", All);
+        test("#{ [= x] }!", Edit::After("="), "=", Incr("== x"));
+        test("#[[]]", Edit::At(3), "\\", Incr("[[\\]]"));
+        test("#[[ab]]", Edit::Match("b"), "\\", Incr("[[a\\]]"));
+        test("#{}}", Edit::After("{"), "{", All);
+        test("A: #[BC]", Edit::After("B"), "{", Incr("B{C"));
+        test("A: #[BC]", Edit::After("B"), "#{", Incr("B#{C"));
+        test("A: #[BC]", Edit::After("B"), "#{}", Incr("B#{}C"));
+        test("#{\"ab\"}A", Edit::At(5), "c", Incr("{\"abc\"}"));
+        test("#{\"ab\"}A", Edit::Range(5..6), "c", All);
+        test("a#[]b", Edit::After("["), "#{", Incr("[#{]"));
+        test("a#{call(); abc}b", Edit::At(8), "[]", Incr("{call([]); abc}"));
+        test(
+            "a #while x {\n g(x) \n}  b",
+            Edit::After("{"),
+            "//",
+            Incr("{//\n g(x) \n}"),
+        );
+        test("a#[]b", Edit::After("["), "[hey]", Incr("[[hey]]"));
     }
 }

--- a/crates/typst-syntax/src/reparser.rs
+++ b/crates/typst-syntax/src/reparser.rs
@@ -392,4 +392,24 @@ mod tests {
         );
         test("a#[]b", Edit::After("["), "[hey]", Incr("[[hey]]"));
     }
+
+    /// Test unclosed strings/blocks in embedded code.
+    #[test]
+    fn test_reparse_unclosed_embedded() {
+        use Reparse::*;
+        test("#\"a\nb\nc", Edit::End, "\"", All);
+        test("#return \"a\nb\nc", Edit::End, "\"", All);
+        test("#import \"@preview/pkg", Edit::End, "\"", All);
+        test("#import [a\nb\nc", Edit::End, "]", All);
+        test("#import $a\nb\nc", Edit::End, "$", All);
+        test("#set thing\"a\n", Edit::End, "\"", All);
+        test("#let x = \"a\nb\nc", Edit::End, "\"", All);
+        test("#let x = {\"a\nb\nc}", Edit::After("c"), "\"", Incr("{\"a\nb\nc\"}"));
+        test("#if x {\"a\nb\nc", Edit::End, "\"", All);
+        test("#if x \"a\nb\nc", Edit::End, "\"", All);
+        test("#if x \"a\nb\nc", Edit::After("x "), "{}", All);
+        test("#if x $a\nb\nc", Edit::End, "$", All);
+        test("#for x in \"a\nb\nc", Edit::End, "\"", All);
+        test("#for x \"a\nb\nc", Edit::After("x "), "in ", All);
+    }
 }

--- a/crates/typst-syntax/src/set.rs
+++ b/crates/typst-syntax/src/set.rs
@@ -89,16 +89,14 @@ pub const MATH_EXPR: SyntaxSet = syntax_set!(
 );
 
 /// Syntax kinds that can start a code expression.
-pub const CODE_EXPR: SyntaxSet = CODE_PRIMARY.union(UNARY_OP);
+///
+/// Underscores can only start an arrow function (`_ => {}`) or an assignment
+/// (`_ = x`).
+pub const CODE_EXPR: SyntaxSet =
+    ATOMIC_CODE_EXPR.union(UNARY_OP).add(SyntaxKind::Underscore);
 
 /// Syntax kinds that can start an atomic code expression.
-pub const ATOMIC_CODE_EXPR: SyntaxSet = ATOMIC_CODE_PRIMARY;
-
-/// Syntax kinds that can start a code primary.
-pub const CODE_PRIMARY: SyntaxSet = ATOMIC_CODE_PRIMARY.add(SyntaxKind::Underscore);
-
-/// Syntax kinds that can start an atomic code primary.
-pub const ATOMIC_CODE_PRIMARY: SyntaxSet = syntax_set!(
+pub const ATOMIC_CODE_EXPR: SyntaxSet = syntax_set!(
     Ident,
     LeftBrace,
     LeftBracket,

--- a/tests/suite/scripting/for.typ
+++ b/tests/suite/scripting/for.typ
@@ -133,3 +133,8 @@ A#for "v" thing
 
 // Error: 7 expected keyword `in`
 #for a + b in iter {}
+
+// Error: 1:8-4:1 unclosed string
+#for x "a
+b
+c

--- a/tests/suite/scripting/import.typ
+++ b/tests/suite/scripting/import.typ
@@ -491,3 +491,20 @@ This is never reached.
 --- import-from-file-package-lookalike eval ---
 // Error: 9-28 file not found (searched at tests/suite/scripting/#test/mypkg:1.0.0)
 #import "#test/mypkg:1.0.0": *
+
+--- issue-7393-import-error-string-unclosed eval ---
+// More dedicated tests for this are in `crates/typst-syntax/src/reparser.rs`
+// Error: 1:9-3:1 unclosed string
+#import "@preview/unify:0.1.0
+
+--- issue-7393-import-error-string-unclosed-newlines eval ---
+// Error: 1:9-5:1 unclosed string
+#import "a
+b
+c
+
+--- issue-7393-import-error-extra-quote eval ---
+// Error: 1:31-4:1 unclosed string
+#import "@preview/unify:0.1.0""a
+b
+c

--- a/tests/suite/scripting/ops.typ
+++ b/tests/suite/scripting/ops.typ
@@ -363,6 +363,22 @@
 // Error: 10 expected expression
 #test({2*}, 2)
 
+--- ops-bad-token-rhs eval ---
+// Error: 6 expected expression
+// Error: 7-10 invalid number suffix: p
+#(1 + 12p)
+// Error: 6 expected expression
+// Error: 7-8 the character `~` is not valid in code
+#(1 / ~)
+
+--- ops-bad-token-lhs eval ---
+// Error: 3-4 the character `\` is not valid in code
+// Error: 5-6 unexpected star
+#(\ * 1)
+// Error: 3-7 unclosed label
+// Error: 8-11 unexpected operator `and`
+#(<lbl and 1)
+
 --- ops-unary-plus-on-content eval ---
 // Error: 3-13 cannot apply unary '+' to content
 #(+([] + []))

--- a/tests/suite/scripting/ops.typ
+++ b/tests/suite/scripting/ops.typ
@@ -364,10 +364,8 @@
 #test({2*}, 2)
 
 --- ops-bad-token-rhs eval ---
-// Error: 6 expected expression
 // Error: 7-10 invalid number suffix: p
 #(1 + 12p)
-// Error: 6 expected expression
 // Error: 7-8 the character `~` is not valid in code
 #(1 / ~)
 


### PR DESCRIPTION
Closes #7393

The root of this issue was not in the reparser, but in how we would _intially_ parse unclosed strings at the end of code expressions.

When parsing the unclosed string in `#import "str`, we would produce this tree:
```
Markup: [
    Hash: "#",
    ModuleImport: [
        Import: "import",
        Error: "" (expected expression),
    ],
    Error: "" (expected semicolon or line break),
    Space: " ",
    SmartQuote: "\"",
    Text: "str",
]
```
The unclosed string is not included in the code expression as part of either error, and its contents are actually parsed as markup!

However, this only reveals itself as a problem when we later add a closing quote and attempt to reparse `#import "str"`. The reparser starts from the location the quote was added (treating the new quote as markup) and only reparses a small section of markup expressions, leaving the code mode errors unchanged.

### Fix

The first commit upgrades the testing framework for reparsing making it more explicit and more ergonomic to edit. The second commit adds tests and implements the fix for unclosed strings in the parser.

There are two changes in the second commit that need to happen together:

First is the change to `Parser::expected` to consume lexing errors instead of skipping them. This is the core fix and resolves every case of this error I was able to think of when looking through the parser.

However this is not particularly principled, and we really ought to add some kind of fuzz testing for incremental parsing to make sure this doesn't crop up again.

Second is the change to the `ATOMIC_CODE_PRIMARY` check in `embedded_code_expr`. This check called `p.unexpected()` and relied on the call to `p.expected("expression")` at the end of  `code_primary` (via `code_expr_prec`) not consuming erroneous tokens, which became an incorrect assumption given the first change. Luckily, moving the `p.unexpected()` call inwards to `code_primary` fully preserves the original behavior (since `p.unexpected()` calling `trim_errors` would remove the empty error caused by `p.expected("expression")`). This also removed any need for the `ATOMIC_CODE_PRIMARY` syntax set, so I removed it from `set.rs` for clarity.