### PR TITLE
Fix hypenation bug in words with apostrophe

### DIFF
--- a/crates/typst-layout/src/inline/linebreak.rs
+++ b/crates/typst-layout/src/inline/linebreak.rs
@@ -760,7 +760,7 @@ fn breakpoints(p: &Preparation, mut f: impl FnMut(usize, Breakpoint)) {
         // Hyphenate between the last and current breakpoint.
         if hyphenate && last < point {
             for segment in text[last..point].split_word_bounds() {
-                if !segment.is_empty() && segment.chars().all(char::is_alphabetic) {
+                if !segment.is_empty() && segment.chars().any(char::is_alphabetic) {
                     hyphenations(p, &lb, last, segment, &mut f);
                 }
                 last += segment.len();


### PR DESCRIPTION
Words with apostrophes should be hyphenated (example: "tomorrow's weather").  This is currently not done.

The patch to have that is super simple, just replace a `segment.chars().all` with `segment.chars().any`.

Please see [a discussion in the forum](https://forum.typst.app/t/is-hyphenation-disabled-in-words-with-apostrophes/6611/3) and [this issue](https://github.com/typst/typst/issues/7087).