### PR TITLE
Remove a redundant `()` in a doc example

### DIFF
--- a/crates/typst-library/src/foundations/int.rs
+++ b/crates/typst-library/src/foundations/int.rs
@@ -56,7 +56,7 @@ impl i64 {
     /// #int(2.7) \
     /// #int(decimal("3.8")) \
     /// #(int("27") + int("4")) \
-    /// #(int("beef", base: 16))
+    /// #int("beef", base: 16)
     /// ```
     #[func(constructor)]
     pub fn construct(


### PR DESCRIPTION
This is a trivial PR. Please see the file changed.

The example was added in #7386.

<!--
Thanks for your interest in landing a change in Typst! Before opening the PR, please review our contribution guidelines: https://github.com/typst/typst/blob/main/CONTRIBUTING.md

In particular, please keep in mind that we do not accept contributions implemented by an AI model. We would also ask you to refrain from using AI to write your pull request description. Summarizing your work helps organizing your thoughts as much as it helps us with seeing the human thought process behind a particular change.
-->
