### PR TITLE
Explain how to use multiple fonts in sub/superscript docs

### DIFF
--- a/crates/typst-library/src/text/shift.rs
+++ b/crates/typst-library/src/text/shift.rs
@@ -1,7 +1,7 @@
 use crate::introspection::Tagged;
 use ttf_parser::Tag;
 
-use crate::foundations::{elem, Content, Smart};
+use crate::foundations::{Content, Smart, elem};
 use crate::layout::{Em, Length};
 use crate::text::{FontMetrics, ScriptMetrics, TextSize};
 

--- a/crates/typst-library/src/text/shift.rs
+++ b/crates/typst-library/src/text/shift.rs
@@ -1,7 +1,7 @@
 use crate::introspection::Tagged;
 use ttf_parser::Tag;
 
-use crate::foundations::{Content, Smart, elem};
+use crate::foundations::{elem, Content, Smart};
 use crate::layout::{Em, Length};
 use crate::text::{FontMetrics, ScriptMetrics, TextSize};
 
@@ -42,6 +42,10 @@ pub struct SubElem {
     /// If set to `{auto}`, the baseline is shifted according to the metrics
     /// provided by the font, with a fallback to `{0.2em}` in case the font does
     /// not define the necessary metrics.
+    ///
+    /// When using multiple fonts, it might be necessary to set `baseline` and
+    /// [`size`]($sub.size) explicitly. See [`super`]($super.baseline) for an
+    /// example.
     pub baseline: Smart<Length>,
 
     /// The font size for synthesized subscripts.
@@ -101,6 +105,25 @@ pub struct SuperElem {
     /// Note that, since the baseline shift is applied downward, you will need
     /// to provide a negative value for the content to appear as raised above
     /// the normal baseline.
+    ///
+    /// Sometimes it is necessary to set `baseline` and [`size`]($super.size)
+    /// explicitly. In the following example, the superscripted text uses
+    /// multiple fonts with incompatible metrics. To avoid misalignment, we
+    /// override the metrics for all fonts.
+    ///
+    /// ```example
+    /// #let tz(timezone) = text(
+    ///   font: "Roboto",
+    ///   smallcaps(lower(timezone)),
+    /// )
+    ///
+    /// #set super(
+    ///   baseline: -0.4em,
+    ///   size: 0.6em,
+    ///   typographic: false,
+    /// )
+    /// 14:00#super[#tz[UTC], not #tz[CET]]
+    /// ```
     pub baseline: Smart<Length>,
 
     /// The font size for synthesized superscripts.

--- a/crates/typst-library/src/text/shift.rs
+++ b/crates/typst-library/src/text/shift.rs
@@ -117,6 +117,10 @@ pub struct SuperElem {
     ///   smallcaps(timezone, all: true),
     /// )
     ///
+    /// // Use metrics provided by each font
+    /// 0#super(tz[UTC]) vs. 0#super[not]
+    ///
+    /// // Override and unify the metrics
     /// #set super(
     ///   baseline: -0.4em,
     ///   size: 0.6em,

--- a/crates/typst-library/src/text/shift.rs
+++ b/crates/typst-library/src/text/shift.rs
@@ -114,7 +114,7 @@ pub struct SuperElem {
     /// ```example
     /// #let tz(timezone) = text(
     ///   font: "Roboto",
-    ///   smallcaps(lower(timezone)),
+    ///   smallcaps(timezone, all: true),
     /// )
     ///
     /// #set super(

--- a/crates/typst-library/src/text/shift.rs
+++ b/crates/typst-library/src/text/shift.rs
@@ -117,16 +117,16 @@ pub struct SuperElem {
     ///   smallcaps(timezone, all: true),
     /// )
     ///
-    /// // Use metrics provided by each font
-    /// 0#super(tz[UTC]) vs. 0#super[not]
+    /// / Per-font metrics:
+    ///   14:00#super[#tz[UTC], not #tz[CET]]
     ///
-    /// // Override and unify the metrics
     /// #set super(
     ///   baseline: -0.4em,
     ///   size: 0.6em,
     ///   typographic: false,
     /// )
-    /// 14:00#super[#tz[UTC], not #tz[CET]]
+    /// / Unified metrics:
+    ///   14:00#super[#tz[UTC], not #tz[CET]]
     /// ```
     pub baseline: Smart<Length>,
 


### PR DESCRIPTION
Resolves #8090

The baseline and size of sub/superscripts are determined by the font.
If you use multiple fonts with incompatible metrics, then the result will be poor, unless the metrics are overridden.

It looks like a bug, but there's nothing that Typst can do. Therefore, I'm submitting this PR.

## About the added example

<img width="400" alt="图片" src="https://github.com/user-attachments/assets/3215b432-0efe-4f52-8132-5898b2855ef1" />


<details>
<summary>Outdated screenshots</summary>


<img width="200" alt="图片" src="https://github.com/user-attachments/assets/cf40ec90-8781-46d7-bd17-3bca5e14f8a7" />

With `set super(…)`:

<img width="200" alt="图片" src="https://github.com/user-attachments/assets/826ebd48-2bf3-4389-ba0c-f52a7013f8da" />

Without `set super(…)`:

<img width="200" alt="图片" src="https://github.com/user-attachments/assets/65012200-1c44-45bb-b41d-43c9b507df2e" />

</details>

The example added in this PR is kind of atypical, but I can't come up with better ones.
In the original scenario that triggered this problem, the superscript contained both Chinese and English, so it was natural to use multiple fonts (_KaiTi_ for Chinese and _TeX Gyre Termes_ for English).
However, fonts in typst-assets and typst-dev-assets are quite limited. 
It looks like _Roboto_ and _Ubuntu_ are the only two text fonts (excluding math, emoji, and programming fonts) that have metrics incompatible with other fonts.


<details><summary>Fonts in typst-dev-assets and their metrics</summary>

```sh
fd -t f -x sh -c 'echo ======= {} ======== && ttx -t head -t OS/2 -o - {} | rg "unit|SuperscriptY"' > a.log
```

```xml
======= ./IBMPlexSans-Regular.ttf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="600"/>
    <ySuperscriptYOffset value="350"/>
======= ./IBMPlexSansDevanagari-Regular.ttf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="600"/>
    <ySuperscriptYOffset value="350"/>
======= ./IBMPlexMath-Regular.otf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="600"/>
    <ySuperscriptYOffset value="350"/>
======= ./IBMPlexSerif-Regular.ttf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="600"/>
    <ySuperscriptYOffset value="350"/>
======= ./CascadiaCode-Regular.ttf ========
    <unitsPerEm value="2048"/>
    <ySuperscriptYSize value="1229"/>
    <ySuperscriptYOffset value="717"/>
======= ./IBMPlexSans-Bold.ttf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="600"/>
    <ySuperscriptYOffset value="350"/>
======= ./Concrete-Math.otf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="699"/>
    <ySuperscriptYOffset value="479"/>
======= ./Asana-Math.otf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="699"/>
    <ySuperscriptYOffset value="360"/>
======= ./Garamond-Math.otf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="699"/>
    <ySuperscriptYOffset value="479"/>
======= ./IBMPlexSans-Light.ttf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="600"/>
    <ySuperscriptYOffset value="350"/>
======= ./IBMPlexSans-Medium.ttf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="600"/>
    <ySuperscriptYOffset value="350"/>
======= ./InriaSerif-BoldItalic.ttf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="600"/>
    <ySuperscriptYOffset value="350"/>
======= ./IBMPlexSansCondensed-Regular.ttf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="600"/>
    <ySuperscriptYOffset value="350"/>
======= ./NotoSansArabic-Regular.ttf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="600"/>
    <ySuperscriptYOffset value="350"/>
======= ./InriaSerif-Regular.ttf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="600"/>
    <ySuperscriptYOffset value="350"/>
======= ./InriaSerif-Bold.ttf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="600"/>
    <ySuperscriptYOffset value="350"/>
======= ./NotoSansThai-Regular.ttf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="600"/>
    <ySuperscriptYOffset value="350"/>
======= ./NotoSansSymbols2-Regular.ttf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="600"/>
    <ySuperscriptYOffset value="350"/>
======= ./LibertinusMath-Regular.otf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="600"/>
    <ySuperscriptYOffset value="350"/>
======= ./InriaSerif-Italic.ttf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="600"/>
    <ySuperscriptYOffset value="350"/>
======= ./NotoSansMath-Regular.ttf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="600"/>
    <ySuperscriptYOffset value="350"/>
======= ./NotoSerifCJKjp-Regular.otf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="600"/>
    <ySuperscriptYOffset value="350"/>
======= ./NotoColorEmoji-Regular-COLR.subset.ttf ========
    <unitsPerEm value="1024"/>
    <ySuperscriptYSize value="614"/>
    <ySuperscriptYOffset value="358"/>
======= ./NotoSerifHebrew-Regular.ttf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="600"/>
    <ySuperscriptYOffset value="350"/>
======= ./NotoSerifHebrew-Bold.ttf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="600"/>
    <ySuperscriptYOffset value="350"/>
======= ./NotoSerifCJKtc-Regular.otf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="600"/>
    <ySuperscriptYOffset value="350"/>
======= ./NotoSerifCJKtc-Bold.otf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="600"/>
    <ySuperscriptYOffset value="350"/>
======= ./NotoSerifCJKsc-Regular.otf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="600"/>
    <ySuperscriptYOffset value="350"/>
======= ./NotoSerifCJKsc-Bold.otf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="600"/>
    <ySuperscriptYOffset value="350"/>
======= ./PTSans-Regular.ttf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="600"/>
    <ySuperscriptYOffset value="350"/>
======= ./Roboto-Regular.ttf ========
    <unitsPerEm value="2048"/>
    <ySuperscriptYSize value="1331"/>
    <ySuperscriptYOffset value="977"/>
======= ./STIXTwoMath-Regular.otf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="500"/>
    <ySuperscriptYOffset value="500"/>
======= ./NotoSerifCJKkr-Regular.otf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="600"/>
    <ySuperscriptYOffset value="350"/>
======= ./SourceSerif4-Regular.otf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="600"/>
    <ySuperscriptYOffset value="350"/>
======= ./TwitterColorEmoji.ttf ========
    <unitsPerEm value="2048"/>
    <ySuperscriptYSize value="1433"/>
    <ySuperscriptYOffset value="983"/>
======= ./XITSMath-Regular.otf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="500"/>
    <ySuperscriptYOffset value="500"/>
======= ./texgyrebonum-math.otf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="699"/>
    <ySuperscriptYOffset value="479"/>
======= ./PennstanderMath-Regular.otf ========
    <unitsPerEm value="2000"/>
    <ySuperscriptYSize value="1200"/>
    <ySuperscriptYOffset value="700"/>
======= ./Ubuntu-Regular.ttf ========
    <unitsPerEm value="1000"/>
    <ySuperscriptYSize value="650"/>
    <ySuperscriptYOffset value="477"/>
```

</details>

<details><summary>Fonts in typst-dev-assets and their metrics, organized by AI</summary>

| unitsPerEm | ySuperscriptYSize | ySuperscriptYOffset | Fonts |
|------------|------------------|--------------------|-----------|
| 1000 | 600 | 350 | IBMPlexSans-Regular, IBMPlexSansDevanagari-Regular, IBMPlexMath-Regular, IBMPlexSerif-Regular, IBMPlexSans-Bold, IBMPlexSans-Light, IBMPlexSans-Medium, InriaSerif-BoldItalic, IBMPlexSansCondensed-Regular, NotoSansArabic-Regular, InriaSerif-Regular, InriaSerif-Bold, NotoSansThai-Regular, NotoSansSymbols2-Regular, LibertinusMath-Regular, InriaSerif-Italic, NotoSansMath-Regular, NotoSerifCJKjp-Regular, NotoSerifHebrew-Regular, NotoSerifHebrew-Bold, NotoSerifCJKtc-Regular, NotoSerifCJKtc-Bold, NotoSerifCJKsc-Regular, NotoSerifCJKsc-Bold, PTSans-Regular, NotoSerifCJKkr-Regular, SourceSerif4-Regular |
| 1000 | 699 | 479 | Concrete-Math, Garamond-Math, texgyrebonum-math |
| 1000 | 699 | 360 | Asana-Math |
| 1000 | 500 | 500 | STIXTwoMath-Regular, XITSMath-Regular |
| 1000 | 650 | 477 | **Ubuntu**-Regular |
| 1024 | 614 | 358 | NotoColorEmoji-Regular-COLR.subset |
| 2000 | 1200 | 700 | PennstanderMath-Regular |
| 2048 | 1229 | 717 | CascadiaCode-Regular |
| 2048 | 1331 | 977 | **Roboto**-Regular |
| 2048 | 1433 | 983 | TwitterColorEmoji |

</details>

<!--
Thanks for your interest in landing a change in Typst! Before opening the PR, please review our contribution guidelines: https://github.com/typst/typst/blob/main/CONTRIBUTING.md

In particular, please keep in mind that we do not accept contributions implemented by an AI model. We would also ask you to refrain from using AI to write your pull request description. Summarizing your work helps organizing your thoughts as much as it helps us with seeing the human thought process behind a particular change.
-->
