### PR TITLE
Document that the resulting size may not match the given `{accent,stretch}.size`

### DIFF
--- a/crates/typst-library/src/math/accent.rs
+++ b/crates/typst-library/src/math/accent.rs
@@ -72,8 +72,25 @@ pub struct AccentElem {
 
     /// The size of the accent, relative to the width of the base.
     ///
-    /// ```example
+    /// ```example:"Basic usage"
     /// $dash(A, size: #150%)$
+    /// ```
+    ///
+    /// Note that the resulting accent may not have the exact desired size. For
+    /// example, an arrow may be either a pre-defined short glyph, or a long
+    /// glyph assembled from building blocks (arrowhead + line) provided by the
+    /// font. The sizes of the two possibilities may not cover the entire span.
+    /// Consequently, arrows of certain intermediate sizes cannot be constructed.
+    ///
+    /// ```example:"Size of arrow growing discontinuously"
+    /// >>> #set par(spacing: 0.3em)
+    /// #for i in range(6) {
+    ///   $ arrow(#box(
+    ///     width: 0.4em + 0.3em * i,
+    ///     fill: aqua,
+    ///     height: 0.4em,
+    ///   )) $
+    /// }
     /// ```
     #[default(Rel::one())]
     pub size: Rel<Length>,

--- a/crates/typst-library/src/math/attach.rs
+++ b/crates/typst-library/src/math/attach.rs
@@ -132,10 +132,9 @@ pub struct StretchElem {
     /// #for size in (
     ///   100%, // short
     ///   101%, 200%, // tall
-    ///   201%, 300%, 400%, 500%, 600%, // grande
+    ///   201%, 300%, 400%, 500%, 600%, // taller
     /// ) {
     ///   $stretch(integral, size: #size)$
-    ///   h(-0.3em, weak: true)
     /// }
     /// ```
     #[default(Rel::one())]

--- a/crates/typst-library/src/math/attach.rs
+++ b/crates/typst-library/src/math/attach.rs
@@ -119,6 +119,25 @@ pub struct StretchElem {
 
     /// The size to stretch to, relative to the maximum size of the glyph and
     /// its attachments.
+    ///
+    /// Note that the resulting glyph may not have the exact desired size. A
+    /// stretched glyph may be either a pre-defined glyph, or a glyph assembled
+    /// from building blocks provided by the font. The possible sizes may not
+    /// cover the entire span. In the example below, when the `size` parameter
+    /// is increased from `{101%}` to `{200%}`, the selected glyph remains the
+    /// same, so the actual size does not change.
+    ///
+    /// ```example:"Size of ∫ growing discontinuously"
+    /// >>> #set align(center)
+    /// #for size in (
+    ///   100%, // short
+    ///   101%, 200%, // tall
+    ///   201%, 300%, 400%, 500%, 600%, // grande
+    /// ) {
+    ///   $stretch(integral, size: #size)$
+    ///   h(-0.3em, weak: true)
+    /// }
+    /// ```
     #[default(Rel::one())]
     pub size: Rel<Length>,
 }


### PR DESCRIPTION
This was discussed many times before. Links can be found in https://github.com/typst/typst/issues/7956#issuecomment-4081957252.

If there is no plan to change this behavior, then I think #7796 can be closed by this PR.

Reference:

- https://learn.microsoft.com/en-us/typography/opentype/spec/math#math-variants
- https://github.com/notofonts/math/blob/main/documentation/building-math-fonts/index.md#size-variants

<!--
Thanks for your interest in landing a change in Typst! Before opening the PR, please review our contribution guidelines: https://github.com/typst/typst/blob/main/CONTRIBUTING.md

In particular, please keep in mind that we do not accept contributions implemented by an AI model. We would also ask you to refrain from using AI to write your pull request description. Summarizing your work helps organizing your thoughts as much as it helps us with seeing the human thought process behind a particular change.
-->
