### PR TITLE
Fix crash in within selector

### DIFF
--- a/crates/typst-library/src/introspection/introspector.rs
+++ b/crates/typst-library/src/introspection/introspector.rs
@@ -315,6 +315,14 @@ impl<P> ElementIntrospector<P> {
                         Err(i) => i,
                     };
 
+                    // If the ancestor is fully contained in one of the list
+                    // elements, we exclude the list element from both the start
+                    // and end, leading to `end < start``.
+                    if end_in_list < start_in_list {
+                        debug_assert_eq!(end_in_list + 1, start_in_list);
+                        continue;
+                    }
+
                     // Clamp at `visited` to ensure we don't yield elements
                     // twice.
                     let start_in_list = start_in_list.max(visited);

--- a/tests/suite/introspection/query.typ
+++ b/tests/suite/introspection/query.typ
@@ -290,9 +290,17 @@ What's *up* with *you?*
 #test-selector(selector-within(heading, <a>), ([1], [2], [3]))
 #test-selector(selector-within(heading, <b>), ([4], [5]))
 
---- query-bundle-logical-order bundle ---
-#let m(s) = [#metadata(s) <hi>]
+--- query-within-inverted paged empty ---
+// Test a case where the ancestor is fully contained in one of the children.
+#let m(l) = [#metadata(none)#l]
+#strong({
+  m(<a>)
+  m(<b>)
+  m(<c>)
+})
+#context test(query(selector-within(strong, <b>)), ())
 
+--- query-bundle-logical-order bundle ---
 #metadata(1)
 #document("hi.html")[
   #metadata("a")


### PR DESCRIPTION
When a matching element for the ancestor part of a within selector was fully contained in one of the supposed descendants, `query` would crash because `end_in_list < start_in_list`. 