### PR TITLE
Fix math function tooltips/completions, and add `MathFieldAccess` and `LinkedNode::mode`

### DIFF
--- a/crates/typst-eval/src/call.rs
+++ b/crates/typst-eval/src/call.rs
@@ -42,7 +42,14 @@ impl Eval for ast::FuncCall<'_> {
             } else {
                 (target_expr.eval(vm)?, None)
             };
-            match eval_field_callee(vm, access, target, false)? {
+            match eval_field_callee(
+                vm,
+                access.to_untyped(),
+                field.as_str(),
+                field.span(),
+                target,
+                false,
+            )? {
                 FieldCallee::Func(func) => {
                     let args = match maybe_args {
                         Some(args) => args,
@@ -91,7 +98,7 @@ fn eval_math_call(vm: &mut Vm, math_call: ast::MathCall) -> SourceResult<Value> 
     vm.engine.route.check_call_depth().at(span)?;
 
     let math_call_result = match callee {
-        ast::MathCallee::MathIdent(ident) => {
+        ast::MathAccess::MathIdent(ident) => {
             let callee_value = ident.eval(vm)?;
             // We need to call `trace_at` for the callee manually because we did
             // not evaluate via `ast::Expr::eval()`.
@@ -101,7 +108,7 @@ fn eval_math_call(vm: &mut Vm, math_call: ast::MathCall) -> SourceResult<Value> 
                 Err(err) => FieldCallee::NonFunc(callee_value, err),
             }
         }
-        ast::MathCallee::FieldAccess(access) => {
+        ast::MathAccess::MathFieldAccess(access) => {
             let target_expr = access.target();
             target_span = target_expr.span();
             let field = access.field();
@@ -126,7 +133,14 @@ fn eval_math_call(vm: &mut Vm, math_call: ast::MathCall) -> SourceResult<Value> 
                         math_call.to_untyped().clone().into_text();
                 );
             }
-            eval_field_callee(vm, access, target, true)?
+            eval_field_callee(
+                vm,
+                access.to_untyped(),
+                field.as_str(),
+                field.span(),
+                target,
+                true,
+            )?
         }
     };
 
@@ -225,13 +239,12 @@ enum FieldCallee {
 ///   e.g. `(at: x => ...).at(key)`.
 fn eval_field_callee<'a, 'b>(
     vm: &'a mut Vm<'b>,
-    access: ast::FieldAccess,
+    access: &SyntaxNode,
+    field: &str,
+    field_span: Span,
     target: Value,
     in_math: bool,
 ) -> SourceResult<FieldCallee> {
-    let field_node = access.field();
-    let field_span = field_node.span();
-    let field = field_node.as_str();
     let sink = (&mut vm.engine, field_span);
 
     let mut is_method_call = false;
@@ -251,7 +264,7 @@ fn eval_field_callee<'a, 'b>(
         target.field(field, sink).at(field_span)?
     } else {
         // Otherwise we cannot call this field and produce an error.
-        let full_text = || access.to_untyped().clone().into_text();
+        let full_text = || access.clone().into_text();
         match target.field(field, sink) {
             // The field does exist.
             Ok(callee_value) => {
@@ -479,7 +492,7 @@ impl Eval for ast::MathArgs<'_> {
 fn unparse_math_args(
     vm: &mut Vm,
     args: ast::MathArgs,
-    callee: ast::MathCallee,
+    callee: ast::MathAccess,
 ) -> SourceResult<Content> {
     let mut body = Vec::new();
     let mut errors = EcoVec::new();
@@ -726,6 +739,9 @@ impl<'a> CapturesVisitor<'a> {
 
             // Don't capture the field of a field access.
             Some(ast::Expr::FieldAccess(access)) => {
+                self.visit(access.target().to_untyped());
+            }
+            Some(ast::Expr::MathFieldAccess(access)) => {
                 self.visit(access.target().to_untyped());
             }
 

--- a/crates/typst-eval/src/call.rs
+++ b/crates/typst-eval/src/call.rs
@@ -313,9 +313,7 @@ fn eval_field_callee<'a, 'b>(
         }
     };
 
-    if vm.inspected == Some(access.span()) {
-        vm.trace(callee_value.clone());
-    }
+    vm.trace_at(access.span(), &callee_value);
 
     match callee_value.clone().cast::<Func>() {
         Ok(func) if is_method_call => Ok(FieldCallee::Method(func, target)),

--- a/crates/typst-eval/src/call.rs
+++ b/crates/typst-eval/src/call.rs
@@ -93,6 +93,9 @@ fn eval_math_call(vm: &mut Vm, math_call: ast::MathCall) -> SourceResult<Value> 
     let math_call_result = match callee {
         ast::MathCallee::MathIdent(ident) => {
             let callee_value = ident.eval(vm)?;
+            // We need to call `trace_at` for the callee manually because we did
+            // not evaluate via `ast::Expr::eval()`.
+            vm.trace_at(ident.span(), &callee_value);
             match callee_value.clone().cast::<Func>() {
                 Ok(func) => FieldCallee::Func(func),
                 Err(err) => FieldCallee::NonFunc(callee_value, err),

--- a/crates/typst-eval/src/code.rs
+++ b/crates/typst-eval/src/code.rs
@@ -6,6 +6,7 @@ use typst_library::foundations::{
     NativeElement, Selector, Str, Value, ops,
 };
 use typst_library::introspection::{Counter, State};
+use typst_syntax::Span;
 use typst_syntax::ast::{self, AstNode};
 use typst_utils::singleton;
 
@@ -101,6 +102,7 @@ impl Eval for ast::Expr<'_> {
             Self::Math(v) => v.eval(vm).map(Value::Content),
             Self::MathText(v) => v.eval(vm).map(Value::Content),
             Self::MathIdent(v) => v.eval(vm),
+            Self::MathFieldAccess(v) => v.eval(vm),
             Self::MathShorthand(v) => v.eval(vm),
             Self::MathAlignPoint(v) => v.eval(vm).map(Value::Content),
             Self::MathCall(v) => v.eval(vm),
@@ -347,31 +349,39 @@ impl Eval for ast::FieldAccess<'_> {
     type Output = Value;
 
     fn eval(self, vm: &mut Vm) -> SourceResult<Self::Output> {
-        let value = self.target().eval(vm)?;
+        let target = self.target().eval(vm)?;
         let field = self.field();
-        let field_span = field.span();
-
-        let err = match value.field(&field, (&mut vm.engine, field_span)).at(field_span) {
-            Ok(value) => return Ok(value),
-            Err(err) => err,
-        };
-
-        // Check whether this is a get rule field access.
-        if let Value::Func(func) = &value
-            && let Some(element) = func.to_element()
-            && let Some(id) = element.field_id(&field)
-            && let styles = vm.context.styles().at(field.span())
-            && let Ok(value) = element
-                .field_from_styles(id, styles.as_ref().map(|&s| s).unwrap_or_default())
-        {
-            // Only validate the context once we know that this is indeed
-            // a field from the style chain.
-            let _ = styles?;
-            return Ok(value);
-        }
-
-        Err(err)
+        access_field(vm, target, field.as_str(), field.span())
     }
+}
+
+/// Access a field on a target value.
+pub(crate) fn access_field(
+    vm: &mut Vm,
+    target: Value,
+    field: &str,
+    field_span: Span,
+) -> SourceResult<Value> {
+    let err = match target.field(field, (&mut vm.engine, field_span)).at(field_span) {
+        Ok(value) => return Ok(value),
+        Err(err) => err,
+    };
+
+    // Check whether this is a get rule field access.
+    if let Value::Func(func) = &target
+        && let Some(element) = func.to_element()
+        && let Some(id) = element.field_id(field)
+        && let styles = vm.context.styles().at(field_span)
+        && let Ok(value) =
+            element.field_from_styles(id, styles.as_ref().map(|&s| s).unwrap_or_default())
+    {
+        // Only validate the contextual styles once we know that this is indeed
+        // a field from the style chain.
+        let _ = styles?;
+        return Ok(value);
+    }
+
+    Err(err)
 }
 
 impl Eval for ast::Contextual<'_> {

--- a/crates/typst-eval/src/code.rs
+++ b/crates/typst-eval/src/code.rs
@@ -79,7 +79,7 @@ impl Eval for ast::Expr<'_> {
             error!(span, "{} is only allowed directly in code and content blocks", name)
         };
 
-        let v = match self {
+        let value = match self {
             Self::Text(v) => v.eval(vm).map(Value::Content),
             Self::Space(v) => v.eval(vm).map(Value::Content),
             Self::Linebreak(v) => v.eval(vm).map(Value::Content),
@@ -143,11 +143,11 @@ impl Eval for ast::Expr<'_> {
         }?
         .spanned(span);
 
-        if vm.inspected == Some(span) {
-            vm.trace(v.clone());
-        }
+        // This satisfies the obligation to call `Vm::trace` for almost all
+        // value-producing expressions!
+        vm.trace_at(span, &value);
 
-        Ok(v)
+        Ok(value)
     }
 }
 

--- a/crates/typst-eval/src/lib.rs
+++ b/crates/typst-eval/src/lib.rs
@@ -68,7 +68,7 @@ pub fn eval(
     let root = source.root();
     let mut vm = Vm::new(engine, context.track(), scopes, root.span());
 
-    // Check for well-formedness unless we are in trace mode.
+    // Require the syntax to be well-formed unless we are tracing a span.
     let errors = root.errors();
     if !errors.is_empty() && vm.inspected.is_none() {
         return Err(errors.into_iter().map(Into::into).collect());

--- a/crates/typst-eval/src/math.rs
+++ b/crates/typst-eval/src/math.rs
@@ -56,6 +56,31 @@ impl Eval for ast::MathIdent<'_> {
     }
 }
 
+impl Eval for ast::MathFieldAccess<'_> {
+    type Output = Value;
+
+    fn eval(self, vm: &mut Vm) -> SourceResult<Self::Output> {
+        let target = self.target().eval(vm)?;
+        let field = self.field();
+        crate::code::access_field(vm, target, field.as_str(), field.span())
+    }
+}
+
+impl Eval for ast::MathAccess<'_> {
+    type Output = Value;
+
+    fn eval(self, vm: &mut Vm) -> SourceResult<Self::Output> {
+        let value = match self {
+            ast::MathAccess::MathIdent(ident) => ident.eval(vm)?,
+            ast::MathAccess::MathFieldAccess(access) => access.eval(vm)?,
+        };
+        // We need to call `trace_at` for the value because we did not evaluate
+        // via `ast::Expr::eval()`.
+        vm.trace_at(self.span(), &value);
+        Ok(value)
+    }
+}
+
 impl Eval for ast::MathShorthand<'_> {
     type Output = Value;
 

--- a/crates/typst-eval/src/vm.rs
+++ b/crates/typst-eval/src/vm.rs
@@ -20,7 +20,8 @@ pub struct Vm<'a> {
     pub flow: Option<FlowEvent>,
     /// The stack of scopes.
     pub scopes: Scopes<'a>,
-    /// A span that is currently under inspection.
+    /// A span that is currently under inspection. If this is `Some`, we're in
+    /// tracing mode, and will record every value the given span sees.
     pub inspected: Option<Span>,
     /// Data that is contextually made accessible to code behind the scenes.
     pub context: Tracked<'a, Context<'a>>,
@@ -55,9 +56,7 @@ impl<'a> Vm<'a> {
     /// This will insert the value into the top-most scope and make it available
     /// for dynamic tracing, assisting IDE functionality.
     pub fn bind(&mut self, var: ast::Ident, binding: Binding) {
-        if self.inspected == Some(var.span()) {
-            self.trace(binding.read().clone());
-        }
+        self.trace_at(var.span(), binding.read());
 
         // This will become an error in the parser if `is` becomes a keyword.
         if var.get() == "is" {
@@ -73,12 +72,22 @@ impl<'a> Vm<'a> {
         self.scopes.top.bind(var.get().clone(), binding);
     }
 
-    /// Trace a value.
+    /// Helper to only call [`Self::trace`] for a value if we're inspecting its
+    /// span. This method (or `trace`) should be called for every value produced
+    /// by an expression.
+    pub fn trace_at(&mut self, span: Span, value: &Value) {
+        if self.inspected == Some(span) {
+            self.trace(value.clone());
+        }
+    }
+
+    /// Trace a value. Tracing powers IDE tooltips and hover info. This method
+    /// should be called for every value produced by an expression.
     #[cold]
     pub fn trace(&mut self, value: Value) {
         self.engine
             .sink
-            .value(value.clone(), self.context.styles().ok().map(|s| s.to_map()));
+            .value(value, self.context.styles().ok().map(|s| s.to_map()));
     }
 }
 

--- a/crates/typst-ide/src/analyze.rs
+++ b/crates/typst-ide/src/analyze.rs
@@ -33,7 +33,10 @@ pub fn analyze_expr(
             }
 
             if let Some(parent) = node.parent()
-                && parent.kind() == SyntaxKind::FieldAccess
+                && matches!(
+                    parent.kind(),
+                    SyntaxKind::FieldAccess | SyntaxKind::MathFieldAccess
+                )
                 && node.index() > 0
             {
                 return analyze_expr(world, parent);

--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -300,6 +300,8 @@ fn complete_math(ctx: &mut CompletionContext) -> bool {
         ctx.leaf.parent_kind(),
         Some(SyntaxKind::Equation)
             | Some(SyntaxKind::Math)
+            | Some(SyntaxKind::MathCall)
+            | Some(SyntaxKind::MathArgs)
             | Some(SyntaxKind::MathFrac)
             | Some(SyntaxKind::MathAttach)
     ) {
@@ -321,10 +323,7 @@ fn complete_math(ctx: &mut CompletionContext) -> bool {
     }
 
     // Behind existing atom or identifier: "$a|$" or "$abc|$".
-    if matches!(
-        ctx.leaf.kind(),
-        SyntaxKind::Text | SyntaxKind::MathText | SyntaxKind::MathIdent
-    ) {
+    if matches!(ctx.leaf.kind(), SyntaxKind::MathText | SyntaxKind::MathIdent) {
         ctx.from = ctx.leaf.offset();
         math_completions(ctx);
         return true;
@@ -663,6 +662,11 @@ fn show_rule_recipe_completions(ctx: &mut CompletionContext) {
 }
 
 /// Complete call and set rule parameters.
+///
+/// FUTURE: Make this work for math functions. This will require a much deeper
+/// refactoring of `param_completions` below, including handling 2d arguments
+/// correctly and ensuring we add a hash in math when suggesting to insert
+/// values that aren't strings.
 fn complete_params(ctx: &mut CompletionContext) -> bool {
     // Ensure that we are in a function call or set rule's argument list.
     let (callee, set, args, args_linked) = if let Some(parent) = ctx.leaf.parent()
@@ -868,16 +872,16 @@ fn path_completion(func: &Func, param: &ParamInfo) -> Option<&'static [&'static 
 
 /// Complete in code mode.
 fn complete_code(ctx: &mut CompletionContext) -> bool {
-    if matches!(
+    debug_assert!(!matches!(
         ctx.leaf.parent_kind(),
         None | Some(SyntaxKind::Markup)
             | Some(SyntaxKind::Math)
+            | Some(SyntaxKind::MathCall)
+            | Some(SyntaxKind::MathArgs)
             | Some(SyntaxKind::MathFrac)
             | Some(SyntaxKind::MathAttach)
             | Some(SyntaxKind::MathRoot)
-    ) {
-        return false;
-    }
+    ));
 
     // An existing identifier: "{ pa| }".
     // Ignores named pair keys as they are not variables (as in "(pa|: 23)").
@@ -1680,7 +1684,10 @@ mod tests {
 
     #[test]
     fn test_autocomplete_hash_expr() {
+        test("#", -1).must_include(["int", "if conditional"]);
         test("#i", -1).must_include(["int", "if conditional"]);
+        test("$#$", -2).must_include(["int", "if conditional"]);
+        test("$#i$", -2).must_include(["int", "if conditional"]);
     }
 
     #[test]
@@ -1703,6 +1710,38 @@ mod tests {
     fn test_autocomplete_math_scope() {
         test("$#col$", -2).must_include(["colbreak"]).must_exclude(["colon"]);
         test("$col$", -2).must_include(["colon"]).must_exclude(["colbreak"]);
+        test("$(col)$", -3).must_include(["colon"]).must_exclude(["colbreak"]);
+        test("$1/col$", -2).must_include(["colon"]).must_exclude(["colbreak"]);
+    }
+
+    /// Basic tests for field access autocompletion in code and math.
+    #[test]
+    fn test_autocomplete_field_access() {
+        test("#assert.", -1).must_include(["eq", "ne"]);
+        test("$#assert.$", -2).must_include(["eq", "ne"]);
+        // Note that we still include `ne` even though we've started typing.
+        test("#assert.e", -1).must_include(["eq", "ne"]);
+        test("#(assert.e)", -2).must_include(["eq", "ne"]);
+        test("$#assert.e$", -2).must_include(["eq", "ne"]);
+        test("$#std.assert.e$", -2)
+            .must_include(["eq", "ne"])
+            .must_exclude(["lt"]);
+        test("$std.assert.e$", -2)
+            .must_include(["eq", "ne"])
+            .must_exclude(["lt"]);
+    }
+
+    /// Test autocomplete inside math function call arguments.
+    #[test]
+    fn test_autocomplete_math_func_call() {
+        test("$f(#pi)$", -3).must_include(["box"]).must_exclude(["pi"]);
+        test("$f(pi)$", -3).must_include(["pi"]).must_exclude(["box"]);
+        test("$pi()$", -4).must_include(["pi"]).must_exclude(["box"]);
+        test("$pi(pi)$", -3).must_include(["pi"]).must_exclude(["box"]);
+        test("$vec(pi)$", -3).must_include(["pi"]).must_exclude(["box"]);
+        // TODO: Fix named/spread args:
+        // test("$vec(size:pi)$", -3).must_include(["pi"]).must_exclude(["box"]);
+        // test("$vec(..pi)$", -3).must_include(["pi"]).must_exclude(["box"]);
     }
 
     /// Test that the `before_window` doesn't slice into invalid byte

--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -111,214 +111,6 @@ pub enum CompletionKind {
     Symbol(EcoString),
 }
 
-/// Complete in markup mode.
-fn complete_markup(ctx: &mut CompletionContext) -> bool {
-    debug_assert_eq!(ctx.leaf.mode_after(), Some(SyntaxMode::Markup));
-
-    // Start of a reference: "@|".
-    if ctx.leaf.kind() == SyntaxKind::Text && ctx.before.ends_with("@") {
-        ctx.from = ctx.cursor;
-        ctx.label_completions();
-        return true;
-    }
-
-    // An existing reference: "@he|".
-    if ctx.leaf.kind() == SyntaxKind::RefMarker {
-        ctx.from = ctx.leaf.offset() + 1;
-        ctx.label_completions();
-        return true;
-    }
-
-    // Behind a half-completed binding: "#let x = |".
-    if let Some(prev) = ctx.leaf.prev_leaf()
-        && prev.kind() == SyntaxKind::Eq
-        && prev.parent_kind() == Some(SyntaxKind::LetBinding)
-    {
-        ctx.from = ctx.cursor;
-        code_completions(ctx, false);
-        return true;
-    }
-
-    // Behind a half-completed context block: "#context |".
-    if let Some(prev) = ctx.leaf.prev_leaf()
-        && prev.kind() == SyntaxKind::Context
-    {
-        ctx.from = ctx.cursor;
-        code_completions(ctx, false);
-        return true;
-    }
-
-    // Directly after a raw block.
-    let mut s = Scanner::new(ctx.text);
-    s.jump(ctx.leaf.offset());
-    if s.eat_if("```") {
-        s.eat_while('`');
-        let start = s.cursor();
-        if s.eat_if(is_id_start) {
-            s.eat_while(is_id_continue);
-        }
-        if s.cursor() == ctx.cursor {
-            ctx.from = start;
-            ctx.raw_completions();
-        }
-        return true;
-    }
-
-    // Anywhere: "|".
-    if ctx.explicit {
-        ctx.from = ctx.cursor;
-        markup_completions(ctx);
-        return true;
-    }
-
-    false
-}
-
-/// Add completions for markup snippets.
-#[rustfmt::skip]
-fn markup_completions(ctx: &mut CompletionContext) {
-    ctx.snippet_completion(
-        "expression",
-        "#${}",
-        "Variables, function calls, blocks, and more.",
-    );
-
-    ctx.snippet_completion(
-        "linebreak",
-        "\\\n${}",
-        "Inserts a forced linebreak.",
-    );
-
-    ctx.snippet_completion(
-        "strong text",
-        "*${strong}*",
-        "Strongly emphasizes content by increasing the font weight.",
-    );
-
-    ctx.snippet_completion(
-        "emphasized text",
-        "_${emphasized}_",
-        "Emphasizes content by setting it in italic font style.",
-    );
-
-    ctx.snippet_completion(
-        "raw text",
-        "`${text}`",
-        "Displays text verbatim, in monospace.",
-    );
-
-    ctx.snippet_completion(
-        "code listing",
-        "```${lang}\n${code}\n```",
-        "Inserts computer code with syntax highlighting.",
-    );
-
-    ctx.snippet_completion(
-        "hyperlink",
-        "https://${example.com}",
-        "Links to a URL.",
-    );
-
-    ctx.snippet_completion(
-        "label",
-        "<${name}>",
-        "Makes the preceding element referenceable.",
-    );
-
-    ctx.snippet_completion(
-        "reference",
-        "@${name}",
-        "Inserts a reference to a label.",
-    );
-
-    ctx.snippet_completion(
-        "heading",
-        "= ${title}",
-        "Inserts a section heading.",
-    );
-
-    ctx.snippet_completion(
-        "list item",
-        "- ${item}",
-        "Inserts an item of a bullet list.",
-    );
-
-    ctx.snippet_completion(
-        "enumeration item",
-        "+ ${item}",
-        "Inserts an item of a numbered list.",
-    );
-
-    ctx.snippet_completion(
-        "enumeration item (numbered)",
-        "${number}. ${item}",
-        "Inserts an explicitly numbered list item.",
-    );
-
-    ctx.snippet_completion(
-        "term list item",
-        "/ ${term}: ${description}",
-        "Inserts an item of a term list.",
-    );
-
-    ctx.snippet_completion(
-        "math (inline)",
-        "$${x}$",
-        "Inserts an inline-level mathematical equation.",
-    );
-
-    ctx.snippet_completion(
-        "math (block)",
-        "$ ${sum_x^2} $",
-        "Inserts a block-level mathematical equation.",
-    );
-}
-
-/// Complete in math mode.
-fn complete_math(ctx: &mut CompletionContext) -> bool {
-    debug_assert_eq!(ctx.leaf.mode_after(), Some(SyntaxMode::Math));
-
-    // Behind existing atom or identifier: "$a|$" or "$abc|$".
-    if matches!(ctx.leaf.kind(), SyntaxKind::MathText | SyntaxKind::MathIdent) {
-        ctx.from = ctx.leaf.offset();
-        math_completions(ctx);
-        return true;
-    }
-
-    // Anywhere: "$|$".
-    if ctx.explicit {
-        ctx.from = ctx.cursor;
-        math_completions(ctx);
-        return true;
-    }
-
-    false
-}
-
-/// Add completions for math snippets.
-#[rustfmt::skip]
-fn math_completions(ctx: &mut CompletionContext) {
-    ctx.scope_completions(true, |_| true);
-
-    ctx.snippet_completion(
-        "subscript",
-        "${x}_${2:2}",
-        "Sets something in subscript.",
-    );
-
-    ctx.snippet_completion(
-        "superscript",
-        "${x}^${2:2}",
-        "Sets something in superscript.",
-    );
-
-    ctx.snippet_completion(
-        "fraction",
-        "${x}/${y}",
-        "Inserts a fraction.",
-    );
-}
-
 /// Complete field accesses.
 fn complete_field_accesses(ctx: &mut CompletionContext) -> bool {
     let (after_dot, textual_dot) = match ctx.leaf.kind() {
@@ -827,6 +619,214 @@ fn path_completion(func: &Func, param: &ParamInfo) -> Option<&'static [&'static 
         (None, "path") => &[],
         _ => return None,
     })
+}
+
+/// Complete in markup mode.
+fn complete_markup(ctx: &mut CompletionContext) -> bool {
+    debug_assert_eq!(ctx.leaf.mode_after(), Some(SyntaxMode::Markup));
+
+    // Start of a reference: "@|".
+    if ctx.leaf.kind() == SyntaxKind::Text && ctx.before.ends_with("@") {
+        ctx.from = ctx.cursor;
+        ctx.label_completions();
+        return true;
+    }
+
+    // An existing reference: "@he|".
+    if ctx.leaf.kind() == SyntaxKind::RefMarker {
+        ctx.from = ctx.leaf.offset() + 1;
+        ctx.label_completions();
+        return true;
+    }
+
+    // Behind a half-completed binding: "#let x = |".
+    if let Some(prev) = ctx.leaf.prev_leaf()
+        && prev.kind() == SyntaxKind::Eq
+        && prev.parent_kind() == Some(SyntaxKind::LetBinding)
+    {
+        ctx.from = ctx.cursor;
+        code_completions(ctx, false);
+        return true;
+    }
+
+    // Behind a half-completed context block: "#context |".
+    if let Some(prev) = ctx.leaf.prev_leaf()
+        && prev.kind() == SyntaxKind::Context
+    {
+        ctx.from = ctx.cursor;
+        code_completions(ctx, false);
+        return true;
+    }
+
+    // Directly after a raw block.
+    let mut s = Scanner::new(ctx.text);
+    s.jump(ctx.leaf.offset());
+    if s.eat_if("```") {
+        s.eat_while('`');
+        let start = s.cursor();
+        if s.eat_if(is_id_start) {
+            s.eat_while(is_id_continue);
+        }
+        if s.cursor() == ctx.cursor {
+            ctx.from = start;
+            ctx.raw_completions();
+        }
+        return true;
+    }
+
+    // Anywhere: "|".
+    if ctx.explicit {
+        ctx.from = ctx.cursor;
+        markup_completions(ctx);
+        return true;
+    }
+
+    false
+}
+
+/// Add completions for markup snippets.
+#[rustfmt::skip]
+fn markup_completions(ctx: &mut CompletionContext) {
+    ctx.snippet_completion(
+        "expression",
+        "#${}",
+        "Variables, function calls, blocks, and more.",
+    );
+
+    ctx.snippet_completion(
+        "linebreak",
+        "\\\n${}",
+        "Inserts a forced linebreak.",
+    );
+
+    ctx.snippet_completion(
+        "strong text",
+        "*${strong}*",
+        "Strongly emphasizes content by increasing the font weight.",
+    );
+
+    ctx.snippet_completion(
+        "emphasized text",
+        "_${emphasized}_",
+        "Emphasizes content by setting it in italic font style.",
+    );
+
+    ctx.snippet_completion(
+        "raw text",
+        "`${text}`",
+        "Displays text verbatim, in monospace.",
+    );
+
+    ctx.snippet_completion(
+        "code listing",
+        "```${lang}\n${code}\n```",
+        "Inserts computer code with syntax highlighting.",
+    );
+
+    ctx.snippet_completion(
+        "hyperlink",
+        "https://${example.com}",
+        "Links to a URL.",
+    );
+
+    ctx.snippet_completion(
+        "label",
+        "<${name}>",
+        "Makes the preceding element referenceable.",
+    );
+
+    ctx.snippet_completion(
+        "reference",
+        "@${name}",
+        "Inserts a reference to a label.",
+    );
+
+    ctx.snippet_completion(
+        "heading",
+        "= ${title}",
+        "Inserts a section heading.",
+    );
+
+    ctx.snippet_completion(
+        "list item",
+        "- ${item}",
+        "Inserts an item of a bullet list.",
+    );
+
+    ctx.snippet_completion(
+        "enumeration item",
+        "+ ${item}",
+        "Inserts an item of a numbered list.",
+    );
+
+    ctx.snippet_completion(
+        "enumeration item (numbered)",
+        "${number}. ${item}",
+        "Inserts an explicitly numbered list item.",
+    );
+
+    ctx.snippet_completion(
+        "term list item",
+        "/ ${term}: ${description}",
+        "Inserts an item of a term list.",
+    );
+
+    ctx.snippet_completion(
+        "math (inline)",
+        "$${x}$",
+        "Inserts an inline-level mathematical equation.",
+    );
+
+    ctx.snippet_completion(
+        "math (block)",
+        "$ ${sum_x^2} $",
+        "Inserts a block-level mathematical equation.",
+    );
+}
+
+/// Complete in math mode.
+fn complete_math(ctx: &mut CompletionContext) -> bool {
+    debug_assert_eq!(ctx.leaf.mode_after(), Some(SyntaxMode::Math));
+
+    // Behind existing atom or identifier: "$a|$" or "$abc|$".
+    if matches!(ctx.leaf.kind(), SyntaxKind::MathText | SyntaxKind::MathIdent) {
+        ctx.from = ctx.leaf.offset();
+        math_completions(ctx);
+        return true;
+    }
+
+    // Anywhere: "$|$".
+    if ctx.explicit {
+        ctx.from = ctx.cursor;
+        math_completions(ctx);
+        return true;
+    }
+
+    false
+}
+
+/// Add completions for math snippets.
+#[rustfmt::skip]
+fn math_completions(ctx: &mut CompletionContext) {
+    ctx.scope_completions(true, |_| true);
+
+    ctx.snippet_completion(
+        "subscript",
+        "${x}_${2:2}",
+        "Sets something in subscript.",
+    );
+
+    ctx.snippet_completion(
+        "superscript",
+        "${x}^${2:2}",
+        "Sets something in superscript.",
+    );
+
+    ctx.snippet_completion(
+        "fraction",
+        "${x}/${y}",
+        "Inserts a fraction.",
+    );
 }
 
 /// Complete in code mode.

--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -304,6 +304,7 @@ fn complete_math(ctx: &mut CompletionContext) -> bool {
             | Some(SyntaxKind::MathArgs)
             | Some(SyntaxKind::MathFrac)
             | Some(SyntaxKind::MathAttach)
+            | Some(SyntaxKind::MathFieldAccess)
     ) {
         return false;
     }
@@ -397,7 +398,10 @@ fn complete_field_accesses(ctx: &mut CompletionContext) -> bool {
         && let Some((value, styles)) =
             analyze_expr(ctx.world, &prev_prev).into_iter().next()
     {
-        debug_assert_eq!(ctx.leaf.parent_kind(), Some(SyntaxKind::FieldAccess));
+        debug_assert!(matches!(
+            ctx.leaf.parent_kind(),
+            Some(SyntaxKind::FieldAccess | SyntaxKind::MathFieldAccess),
+        ));
         ctx.from = ctx.leaf.offset();
         field_access_completions(ctx, &value, &styles);
         return true;
@@ -881,6 +885,7 @@ fn complete_code(ctx: &mut CompletionContext) -> bool {
             | Some(SyntaxKind::MathFrac)
             | Some(SyntaxKind::MathAttach)
             | Some(SyntaxKind::MathRoot)
+            | Some(SyntaxKind::MathFieldAccess)
     ));
 
     // An existing identifier: "{ pa| }".

--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -11,8 +11,8 @@ use typst::foundations::{
 use typst::layout::{Alignment, Dir};
 use typst::syntax::ast::AstNode;
 use typst::syntax::{
-    FileId, LinkedNode, Side, Source, SyntaxKind, ast, is_id_continue, is_id_start,
-    is_ident,
+    FileId, LinkedNode, Side, Source, SyntaxKind, SyntaxMode, ast, is_id_continue,
+    is_id_start, is_ident,
 };
 use typst::text::{FontFlags, RawElem};
 use typst::visualize::Color;
@@ -51,15 +51,20 @@ pub fn autocomplete(
         explicit,
     )?;
 
-    let _ = complete_comments(&mut ctx)
-        || complete_field_accesses(&mut ctx)
+    // Getting the syntax mode also ensures we are not in a comment.
+    let mode = ctx.leaf.mode_after()?;
+
+    _ = complete_field_accesses(&mut ctx)
         || complete_open_labels(&mut ctx)
         || complete_imports(&mut ctx)
         || complete_rules(&mut ctx)
         || complete_params(&mut ctx)
-        || complete_markup(&mut ctx)
-        || complete_math(&mut ctx)
-        || complete_code(&mut ctx);
+        // Only attempt the general completions after the more specific ones.
+        || match mode {
+            SyntaxMode::Markup => complete_markup(&mut ctx),
+            SyntaxMode::Math => complete_math(&mut ctx),
+            SyntaxMode::Code => complete_code(&mut ctx),
+        };
 
     Some((ctx.from, ctx.completions))
 }
@@ -106,34 +111,9 @@ pub enum CompletionKind {
     Symbol(EcoString),
 }
 
-/// Complete in comments. Or rather, don't!
-fn complete_comments(ctx: &mut CompletionContext) -> bool {
-    matches!(ctx.leaf.kind(), SyntaxKind::LineComment | SyntaxKind::BlockComment)
-}
-
 /// Complete in markup mode.
 fn complete_markup(ctx: &mut CompletionContext) -> bool {
-    // Bail if we aren't even in markup.
-    if !matches!(
-        ctx.leaf.parent_kind(),
-        None | Some(SyntaxKind::Markup) | Some(SyntaxKind::Ref)
-    ) {
-        return false;
-    }
-
-    // Start of an interpolated identifier: "#|".
-    if ctx.leaf.kind() == SyntaxKind::Hash {
-        ctx.from = ctx.cursor;
-        code_completions(ctx, true);
-        return true;
-    }
-
-    // An existing identifier: "#pa|".
-    if ctx.leaf.kind() == SyntaxKind::Ident {
-        ctx.from = ctx.leaf.offset();
-        code_completions(ctx, true);
-        return true;
-    }
+    debug_assert_eq!(ctx.leaf.mode_after(), Some(SyntaxMode::Markup));
 
     // Start of a reference: "@|".
     if ctx.leaf.kind() == SyntaxKind::Text && ctx.before.ends_with("@") {
@@ -296,32 +276,7 @@ fn markup_completions(ctx: &mut CompletionContext) {
 
 /// Complete in math mode.
 fn complete_math(ctx: &mut CompletionContext) -> bool {
-    if !matches!(
-        ctx.leaf.parent_kind(),
-        Some(SyntaxKind::Equation)
-            | Some(SyntaxKind::Math)
-            | Some(SyntaxKind::MathCall)
-            | Some(SyntaxKind::MathArgs)
-            | Some(SyntaxKind::MathFrac)
-            | Some(SyntaxKind::MathAttach)
-            | Some(SyntaxKind::MathFieldAccess)
-    ) {
-        return false;
-    }
-
-    // Start of an interpolated identifier: "$#|$".
-    if ctx.leaf.kind() == SyntaxKind::Hash {
-        ctx.from = ctx.cursor;
-        code_completions(ctx, true);
-        return true;
-    }
-
-    // Behind existing interpolated identifier: "$#pa|$".
-    if ctx.leaf.kind() == SyntaxKind::Ident {
-        ctx.from = ctx.leaf.offset();
-        code_completions(ctx, true);
-        return true;
-    }
+    debug_assert_eq!(ctx.leaf.mode_after(), Some(SyntaxMode::Math));
 
     // Behind existing atom or identifier: "$a|$" or "$abc|$".
     if matches!(ctx.leaf.kind(), SyntaxKind::MathText | SyntaxKind::MathIdent) {
@@ -876,17 +831,15 @@ fn path_completion(func: &Func, param: &ParamInfo) -> Option<&'static [&'static 
 
 /// Complete in code mode.
 fn complete_code(ctx: &mut CompletionContext) -> bool {
-    debug_assert!(!matches!(
-        ctx.leaf.parent_kind(),
-        None | Some(SyntaxKind::Markup)
-            | Some(SyntaxKind::Math)
-            | Some(SyntaxKind::MathCall)
-            | Some(SyntaxKind::MathArgs)
-            | Some(SyntaxKind::MathFrac)
-            | Some(SyntaxKind::MathAttach)
-            | Some(SyntaxKind::MathRoot)
-            | Some(SyntaxKind::MathFieldAccess)
-    ));
+    debug_assert_eq!(ctx.leaf.mode_after(), Some(SyntaxMode::Code));
+
+    // Start of embedded code in markup or math: "[#|]", "$#|$".
+    // (if not in markup or math, the kind would be an `Error`).
+    if ctx.leaf.kind() == SyntaxKind::Hash {
+        ctx.from = ctx.cursor;
+        code_completions(ctx, true);
+        return true;
+    }
 
     // An existing identifier: "{ pa| }".
     // Ignores named pair keys as they are not variables (as in "(pa|: 23)").
@@ -895,13 +848,6 @@ fn complete_code(ctx: &mut CompletionContext) -> bool {
     {
         ctx.from = ctx.leaf.offset();
         code_completions(ctx, false);
-        return true;
-    }
-
-    // A potential label (only at the start of an argument list): "(<|".
-    if ctx.before.ends_with("(<") {
-        ctx.from = ctx.cursor;
-        ctx.label_completions();
         return true;
     }
 
@@ -1748,9 +1694,8 @@ mod tests {
         test("$pi()$", -4).must_include(["pi"]).must_exclude(["box"]);
         test("$pi(pi)$", -3).must_include(["pi"]).must_exclude(["box"]);
         test("$vec(pi)$", -3).must_include(["pi"]).must_exclude(["box"]);
-        // TODO: Fix named/spread args:
-        // test("$vec(size:pi)$", -3).must_include(["pi"]).must_exclude(["box"]);
-        // test("$vec(..pi)$", -3).must_include(["pi"]).must_exclude(["box"]);
+        test("$vec(size:pi)$", -3).must_include(["pi"]).must_exclude(["box"]);
+        test("$vec(..pi)$", -3).must_include(["pi"]).must_exclude(["box"]);
     }
 
     /// Test that the `before_window` doesn't slice into invalid byte

--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -365,21 +365,20 @@ fn math_completions(ctx: &mut CompletionContext) {
 
 /// Complete field accesses.
 fn complete_field_accesses(ctx: &mut CompletionContext) -> bool {
-    // Used to determine whether trivia nodes are allowed before '.'.
-    // During an inline expression in markup mode trivia nodes exit the inline expression.
-    let in_markup: bool = matches!(
-        ctx.leaf.parent_kind(),
-        None | Some(SyntaxKind::Markup) | Some(SyntaxKind::Ref)
-    );
+    let (after_dot, textual_dot) = match ctx.leaf.kind() {
+        SyntaxKind::Dot => (true, false),
+        SyntaxKind::Text | SyntaxKind::MathText if ctx.leaf.text() == "." => (true, true),
+        _ => (false, false),
+    };
 
-    // Behind an expression plus dot: "emoji.|".
-    if (ctx.leaf.kind() == SyntaxKind::Dot
-        || (matches!(ctx.leaf.kind(), SyntaxKind::Text | SyntaxKind::MathText)
-            && ctx.leaf.text() == "."))
-        && ctx.leaf.range().end == ctx.cursor
+    // After an expression plus a dot: "emoji.|".
+    if after_dot
         && let Some(prev) = ctx.leaf.prev_sibling()
-        && (!in_markup || prev.range().end == ctx.leaf.range().start)
-        && prev.is::<ast::Expr>()
+        // We don't complete when we had trivia between the previous node
+        // and a textual dot: `[#x .|]`
+        && (!textual_dot || prev.range().end == ctx.leaf.range().start)
+        && prev.is::<ast::Expr>() // The dot must comes after an expression.
+        // And that expression must allow field access
         && (prev.parent_kind() != Some(SyntaxKind::Markup)
             || prev.prev_sibling_kind() == Some(SyntaxKind::Hash))
         && let Some((value, styles)) = analyze_expr(ctx.world, &prev).into_iter().next()
@@ -389,8 +388,8 @@ fn complete_field_accesses(ctx: &mut CompletionContext) -> bool {
         return true;
     }
 
-    // Behind a started field access: "emoji.fa|".
-    if ctx.leaf.kind() == SyntaxKind::Ident
+    // After a started field access: "emoji.fa|".
+    if matches!(ctx.leaf.kind(), SyntaxKind::Ident | SyntaxKind::MathIdent)
         && let Some(prev) = ctx.leaf.prev_sibling()
         && prev.kind() == SyntaxKind::Dot
         && let Some(prev_prev) = prev.prev_sibling()
@@ -398,6 +397,7 @@ fn complete_field_accesses(ctx: &mut CompletionContext) -> bool {
         && let Some((value, styles)) =
             analyze_expr(ctx.world, &prev_prev).into_iter().next()
     {
+        debug_assert_eq!(ctx.leaf.parent_kind(), Some(SyntaxKind::FieldAccess));
         ctx.from = ctx.leaf.offset();
         field_access_completions(ctx, &value, &styles);
         return true;
@@ -1696,13 +1696,17 @@ mod tests {
         test("#{ let x = (1, 2, 3); x. }", -3).must_include(["at", "push", "pop"]);
     }
 
-    /// Test that extra space before '.' is handled correctly.
+    /// Test that extra spaces before a '.' don't cause autocompletion in markup
+    /// or math.
     #[test]
-    fn test_autocomplete_whitespace() {
+    fn test_autocomplete_dot_whitespace() {
         test("#() .", -1).must_exclude(["insert", "remove", "len", "all"]);
         test("#{() .}", -2).must_include(["insert", "remove", "len", "all"]);
+        test("$#() .$", -2).must_exclude(["insert", "remove", "len", "all"]);
+        test("$std.array .$", -2).must_exclude(["insert", "remove", "len", "all"]);
         test("#() .a", -1).must_exclude(["insert", "remove", "len", "all"]);
         test("#{() .a}", -2).must_include(["at", "any", "all"]);
+        test("$std.array .a$", -2).must_exclude(["insert", "remove", "len", "all"]);
     }
 
     /// Test that autocomplete in math uses the correct global scope.

--- a/crates/typst-ide/src/matchers.rs
+++ b/crates/typst-ide/src/matchers.rs
@@ -236,9 +236,10 @@ pub fn deref_target(node: LinkedNode<'_>) -> Option<DerefTarget<'_>> {
         ast::Expr::SetRule(set) => {
             DerefTarget::Callee(expr_node.find(set.target().span())?)
         }
-        ast::Expr::Ident(_) | ast::Expr::MathIdent(_) | ast::Expr::FieldAccess(_) => {
-            DerefTarget::VarAccess(expr_node)
-        }
+        ast::Expr::Ident(_)
+        | ast::Expr::FieldAccess(_)
+        | ast::Expr::MathIdent(_)
+        | ast::Expr::MathFieldAccess(_) => DerefTarget::VarAccess(expr_node),
         ast::Expr::Str(_) => {
             let parent = expr_node.parent()?;
             if parent.kind() == SyntaxKind::ModuleImport {

--- a/crates/typst-ide/src/tooltip.rs
+++ b/crates/typst-ide/src/tooltip.rs
@@ -60,8 +60,13 @@ fn expr_tooltip(world: &dyn IdeWorld, leaf: &LinkedNode) -> Option<Tooltip> {
     let expr = ancestor.cast::<ast::Expr>()?;
     // We only analyze embeddable code expressions or math expressions that
     // access variables.
-    let analyze =
-        expr.hash() || matches!(expr, ast::Expr::MathIdent(_) | ast::Expr::MathCall(_));
+    let analyze = expr.hash()
+        || matches!(
+            expr,
+            ast::Expr::MathIdent(_)
+                | ast::Expr::MathFieldAccess(_)
+                | ast::Expr::MathCall(_)
+        );
     if !analyze {
         return None;
     }

--- a/crates/typst-ide/src/tooltip.rs
+++ b/crates/typst-ide/src/tooltip.rs
@@ -58,7 +58,11 @@ fn expr_tooltip(world: &dyn IdeWorld, leaf: &LinkedNode) -> Option<Tooltip> {
     }
 
     let expr = ancestor.cast::<ast::Expr>()?;
-    if !expr.hash() && !matches!(expr, ast::Expr::MathIdent(_)) {
+    // We only analyze embeddable code expressions or math expressions that
+    // access variables.
+    let analyze =
+        expr.hash() || matches!(expr, ast::Expr::MathIdent(_) | ast::Expr::MathCall(_));
+    if !analyze {
         return None;
     }
 
@@ -199,15 +203,16 @@ fn named_param_tooltip(world: &dyn IdeWorld, leaf: &LinkedNode) -> Option<Toolti
         if let Some(parent) = leaf.parent()
         && let Some(named) = parent.cast::<ast::Named>()
         && let Some(grand) = parent.parent()
-        && matches!(grand.kind(), SyntaxKind::Args)
+        && matches!(grand.kind(), SyntaxKind::Args | SyntaxKind::MathArgs)
         && let Some(grand_grand) = grand.parent()
         && let Some(expr) = grand_grand.cast::<ast::Expr>()
-        && let Some(callee) = match expr {
-            ast::Expr::FuncCall(call) => Some(call.callee()),
-            ast::Expr::SetRule(set) => Some(set.target()),
+        && let Some(callee_span) = match expr {
+            ast::Expr::FuncCall(call) => Some(call.callee().span()),
+            ast::Expr::MathCall(call) => Some(call.callee().span()),
+            ast::Expr::SetRule(set) => Some(set.target().span()),
             _ => None,
         }
-        && let Some(callee) = grand_grand.find(callee.span())
+        && let Some(callee) = grand_grand.find(callee_span)
 
         // Find metadata about the function.
         && let Some(value) = analyze_expr_with_fallback(world, &callee)
@@ -284,8 +289,11 @@ mod tests {
     type Response = Option<Tooltip>;
 
     trait ResponseExt {
+        /// Assert that there is no tooltip.
         fn must_be_none(&self) -> &Self;
+        /// Assert that the tooltip equals the given message.
         fn must_be_text(&self, text: &str) -> &Self;
+        /// Assert that the tooltip equals the given code.
         fn must_be_code(&self, code: &str) -> &Self;
     }
 
@@ -323,6 +331,139 @@ mod tests {
         test("#let x = 1 + 2", -1, Side::After).must_be_none();
         test("#let x = 1 + 2", 5, Side::After).must_be_code("3");
         test("#let x = 1 + 2", 6, Side::Before).must_be_code("3");
+    }
+
+    /// Literal values don't get a tooltip, just idenfitifers.
+    #[test]
+    fn test_tooltip_math_literals() {
+        let world = "$x'^2 &!= \\u{3C0} \"is\" pi #true$";
+        test(world, 0 /*  $  */, Side::After).must_be_none();
+        test(world, 1 /*  x  */, Side::After).must_be_none();
+        test(world, 2 /*  '  */, Side::After).must_be_none();
+        test(world, 3 /*  ^  */, Side::After).must_be_none();
+        test(world, 4 /*  2  */, Side::After).must_be_none();
+        test(world, 5 /*     */, Side::After).must_be_none();
+        test(world, 6 /*  &  */, Side::After).must_be_none();
+        test(world, 7 /*  != */, Side::After).must_be_none();
+        test(world, 10 /* \\ */, Side::After).must_be_none();
+        test(world, 11 /* u  */, Side::After).must_be_none();
+        test(world, 12 /* {  */, Side::After).must_be_none();
+        test(world, 13 /* 3  */, Side::After).must_be_none();
+        test(world, 19 /* \" */, Side::After).must_be_none();
+        test(world, 20 /* is */, Side::After).must_be_none();
+        test(world, 24 /* pi */, Side::After)
+            .must_be_code("symbol(\"π\", (\"alt\", \"ϖ\"))");
+        test(world, 27 /* \# */, Side::After).must_be_none();
+        test(world, 28 /*true*/, Side::After).must_be_none();
+    }
+
+    #[test]
+    fn test_tooltip_math_field_access() {
+        test("$pi.alt$", 1, Side::After).must_be_code("symbol(\"π\", (\"alt\", \"ϖ\"))");
+        test("$pi.alt$", 3, Side::After).must_be_code("symbol(\"ϖ\")");
+        test("$pi.alt$", 4, Side::After).must_be_code("symbol(\"ϖ\")");
+    }
+
+    #[test]
+    fn test_tooltip_set() {
+        let box_desc = "An inline-level container that sizes content.";
+        let fill_desc = "The box's background color.";
+        let red = "rgb(\"#ff4136\")";
+        test("#set box(fill: red,)", 0 /*#*/, Side::After).must_be_none();
+        test("#set box(fill: red,)", 1 /*s*/, Side::After).must_be_none();
+        test("#set box(fill: red,)", 5 /*b*/, Side::After).must_be_text(box_desc);
+        test("#set box(fill: red,)", 8 /*(*/, Side::After).must_be_none();
+        test("#set box(fill: red,)", 9 /*f*/, Side::After).must_be_text(fill_desc);
+        test("#set box(fill: red,)", 13 /*:*/, Side::After).must_be_none();
+        test("#set box(fill: red,)", 15 /*r*/, Side::After).must_be_code(red);
+        test("#set box(fill: red,)", 18 /*,*/, Side::After).must_be_none();
+        test("#set box(fill: red,)", 19 /*)*/, Side::After).must_be_none();
+    }
+
+    #[test]
+    fn test_tooltip_function_call() {
+        let box_desc = "An inline-level container that sizes content.";
+        // Function value
+        test("#box", 0 /*#*/, Side::After).must_be_none();
+        test("#box", 1 /*b*/, Side::After).must_be_text(box_desc);
+        test("#(box)", 0 /*#*/, Side::After).must_be_none();
+        test("#(box)", 1 /*(*/, Side::After).must_be_text(box_desc);
+        test("#(box)", 2 /*b*/, Side::After).must_be_text(box_desc);
+        test("#(box)", 5 /*)*/, Side::After).must_be_text(box_desc);
+        // Basic call
+        test("#box()", 1 /*b*/, Side::After).must_be_text(box_desc);
+        test("#box()", 4 /*(*/, Side::After).must_be_code("box()");
+        test("#box()", 5 /*)*/, Side::After).must_be_code("box()");
+        // Field access call
+        test("#std.box()", 1 /*s*/, Side::After).must_be_code("<module global>");
+        test("#std.box()", 4 /*.*/, Side::After).must_be_text(box_desc);
+        test("#std.box()", 5 /*b*/, Side::After).must_be_text(box_desc);
+        test("#std.box()", 8 /*(*/, Side::After).must_be_code("box()");
+        // Positional args and trailing comma
+        test("#box([],)", 4 /*(*/, Side::After).must_be_code("box(body: [])");
+        test("#box([],)", 5 /*[*/, Side::After).must_be_code("[]");
+        test("#box([],)", 6 /*]*/, Side::After).must_be_code("[]");
+        test("#box([],)", 7 /*,*/, Side::After).must_be_code("box(body: [])");
+        test("#box([],)", 8 /*)*/, Side::After).must_be_code("box(body: [])");
+        // Content args
+        test("#box[]", 4 /*[*/, Side::After).must_be_code("[]");
+        test("#box[]", 5 /*]*/, Side::After).must_be_code("[]");
+        // Named args
+        let fill_desc = "The box's background color.";
+        let red_box = "box(fill: rgb(\"#ff4136\"))";
+        test("#box(fill:red,)", 5 /*f*/, Side::After).must_be_text(fill_desc);
+        test("#box(fill:red,)", 9 /*:*/, Side::After).must_be_code(red_box);
+        test("#box(fill:red,)", 10 /*r*/, Side::After).must_be_code("rgb(\"#ff4136\")");
+        test("#box(fill:red,)", 13 /*,*/, Side::After).must_be_code(red_box);
+        // Spread args
+        test("#box(..none,)", 5 /*.*/, Side::After).must_be_code("box()");
+        test("#box(..none,)", 7 /*(*/, Side::After).must_be_none();
+        test("#box(..none,)", 11 /*,*/, Side::After).must_be_code("box()");
+        test("#box(..([],))", 5 /*.*/, Side::After).must_be_code("box(body: [])");
+        test("#box(..([],))", 7 /*(*/, Side::After).must_be_code("([],)");
+    }
+
+    #[test]
+    fn test_tooltip_math_function_call() {
+        // Content plus parens
+        test("$f(x)$", 1 /*f*/, Side::After).must_be_none();
+        test("$f(x)$", 2 /*(*/, Side::After).must_be_none();
+        test("$f(x)$", 3 /*x*/, Side::After).must_be_none();
+        test("$sin()$", 1 /*s*/, Side::After)
+            .must_be_code("op(text: [sin], limits: false)");
+        // Actual function call + empty arg + trailing comma
+        let vec_z = "vec(children: ([ℤ], []))";
+        test("$vec(ZZ, ,)$", 1 /*v*/, Side::After).must_be_text("A column vector.");
+        test("$vec(ZZ, ,)$", 4 /*(*/, Side::After).must_be_code(vec_z);
+        test("$vec(ZZ, ,)$", 5 /*Z*/, Side::After).must_be_code("symbol(\"ℤ\")");
+        test("$vec(ZZ, ,)$", 7 /*,*/, Side::After).must_be_code(vec_z);
+        test("$vec(ZZ, ,)$", 8 /* */, Side::After).must_be_none();
+        test("$vec(ZZ, ,)$", 9 /*,*/, Side::After).must_be_code(vec_z);
+        test("$vec(ZZ, ,)$", 10 /*)*/, Side::After).must_be_code(vec_z);
+        // Named args
+        let vec_gap = "vec(gap: 0% + 1em, children: ())";
+        test("$vec(gap:#1em)$", 5 /*g*/, Side::After)
+            .must_be_text("The gap between elements.");
+        test("$vec(gap:#1em)$", 8 /*:*/, Side::After).must_be_code(vec_gap);
+        test("$vec(gap:#1em)$", 10 /*1*/, Side::After).must_be_none();
+        // 2d args and spread args
+        let mat = "mat(rows: (([1],), ([2],)))";
+        test("$mat(1; ..#([2],))$", 1 /*m*/, Side::After).must_be_text("A matrix.");
+        test("$mat(1; ..#([2],))$", 5 /*1*/, Side::After).must_be_none();
+        test("$mat(1; ..#([2],))$", 6 /*;*/, Side::After).must_be_code(mat);
+        test("$mat(1; ..#([2],))$", 8 /*.*/, Side::After).must_be_code(mat);
+        test("$mat(1; ..#([2],))$", 10 /*#*/, Side::After).must_be_code(mat);
+        test("$mat(1; ..#([2],))$", 11 /*(*/, Side::After).must_be_code("([2],)");
+        // Symbol function and named arg
+        test("$hat(i,size:#1em)$", 1, Side::After).must_be_code("symbol(\"^\")");
+        test("$hat(i,size:#1em)$", 7, Side::After)
+            .must_be_text("The size of the accent, relative to the width of the base.");
+        // Field access call
+        let box_desc = "An inline-level container that sizes content.";
+        test("$std.box()$", 1 /*s*/, Side::After).must_be_code("<module global>");
+        test("$std.box()$", 4 /*.*/, Side::After).must_be_text(box_desc);
+        test("$std.box()$", 5 /*b*/, Side::After).must_be_text(box_desc);
+        test("$std.box()$", 8 /*(*/, Side::After).must_be_code("box()");
     }
 
     #[test]
@@ -386,5 +527,15 @@ mod tests {
         test(&world, -17, Side::After).must_be_text("A useful function.");
         // Named parameter.
         test(&world, -7, Side::After).must_be_text("Tree with three slashes.");
+    }
+
+    #[test]
+    fn test_tooltip_user_function_in_math() {
+        let world = TestWorld::new("#import \"lib.typ\"\n$lib.foo(none, tree: 2)$")
+            .with_source("lib.typ", crate::tests::EXAMPLE_CLOSURE);
+        // Function itself.
+        test(&world, -18, Side::After).must_be_text("A useful function.");
+        // Named parameter.
+        test(&world, -8, Side::After).must_be_text("Tree with three slashes.");
     }
 }

--- a/crates/typst-ide/src/utils.rs
+++ b/crates/typst-ide/src/utils.rs
@@ -72,6 +72,7 @@ pub fn globals<'a>(world: &'a dyn IdeWorld, leaf: &LinkedNode) -> &'a Scope {
             | Some(SyntaxKind::MathArgs)
             | Some(SyntaxKind::MathFrac)
             | Some(SyntaxKind::MathAttach)
+            | Some(SyntaxKind::MathFieldAccess)
     ) && leaf.kind() != SyntaxKind::Hash
         && leaf.prev_leaf().is_none_or(|prev| prev.kind() != SyntaxKind::Hash);
 

--- a/crates/typst-ide/src/utils.rs
+++ b/crates/typst-ide/src/utils.rs
@@ -68,11 +68,12 @@ pub fn globals<'a>(world: &'a dyn IdeWorld, leaf: &LinkedNode) -> &'a Scope {
         leaf.parent_kind(),
         Some(SyntaxKind::Equation)
             | Some(SyntaxKind::Math)
+            | Some(SyntaxKind::MathCall)
+            | Some(SyntaxKind::MathArgs)
             | Some(SyntaxKind::MathFrac)
             | Some(SyntaxKind::MathAttach)
-    ) && leaf
-        .prev_leaf()
-        .is_none_or(|prev| !matches!(prev.kind(), SyntaxKind::Hash));
+    ) && leaf.kind() != SyntaxKind::Hash
+        && leaf.prev_leaf().is_none_or(|prev| prev.kind() != SyntaxKind::Hash);
 
     let library = world.library();
     if in_math { library.math.scope() } else { library.global.scope() }

--- a/crates/typst-ide/src/utils.rs
+++ b/crates/typst-ide/src/utils.rs
@@ -6,7 +6,7 @@ use ecow::{EcoString, eco_format};
 use typst::engine::{Engine, Route, Sink, Traced};
 use typst::foundations::{Scope, Value};
 use typst::introspection::EmptyIntrospector;
-use typst::syntax::{LinkedNode, SyntaxKind};
+use typst::syntax::{LinkedNode, SyntaxMode};
 use typst::text::{FontInfo, FontStyle};
 use typst::utils::Protected;
 
@@ -64,20 +64,12 @@ pub fn summarize_font_family(mut variants: Vec<&FontInfo>) -> EcoString {
 
 /// The global definitions at the given node.
 pub fn globals<'a>(world: &'a dyn IdeWorld, leaf: &LinkedNode) -> &'a Scope {
-    let in_math = matches!(
-        leaf.parent_kind(),
-        Some(SyntaxKind::Equation)
-            | Some(SyntaxKind::Math)
-            | Some(SyntaxKind::MathCall)
-            | Some(SyntaxKind::MathArgs)
-            | Some(SyntaxKind::MathFrac)
-            | Some(SyntaxKind::MathAttach)
-            | Some(SyntaxKind::MathFieldAccess)
-    ) && leaf.kind() != SyntaxKind::Hash
-        && leaf.prev_leaf().is_none_or(|prev| prev.kind() != SyntaxKind::Hash);
-
     let library = world.library();
-    if in_math { library.math.scope() } else { library.global.scope() }
+    if leaf.mode_after() == Some(SyntaxMode::Math) {
+        library.math.scope()
+    } else {
+        library.global.scope()
+    }
 }
 
 /// Checks whether the given value or any of its constituent parts satisfy the

--- a/crates/typst-syntax/src/ast.rs
+++ b/crates/typst-syntax/src/ast.rs
@@ -292,6 +292,8 @@ pub enum Expr<'a> {
     MathText(MathText<'a>),
     /// An identifier in math: `pi`.
     MathIdent(MathIdent<'a>),
+    /// A field access in math: `arrow.r.long.double.bar`.
+    MathFieldAccess(MathFieldAccess<'a>),
     /// A shorthand for a unicode codepoint in math: `a <= b`.
     MathShorthand(MathShorthand<'a>),
     /// An alignment point in math: `&`.
@@ -405,6 +407,9 @@ impl<'a> AstNode<'a> for Expr<'a> {
             SyntaxKind::Math => Some(Self::Math(Math(node))),
             SyntaxKind::MathText => Some(Self::MathText(MathText(node))),
             SyntaxKind::MathIdent => Some(Self::MathIdent(MathIdent(node))),
+            SyntaxKind::MathFieldAccess => {
+                Some(Self::MathFieldAccess(MathFieldAccess(node)))
+            }
             SyntaxKind::MathShorthand => Some(Self::MathShorthand(MathShorthand(node))),
             SyntaxKind::MathAlignPoint => {
                 Some(Self::MathAlignPoint(MathAlignPoint(node)))
@@ -475,6 +480,7 @@ impl<'a> AstNode<'a> for Expr<'a> {
             Self::Math(v) => v.to_untyped(),
             Self::MathText(v) => v.to_untyped(),
             Self::MathIdent(v) => v.to_untyped(),
+            Self::MathFieldAccess(v) => v.to_untyped(),
             Self::MathShorthand(v) => v.to_untyped(),
             Self::MathAlignPoint(v) => v.to_untyped(),
             Self::MathCall(v) => v.to_untyped(),
@@ -947,6 +953,53 @@ impl Deref for MathIdent<'_> {
 }
 
 node! {
+    /// A field access in math: `arrow.r.long.double.bar`.
+    struct MathFieldAccess
+}
+
+impl<'a> MathFieldAccess<'a> {
+    /// The expression to access the field on.
+    pub fn target(self) -> MathAccess<'a> {
+        self.0.cast_first()
+    }
+
+    /// The name of the field.
+    pub fn field(self) -> MathIdent<'a> {
+        self.0.cast_last()
+    }
+}
+
+/// A variable or field access in math.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum MathAccess<'a> {
+    MathIdent(MathIdent<'a>),
+    MathFieldAccess(MathFieldAccess<'a>),
+}
+
+impl<'a> AstNode<'a> for MathAccess<'a> {
+    fn from_untyped(node: &'a SyntaxNode) -> Option<Self> {
+        match node.kind() {
+            SyntaxKind::MathIdent => Some(Self::MathIdent(MathIdent(node))),
+            SyntaxKind::MathFieldAccess => {
+                Some(Self::MathFieldAccess(MathFieldAccess(node)))
+            }
+            _ => Option::None,
+        }
+    }
+
+    fn to_untyped(self) -> &'a SyntaxNode {
+        match self {
+            Self::MathIdent(v) => v.to_untyped(),
+            Self::MathFieldAccess(v) => v.to_untyped(),
+        }
+    }
+
+    fn placeholder() -> Self {
+        Self::MathIdent(MathIdent::placeholder())
+    }
+}
+
+node! {
     /// A shorthand for a unicode codepoint in math: `a <= b`.
     struct MathShorthand
 }
@@ -1010,43 +1063,15 @@ node! {
 }
 
 impl<'a> MathCall<'a> {
-    /// The function to call.
-    pub fn callee(self) -> MathCallee<'a> {
+    /// The function to call. If not actually a function, will be rendered as
+    /// content next to its arguments.
+    pub fn callee(self) -> MathAccess<'a> {
         self.0.cast_first()
     }
 
     /// The arguments to the function.
     pub fn args(self) -> MathArgs<'a> {
         self.0.cast_last()
-    }
-}
-
-/// A function to call in math. If not actually a function, will be rendered
-/// as content next to its arguments.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum MathCallee<'a> {
-    MathIdent(MathIdent<'a>),
-    FieldAccess(FieldAccess<'a>),
-}
-
-impl<'a> AstNode<'a> for MathCallee<'a> {
-    fn from_untyped(node: &'a SyntaxNode) -> Option<Self> {
-        match node.kind() {
-            SyntaxKind::MathIdent => Some(Self::MathIdent(MathIdent(node))),
-            SyntaxKind::FieldAccess => Some(Self::FieldAccess(FieldAccess(node))),
-            _ => Option::None,
-        }
-    }
-
-    fn to_untyped(self) -> &'a SyntaxNode {
-        match self {
-            Self::MathIdent(v) => v.to_untyped(),
-            Self::FieldAccess(v) => v.to_untyped(),
-        }
-    }
-
-    fn placeholder() -> Self {
-        Self::MathIdent(MathIdent::placeholder())
     }
 }
 

--- a/crates/typst-syntax/src/highlight.rs
+++ b/crates/typst-syntax/src/highlight.rs
@@ -178,6 +178,7 @@ pub fn highlight(node: &LinkedNode) -> Option<Tag> {
         SyntaxKind::Math => None,
         SyntaxKind::MathText => None,
         SyntaxKind::MathIdent => highlight_ident(node),
+        SyntaxKind::MathFieldAccess => None,
         SyntaxKind::MathShorthand => Some(Tag::Escape),
         SyntaxKind::MathAlignPoint => Some(Tag::MathOperator),
         SyntaxKind::MathCall => None,
@@ -332,7 +333,7 @@ fn highlight_ident(node: &LinkedNode) -> Option<Tag> {
     }
 
     // Are we in math?
-    if node.kind() == SyntaxKind::MathIdent {
+    if matches!(node.kind(), SyntaxKind::MathIdent | SyntaxKind::MathFieldAccess) {
         return Some(Tag::Interpolated);
     }
 

--- a/crates/typst-syntax/src/kind.rs
+++ b/crates/typst-syntax/src/kind.rs
@@ -79,6 +79,8 @@ pub enum SyntaxKind {
     MathText,
     /// An identifier in math: `pi`.
     MathIdent,
+    /// A field access in math: `arrow.r.long.double.bar`.
+    MathFieldAccess,
     /// A shorthand for a unicode codepoint in math: `a <= b`.
     MathShorthand,
     /// An alignment point in math: `&`.
@@ -416,6 +418,7 @@ impl SyntaxKind {
             Self::Math => "math",
             Self::MathText => "math text",
             Self::MathIdent => "math identifier",
+            Self::MathFieldAccess => "math field access",
             Self::MathShorthand => "math shorthand",
             Self::MathAlignPoint => "math alignment point",
             Self::MathCall => "math function call",

--- a/crates/typst-syntax/src/kind.rs
+++ b/crates/typst-syntax/src/kind.rs
@@ -1,3 +1,5 @@
+use crate::SyntaxMode;
+
 /// A syntactical building block of a Typst file.
 ///
 /// Can be created by the lexer or by the parser.
@@ -70,9 +72,9 @@ pub enum SyntaxKind {
     TermItem,
     /// Introduces a term item: `/`.
     TermMarker,
+
     /// A mathematical equation: `$x$`, `$ x^2 $`.
     Equation,
-
     /// The contents of a mathematical equation: `x^2 + 1`.
     Math,
     /// A lone text fragment in math: `x`, `25`, `3.1415`, `=`, `|`, `[`.
@@ -521,5 +523,331 @@ impl SyntaxKind {
             Self::Destructuring => "destructuring pattern",
             Self::DestructAssignment => "destructuring assignment expression",
         }
+    }
+}
+
+/// How to determine the [`SyntaxMode`] we will be in when immediately after a
+/// node of this kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ModeAfter {
+    /// The mode is known!
+    Known(SyntaxMode),
+    /// The syntax mode after this kind is based on its parent.
+    Parent,
+    /// We treat comments and the bodies of raw text as not producing any syntax
+    /// mode.
+    None,
+    /// Text under `Raw` is `None`, otherwise it is markup.
+    Text,
+    /// After the opening raw delimiter is `None`, but after the closing one is
+    /// the same as the parent `Raw`.
+    RawDelim,
+    /// Dollar signs in an equation. After the opening dollar sign is math mode,
+    /// after the closing dollar sign is the same as the parent `Equation`.
+    Dollar,
+    /// Spaces are usually only based on their parent, but an edge case with
+    /// `Equation` requires special handling.
+    ///
+    /// In equations, unlike in code and content blocks, the spaces at the edges
+    /// are not included in the `Math` wrapper kind, and require special
+    /// handling to still return as math mode.
+    Space,
+    /// Kinds that can be embedded in markup or math with a hash, but can also
+    /// be used without a hash in other contexts.
+    ///
+    /// As an example, the mode after `<label>` in these will be:
+    /// - Code in `#let x = <label>`
+    /// - Markup in `<label>`
+    /// - Code in `#<label>`
+    Embeddable,
+}
+
+impl SyntaxKind {
+    /// How to determine the [`SyntaxMode`] we will be in when immediately after
+    /// a node of this kind.
+    ///
+    /// The high-level interface for this is [`crate::LinkedNode::mode_after`].
+    pub(crate) fn mode_after(self) -> ModeAfter {
+        use ModeAfter::*;
+        use SyntaxMode::{Code, Markup, Math};
+
+        // For the kinds which are not `Known`, the possible modes are listed in
+        // a comment with the parent kinds that can cause that mode, although
+        // `expr` and `part` are used as shorthands when the list of parent
+        // kinds would be too long (otherwise, the list of kinds should be
+        // exhaustive). `expr` is a kind which can be a top-level expression in
+        // its mode, and `part` is a kind which is just a part of an expression.
+        match self {
+            Self::End => None,     // none
+            Self::Error => Parent, // code/math/markup
+
+            Self::Shebang => None,      // none
+            Self::LineComment => None,  // none
+            Self::BlockComment => None, // none
+
+            Self::Markup => Known(Markup),
+            Self::Text => Text,        // none: Raw | markup: expr
+            Self::Space => Space,      // code/math: part | markup: expr/part
+            Self::Linebreak => Parent, // math/markup: expr
+            Self::Parbreak => Known(Markup),
+            Self::Escape => Parent, // math/markup: expr
+            Self::Shorthand => Known(Markup),
+            Self::SmartQuote => Known(Markup),
+            Self::Strong => Known(Markup),
+            Self::Emph => Known(Markup),
+            Self::Raw => Embeddable,    // code/markup: expr
+            Self::RawLang => None,      // none
+            Self::RawDelim => RawDelim, // none: opening backticks | code/markup: Raw
+            Self::RawTrimmed => None,   // none
+            Self::Link => Known(Markup),
+            Self::Label => Embeddable, // code/markup: expr
+            Self::Ref => Known(Markup),
+            Self::RefMarker => Known(Markup),
+            Self::Heading => Known(Markup),
+            Self::HeadingMarker => Known(Markup),
+            Self::ListItem => Known(Markup),
+            Self::ListMarker => Known(Markup),
+            Self::EnumItem => Known(Markup),
+            Self::EnumMarker => Known(Markup),
+            Self::TermItem => Known(Markup),
+            Self::TermMarker => Known(Markup),
+
+            Self::Equation => Embeddable, // code/markup: expr
+            Self::Math => Known(Math),
+            Self::MathText => Known(Math),
+            Self::MathIdent => Known(Math),
+            Self::MathFieldAccess => Known(Math),
+            Self::MathShorthand => Known(Math),
+            Self::MathAlignPoint => Known(Math),
+            Self::MathCall => Known(Math),
+            Self::MathArgs => Known(Math),
+            Self::MathDelimited => Known(Math),
+            Self::MathAttach => Known(Math),
+            Self::MathPrimes => Known(Math),
+            Self::MathFrac => Known(Math),
+            Self::MathRoot => Known(Math),
+
+            Self::Hash => Known(Code),
+            Self::LeftBrace => Known(Code),
+            Self::RightBrace => Known(Code),
+            Self::LeftBracket => Known(Markup),
+            Self::RightBracket => Parent, // code/markup: ContentBlock
+            Self::LeftParen => Parent,    // code: part | math: MathArgs/MathDelimited
+            Self::RightParen => Parent,   // code: part | math: MathArgs/MathDelimited
+            Self::Comma => Parent,        // code: part | math: MathArgs
+            Self::Semicolon => Parent,    // code: CodeBlock | math/markup: after embedded
+            Self::Colon => Parent,        // code: part | math: Named | markup: TermItem
+            Self::Star => Parent,         // code: Binary/ModuleImport | markup: Strong
+            Self::Underscore => Parent,   // code: part | math: MathAttach | markup: Emph
+            Self::Dollar => Dollar,       // code/markup: Equation | math: opening dollar
+            Self::Plus => Known(Code),
+            Self::Minus => Known(Code),
+            Self::Slash => Parent, // code: Binary | math: MathFrac
+            Self::Hat => Known(Math),
+            Self::Dot => Parent, // code: part | math: MathFieldAccess
+            Self::Eq => Known(Code),
+            Self::EqEq => Known(Code),
+            Self::ExclEq => Known(Code),
+            Self::Lt => Known(Code),
+            Self::LtEq => Known(Code),
+            Self::Gt => Known(Code),
+            Self::GtEq => Known(Code),
+            Self::PlusEq => Known(Code),
+            Self::HyphEq => Known(Code),
+            Self::StarEq => Known(Code),
+            Self::SlashEq => Known(Code),
+            Self::Dots => Parent, // code/math: Spread
+            Self::Arrow => Known(Code),
+            Self::Root => Known(Math),
+            Self::Bang => Known(Math),
+
+            Self::Not => Known(Code),
+            Self::And => Known(Code),
+            Self::Or => Known(Code),
+            Self::None => Known(Code),
+            Self::Auto => Known(Code),
+            Self::Let => Known(Code),
+            Self::Set => Known(Code),
+            Self::Show => Known(Code),
+            Self::Context => Known(Code),
+            Self::If => Known(Code),
+            Self::Else => Known(Code),
+            Self::For => Known(Code),
+            Self::In => Known(Code),
+            Self::While => Known(Code),
+            Self::Break => Known(Code),
+            Self::Continue => Known(Code),
+            Self::Return => Known(Code),
+            Self::Import => Known(Code),
+            Self::Include => Known(Code),
+            Self::As => Known(Code),
+
+            Self::Code => Known(Code),
+            Self::Ident => Embeddable, // code: expr/part | math: Named
+            Self::Bool => Known(Code),
+            Self::Int => Known(Code),
+            Self::Float => Known(Code),
+            Self::Numeric => Known(Code),
+            Self::Str => Embeddable, // code/math: expr
+            Self::CodeBlock => Known(Code),
+            Self::ContentBlock => Embeddable, // code: expr | markup: Ref
+            Self::Parenthesized => Known(Code),
+            Self::Array => Known(Code),
+            Self::Dict => Known(Code),
+            Self::Named => Parent, // code: part | math: MathArgs
+            Self::Keyed => Known(Code),
+            Self::Unary => Known(Code),
+            Self::Binary => Known(Code),
+            Self::FieldAccess => Known(Code),
+            Self::FuncCall => Known(Code),
+            Self::Args => Known(Code),
+            Self::Spread => Parent, // code: part | math: MathArgs
+            Self::Closure => Known(Code),
+            Self::Params => Known(Code),
+            Self::LetBinding => Known(Code),
+            Self::SetRule => Known(Code),
+            Self::ShowRule => Known(Code),
+            Self::Contextual => Known(Code),
+            Self::Conditional => Known(Code),
+            Self::WhileLoop => Known(Code),
+            Self::ForLoop => Known(Code),
+            Self::ModuleImport => Known(Code),
+            Self::ImportItems => Known(Code),
+            Self::ImportItemPath => Known(Code),
+            Self::RenamedImportItem => Known(Code),
+            Self::ModuleInclude => Known(Code),
+            Self::LoopBreak => Known(Code),
+            Self::LoopContinue => Known(Code),
+            Self::FuncReturn => Known(Code),
+            Self::Destructuring => Known(Code),
+            Self::DestructAssignment => Known(Code),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{LinkedNode, Side, Source};
+
+    #[track_caller]
+    fn test_mode(
+        text: &str,
+        cursors: impl IntoIterator<Item = usize>,
+        expected: Option<SyntaxMode>,
+    ) {
+        let source = Source::detached(text);
+        let root = LinkedNode::new(source.root());
+        for cursor in cursors {
+            let leaf = root.leaf_at(cursor, Side::After).unwrap();
+            let c = source.text()[cursor..].chars().next().unwrap();
+            assert_eq!(leaf.mode_after(), expected, "different at '{c}' index {cursor}");
+        }
+    }
+
+    #[test]
+    fn test_mode_after() {
+        use SyntaxMode::{Code, Markup, Math};
+
+        // Trivia
+        test_mode("#! typ", [0, 1, 2, 3], None);
+        test_mode("#! typ\n", [6], Some(Markup));
+        test_mode("// xxx", [0, 1, 2, 3], None);
+        test_mode("\n// xxx\n", [0, 7], Some(Markup));
+        test_mode("/* xxx */", [0, 1, 2, 3, 4, 7, 8], None);
+
+        // Syntax errors
+        test_mode("*/", [0, 1], Some(Markup));
+        test_mode("#{*/}", [2, 3], Some(Code));
+        test_mode("$*/$", [1, 2], Some(Math));
+
+        // Markup
+        test_mode("https://typst.org", [0], Some(Markup));
+        test_mode("a\\bcd", [0, 1, 2, 3], Some(Markup));
+        test_mode("a   c\n\n d\\\nef", [1, 5, 9], Some(Markup));
+        test_mode("\\u{41}", [0, 1, 2, 3, 5], Some(Markup));
+        test_mode("\"abc\"", [0, 1, 4], Some(Markup));
+        test_mode("a-?b", [1, 2], Some(Markup));
+        test_mode("_*abcd*_", [0, 1, 6, 7], Some(Markup));
+        test_mode("<label>", [0, 1], Some(Markup));
+        test_mode("@label[x @y]", [0, 1, 6, 7, 8, 9, 11], Some(Markup));
+        test_mode("= marker", [0, 1, 2], Some(Markup));
+        test_mode("- marker", [0, 1, 2], Some(Markup));
+        test_mode("+ marker", [0, 1, 2], Some(Markup));
+        test_mode("/ marker: y", [0, 1, 2, 8, 9, 10], Some(Markup));
+
+        // Basic code
+        test_mode("#{x;1}", [0, 1, 2, 3, 4], Some(Code));
+        test_mode("#(x)", [1, 2, 3], Some(Code));
+        test_mode("#(1,2,)", [1, 2, 3, 5, 6], Some(Code));
+        test_mode("#(a:1,\"b\":2)", [1, 2, 3, 4, 5, 6, 7, 8, 9, 11], Some(Code));
+        test_mode("#{-x}", [2], Some(Code));
+        test_mode("#{a / b}", [4], Some(Code));
+        test_mode("#a.b", [1, 2, 3], Some(Code));
+        test_mode("#$$.at()", [2, 3], Some(Code));
+        test_mode("#[].at()", [2, 3], Some(Code));
+        test_mode("#f(x, ..y)", [2, 4, 6], Some(Code));
+        test_mode("#{(x) => {}}", [3, 6], Some(Code));
+        test_mode("#let x = 1", [1, 7], Some(Code));
+        test_mode("#let x;", [6], Some(Markup)); // After semicolon is the parent
+        test_mode("#set text()", [1, 4], Some(Code));
+        test_mode("#show text : it => it", [1, 11], Some(Code));
+        test_mode("#context 1", [1, 8], Some(Code));
+        test_mode("#while true {break;continue;}", [1, 13, 19], Some(Code));
+        test_mode("#for a in b {}", [1, 7], Some(Code));
+        test_mode("#if true {} else {}", [1, 12], Some(Code));
+        test_mode("#import \"lib.typ\" : a, b as d, e.f", [2, 8, 21, 25, 32], Some(Code));
+        test_mode("#include \"lib.typ\"", [1], Some(Code));
+        test_mode("#let f() = { return 1 }", [13], Some(Code));
+        test_mode("#{(x, _, ..y) = (1, 2, ..z)}", [2, 14], Some(Code));
+        test_mode("= #1.1", [2, 3], Some(Code));
+
+        // Math
+        test_mode("$$", [0], Some(Math)); // Opening dollar is math
+        test_mode("$$", [1], Some(Markup)); // Closing dollar is parent
+        test_mode("#$$", [2], Some(Code)); // Closing dollar is parent
+        test_mode("$ a b $", [1, 3, 5], Some(Math)); // Just the spaces
+        test_mode("$\na\nb\n$", [1, 3, 5], Some(Math)); // Just the newlines
+        test_mode("$arrow$", [1], Some(Math));
+        test_mode("$123.32$", [1, 2, 4, 5], Some(Math));
+        test_mode("$+12 * y!", [1, 5, 8], Some(Math));
+        test_mode("$1/2$", [2], Some(Math));
+        test_mode("$f''$", [2], Some(Math));
+        test_mode("$f_(x)^y$", [2, 3, 6, 7], Some(Math));
+        test_mode("$a>=b$", [2], Some(Math));
+        test_mode("$√x$", [1, 4], Some(Math));
+        test_mode("$&x$", [1], Some(Math));
+        test_mode("$\\#\\u{41}$", [1, 2, 3, 4, 5, 6], Some(Math));
+        test_mode("$ff(x, sin(y), abs(z))$", [3, 4, 5, 7, 10, 15, 18], Some(Math));
+        test_mode("$ff(..args, named: key)$", [4, 6, 16, 17], Some(Math));
+        test_mode("$arrow.r$", [6], Some(Math));
+
+        // Raw text
+        test_mode("`r`", [0, 1], None);
+        test_mode("`r`", [2], Some(Markup));
+        test_mode("` \n r\n `", [1, 2, 3, 4, 5, 6], None);
+        test_mode("#`r`", [1, 2], None);
+        test_mode("#`r`", [3], Some(Code));
+        test_mode("```l r\n```", [7], Some(Markup));
+        test_mode("```l r\n```", [0, 3, 4, 5, 6], None);
+        test_mode("#```l r\n```", [8], Some(Code));
+        test_mode("#```l r\n```", [1, 4, 5, 6, 7], None);
+
+        // Edge cases with embedded code expressions
+        test_mode("#<l>", [1, 2, 3], Some(Code));
+        test_mode("$#pa$", [2, 3], Some(Code));
+        test_mode("$#{x}$", [2], Some(Code));
+        test_mode("$#[x]$", [1, 4], Some(Code));
+        test_mode("$#[x]$", [2, 3], Some(Markup));
+        test_mode("$#f(x, ..args, named: key)$", [3, 4, 5, 7, 9, 19, 20], Some(Code));
+        test_mode("$#context 1$", [9, 10], Some(Code));
+        test_mode("$#context $", [9], Some(Code));
+        test_mode("$#std.align$", [2, 5, 6], Some(Code));
+        test_mode("$ff(named: #ident)$", [12], Some(Code));
+        test_mode("$ #$x$; $", [0, 1, 3, 4, 6, 7], Some(Math));
+        test_mode("$ #$x$; $", [8], Some(Markup));
+        test_mode("$ #$x$; $", [2, 5], Some(Code));
+        test_mode("#[$x$]", [2, 3], Some(Math));
+        test_mode("#[$x$]", [1, 4], Some(Markup));
     }
 }

--- a/crates/typst-syntax/src/lexer.rs
+++ b/crates/typst-syntax/src/lexer.rs
@@ -661,16 +661,16 @@ impl Lexer<'_> {
         (kind, None)
     }
 
-    /// Parse a single `MathIdent` or an entire `FieldAccess`.
+    /// Parse a single `MathIdent` or an entire `MathFieldAccess`.
     fn math_ident_or_field(&mut self, start: usize) -> (SyntaxKind, SyntaxNode) {
         let mut kind = SyntaxKind::MathIdent;
         let mut node = SyntaxNode::leaf(kind, self.s.from(start));
         while let Some(ident) = self.maybe_dot_ident() {
-            kind = SyntaxKind::FieldAccess;
+            kind = SyntaxKind::MathFieldAccess;
             let field_children = vec![
                 node,
                 SyntaxNode::leaf(SyntaxKind::Dot, '.'),
-                SyntaxNode::leaf(SyntaxKind::Ident, ident),
+                SyntaxNode::leaf(SyntaxKind::MathIdent, ident),
             ];
             node = SyntaxNode::inner(kind, field_children);
         }

--- a/crates/typst-syntax/src/node.rs
+++ b/crates/typst-syntax/src/node.rs
@@ -5,7 +5,8 @@ use std::sync::Arc;
 
 use ecow::{EcoString, EcoVec, eco_format, eco_vec};
 
-use crate::{FileId, Span, SyntaxKind};
+use crate::kind::ModeAfter;
+use crate::{FileId, Span, SyntaxKind, SyntaxMode};
 
 /// A node in the untyped syntax tree.
 #[derive(Clone, Eq, PartialEq, Hash)]
@@ -774,6 +775,53 @@ impl<'a> LinkedNode<'a> {
         }
 
         None
+    }
+
+    /// Get the [`SyntaxMode`] we will be in when immediately after this node.
+    ///
+    /// Unlike some other `LinkedNode` methods, this does not treat all trivia
+    /// the same: it returns `None` for both comments and the bodies of raw text
+    /// and returns `Some` for whitespace (based on the parent's mode). The only
+    /// other way this would return `None` is when inside a partial tree, i.e.
+    /// one not rooted in `Markup`, `Math`, or `Code`.
+    ///
+    /// Also note that errors inherit the mode of their parent.
+    pub fn mode_after(&self) -> Option<SyntaxMode> {
+        match self.kind().mode_after() {
+            ModeAfter::Known(mode) => Some(mode),
+            // Comments and the bodies of raw text have no mode.
+            ModeAfter::None => None,
+            ModeAfter::Text if self.parent_kind() == Some(SyntaxKind::Raw) => None,
+            ModeAfter::RawDelim if self.index == 0 => None,
+            // Text not under raw is always markup.
+            ModeAfter::Text => Some(SyntaxMode::Markup),
+            // An opening dollar sign starts math mode.
+            ModeAfter::Dollar if self.index == 0 => Some(SyntaxMode::Math),
+            // Spaces at the left/right of an equation are still in math mode.
+            ModeAfter::Space if self.parent_kind() == Some(SyntaxKind::Equation) => {
+                Some(SyntaxMode::Math)
+            }
+            // The position after something embedded with a hash is still code.
+            ModeAfter::Embeddable
+                if self
+                    .prev_sibling_with_trivia()
+                    .is_some_and(|prev| prev.kind() == SyntaxKind::Hash) =>
+            {
+                Some(SyntaxMode::Code)
+            }
+            // Otherwise, we're simply based on our parent's mode.
+            ModeAfter::Parent
+            | ModeAfter::RawDelim
+            | ModeAfter::Space
+            | ModeAfter::Dollar
+            | ModeAfter::Embeddable => self.parent_mode(),
+        }
+    }
+
+    /// Get the [`SyntaxMode`] we will be in when immediately after the parent
+    /// of this node.
+    pub fn parent_mode(&self) -> Option<SyntaxMode> {
+        self.parent().and_then(Self::mode_after)
     }
 }
 

--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -260,8 +260,9 @@ fn math_expr_prec(p: &mut Parser, min_prec: u8, stop_set: SyntaxSet) {
     let mut continuable = false;
     match p.current() {
         SyntaxKind::Hash => embedded_code_expr(p),
-        // The lexer manages creating full FieldAccess nodes if needed.
-        SyntaxKind::MathIdent | SyntaxKind::FieldAccess => {
+
+        // The lexer manages creating full MathFieldAccess nodes if needed.
+        SyntaxKind::MathIdent | SyntaxKind::MathFieldAccess => {
             continuable = true;
             p.eat();
             // Parse a function call for an identifier or field access.

--- a/crates/typst-syntax/src/set.rs
+++ b/crates/typst-syntax/src/set.rs
@@ -66,7 +66,7 @@ pub const STMT: SyntaxSet = syntax_set!(Let, Set, Show, Import, Include, Return)
 pub const MATH_EXPR: SyntaxSet = syntax_set!(
     Hash,
     MathIdent,
-    FieldAccess,
+    MathFieldAccess,
     Dot,
     Comma,
     Semicolon,


### PR DESCRIPTION
This PR fixes a number of issues with IDE functionality in Typst and adds two major refactorings to simplify future maintenance of these features.

The major refactorings are the addition of the `MathFieldAccess` syntax kind and the `LinkedNode::mode` method. `MathFieldAccess` is meant to further distinguish math from code in the syntax tree (in the same vein as `Ident` vs. `MathIdent`), which both simplifies the implementation of `LinkedNode::mode` and will be useful for future math syntax refactorings. The implementation of `LinkedNode::mode` supersedes PR #7407, but I've changed the implementation to use a data-oriented approach by having the `LinkedNode` method match on an enum, `ModeSearch,` which is only dependent on the `SyntaxKind`.

However, I only implemented the refactorings _after_ having resolved most of the issues via the prior commits. I did this so that I could better understand where those errors were actually coming from and so we could more clearly see the benefits of the refactorings to code clarity without them also affecting behavior. Although the addition of `LinkedNode::mode` did allow for fixing completions for named and spread arguments in math which I couldn't find a way to resolve beforehand.

- Closes #6312
- Resolves a regression added in #7865 where we weren't calling `trace` on identifiers
- Adds many tooltip and completion tests for function calls in math and code
- Adds `SyntaxKind::MathFieldAccess`
- Adds the method `LinkedNode::mode(&self) -> Option<SyntaxMode>`
- Refactors a bunch of stuff in `typst-ide`