### PR TITLE
Write `width` and `height` attributes on `img`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3097,6 +3097,7 @@ dependencies = [
 name = "typst-html"
 version = "0.14.2"
 dependencies = [
+ "az",
  "bumpalo",
  "comemo",
  "ecow",

--- a/crates/typst-html/Cargo.toml
+++ b/crates/typst-html/Cargo.toml
@@ -20,6 +20,7 @@ typst-syntax = { workspace = true }
 typst-timing = { workspace = true }
 typst-utils = { workspace = true }
 typst-svg = { workspace = true }
+az = { workspace = true }
 bumpalo = { workspace = true }
 comemo = { workspace = true }
 ecow = { workspace = true }

--- a/crates/typst-html/src/rules.rs
+++ b/crates/typst-html/src/rules.rs
@@ -1,6 +1,7 @@
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
+use az::SaturatingAs;
 use comemo::Track;
 use ecow::{EcoVec, eco_format};
 use typst_library::diag::{At, bail, warning};
@@ -763,6 +764,14 @@ const IMAGE_RULE: ShowFn<ImageElem> = |elem, engine, styles| {
     if let Some(alt) = elem.alt.get_cloned(styles) {
         attrs.push(attr::alt, alt);
     }
+
+    // The `width` and `height` properties on the HTML element are only used to
+    // reserve space while the browser is fetching. They are integers. Still, in
+    // case of fractional image sizes, rounding is better than nothing and will
+    // not disrupt the aspect ratio of the final image.
+    let cast = |v: f64| eco_format!("{}", v.round().saturating_as::<i64>());
+    attrs.push(attr::width, cast(image.width()));
+    attrs.push(attr::height, cast(image.height()));
 
     let mut inline = css::Properties::new();
 

--- a/tests/ref/html/hashes.txt
+++ b/tests/ref/html/hashes.txt
@@ -38,10 +38,10 @@ c3be983a199a95106caffe0572463a58 html-style
 f9671e4e56820cd2f5fbd767d04eabc0 html-textarea-starting-with-newline
 32384d981e4ee5b9ba51251e447dcf31 html-typed
 58895c458693621c61d4d498ab0f8b64 html-untyped-style-content
-7d05ff4786d4e199a0964303418d3347 image-jpg-html-base64
-934a6ea8c0b0a089ae6b85d720f8855c image-pdf-basic
-d5b7eaa1581f0f4a2c2cfbb67b708db7 image-scaling-methods
-306d8254faffbba501fdb84e8b908be7 image-sizing-html-css
+2de3be3f0dbfa160e245c8f69aa74d45 image-jpg-html-base64
+7ec40ca9ce2a8477e71dbef84942cfdd image-pdf-basic
+0d91b680b8b489b2efbd58305809f304 image-scaling-methods
+b4fa758083a286496c9edcbe6dcdc002 image-sizing-html-css
 3277fec377f92a3ca4d6d78ad5bccfcc issue-7751-table-cell-show-rules
 44fbc75996ca7154896d82a2cc32da32 link-basic
 7958585bce8c5ddabbcf61103aeb8bf2 link-html-frame


### PR DESCRIPTION
Writing these attributes reduces layout shifts due loading images and is good practice. For base64 images, it might be less relevant (though they are possibly still decoded asynchronously), but still. Also, we want to support non-inlined images, too, in the future.