### PR TITLE
More examples on how to use stops within gradients

### DIFF
--- a/crates/typst-library/src/visualize/gradient.rs
+++ b/crates/typst-library/src/visualize/gradient.rs
@@ -71,18 +71,18 @@ use crate::visualize::{Color, ColorSpace, WeightedColor};
 /// stops evenly which is a reasonable default in order to provide a smooth
 /// gradient.
 ///
-/// ```example:"Smooth Gradient between Red and Blue"
+/// ```example
 /// #rect(
-///   width: 100%, 
+///   width: 100%,
 ///   height: 20pt,
 ///   fill: gradient.linear(red, blue)
 /// )
 /// ```
 ///
-/// We can use manually-defined stops in order to end the gradient "early"
+/// We can use manually-defined stops in order to end the gradient early
 /// rather than in a smooth way.
 ///
-/// ```example:"Smooth Gradient with Manually-Defined Stops"
+/// ```example
 /// #block(
 ///   width: 100%,
 ///   inset: 4pt,
@@ -104,11 +104,11 @@ use crate::visualize::{Color, ColorSpace, WeightedColor};
 /// ```
 ///
 /// We can go even further.
-/// Sometimes it is preferable to have a "gradient" that is not smooth
-/// and instead "blocky" or "stepwise". For example, you can display a progress
+/// Sometimes it is preferable to have a gradient that is not smooth
+/// and instead blocky or stepwise. For example, you can display a progress
 /// bar using a simple linear gradient with manually defined stops.
-/// 
-/// ```example:"Simple Progress Bar"
+///
+/// ```example
 /// #block(
 ///   width: 100%,
 ///   inset: 4pt,
@@ -119,7 +119,7 @@ use crate::visualize::{Color, ColorSpace, WeightedColor};
 /// )[We're 2/3 done!]
 /// ```
 ///
-/// You could also use [`stack`]($stack) (with `dir: ltr`) to make a progress
+/// You could also use [`stack`]($stack) (with `{dir: ltr}`) to make a progress
 /// bar (which is probably more sensible), but this at least helps display how
 /// to write custom stops.
 ///

--- a/crates/typst-library/src/visualize/gradient.rs
+++ b/crates/typst-library/src/visualize/gradient.rs
@@ -68,7 +68,60 @@ use crate::visualize::{Color, ColorSpace, WeightedColor};
 /// that determines how far along the gradient the stop is located. The stop's
 /// color is the color of the gradient at that position. You can choose to omit
 /// the offsets when defining a gradient. In this case, Typst will space all
-/// stops evenly.
+/// stops evenly which is a reasonable default in order to provide a smooth
+/// gradient.
+///
+/// ```example:"Smooth Gradient between Red and Blue"
+/// #rect(
+///   width: 100%, 
+///   height: 20pt,
+///   fill: gradient.linear(red, blue)
+/// )
+/// ```
+///
+/// We can use manually-defined stops in order to end the gradient "early"
+/// rather than in a smooth way.
+///
+/// ```example:"Smooth Gradient with Manually-Defined Stops"
+/// #block(
+///   width: 100%,
+///   inset: 4pt,
+///   fill: gradient.linear(
+///     (red, 0%),
+///     (blue, 50%),
+///     (blue, 100%)
+///   ),
+///   align(
+///     right,
+///     block(
+///       width: 50%,
+///       align(
+///         left
+///       )[I'm already fully blue]
+///     )
+///   )
+/// )
+/// ```
+///
+/// We can go even further.
+/// Sometimes it is preferable to have a "gradient" that is not smooth
+/// and instead "blocky" or "stepwise". For example, you can display a progress
+/// bar using a simple linear gradient with manually defined stops.
+/// 
+/// ```example:"Simple Progress Bar"
+/// #block(
+///   width: 100%,
+///   inset: 4pt,
+///   fill: gradient.linear(
+///     (aqua, 0%), (aqua, 100%*2/3),
+///     (gray, 100%*2/3), (gray, 100%)
+///   ),
+/// )[We're 2/3 done!]
+/// ```
+///
+/// You could also use [`stack`]($stack) (with `dir: ltr`) to make a progress
+/// bar (which is probably more sensible), but this at least helps display how
+/// to write custom stops.
 ///
 /// Typst predefines color maps that you can use as stops. See the
 /// [`color`]($color/#predefined-color-maps) documentation for more details.
@@ -200,7 +253,7 @@ impl Gradient {
     pub fn linear(
         args: &mut Args,
         span: Span,
-        /// The color [stops](#stops) of the gradient.
+        /// The unnamed (positional) arguments are the color [stops](#stops) of the gradient.
         #[variadic]
         stops: Vec<Spanned<GradientStop>>,
         /// The color space in which to interpolate the gradient.
@@ -289,7 +342,7 @@ impl Gradient {
     #[func(title = "Radial Gradient")]
     fn radial(
         span: Span,
-        /// The color [stops](#stops) of the gradient.
+        /// The unnamed (positional) arguments are the color [stops](#stops) of the gradient.
         #[variadic]
         stops: Vec<Spanned<GradientStop>>,
         /// The color space in which to interpolate the gradient.
@@ -405,7 +458,7 @@ impl Gradient {
     #[func(title = "Conic Gradient")]
     pub fn conic(
         span: Span,
-        /// The color [stops](#stops) of the gradient.
+        /// The unnamed (positional) arguments are the color [stops](#stops) of the gradient.
         #[variadic]
         stops: Vec<Spanned<GradientStop>>,
         /// The angle of the gradient.

--- a/crates/typst-library/src/visualize/gradient.rs
+++ b/crates/typst-library/src/visualize/gradient.rs
@@ -72,13 +72,13 @@ use crate::visualize::{Color, ColorSpace, WeightedColor};
 ///
 /// ```example
 /// #rect(
-///   width: 100%, 
+///   width: 100%,
 ///   height: 20pt,
 ///   fill: gradient.linear(red, blue)
 /// )
 /// ```
 ///
-/// We can use manually-defined stops in order to end the gradient "early"
+/// We can use manually-defined stops in order to end the gradient early
 /// rather than in a smooth way.
 ///
 /// ```example
@@ -103,10 +103,10 @@ use crate::visualize::{Color, ColorSpace, WeightedColor};
 /// ```
 ///
 /// We can go even further.
-/// Sometimes it is preferable to have a "gradient" that is not smooth
-/// and instead "blocky" or "stepwise". For example, you can display a progress
+/// Sometimes it is preferable to have a gradient that is not smooth
+/// and instead blocky or stepwise. For example, you can display a progress
 /// bar using a simple linear gradient with manually defined stops.
-/// 
+///
 /// ```example
 /// #block(
 ///   width: 100%,

--- a/crates/typst-library/src/visualize/gradient.rs
+++ b/crates/typst-library/src/visualize/gradient.rs
@@ -268,7 +268,7 @@ impl Gradient {
     pub fn linear(
         args: &mut Args,
         span: Span,
-        /// The unnamed (positional) arguments are the color @gradient.stops[stops] of the gradient.
+        /// The unnamed (positional) arguments are the color @gradient:stops[stops] of the gradient.
         #[variadic]
         stops: Vec<Spanned<GradientStop>>,
         /// The color space in which to interpolate the gradient.
@@ -357,7 +357,7 @@ impl Gradient {
     #[func(title = "Radial Gradient")]
     fn radial(
         span: Span,
-        /// The unnamed (positional) arguments are the color @gradient.stops[stops] of the gradient.
+        /// The unnamed (positional) arguments are the color @gradient:stops[stops] of the gradient.
         #[variadic]
         stops: Vec<Spanned<GradientStop>>,
         /// The color space in which to interpolate the gradient.
@@ -474,7 +474,7 @@ impl Gradient {
     #[func(title = "Conic Gradient")]
     pub fn conic(
         span: Span,
-        /// The unnamed (positional) arguments are the color @gradient.stops[stops] of the gradient.
+        /// The unnamed (positional) arguments are the color @gradient:stops[stops] of the gradient.
         #[variadic]
         stops: Vec<Spanned<GradientStop>>,
         /// The angle of the gradient.

--- a/crates/typst-library/src/visualize/gradient.rs
+++ b/crates/typst-library/src/visualize/gradient.rs
@@ -67,7 +67,62 @@ use crate::visualize::{Color, ColorSpace, WeightedColor};
 /// that determines how far along the gradient the stop is located. The stop's
 /// color is the color of the gradient at that position. You can choose to omit
 /// the offsets when defining a gradient. In this case, Typst will space all
-/// stops evenly.
+/// stops evenly which is a reasonable default in order to provide a smooth
+/// gradient.
+///
+/// ```example
+/// #rect(
+///   width: 100%, 
+///   height: 20pt,
+///   fill: gradient.linear(red, blue)
+/// )
+/// ```
+///
+/// We can use manually-defined stops in order to end the gradient "early"
+/// rather than in a smooth way.
+///
+/// ```example
+/// #block(
+///   width: 100%,
+///   inset: 4pt,
+///   fill: gradient.linear(
+///     (red, 0%),
+///     (blue, 50%),
+///     (blue, 100%)
+///   ),
+///   align(
+///     right,
+///     block(
+///       width: 50%,
+///       align(
+///         left
+///       )[I'm already fully blue]
+///     )
+///   )
+/// )
+/// ```
+///
+/// We can go even further.
+/// Sometimes it is preferable to have a "gradient" that is not smooth
+/// and instead "blocky" or "stepwise". For example, you can display a progress
+/// bar using a simple linear gradient with manually defined stops.
+/// 
+/// ```example
+/// #block(
+///   width: 100%,
+///   inset: 4pt,
+///   fill: gradient.linear(
+///     (aqua, 0%), (aqua, 100%*2/3),
+///     (gray, 100%*2/3), (gray, 100%)
+///   ),
+/// )[We're 2/3 done!]
+/// ```
+///
+/// You could also use @stack[`stack`] (with `dir: ltr`) to make a progress
+/// bar (which is probably more sensible due to the
+/// @gradient:note-on-file-sizes[file size implications of using `gradient`]),
+/// but this at least helps display how
+/// to write custom stops.
 ///
 /// Typst predefines color maps that you can use as stops. See the
 /// @color:predefined-color-maps[`color`] documentation for more details.
@@ -213,7 +268,7 @@ impl Gradient {
     pub fn linear(
         args: &mut Args,
         span: Span,
-        /// The color @gradient:stops[stops] of the gradient.
+        /// The unnamed (positional) arguments are the color @gradient.stops[stops] of the gradient.
         #[variadic]
         stops: Vec<Spanned<GradientStop>>,
         /// The color space in which to interpolate the gradient.
@@ -302,7 +357,7 @@ impl Gradient {
     #[func(title = "Radial Gradient")]
     fn radial(
         span: Span,
-        /// The color @gradient:stops[stops] of the gradient.
+        /// The unnamed (positional) arguments are the color @gradient.stops[stops] of the gradient.
         #[variadic]
         stops: Vec<Spanned<GradientStop>>,
         /// The color space in which to interpolate the gradient.
@@ -419,7 +474,7 @@ impl Gradient {
     #[func(title = "Conic Gradient")]
     pub fn conic(
         span: Span,
-        /// The color @gradient:stops[stops] of the gradient.
+        /// The unnamed (positional) arguments are the color @gradient.stops[stops] of the gradient.
         #[variadic]
         stops: Vec<Spanned<GradientStop>>,
         /// The angle of the gradient.


### PR DESCRIPTION
Instead of adding one sloppy (pun intended) example under the "stops" parameter description, I think it makes more sense to (a) explain under the "stops" parameter that it is our name for the (unnamed) positional arguments and (b) add more examples with different manually-defined "stops" in the section about stops.

I added three examples showing my own personal progression in understanding. First realizing that I can just provide my own list of colors (instead of a pre-defined color map). Then realizing that I could shift the boundaries of the colors by using manually-defined stops. Finally, doing something slightly more complicated by preventing a gradient except within a small transition region of a progress bar.

This resolves #3109 