### PR TITLE
Do not emit note-style citations when already in a footnote

### DIFF
--- a/crates/typst-library/src/model/bibliography.rs
+++ b/crates/typst-library/src/model/bibliography.rs
@@ -771,7 +771,8 @@ impl<'a> Generator<'a> {
                 subinfos,
                 span: first.span(),
                 footnote: normal
-                    && style.settings.class == citationberg::StyleClass::Note,
+                    && style.settings.class == citationberg::StyleClass::Note
+                    && !first.infootnote.unwrap_or(false),
             });
 
             driver.citation(CitationRequest::new(

--- a/crates/typst-library/src/model/cite.rs
+++ b/crates/typst-library/src/model/cite.rs
@@ -7,7 +7,7 @@ use crate::foundations::{
 };
 use crate::introspection::Locatable;
 use crate::model::bibliography::Works;
-use crate::model::{CslSource, CslStyle};
+use crate::model::{CslSource, CslStyle, FootnoteElem};
 use crate::text::{Lang, Region, TextElem};
 
 /// Cite a work from the bibliography.
@@ -115,6 +115,11 @@ pub struct CiteElem {
     #[internal]
     #[synthesized]
     pub region: Option<Region>,
+
+    /// Whether this citation is inside a footnote.
+    #[internal]
+    #[synthesized]
+    pub infootnote: bool,
 }
 
 impl Synthesize for Packed<CiteElem> {
@@ -122,6 +127,7 @@ impl Synthesize for Packed<CiteElem> {
         let elem = self.as_mut();
         elem.lang = Some(styles.get(TextElem::lang));
         elem.region = Some(styles.get(TextElem::region));
+        elem.infootnote = Some(styles.get(FootnoteElem::infootnote));
         Ok(())
     }
 }

--- a/crates/typst-library/src/model/footnote.rs
+++ b/crates/typst-library/src/model/footnote.rs
@@ -79,6 +79,10 @@ pub struct FootnoteElem {
     #[default(Numbering::Pattern(NumberingPattern::from_str("1").unwrap()))]
     pub numbering: Numbering,
 
+    #[internal]
+    #[parse(Some(false))]
+    pub infootnote: bool,
+
     /// The content to put into the footnote. Can also be the label of another
     /// footnote this one should point to.
     #[required]
@@ -315,7 +319,12 @@ impl Packed<FootnoteEntry> {
         let alt = num.plain_text();
         let link = DirectLinkElem::new(dest, num, Some(alt)).pack().spanned(span);
         let sup = SuperElem::new(link).pack().spanned(span);
-        let body = self.note.body_content().unwrap().clone();
+        let body = self
+            .note
+            .body_content()
+            .unwrap()
+            .clone()
+            .styled(FootnoteElem::infootnote.set(true));
 
         Ok((sup, body))
     }


### PR DESCRIPTION
Add a boolean variable so that Cite knows whether it is in a footnote.
```
foo #footnote[See, for example: #cite(<alpha>)]
foo #footnote[See, for example: #cite(<alpha>)]
foo #footnote[See, for example: #cite(<alpha>)]

foo #footnote[See, for example: #cite(<beta>)]
foo #footnote[See, for example: #cite(<beta>)]
foo #footnote[See, for example: #cite(<beta>)]

foo #footnote[See, for example: #cite(<alpha>)]
```

<img width="2630" height="516" alt="image" src="https://github.com/user-attachments/assets/0414af73-79fe-4118-917a-8edba94578e2" />
