### PR TITLE
Fix inconsistent pdf bookmark nesting between the compiler and the web app

### DIFF
--- a/crates/typst-pdf/src/outline.rs
+++ b/crates/typst-pdf/src/outline.rs
@@ -13,7 +13,7 @@ pub(crate) fn build_outline(gc: &GlobalContext) -> KrillaOutline {
 
     let flat = elems
         .iter()
-        .map(|elem| {
+        .filter_map(|elem| {
             let heading = elem.to_packed::<HeadingElem>().unwrap();
 
             let level = heading.resolve_level(StyleChain::default());
@@ -32,7 +32,7 @@ pub(crate) fn build_outline(gc: &GlobalContext) -> KrillaOutline {
             });
 
             let include = boomarked && visible;
-            (heading, level, include)
+            include.then_some((heading, level, include))
         })
         .collect::<Vec<_>>();
 


### PR DESCRIPTION
<!--
Thanks for your interest in landing a change in Typst! Before opening the PR, please review our contribution guidelines: https://github.com/typst/typst/blob/main/CONTRIBUTING.md

In particular, please keep in mind that we do not accept contributions implemented by an AI model. We would also ask you to refrain from using AI to write your pull request description. Summarizing your work helps organizing your thoughts as much as it helps us with seeing the human thought process behind a particular change.
-->
Fixes #5615

This PR adds a filter to the internal tree structure the compiler uses to generate PDF bookmarks from. It removes all nodes that will not be included in the final outline, so they can not affect its structure.

With this change, the bookmarks of a compiled PDF are matching the outline that is visible in the Typst web app:

```typ
#outline(
  title: auto,
  indent: 2em,
)
    
#heading("Heading A.1", level: 1, outlined: true, bookmarked: true)
#heading("Heading B.1", level: 2, outlined: false, bookmarked: false)
#heading("Heading C.1", level: 3, outlined: true, bookmarked: true)
#heading("Heading C.2", level: 3, outlined: true, bookmarked: true)
#heading("Heading C.3", level: 3, outlined: true, bookmarked: true)

#heading("Heading A.1", level: 1, outlined: false, bookmarked: false)
#heading("Heading B.2", level: 2, outlined: true, bookmarked: true)
#heading("Heading C.1", level: 3, outlined: true, bookmarked: true)
#heading("Heading C.2", level: 3, outlined: true, bookmarked: true)
```

<img width="2022" height="970" alt="image" src="https://github.com/user-attachments/assets/209c042a-1ecf-4e27-a619-a6d9649d02b6" />
<img width="2079" height="793" alt="image" src="https://github.com/user-attachments/assets/6af2478c-37bc-4d45-929b-cbe8dcfcedcd" />
