### PR TITLE
Fix overflow of `norm` in certain ranges

### DIFF
--- a/crates/typst-library/src/foundations/calc.rs
+++ b/crates/typst-library/src/foundations/calc.rs
@@ -1153,9 +1153,7 @@ pub fn norm(
         bail!(p.span, "p must be greater than zero");
     }
 
-    // Create an iterator over the absolute values.
     let abs = values.iter().map(|v| f64::abs(*v));
-
     let max = abs.clone().max_by(|a, b| a.total_cmp(b)).unwrap_or(0.0);
 
     Ok(if p.v.is_infinite() {
@@ -1166,8 +1164,9 @@ pub fn norm(
         // This is a special case to avoid division by zero in the trick below.
         0.0
     } else {
-        // Compute `max * (sum_i (x_i / max)^p)^(1 / p)` instead of raising `x_i^p` directly, to avoid overflowing.
-        // This is described further in https://timvieira.github.io/blog/numerically-stable-p-norms/
+        // Compute `max * (sum_i (x_i / max)^p)^(1 / p)` instead of raising
+        // `x_i^p` directly, to avoid overflowing. This is described further in
+        // <https://timvieira.github.io/blog/numerically-stable-p-norms/>.
         max * libm::pow(abs.map(|v| libm::pow(v / max, p.v)).sum::<f64>(), 1.0 / p.v)
     })
 }

--- a/crates/typst-library/src/foundations/calc.rs
+++ b/crates/typst-library/src/foundations/calc.rs
@@ -1154,13 +1154,21 @@ pub fn norm(
     }
 
     // Create an iterator over the absolute values.
-    let abs = values.into_iter().map(f64::abs);
+    let abs = values.iter().map(|v| f64::abs(*v));
+
+    let max = abs.clone().max_by(|a, b| a.total_cmp(b)).unwrap_or(0.0);
 
     Ok(if p.v.is_infinite() {
         // When p is infinity, the p-norm is the maximum of the absolute values.
-        abs.max_by(|a, b| a.total_cmp(b)).unwrap_or(0.0)
+        max
+    } else if max == 0.0 {
+        // When the maximum absolute value is 0, the norm is just 0.
+        // This is a special case to avoid division by zero in the trick below.
+        0.0
     } else {
-        libm::pow(abs.map(|v| libm::pow(v, p.v)).sum::<f64>(), 1.0 / p.v)
+        // Compute `max * (sum_i (x_i / max)^p)^(1 / p)` instead of raising `x_i^p` directly, to avoid overflowing.
+        // This is described further in https://timvieira.github.io/blog/numerically-stable-p-norms/
+        max * libm::pow(abs.map(|v| libm::pow(v / max, p.v)).sum::<f64>(), 1.0 / p.v)
     })
 }
 

--- a/tests/suite/foundations/calc.typ
+++ b/tests/suite/foundations/calc.typ
@@ -409,6 +409,9 @@
 #test(calc.norm(), 0.0)
 #test(calc.norm(p: 3, 1, -2), calc.pow(9, 1/3))
 #test(calc.norm(p: calc.inf, 1, -2), 2.0)
+#test(calc.norm(p: 309, 10), 10)
+#test(calc.norm(p: 2, 0), 0)
+#test(calc.norm(p: 100, 1210), 1210)
 
 --- calc-norm-negative-p eval ---
 // Error: 15-17 p must be greater than zero


### PR DESCRIPTION
Fix for #8148.
