### PR TITLE
Consider replaced elements as supportive for whitespace protection

### DIFF
--- a/crates/typst-html/src/convert.rs
+++ b/crates/typst-html/src/convert.rs
@@ -429,6 +429,8 @@ impl<'a> Protector<'a> {
                 HtmlNode::Element(element) => {
                     if tag::is_block_by_default(element.tag) || element.tag == tag::br {
                         self.collapsing();
+                    } else if tag::is_replaced(element.tag) {
+                        self.supportive();
                     } else if !element.pre_span {
                         // Recursively visit the children of inline-level
                         // elements while making sure to not revisit pre-wrapped

--- a/crates/typst-html/src/tag.rs
+++ b/crates/typst-html/src/tag.rs
@@ -453,6 +453,25 @@ pub fn is_script_supporting_element(tag: HtmlTag) -> bool {
     matches!(tag, self::script | self::template)
 }
 
+// § 15.4 Replaced elements
+
+/// Whether the element is considered a "replaced element".
+///
+/// See also: https://www.w3.org/TR/css-display-3/#replaced-element
+pub fn is_replaced(tag: HtmlTag) -> bool {
+    matches!(
+        tag,
+        self::audio
+            | self::canvas
+            | self::embed
+            | self::iframe
+            | self::img
+            | self::input
+            | self::object
+            | self::video
+    )
+}
+
 // Defaults of the CSS `display` property.
 
 /// Whether nodes with the tag have the CSS property `display: block` by

--- a/tests/ref/html/hashes.txt
+++ b/tests/ref/html/hashes.txt
@@ -33,6 +33,7 @@ eeecf9598691783d361c20acf47a8775 html-elem-alone-context
 1e1005b4ac5db07bd074e5d12aa2162e html-pre-starting-with-newline
 9fc3a113490cc039e8ba83bf734a6b59 html-script
 de4b0b9e9a41128ffdb982bae7550178 html-space-collapsing
+9aefaa50d4f4f7a8e2c20feec6b8e7db html-space-protection-replaced
 c3be983a199a95106caffe0572463a58 html-style
 568cbc99dba4312ba440431d779ec70a html-style-str
 f9671e4e56820cd2f5fbd767d04eabc0 html-textarea-starting-with-newline
@@ -41,7 +42,7 @@ f9671e4e56820cd2f5fbd767d04eabc0 html-textarea-starting-with-newline
 2de3be3f0dbfa160e245c8f69aa74d45 image-jpg-html-base64
 7ec40ca9ce2a8477e71dbef84942cfdd image-pdf-basic
 0d91b680b8b489b2efbd58305809f304 image-scaling-methods
-b4fa758083a286496c9edcbe6dcdc002 image-sizing-html-css
+5d4cee8916629f49710be903b79d0b27 image-sizing-html-css
 3277fec377f92a3ca4d6d78ad5bccfcc issue-7751-table-cell-show-rules
 44fbc75996ca7154896d82a2cc32da32 link-basic
 7958585bce8c5ddabbcf61103aeb8bf2 link-html-frame

--- a/tests/suite/html/syntax.typ
+++ b/tests/suite/html/syntax.typ
@@ -146,6 +146,9 @@ A#"  "B#"   C"
 #html.pre("A  B")
 // -> <pre>A  B</pre>
 
+--- html-space-protection-replaced html ---
+A #html.input(type: "text")
+
 --- html-pre-starting-with-newline html ---
 #html.pre("hello")
 #html.pre("\nhello")


### PR DESCRIPTION
Typst protects explicit whitespace that would otherwise be collapsed by CSS by wrapping it in a `<span>` with `white-space: pre-wrap`. This ensures that explicit trailing or consecutive whitespace (e.g. `#"A "` or `#"A  B"`) is correctly retained in browsers. However, this logic previously did not treat elements like `<input>` or `<img>` correctly. This meant that for the markup `A #html.input(type: "text")`, Typst would emit such a span even though browsers do not collapse the space after the "A". With this PR, HTML _replaced elements_ are now considered as _supportive_ for the purpose of whitespace protection in HTML, avoiding such unnecessary spans.
