### PR TITLE
Don't emit trace in short diagnostic format

### DIFF
--- a/crates/typst-kit/src/diagnostics.rs
+++ b/crates/typst-kit/src/diagnostics.rs
@@ -86,14 +86,16 @@ pub fn emit<'a>(
         term::emit(dest, &config, &files, &diag)?;
 
         // Stacktrace-like helper diagnostics.
-        let mut traced = false;
-        for point in &diagnostic.trace {
-            emit_trace(dest, &mut files, point)?;
-            traced = true;
-        }
+        if format == DiagnosticFormat::Human {
+            let mut traced = false;
+            for point in &diagnostic.trace {
+                emit_trace(dest, &mut files, point)?;
+                traced = true;
+            }
 
-        if traced {
-            writeln!(dest)?;
+            if traced {
+                writeln!(dest)?;
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #8170 by omitting the trace when the short diagnostic format is used.