### PR TITLE
Fix missing live output generation for html and pdftags

### DIFF
--- a/tests/wrapper/src/main.rs
+++ b/tests/wrapper/src/main.rs
@@ -135,7 +135,7 @@ fn regen(cmd: RegenCommand) {
         // Allow a failing test suite.
         let status = Command::new("cargo")
             .args(["test", "--workspace", "--test=tests"])
-            .args(["--", "--no-report", "--stages=svg,pdf", "--exact"])
+            .args(["--", "--no-report", "--stages=pdf,pdftags,svg,html", "--exact"])
             .args(["--"])
             .args(missing_names)
             .run();


### PR DESCRIPTION
I forgot to update the wrapper to also regenerate `html` and `pdftags` output, arguably it could be even smarter and check the extensions of the missing tests to infer which stages need to be run. But honestly most of the time is spent compiling the test runner...