### PR TITLE
Fold `html.elem.attrs`

### DIFF
--- a/crates/typst-html/src/dom.rs
+++ b/crates/typst-html/src/dom.rs
@@ -5,7 +5,7 @@ use ecow::{EcoString, EcoVec};
 use typst_library::diag::{HintedStrResult, SourceResult, StrResult, bail};
 use typst_library::engine::Engine;
 use typst_library::foundations::{
-    Content, Dict, Output, Repr, Str, StyleChain, Target, cast,
+    Content, Dict, Fold, Output, Repr, Str, StyleChain, Target, cast,
 };
 use typst_library::introspection::{Introspector, Location, Tag};
 use typst_library::layout::{Abs, Frame, Point};
@@ -391,6 +391,21 @@ impl HtmlAttrs {
             .iter_mut()
             .find(|&&mut (k, _)| k == attr)
             .map(|(_, v)| v)
+    }
+}
+
+impl Fold for HtmlAttrs {
+    fn fold(mut self, outer: Self) -> Self {
+        // TODO: We might want to use a data structure where this is more
+        // efficient (while keeping small attribute lists efficient, too), but
+        // for now, this is okay.
+        self.0.reserve(outer.0.len());
+        for pair in outer.0 {
+            if !self.0.iter().any(|&(attr, _)| attr == pair.0) {
+                self.0.push(pair);
+            }
+        }
+        self
     }
 }
 

--- a/crates/typst-html/src/lib.rs
+++ b/crates/typst-html/src/lib.rs
@@ -65,6 +65,7 @@ pub struct HtmlElem {
     pub tag: HtmlTag,
 
     /// The element's HTML attributes.
+    #[fold]
     pub attrs: HtmlAttrs,
 
     /// The element's CSS properties. Currently only used for generated styles.

--- a/tests/ref/html/hashes.txt
+++ b/tests/ref/html/hashes.txt
@@ -26,6 +26,7 @@ f05d21fa2b913016803bf5476a1b6826 footnote-ref-multiple
 173d20de89ff8a56303aa8357ec2c323 heading-html-basic
 3779fea930339d8b6b37305dee2f7d1d html-deco
 eeecf9598691783d361c20acf47a8775 html-elem-alone-context
+e34ea44e32ada9e0685b72d6e82ecfd5 html-elem-attrs-fold
 2ea76ccf8bdc8f8a39f586aab6ed80c9 html-elem-custom
 52de31c777d4b7b8d356b54138b5fe14 html-elem-metadata
 0a1d1443e72ef554d74d15ae49cd076c html-escapable-raw-text-contains-closing-tag

--- a/tests/suite/html/elem.typ
+++ b/tests/suite/html/elem.typ
@@ -20,6 +20,13 @@ Text
 #html.elem("multi-word-component")[Hi]
 #html.elem("element-")[Hi]
 
+--- html-elem-attrs-fold html ---
+#set html.elem(attrs: (a: "1"))
+#set html.elem(attrs: (c: "3"))
+#set html.elem(attrs: (d: "4"))
+#set html.elem(attrs: (c: "3'"))
+#html.elem("div", attrs: (a: "1'", b: "2"))
+
 --- html-elem-invalid eval ---
 // Error: 12-24 the character "@" is not valid in a tag name
 #html.elem("my@element")


### PR DESCRIPTION
This PR implements folding for `html.elem.attrs`. The folding operation retains both the inner and outer attributes, but inner ones overwrite outer ones such that no duplicates appear.

With this folding, one can use set rules on `html.elem` to add additional attributes to an element. So far, this is not yet super useful because it only works on leaves (since every element in the subtree is affected), but with https://github.com/typst/typst/issues/7266 it would be more useful.

Makes progress towards https://github.com/typst/typst/issues/6959.

### Example
```typ
#set html.elem(attrs: (a: "1"))
#set html.elem(attrs: (c: "3"))
#set html.elem(attrs: (d: "4"))
#set html.elem(attrs: (c: "3'"))
#html.elem("div", attrs: (a: "1'", b: "2"))
```
```html
<div a="1'" b="2" c="3'" d="4"></div>
```