### PR TITLE
Fix handling of tags and inner elements in neutral group finishing

### DIFF
--- a/crates/typst-realize/src/lib.rs
+++ b/crates/typst-realize/src/lib.rs
@@ -863,9 +863,25 @@ fn finish_innermost_grouping(s: &mut State) -> SourceResult<()> {
                     visit(s, content, styles)?;
                 }
             } else {
-                let start = s.sink.len();
-                s.sink.extend_from_slice(slice);
-                finish_grouping(s, rule, start)?;
+                // Trim and revisit leading non-trigger elements.
+                // `finish_grouping` only takes care of trimming trailing
+                // elements as usually a grouping cannot start without a trigger
+                // element.
+                let trimmed = slice.trim_start_matches(|(c, _)| {
+                    (rule.effect)(c) != GroupingEffect::Trigger
+                });
+                let split = slice.len() - trimmed.len();
+                for &(content, styles) in &slice[..split] {
+                    visit(s, content, styles)?;
+                }
+
+                // If we only had inner elements and tags, don't finish the
+                // group at all.
+                if !trimmed.is_empty() {
+                    let start = s.sink.len();
+                    s.sink.extend_from_slice(trimmed);
+                    finish_grouping(s, rule, start)?;
+                }
             }
         }
         Ok(())

--- a/tests/ref/html/hashes.txt
+++ b/tests/ref/html/hashes.txt
@@ -79,6 +79,7 @@ fd1da4256fac4f0d6585d235f395ba7d par-semantic-html
 e0f41d4c8b6dc348c1153f45a86177a1 par-semantic-html-blocky
 643de0e3e92663a1cdc6e6b789f15122 par-semantic-html-fully-inline
 ece5ab4a1d0162b9e1da100cb126064f par-semantic-html-mixed
+239289b41129bae9878ed04460581ea8 par-semantic-html-mixed-tags
 ad987718b189a7a4f9de0f75c8aa9e29 par-semantic-html-parbreak
 04f74c1f6a4cd13b788d6144b31e56e4 par-semantic-html-top-level
 04f74c1f6a4cd13b788d6144b31e56e4 par-semantic-html-top-level-typed

--- a/tests/suite/model/par.typ
+++ b/tests/suite/model/par.typ
@@ -140,6 +140,35 @@ I'm a paragraph.
   A
 ]
 
+--- par-semantic-html-mixed-tags html ---
+#html.div({
+  html.span()
+  html.div()
+  // Inline segment starts with a tag.
+  metadata(none)
+  html.span()
+  parbreak()
+})
+
+#html.div({
+  heading[A]
+  // Inline segment ends with a tag.
+  html.span()
+  metadata(none)
+  html.div()
+  html.div()
+})
+
+#html.div({
+  parbreak()
+  html.span()
+  html.div()
+  // Segment consists only of tags.
+  metadata(none)
+  html.div()
+  html.span()
+})
+
 --- par-semantic-html-parbreak html ---
 // Test that parbreaks force inline elements into paragraphs.
 


### PR DESCRIPTION
Fixes a small bug introduced in https://github.com/typst/typst/pull/8181