### PR TITLE
Add syntax warnings

### DIFF
--- a/crates/typst-eval/src/lib.rs
+++ b/crates/typst-eval/src/lib.rs
@@ -68,9 +68,16 @@ pub fn eval(
     let root = source.root();
     let mut vm = Vm::new(engine, context.track(), scopes, root.span());
 
-    // Check for well-formedness unless we are in trace mode.
-    let errors = root.errors();
+    // Check for errors or warnings in the syntax tree before evaluating it.
+    // However, if we're inspecting a span, we keep going with evaluation
+    // regardless of syntax errors.
+    let (errors, warnings) = root.errors_and_warnings();
+    for warning in warnings {
+        vm.engine.sink.warn(warning.into());
+    }
     if !errors.is_empty() && vm.inspected.is_none() {
+        // We _could_ also return the warnings here with the errors, but we want
+        // to only use the sink for warnings for consistency.
         return Err(errors.into_iter().map(Into::into).collect());
     }
 
@@ -96,7 +103,7 @@ pub fn eval(
 pub fn eval_string(
     world: Tracked<dyn World + '_>,
     library: &LazyHash<Library>,
-    sink: TrackedMut<Sink>,
+    mut sink: TrackedMut<Sink>,
     introspector: Tracked<dyn Introspector + '_>,
     context: Tracked<Context>,
     string: &str,
@@ -116,9 +123,14 @@ pub fn eval_string(
         SpanMode::Mapped { id, mapper } => root.synthesize_mapped(id, mapper),
     }
 
-    // Check for well-formedness.
-    let errors = root.errors();
+    // Check for errors or warnings in the syntax tree before evaluating it.
+    let (errors, warnings) = root.errors_and_warnings();
+    for warning in warnings {
+        sink.warn(warning.into());
+    }
     if !errors.is_empty() {
+        // We _could_ also return the warnings here with the errors, but we want
+        // to only use the sink for warnings for consistency.
         return Err(errors.into_iter().map(Into::into).collect());
     }
 

--- a/crates/typst-eval/src/markup.rs
+++ b/crates/typst-eval/src/markup.rs
@@ -146,15 +146,8 @@ impl Eval for ast::Strong<'_> {
     type Output = Content;
 
     fn eval(self, vm: &mut Vm) -> SourceResult<Self::Output> {
-        let body = self.body();
-        if body.exprs().next().is_none() {
-            vm.engine.sink.warn(warning!(
-                self.span(), "no text within stars";
-                hint: "using multiple consecutive stars (e.g. **) has no additional effect";
-            ));
-        }
-
-        Ok(StrongElem::new(body.eval(vm)?).pack())
+        let body = self.body().eval(vm)?;
+        Ok(StrongElem::new(body).pack())
     }
 }
 
@@ -162,16 +155,8 @@ impl Eval for ast::Emph<'_> {
     type Output = Content;
 
     fn eval(self, vm: &mut Vm) -> SourceResult<Self::Output> {
-        let body = self.body();
-        if body.exprs().next().is_none() {
-            vm.engine.sink.warn(warning!(
-                self.span(), "no text within underscores";
-                hint: "using multiple consecutive underscores (e.g. __) has no \
-                       additional effect";
-            ));
-        }
-
-        Ok(EmphElem::new(body.eval(vm)?).pack())
+        let body = self.body().eval(vm)?;
+        Ok(EmphElem::new(body).pack())
     }
 }
 

--- a/crates/typst-library/src/diag.rs
+++ b/crates/typst-library/src/diag.rs
@@ -17,7 +17,7 @@ use std::string::FromUtf8Error;
 use az::SaturatingAs;
 use comemo::Tracked;
 use typst_syntax::package::{PackageSpec, PackageVersion};
-use typst_syntax::{Lines, Span, Spanned, SyntaxError, VirtualRoot};
+use typst_syntax::{Lines, Span, Spanned, SyntaxDiagnostic, VirtualRoot};
 use utf8_iter::ErrorReportingUtf8Chars;
 
 use crate::engine::Engine;
@@ -384,14 +384,15 @@ impl SourceDiagnostic {
     }
 }
 
-impl From<SyntaxError> for SourceDiagnostic {
-    fn from(error: SyntaxError) -> Self {
+impl From<SyntaxDiagnostic> for SourceDiagnostic {
+    fn from(syntax_diag: SyntaxDiagnostic) -> Self {
+        let SyntaxDiagnostic { is_error, span, message, hints } = syntax_diag;
         Self {
-            severity: Severity::Error,
-            span: error.span,
-            message: error.message,
+            severity: if is_error { Severity::Error } else { Severity::Warning },
+            span,
+            message,
             trace: eco_vec![],
-            hints: error.hints.into_iter().map(Spanned::detached).collect(),
+            hints: hints.into_iter().map(Spanned::detached).collect(),
         }
     }
 }

--- a/crates/typst-syntax/src/kind.rs
+++ b/crates/typst-syntax/src/kind.rs
@@ -378,8 +378,8 @@ impl SyntaxKind {
     }
 
     /// Whether this is an error.
-    pub fn is_error(self) -> bool {
-        self == Self::Error
+    pub const fn is_error(self) -> bool {
+        matches!(self, Self::Error)
     }
 
     /// A human-readable name for the kind.

--- a/crates/typst-syntax/src/lexer.rs
+++ b/crates/typst-syntax/src/lexer.rs
@@ -1,6 +1,6 @@
 use std::num::IntErrorKind;
 
-use ecow::{EcoString, eco_format};
+use ecow::{EcoString, EcoVec, eco_format, eco_vec};
 use typst_utils::default_math_class;
 use unicode_ident::{is_xid_continue, is_xid_start};
 use unicode_math_class::MathClass;
@@ -8,7 +8,7 @@ use unicode_script::{Script, UnicodeScript};
 use unicode_segmentation::UnicodeSegmentation;
 use unscanny::Scanner;
 
-use crate::{SyntaxError, SyntaxKind, SyntaxMode, SyntaxNode};
+use crate::{SyntaxKind, SyntaxMode, SyntaxNode};
 
 /// An iterator over a source code string which returns tokens.
 #[derive(Clone)]
@@ -20,8 +20,9 @@ pub(super) struct Lexer<'s> {
     mode: SyntaxMode,
     /// Whether the last token contained a newline.
     newline: bool,
-    /// An error for the last token.
-    error: Option<SyntaxError>,
+    /// An error plus hints for the current token being produced. This is always
+    /// `None` between calls to [`Lexer::next`].
+    error: Option<(EcoString, EcoVec<EcoString>)>,
 }
 
 impl<'s> Lexer<'s> {
@@ -73,14 +74,15 @@ impl<'s> Lexer<'s> {
 impl Lexer<'_> {
     /// Construct a full-positioned syntax error.
     fn error(&mut self, message: impl Into<EcoString>) -> SyntaxKind {
-        self.error = Some(SyntaxError::new(message));
+        debug_assert!(self.error.is_none());
+        self.error = Some((message.into(), eco_vec![]));
         SyntaxKind::Error
     }
 
     /// If the current node is an error, adds a hint.
     fn hint(&mut self, message: impl Into<EcoString>) {
-        if let Some(error) = &mut self.error {
-            error.hints.push(message.into());
+        if let Some((_message, hints)) = &mut self.error {
+            hints.push(message.into());
         }
     }
 }
@@ -122,7 +124,7 @@ impl Lexer<'_> {
 
         let text = self.s.from(start);
         let node = match self.error.take() {
-            Some(error) => SyntaxNode::error(error, text),
+            Some((message, hints)) => SyntaxNode::error(message, text).with_hints(hints),
             None => SyntaxNode::leaf(kind, text),
         };
         (kind, node)
@@ -274,8 +276,8 @@ impl Lexer<'_> {
                 Some('`') => found += 1,
                 Some(_) => found = 0,
                 None => {
-                    let msg = SyntaxError::new("unclosed raw text");
-                    let error = SyntaxNode::error(msg, self.s.from(start));
+                    let message = "unclosed raw text";
+                    let error = SyntaxNode::error(message, self.s.from(start));
                     return (SyntaxKind::Error, error);
                 }
             }
@@ -722,8 +724,8 @@ impl Lexer<'_> {
                 let node = if self.s.from(start) != "_" {
                     SyntaxNode::leaf(SyntaxKind::Ident, self.s.from(start))
                 } else {
-                    let msg = SyntaxError::new("expected identifier, found underscore");
-                    SyntaxNode::error(msg, self.s.from(start))
+                    let message = "expected identifier, found underscore";
+                    SyntaxNode::error(message, self.s.from(start))
                 };
                 return Some(node);
             }

--- a/crates/typst-syntax/src/lib.rs
+++ b/crates/typst-syntax/src/lib.rs
@@ -22,7 +22,9 @@ pub use self::lexer::{
     link_prefix, split_newlines,
 };
 pub use self::lines::Lines;
-pub use self::node::{LinkedChildren, LinkedNode, Side, SyntaxError, SyntaxNode};
+pub use self::node::{
+    Diagnosis, LinkedChildren, LinkedNode, Side, SyntaxDiagnostic, SyntaxNode,
+};
 pub use self::parser::{parse, parse_code, parse_math};
 pub use self::path::{
     FileId, PathError, RootedPath, VirtualPath, VirtualRoot, VirtualizeError,

--- a/crates/typst-syntax/src/node.rs
+++ b/crates/typst-syntax/src/node.rs
@@ -690,7 +690,17 @@ impl ErrorNode {
 
 impl Debug for ErrorNode {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "Error: {:?} ({})", self.text, self.error.message)
+        if self.text.is_empty() && self.error.hints.is_empty() {
+            write!(f, "Error: {:?}", self.error.message)
+        } else {
+            let mut out = f.debug_struct("Error:");
+            out.field("text", &self.text);
+            out.field("message", &self.error.message);
+            for hint in &self.error.hints {
+                out.field("hint", hint);
+            }
+            out.finish()
+        }
     }
 }
 
@@ -1148,7 +1158,7 @@ Markup: 14 [
             "\
 Markup: 1 [
     Hash: \"#\",
-    Error: \"\" (expected expression),
+    Error: \"expected expression\",
 ]"
         );
         // A syntax error with multiple hints:
@@ -1157,7 +1167,12 @@ Markup: 1 [
             "\
 Markup: 2 [
     Hash: \"#\",
-    Error: \"#\" (the character `#` is not valid in code),
+    Error: {
+        text: \"#\",
+        message: \"the character `#` is not valid in code\",
+        hint: \"the preceding hash is causing this to parse in code mode\",
+        hint: \"try escaping the preceding hash: `\\\\#`\",
+    },
 ]"
         );
     }

--- a/crates/typst-syntax/src/node.rs
+++ b/crates/typst-syntax/src/node.rs
@@ -73,7 +73,7 @@ impl SyntaxNode {
         match &self.0 {
             NodeKind::Leaf(leaf) => leaf.len(),
             NodeKind::Inner(inner) => inner.len,
-            NodeKind::Error(node) => node.len(),
+            NodeKind::Error(err) => err.len(),
         }
     }
 
@@ -82,7 +82,7 @@ impl SyntaxNode {
         match &self.0 {
             NodeKind::Leaf(leaf) => leaf.span,
             NodeKind::Inner(inner) => inner.span,
-            NodeKind::Error(node) => node.error.span,
+            NodeKind::Error(err) => err.error.span,
         }
     }
 
@@ -94,7 +94,7 @@ impl SyntaxNode {
         match &self.0 {
             NodeKind::Leaf(leaf) => &leaf.text,
             NodeKind::Inner(_) => &EMPTY,
-            NodeKind::Error(node) => &node.text,
+            NodeKind::Error(err) => &err.text,
         }
     }
 
@@ -104,14 +104,14 @@ impl SyntaxNode {
     pub fn into_text(self) -> EcoString {
         match self.0 {
             NodeKind::Leaf(leaf) => leaf.text,
-            NodeKind::Error(node) => node.text.clone(),
+            NodeKind::Error(err) => err.text.clone(),
             NodeKind::Inner(_) => {
                 let mut text = EcoString::with_capacity(self.len());
                 self.traverse(|node| {
                     match &node.0 {
                         NodeKind::Leaf(leaf) => text.push_str(&leaf.text),
                         NodeKind::Inner(_) => {}
-                        NodeKind::Error(node) => text.push_str(&node.text),
+                        NodeKind::Error(err) => text.push_str(&err.text),
                     }
                     node.children()
                 });
@@ -143,8 +143,8 @@ impl SyntaxNode {
         self.traverse(|node| match &node.0 {
             NodeKind::Inner(inner) if inner.erroneous => inner.children.iter(),
             NodeKind::Inner(_) | NodeKind::Leaf(_) => [].iter(),
-            NodeKind::Error(node) => {
-                vec.push(node.error.clone());
+            NodeKind::Error(err) => {
+                vec.push(err.error.clone());
                 [].iter()
             }
         });
@@ -187,8 +187,8 @@ impl SyntaxNode {
             NodeKind::Inner(inner) => {
                 Arc::make_mut(inner).synthesize_with_impl(offset, f)
             }
-            NodeKind::Error(node) => {
-                Arc::make_mut(node).error.span = f(offset..offset + node.len())
+            NodeKind::Error(err) => {
+                Arc::make_mut(err).error.span = f(offset..offset + err.len())
             }
         }
     }
@@ -258,7 +258,7 @@ impl SyntaxNode {
         match &mut self.0 {
             NodeKind::Leaf(leaf) => leaf.span = mid,
             NodeKind::Inner(inner) => Arc::make_mut(inner).numberize(id, None, within)?,
-            NodeKind::Error(node) => Arc::make_mut(node).error.span = mid,
+            NodeKind::Error(err) => Arc::make_mut(err).error.span = mid,
         }
 
         Ok(())
@@ -344,7 +344,7 @@ impl SyntaxNode {
         match &self.0 {
             NodeKind::Leaf(leaf) => leaf.span.number() + 1,
             NodeKind::Inner(inner) => inner.upper,
-            NodeKind::Error(node) => node.error.span.number() + 1,
+            NodeKind::Error(err) => err.error.span.number() + 1,
         }
     }
 }
@@ -354,7 +354,7 @@ impl Debug for SyntaxNode {
         match &self.0 {
             NodeKind::Leaf(leaf) => leaf.fmt(f),
             NodeKind::Inner(inner) => inner.fmt(f),
-            NodeKind::Error(node) => node.fmt(f),
+            NodeKind::Error(err) => err.fmt(f),
         }
     }
 }

--- a/crates/typst-syntax/src/node.rs
+++ b/crates/typst-syntax/src/node.rs
@@ -10,35 +10,35 @@ use crate::{FileId, RangeMapper, Span, SyntaxKind, SyntaxMode};
 
 /// A node in the untyped syntax tree.
 #[derive(Clone, Eq, PartialEq, Hash)]
-pub struct SyntaxNode(NodeKind);
+pub struct SyntaxNode(Node);
 
-/// The three internal representations.
+/// The internal representations of a node in the syntax tree.
 #[derive(Clone, Eq, PartialEq, Hash)]
-enum NodeKind {
-    /// A leaf node.
+enum Node {
+    /// A leaf node containing text.
     Leaf(LeafNode),
-    /// A reference-counted inner node.
+    /// A reference-counted inner node containing an array of children.
     Inner(Arc<InnerNode>),
-    /// An error node.
+    /// An error node containing an error message for some text.
     Error(Arc<ErrorNode>),
 }
 
 impl SyntaxNode {
     /// Create a new leaf node.
     pub fn leaf(kind: SyntaxKind, text: impl Into<EcoString>) -> Self {
-        Self(NodeKind::Leaf(LeafNode::new(kind, text.into())))
+        Self(Node::Leaf(LeafNode::new(kind, text.into())))
     }
 
     /// Create a new inner node with children.
     pub fn inner(kind: SyntaxKind, children: Vec<SyntaxNode>) -> Self {
-        Self(NodeKind::Inner(Arc::new(InnerNode::new(kind, children))))
+        Self(Node::Inner(Arc::new(InnerNode::new(kind, children))))
     }
 
     /// Create a new error node with a user-presentable message for the given
     /// text. Note that the message is the first argument, and the text causing
     /// the error is the second argument.
     pub fn error(message: impl Into<EcoString>, text: impl Into<EcoString>) -> Self {
-        Self(NodeKind::Error(Arc::new(ErrorNode::new(message.into(), text.into()))))
+        Self(Node::Error(Arc::new(ErrorNode::new(message.into(), text.into()))))
     }
 
     /// Add a user-presentable hint to an existing error. Panics if this is not
@@ -46,10 +46,10 @@ impl SyntaxNode {
     #[track_caller]
     pub fn hint(&mut self, hint: impl Into<EcoString>) {
         match &mut self.0 {
-            NodeKind::Leaf(_) | NodeKind::Inner(_) => {
+            Node::Leaf(_) | Node::Inner(_) => {
                 panic!("expected an error node")
             }
-            NodeKind::Error(err) => Arc::make_mut(err).error.hints.push(hint.into()),
+            Node::Error(err) => Arc::make_mut(err).error.hints.push(hint.into()),
         }
     }
 
@@ -58,10 +58,10 @@ impl SyntaxNode {
     #[track_caller]
     pub fn with_hints(mut self, hints: impl IntoIterator<Item = EcoString>) -> Self {
         match &mut self.0 {
-            NodeKind::Leaf(_) | NodeKind::Inner(_) => {
+            Node::Leaf(_) | Node::Inner(_) => {
                 panic!("expected an error node")
             }
-            NodeKind::Error(err) => Arc::make_mut(err).error.hints.extend(hints),
+            Node::Error(err) => Arc::make_mut(err).error.hints.extend(hints),
         }
         self
     }
@@ -74,7 +74,7 @@ impl SyntaxNode {
         if matches!(kind, SyntaxKind::Error) {
             panic!("cannot create error placeholder");
         }
-        Self(NodeKind::Leaf(LeafNode {
+        Self(Node::Leaf(LeafNode {
             kind,
             text: EcoString::new(),
             span: Span::detached(),
@@ -84,9 +84,9 @@ impl SyntaxNode {
     /// The type of the node.
     pub fn kind(&self) -> SyntaxKind {
         match &self.0 {
-            NodeKind::Leaf(leaf) => leaf.kind,
-            NodeKind::Inner(inner) => inner.kind,
-            NodeKind::Error(_) => SyntaxKind::Error,
+            Node::Leaf(leaf) => leaf.kind,
+            Node::Inner(inner) => inner.kind,
+            Node::Error(_) => SyntaxKind::Error,
         }
     }
 
@@ -98,18 +98,18 @@ impl SyntaxNode {
     /// The byte length of the node in the source text.
     pub fn len(&self) -> usize {
         match &self.0 {
-            NodeKind::Leaf(leaf) => leaf.text.len(),
-            NodeKind::Inner(inner) => inner.len,
-            NodeKind::Error(err) => err.text.len(),
+            Node::Leaf(leaf) => leaf.text.len(),
+            Node::Inner(inner) => inner.len,
+            Node::Error(err) => err.text.len(),
         }
     }
 
     /// The span of the node.
     pub fn span(&self) -> Span {
         match &self.0 {
-            NodeKind::Leaf(leaf) => leaf.span,
-            NodeKind::Inner(inner) => inner.span,
-            NodeKind::Error(err) => err.error.span,
+            Node::Leaf(leaf) => leaf.span,
+            Node::Inner(inner) => inner.span,
+            Node::Error(err) => err.error.span,
         }
     }
 
@@ -119,9 +119,9 @@ impl SyntaxNode {
     pub fn text(&self) -> &EcoString {
         static EMPTY: EcoString = EcoString::new();
         match &self.0 {
-            NodeKind::Leaf(leaf) => &leaf.text,
-            NodeKind::Inner(_) => &EMPTY,
-            NodeKind::Error(err) => &err.text,
+            Node::Leaf(leaf) => &leaf.text,
+            Node::Inner(_) => &EMPTY,
+            Node::Error(err) => &err.text,
         }
     }
 
@@ -130,15 +130,15 @@ impl SyntaxNode {
     /// Builds the string if this is an inner node.
     pub fn into_text(self) -> EcoString {
         match self.0 {
-            NodeKind::Leaf(leaf) => leaf.text,
-            NodeKind::Error(err) => err.text.clone(),
-            NodeKind::Inner(_) => {
+            Node::Leaf(leaf) => leaf.text,
+            Node::Error(err) => err.text.clone(),
+            Node::Inner(_) => {
                 let mut text = EcoString::with_capacity(self.len());
                 self.traverse(|node| {
                     match &node.0 {
-                        NodeKind::Leaf(leaf) => text.push_str(&leaf.text),
-                        NodeKind::Inner(_) => {}
-                        NodeKind::Error(err) => text.push_str(&err.text),
+                        Node::Leaf(leaf) => text.push_str(&leaf.text),
+                        Node::Inner(_) => {}
+                        Node::Error(err) => text.push_str(&err.text),
                     }
                     node.children()
                 });
@@ -150,17 +150,17 @@ impl SyntaxNode {
     /// The node's children.
     pub fn children(&self) -> std::slice::Iter<'_, SyntaxNode> {
         match &self.0 {
-            NodeKind::Leaf(_) | NodeKind::Error(_) => [].iter(),
-            NodeKind::Inner(inner) => inner.children.iter(),
+            Node::Leaf(_) | Node::Error(_) => [].iter(),
+            Node::Inner(inner) => inner.children.iter(),
         }
     }
 
     /// Whether the node or its children contain an error.
     pub fn erroneous(&self) -> bool {
         match &self.0 {
-            NodeKind::Leaf(_) => false,
-            NodeKind::Inner(inner) => inner.erroneous,
-            NodeKind::Error(_) => true,
+            Node::Leaf(_) => false,
+            Node::Inner(inner) => inner.erroneous,
+            Node::Error(_) => true,
         }
     }
 
@@ -168,9 +168,9 @@ impl SyntaxNode {
     pub fn errors(&self) -> Vec<SyntaxError> {
         let mut vec = Vec::new();
         self.traverse(|node| match &node.0 {
-            NodeKind::Inner(inner) if inner.erroneous => inner.children.iter(),
-            NodeKind::Inner(_) | NodeKind::Leaf(_) => [].iter(),
-            NodeKind::Error(err) => {
+            Node::Inner(inner) if inner.erroneous => inner.children.iter(),
+            Node::Inner(_) | Node::Leaf(_) => [].iter(),
+            Node::Error(err) => {
                 vec.push(err.error.clone());
                 [].iter()
             }
@@ -203,11 +203,9 @@ impl SyntaxNode {
         f: &mut impl FnMut(Range<usize>) -> Span,
     ) {
         match &mut self.0 {
-            NodeKind::Leaf(leaf) => leaf.span = f(offset..offset + leaf.text.len()),
-            NodeKind::Inner(inner) => {
-                Arc::make_mut(inner).synthesize_with_impl(offset, f)
-            }
-            NodeKind::Error(err) => {
+            Node::Leaf(leaf) => leaf.span = f(offset..offset + leaf.text.len()),
+            Node::Inner(inner) => Arc::make_mut(inner).synthesize_with_impl(offset, f),
+            Node::Error(err) => {
                 Arc::make_mut(err).error.span = f(offset..offset + err.text.len())
             }
         }
@@ -216,9 +214,9 @@ impl SyntaxNode {
     /// Whether the two syntax nodes are the same apart from spans.
     pub fn spanless_eq(&self, other: &Self) -> bool {
         match (&self.0, &other.0) {
-            (NodeKind::Leaf(a), NodeKind::Leaf(b)) => a.spanless_eq(b),
-            (NodeKind::Inner(a), NodeKind::Inner(b)) => a.spanless_eq(b),
-            (NodeKind::Error(a), NodeKind::Error(b)) => a.spanless_eq(b),
+            (Node::Leaf(a), Node::Leaf(b)) => a.spanless_eq(b),
+            (Node::Inner(a), Node::Inner(b)) => a.spanless_eq(b),
+            (Node::Error(a), Node::Error(b)) => a.spanless_eq(b),
             _ => false,
         }
     }
@@ -232,9 +230,9 @@ impl SyntaxNode {
     pub(super) fn convert_to_kind(&mut self, kind: SyntaxKind) {
         debug_assert!(!kind.is_error());
         match &mut self.0 {
-            NodeKind::Leaf(leaf) => leaf.kind = kind,
-            NodeKind::Inner(inner) => Arc::make_mut(inner).kind = kind,
-            NodeKind::Error(_) => panic!("cannot convert error"),
+            Node::Leaf(leaf) => leaf.kind = kind,
+            Node::Inner(inner) => Arc::make_mut(inner).kind = kind,
+            Node::Error(_) => panic!("cannot convert error"),
         }
     }
 
@@ -276,9 +274,9 @@ impl SyntaxNode {
 
         let mid = Span::from_number(id, (within.start + within.end) / 2).unwrap();
         match &mut self.0 {
-            NodeKind::Leaf(leaf) => leaf.span = mid,
-            NodeKind::Inner(inner) => Arc::make_mut(inner).numberize(id, None, within)?,
-            NodeKind::Error(err) => Arc::make_mut(err).error.span = mid,
+            Node::Leaf(leaf) => leaf.span = mid,
+            Node::Inner(inner) => Arc::make_mut(inner).numberize(id, None, within)?,
+            Node::Error(err) => Arc::make_mut(err).error.span = mid,
         }
 
         Ok(())
@@ -303,27 +301,27 @@ impl SyntaxNode {
 
     /// Whether this is a leaf node.
     pub(super) fn is_leaf(&self) -> bool {
-        matches!(self.0, NodeKind::Leaf(_))
+        matches!(self.0, Node::Leaf(_))
     }
 
     /// Whether this is an inner node.
     pub(super) fn is_inner(&self) -> bool {
-        matches!(self.0, NodeKind::Inner(_))
+        matches!(self.0, Node::Inner(_))
     }
 
     /// The number of descendants, including the node itself.
     pub(super) fn descendants(&self) -> usize {
         match &self.0 {
-            NodeKind::Leaf(_) | NodeKind::Error(_) => 1,
-            NodeKind::Inner(inner) => inner.descendants,
+            Node::Leaf(_) | Node::Error(_) => 1,
+            Node::Inner(inner) => inner.descendants,
         }
     }
 
     /// The node's children, mutably.
     pub(super) fn children_mut(&mut self) -> &mut [SyntaxNode] {
         match &mut self.0 {
-            NodeKind::Leaf(_) | NodeKind::Error(_) => &mut [],
-            NodeKind::Inner(inner) => &mut Arc::make_mut(inner).children,
+            Node::Leaf(_) | Node::Error(_) => &mut [],
+            Node::Inner(inner) => &mut Arc::make_mut(inner).children,
         }
     }
 
@@ -335,7 +333,7 @@ impl SyntaxNode {
         range: Range<usize>,
         replacement: Vec<SyntaxNode>,
     ) -> NumberingResult {
-        if let NodeKind::Inner(inner) = &mut self.0 {
+        if let Node::Inner(inner) = &mut self.0 {
             Arc::make_mut(inner).replace_children(range, replacement)?;
         }
         Ok(())
@@ -349,7 +347,7 @@ impl SyntaxNode {
         prev_descendants: usize,
         new_descendants: usize,
     ) {
-        if let NodeKind::Inner(inner) = &mut self.0 {
+        if let Node::Inner(inner) = &mut self.0 {
             Arc::make_mut(inner).update_parent(
                 prev_len,
                 new_len,
@@ -362,9 +360,9 @@ impl SyntaxNode {
     /// The upper bound of assigned numbers in this subtree.
     pub(super) fn upper(&self) -> u64 {
         match &self.0 {
-            NodeKind::Leaf(leaf) => leaf.span.number() + 1,
-            NodeKind::Inner(inner) => inner.upper,
-            NodeKind::Error(err) => err.error.span.number() + 1,
+            Node::Leaf(leaf) => leaf.span.number() + 1,
+            Node::Inner(inner) => inner.upper,
+            Node::Error(err) => err.error.span.number() + 1,
         }
     }
 }
@@ -372,9 +370,9 @@ impl SyntaxNode {
 impl Debug for SyntaxNode {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match &self.0 {
-            NodeKind::Leaf(leaf) => leaf.fmt(f),
-            NodeKind::Inner(inner) => inner.fmt(f),
-            NodeKind::Error(err) => err.fmt(f),
+            Node::Leaf(leaf) => leaf.fmt(f),
+            Node::Inner(inner) => inner.fmt(f),
+            Node::Error(err) => err.fmt(f),
         }
     }
 }
@@ -786,7 +784,7 @@ impl<'a> LinkedNode<'a> {
             return Some(self.clone());
         }
 
-        if let NodeKind::Inner(inner) = &self.0 {
+        if let Node::Inner(inner) = &self.0 {
             // The parent of a subtree has a smaller span number than all of its
             // descendants. Therefore, we can bail out early if the target span's
             // number is smaller than our number.

--- a/crates/typst-syntax/src/node.rs
+++ b/crates/typst-syntax/src/node.rs
@@ -1123,6 +1123,45 @@ mod tests {
     use super::*;
     use crate::Source;
 
+    /// Test the debug output of a `SyntaxNode`.
+    #[test]
+    fn test_debug() {
+        // A standard syntax tree:
+        assert_eq!(
+            format!("{:#?}", crate::parse("= Head <label>")),
+            "\
+Markup: 14 [
+    Heading: 6 [
+        HeadingMarker: \"=\",
+        Space: \" \",
+        Markup: 4 [
+            Text: \"Head\",
+        ],
+    ],
+    Space: \" \",
+    Label: \"<label>\",
+]"
+        );
+        // A basic syntax error:
+        assert_eq!(
+            format!("{:#?}", crate::parse("#")),
+            "\
+Markup: 1 [
+    Hash: \"#\",
+    Error: \"\" (expected expression),
+]"
+        );
+        // A syntax error with multiple hints:
+        assert_eq!(
+            format!("{:#?}", crate::parse("##")),
+            "\
+Markup: 2 [
+    Hash: \"#\",
+    Error: \"#\" (the character `#` is not valid in code),
+]"
+        );
+    }
+
     #[test]
     fn test_linked_node() {
         let source = Source::detached("#set text(12pt, red)");

--- a/crates/typst-syntax/src/node.rs
+++ b/crates/typst-syntax/src/node.rs
@@ -62,7 +62,7 @@ impl SyntaxNode {
             NodeWrapper::Node(Node::Leaf(_) | Node::Inner(_)) => {
                 panic!("expected an error or warning")
             }
-            NodeWrapper::Node(Node::Error(err)) => &mut Arc::make_mut(err).error.hints,
+            NodeWrapper::Node(Node::Error(err)) => &mut Arc::make_mut(err).hints,
             NodeWrapper::Warning(warn) => &mut Arc::make_mut(warn).hints,
         }
     }
@@ -155,7 +155,7 @@ impl SyntaxNode {
         match self.node() {
             Node::Leaf(leaf) => leaf.span,
             Node::Inner(inner) => inner.span,
-            Node::Error(err) => err.error.span,
+            Node::Error(err) => err.span,
         }
     }
 
@@ -233,7 +233,7 @@ impl SyntaxNode {
             }
             NodeWrapper::Node(Node::Inner(_) | Node::Leaf(_)) => [].iter(),
             NodeWrapper::Node(Node::Error(err)) => {
-                errors.push(err.error.clone());
+                errors.push(err.diagnostic());
                 [].iter()
             }
             NodeWrapper::Warning(warn) => {
@@ -282,7 +282,7 @@ impl SyntaxNode {
                 }
             }
             Node::Error(err) => {
-                Arc::make_mut(err).error.span = f(offset..offset + err.text.len())
+                Arc::make_mut(err).span = f(offset..offset + err.text.len());
             }
         }
     }
@@ -356,7 +356,7 @@ impl SyntaxNode {
         match self.node_mut() {
             Node::Leaf(leaf) => leaf.span = mid,
             Node::Inner(inner) => Arc::make_mut(inner).numberize(id, None, within)?,
-            Node::Error(err) => Arc::make_mut(err).error.span = mid,
+            Node::Error(err) => Arc::make_mut(err).span = mid,
         }
 
         Ok(())
@@ -446,7 +446,7 @@ impl SyntaxNode {
         match self.node() {
             Node::Leaf(leaf) => leaf.span.number() + 1,
             Node::Inner(inner) => inner.upper,
-            Node::Error(err) => err.error.span.number() + 1,
+            Node::Error(err) => err.span.number() + 1,
         }
     }
 }
@@ -803,8 +803,13 @@ pub struct SyntaxDiagnostic {
 struct ErrorNode {
     /// The source text of the node.
     text: EcoString,
-    /// The syntax error.
-    error: SyntaxDiagnostic,
+    /// The span targeted by the error.
+    span: Span,
+    /// The error message.
+    message: EcoString,
+    /// Additional hints to the user indicating how this error could be avoided
+    /// or worked around.
+    hints: EcoVec<EcoString>,
 }
 
 impl ErrorNode {
@@ -812,32 +817,39 @@ impl ErrorNode {
     fn new(message: EcoString, text: EcoString) -> Self {
         Self {
             text,
-            error: SyntaxDiagnostic {
-                is_error: true,
-                span: Span::detached(),
-                message,
-                hints: eco_vec![],
-            },
+            span: Span::detached(),
+            message,
+            hints: eco_vec![],
+        }
+    }
+
+    /// Produce the syntax diagnostic for an error.
+    fn diagnostic(&self) -> SyntaxDiagnostic {
+        SyntaxDiagnostic {
+            is_error: true,
+            span: self.span,
+            message: self.message.clone(),
+            hints: self.hints.clone(),
         }
     }
 
     /// Whether the two error nodes are the same apart from spans.
     fn spanless_eq(&self, other: &Self) -> bool {
         self.text == other.text
-            && self.error.message == other.error.message
-            && self.error.hints == other.error.hints
+            && self.message == other.message
+            && self.hints == other.hints
     }
 }
 
 impl Debug for ErrorNode {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        if self.text.is_empty() && self.error.hints.is_empty() {
-            write!(f, "Error: {:?}", self.error.message)
+        if self.text.is_empty() && self.hints.is_empty() {
+            write!(f, "Error: {:?}", self.message)
         } else {
             let mut out = f.debug_struct("Error:");
             out.field("text", &self.text);
-            out.field("message", &self.error.message);
-            for hint in &self.error.hints {
+            out.field("message", &self.message);
+            for hint in &self.hints {
                 out.field("hint", hint);
             }
             out.finish()

--- a/crates/typst-syntax/src/node.rs
+++ b/crates/typst-syntax/src/node.rs
@@ -267,12 +267,20 @@ impl SyntaxNode {
     /// Should be called with `offset = 0` on the root node.
     fn synthesize_with(
         &mut self,
-        offset: usize,
+        mut offset: usize,
         f: &mut impl FnMut(Range<usize>) -> Span,
     ) {
         match self.node_mut() {
             Node::Leaf(leaf) => leaf.span = f(offset..offset + leaf.text.len()),
-            Node::Inner(inner) => Arc::make_mut(inner).synthesize_with_impl(offset, f),
+            Node::Inner(inner) => {
+                let inner = Arc::make_mut(inner);
+                inner.span = f(offset..offset + inner.len);
+                inner.upper = inner.span.number();
+                for child in &mut inner.children {
+                    child.synthesize_with(offset, f);
+                    offset += child.len();
+                }
+            }
             Node::Error(err) => {
                 Arc::make_mut(err).error.span = f(offset..offset + err.text.len())
             }
@@ -537,20 +545,6 @@ impl InnerNode {
             diagnosis,
             upper: 0,
             children,
-        }
-    }
-
-    /// Set a synthetic span for the node and all its descendants.
-    fn synthesize_with_impl(
-        &mut self,
-        mut offset: usize,
-        f: &mut impl FnMut(Range<usize>) -> Span,
-    ) {
-        self.span = f(offset..offset + self.len);
-        self.upper = self.span.number();
-        for child in &mut self.children {
-            child.synthesize_with(offset, f);
-            offset += child.len();
         }
     }
 

--- a/crates/typst-syntax/src/node.rs
+++ b/crates/typst-syntax/src/node.rs
@@ -4,13 +4,24 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use ecow::{EcoString, EcoVec, eco_format, eco_vec};
+use typst_utils::debug;
 
 use crate::kind::ModeAfter;
 use crate::{FileId, RangeMapper, Span, SyntaxKind, SyntaxMode};
 
 /// A node in the untyped syntax tree.
 #[derive(Clone, Eq, PartialEq, Hash)]
-pub struct SyntaxNode(Node);
+pub struct SyntaxNode(NodeWrapper);
+
+/// A transparent wrapper around an actual node which allows us to add data,
+/// currently just warning messages, without increasing the size of `Node`.
+#[derive(Clone, Eq, PartialEq, Hash)]
+enum NodeWrapper {
+    /// An actual node in the syntax tree.
+    Node(Node),
+    /// A warning message wrapped directly around another node.
+    Warning(Arc<WarningWrapper>),
+}
 
 /// The internal representations of a node in the syntax tree.
 #[derive(Clone, Eq, PartialEq, Hash)]
@@ -24,45 +35,80 @@ enum Node {
 }
 
 impl SyntaxNode {
+    /// Get the underlying node, descending past warnings.
+    fn node(mut self: &Self) -> &Node {
+        loop {
+            match &self.0 {
+                NodeWrapper::Node(node) => break node,
+                NodeWrapper::Warning(warn) => self = &warn.child,
+            }
+        }
+    }
+
+    /// Get the underlying node mutably, descending past warnings.
+    fn node_mut(mut self: &mut Self) -> &mut Node {
+        loop {
+            match &mut self.0 {
+                NodeWrapper::Node(node) => break node,
+                NodeWrapper::Warning(warn) => self = &mut Arc::make_mut(warn).child,
+            }
+        }
+    }
+
+    /// Get the hints for an error or warning mutably.
+    #[track_caller]
+    fn hints_mut(&mut self) -> &mut EcoVec<EcoString> {
+        match &mut self.0 {
+            NodeWrapper::Node(Node::Leaf(_) | Node::Inner(_)) => {
+                panic!("expected an error or warning")
+            }
+            NodeWrapper::Node(Node::Error(err)) => &mut Arc::make_mut(err).error.hints,
+            NodeWrapper::Warning(warn) => &mut Arc::make_mut(warn).hints,
+        }
+    }
+}
+
+impl SyntaxNode {
     /// Create a new leaf node.
     pub fn leaf(kind: SyntaxKind, text: impl Into<EcoString>) -> Self {
-        Self(Node::Leaf(LeafNode::new(kind, text.into())))
+        Self(NodeWrapper::Node(Node::Leaf(LeafNode::new(kind, text.into()))))
     }
 
     /// Create a new inner node with children.
     pub fn inner(kind: SyntaxKind, children: Vec<SyntaxNode>) -> Self {
-        Self(Node::Inner(Arc::new(InnerNode::new(kind, children))))
+        Self(NodeWrapper::Node(Node::Inner(Arc::new(InnerNode::new(kind, children)))))
     }
 
     /// Create a new error node with a user-presentable message for the given
     /// text. Note that the message is the first argument, and the text causing
     /// the error is the second argument.
     pub fn error(message: impl Into<EcoString>, text: impl Into<EcoString>) -> Self {
-        Self(Node::Error(Arc::new(ErrorNode::new(message.into(), text.into()))))
+        Self(NodeWrapper::Node(Node::Error(Arc::new(ErrorNode::new(
+            message.into(),
+            text.into(),
+        )))))
     }
 
-    /// Add a user-presentable hint to an existing error. Panics if this is not
-    /// an error node.
+    /// Add a warning message to an existing node.
+    pub fn warn(&mut self, message: impl Into<EcoString>) {
+        *self = Self(NodeWrapper::Warning(Arc::new(WarningWrapper::new(
+            std::mem::take(self),
+            message.into(),
+        ))));
+    }
+
+    /// Add a user-presentable hint to an existing error or warning. Panics if
+    /// this is not an error or warning.
     #[track_caller]
     pub fn hint(&mut self, hint: impl Into<EcoString>) {
-        match &mut self.0 {
-            Node::Leaf(_) | Node::Inner(_) => {
-                panic!("expected an error node")
-            }
-            Node::Error(err) => Arc::make_mut(err).error.hints.push(hint.into()),
-        }
+        self.hints_mut().push(hint.into());
     }
 
-    /// Add multiple hints while building an error. Panics if this is not an
-    /// error.
+    /// Add multiple hints while building an error or warning. Panics if this is
+    /// not an error or warning.
     #[track_caller]
     pub fn with_hints(mut self, hints: impl IntoIterator<Item = EcoString>) -> Self {
-        match &mut self.0 {
-            Node::Leaf(_) | Node::Inner(_) => {
-                panic!("expected an error node")
-            }
-            Node::Error(err) => Arc::make_mut(err).error.hints.extend(hints),
-        }
+        self.hints_mut().extend(hints);
         self
     }
 
@@ -74,16 +120,16 @@ impl SyntaxNode {
         if matches!(kind, SyntaxKind::Error) {
             panic!("cannot create error placeholder");
         }
-        Self(Node::Leaf(LeafNode {
+        Self(NodeWrapper::Node(Node::Leaf(LeafNode {
             kind,
             text: EcoString::new(),
             span: Span::detached(),
-        }))
+        })))
     }
 
     /// The type of the node.
     pub fn kind(&self) -> SyntaxKind {
-        match &self.0 {
+        match self.node() {
             Node::Leaf(leaf) => leaf.kind,
             Node::Inner(inner) => inner.kind,
             Node::Error(_) => SyntaxKind::Error,
@@ -97,7 +143,7 @@ impl SyntaxNode {
 
     /// The byte length of the node in the source text.
     pub fn len(&self) -> usize {
-        match &self.0 {
+        match self.node() {
             Node::Leaf(leaf) => leaf.text.len(),
             Node::Inner(inner) => inner.len,
             Node::Error(err) => err.text.len(),
@@ -106,7 +152,7 @@ impl SyntaxNode {
 
     /// The span of the node.
     pub fn span(&self) -> Span {
-        match &self.0 {
+        match self.node() {
             Node::Leaf(leaf) => leaf.span,
             Node::Inner(inner) => inner.span,
             Node::Error(err) => err.error.span,
@@ -118,7 +164,7 @@ impl SyntaxNode {
     /// Returns the empty string if this is an inner node.
     pub fn text(&self) -> &EcoString {
         static EMPTY: EcoString = EcoString::new();
-        match &self.0 {
+        match self.node() {
             Node::Leaf(leaf) => &leaf.text,
             Node::Inner(_) => &EMPTY,
             Node::Error(err) => &err.text,
@@ -129,13 +175,15 @@ impl SyntaxNode {
     ///
     /// Builds the string if this is an inner node.
     pub fn into_text(self) -> EcoString {
+        // This isn't fully efficient for warnings, but the efficient
+        // version is more complicated to read/write due to partial moves.
         match self.0 {
-            Node::Leaf(leaf) => leaf.text,
-            Node::Error(err) => err.text.clone(),
-            Node::Inner(_) => {
+            NodeWrapper::Node(Node::Leaf(leaf)) => leaf.text,
+            NodeWrapper::Node(Node::Error(err)) => err.text.clone(),
+            NodeWrapper::Node(Node::Inner(_)) | NodeWrapper::Warning(_) => {
                 let mut text = EcoString::with_capacity(self.len());
                 self.traverse(|node| {
-                    match &node.0 {
+                    match node.node() {
                         Node::Leaf(leaf) => text.push_str(&leaf.text),
                         Node::Inner(_) => {}
                         Node::Error(err) => text.push_str(&err.text),
@@ -149,33 +197,53 @@ impl SyntaxNode {
 
     /// The node's children.
     pub fn children(&self) -> std::slice::Iter<'_, SyntaxNode> {
-        match &self.0 {
+        match self.node() {
             Node::Leaf(_) | Node::Error(_) => [].iter(),
             Node::Inner(inner) => inner.children.iter(),
         }
     }
 
-    /// Whether the node or its children contain an error.
-    pub fn erroneous(&self) -> bool {
+    /// Whether the node has diagnostic errors and/or warnings in it or its
+    /// children. [`Diagnosis`] has public fields, so you can write
+    /// `node.diagnosis().errors` to determine if a node is erroneous.
+    ///
+    /// This can be used to determine whether [`Self::errors_and_warnings`] will
+    /// return an empty vector without traversing the tree if it will not.
+    pub fn diagnosis(&self) -> Diagnosis {
         match &self.0 {
-            Node::Leaf(_) => false,
-            Node::Inner(inner) => inner.erroneous,
-            Node::Error(_) => true,
+            NodeWrapper::Node(Node::Leaf(_)) => Diagnosis::default(),
+            NodeWrapper::Node(Node::Inner(inner)) => inner.diagnosis,
+            NodeWrapper::Node(Node::Error(_)) => {
+                Diagnosis { errors: true, warnings: false }
+            }
+            NodeWrapper::Warning(warn) => Diagnosis {
+                errors: warn.child.diagnosis().errors,
+                warnings: true,
+            },
         }
     }
 
-    /// The error messages for this node and its descendants.
-    pub fn errors(&self) -> Vec<SyntaxError> {
-        let mut vec = Vec::new();
+    /// The error and warning diagnostics for this node and its descendants.
+    pub fn errors_and_warnings(&self) -> (Vec<SyntaxDiagnostic>, Vec<SyntaxDiagnostic>) {
+        let mut errors = Vec::new();
+        let mut warnings = Vec::new();
         self.traverse(|node| match &node.0 {
-            Node::Inner(inner) if inner.erroneous => inner.children.iter(),
-            Node::Inner(_) | Node::Leaf(_) => [].iter(),
-            Node::Error(err) => {
-                vec.push(err.error.clone());
+            NodeWrapper::Node(Node::Inner(inner)) if inner.diagnosis.either() => {
+                inner.children.iter()
+            }
+            NodeWrapper::Node(Node::Inner(_) | Node::Leaf(_)) => [].iter(),
+            NodeWrapper::Node(Node::Error(err)) => {
+                errors.push(err.error.clone());
                 [].iter()
             }
+            NodeWrapper::Warning(warn) => {
+                warnings.push(warn.diagnostic());
+                // We traverse into the wrapped child of the warning in case
+                // that child is itself a warning.
+                std::slice::from_ref(&warn.child).iter()
+            }
         });
-        vec
+        (errors, warnings)
     }
 
     /// Set a synthetic span for the node and all its descendants.
@@ -202,7 +270,7 @@ impl SyntaxNode {
         offset: usize,
         f: &mut impl FnMut(Range<usize>) -> Span,
     ) {
-        match &mut self.0 {
+        match self.node_mut() {
             Node::Leaf(leaf) => leaf.span = f(offset..offset + leaf.text.len()),
             Node::Inner(inner) => Arc::make_mut(inner).synthesize_with_impl(offset, f),
             Node::Error(err) => {
@@ -214,9 +282,13 @@ impl SyntaxNode {
     /// Whether the two syntax nodes are the same apart from spans.
     pub fn spanless_eq(&self, other: &Self) -> bool {
         match (&self.0, &other.0) {
-            (Node::Leaf(a), Node::Leaf(b)) => a.spanless_eq(b),
-            (Node::Inner(a), Node::Inner(b)) => a.spanless_eq(b),
-            (Node::Error(a), Node::Error(b)) => a.spanless_eq(b),
+            (NodeWrapper::Node(a), NodeWrapper::Node(b)) => match (a, b) {
+                (Node::Leaf(a), Node::Leaf(b)) => a.spanless_eq(b),
+                (Node::Inner(a), Node::Inner(b)) => a.spanless_eq(b),
+                (Node::Error(a), Node::Error(b)) => a.spanless_eq(b),
+                _ => false,
+            },
+            (NodeWrapper::Warning(a), NodeWrapper::Warning(b)) => a.spanless_eq(b),
             _ => false,
         }
     }
@@ -229,7 +301,7 @@ impl SyntaxNode {
     #[track_caller]
     pub(super) fn convert_to_kind(&mut self, kind: SyntaxKind) {
         debug_assert!(!kind.is_error());
-        match &mut self.0 {
+        match self.node_mut() {
             Node::Leaf(leaf) => leaf.kind = kind,
             Node::Inner(inner) => Arc::make_mut(inner).kind = kind,
             Node::Error(_) => panic!("cannot convert error"),
@@ -273,7 +345,7 @@ impl SyntaxNode {
         }
 
         let mid = Span::from_number(id, (within.start + within.end) / 2).unwrap();
-        match &mut self.0 {
+        match self.node_mut() {
             Node::Leaf(leaf) => leaf.span = mid,
             Node::Inner(inner) => Arc::make_mut(inner).numberize(id, None, within)?,
             Node::Error(err) => Arc::make_mut(err).error.span = mid,
@@ -301,17 +373,18 @@ impl SyntaxNode {
 
     /// Whether this is a leaf node.
     pub(super) fn is_leaf(&self) -> bool {
-        matches!(self.0, Node::Leaf(_))
+        matches!(self.node(), Node::Leaf(_))
+        // TODO: Should we also treat non-empty errors as leaves?
     }
 
     /// Whether this is an inner node.
     pub(super) fn is_inner(&self) -> bool {
-        matches!(self.0, Node::Inner(_))
+        matches!(self.node(), Node::Inner(_))
     }
 
     /// The number of descendants, including the node itself.
     pub(super) fn descendants(&self) -> usize {
-        match &self.0 {
+        match self.node() {
             Node::Leaf(_) | Node::Error(_) => 1,
             Node::Inner(inner) => inner.descendants,
         }
@@ -319,7 +392,7 @@ impl SyntaxNode {
 
     /// The node's children, mutably.
     pub(super) fn children_mut(&mut self) -> &mut [SyntaxNode] {
-        match &mut self.0 {
+        match self.node_mut() {
             Node::Leaf(_) | Node::Error(_) => &mut [],
             Node::Inner(inner) => &mut Arc::make_mut(inner).children,
         }
@@ -333,10 +406,12 @@ impl SyntaxNode {
         range: Range<usize>,
         replacement: Vec<SyntaxNode>,
     ) -> NumberingResult {
-        if let Node::Inner(inner) = &mut self.0 {
-            Arc::make_mut(inner).replace_children(range, replacement)?;
+        match self.node_mut() {
+            Node::Leaf(_) | Node::Error(_) => Ok(()),
+            Node::Inner(inner) => {
+                Arc::make_mut(inner).replace_children(range, replacement)
+            }
         }
-        Ok(())
     }
 
     /// Update this node after changes were made to one of its children.
@@ -347,19 +422,20 @@ impl SyntaxNode {
         prev_descendants: usize,
         new_descendants: usize,
     ) {
-        if let Node::Inner(inner) = &mut self.0 {
-            Arc::make_mut(inner).update_parent(
+        match self.node_mut() {
+            Node::Leaf(_) | Node::Error(_) => {}
+            Node::Inner(inner) => Arc::make_mut(inner).update_parent(
                 prev_len,
                 new_len,
                 prev_descendants,
                 new_descendants,
-            );
+            ),
         }
     }
 
     /// The upper bound of assigned numbers in this subtree.
     pub(super) fn upper(&self) -> u64 {
-        match &self.0 {
+        match self.node() {
             Node::Leaf(leaf) => leaf.span.number() + 1,
             Node::Inner(inner) => inner.upper,
             Node::Error(err) => err.error.span.number() + 1,
@@ -370,9 +446,10 @@ impl SyntaxNode {
 impl Debug for SyntaxNode {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match &self.0 {
-            Node::Leaf(leaf) => leaf.fmt(f),
-            Node::Inner(inner) => inner.fmt(f),
-            Node::Error(err) => err.fmt(f),
+            NodeWrapper::Node(Node::Leaf(leaf)) => leaf.fmt(f),
+            NodeWrapper::Node(Node::Inner(inner)) => inner.fmt(f),
+            NodeWrapper::Node(Node::Error(err)) => err.fmt(f),
+            NodeWrapper::Warning(warn) => warn.fmt(f),
         }
     }
 }
@@ -427,8 +504,9 @@ struct InnerNode {
     span: Span,
     /// The number of nodes in the whole subtree, including this node.
     descendants: usize,
-    /// Whether this node or any of its children are erroneous.
-    erroneous: bool,
+    /// Whether this node or any of its children contain an error/warning
+    /// diagnostic.
+    diagnosis: Diagnosis,
     /// The upper bound of this node's numbering range.
     upper: u64,
     /// This node's children, losslessly make up this node.
@@ -443,12 +521,12 @@ impl InnerNode {
 
         let mut len = 0;
         let mut descendants = 1;
-        let mut erroneous = false;
+        let mut diagnosis = Diagnosis::default();
 
         for child in &children {
             len += child.len();
             descendants += child.descendants();
-            erroneous |= child.erroneous();
+            diagnosis = diagnosis.or(child.diagnosis());
         }
 
         Self {
@@ -456,7 +534,7 @@ impl InnerNode {
             len,
             span: Span::detached(),
             descendants,
-            erroneous,
+            diagnosis,
             upper: 0,
             children,
         }
@@ -531,7 +609,7 @@ impl InnerNode {
         self.kind == other.kind
             && self.len == other.len
             && self.descendants == other.descendants
-            && self.erroneous == other.erroneous
+            && self.diagnosis == other.diagnosis
             && self.children.len() == other.children.len()
             && self
                 .children
@@ -584,14 +662,21 @@ impl InnerNode {
             + replacement.iter().map(SyntaxNode::descendants).sum::<usize>()
             - superseded.iter().map(SyntaxNode::descendants).sum::<usize>();
 
-        // Determine whether we're still erroneous after the replacement. That's
-        // the case if
-        // - any of the new nodes is erroneous,
-        // - or if we were erroneous before due to a non-superseded node.
-        self.erroneous = replacement.iter().any(SyntaxNode::erroneous)
-            || (self.erroneous
-                && (self.children[..range.start].iter().any(SyntaxNode::erroneous))
-                || self.children[range.end..].iter().any(SyntaxNode::erroneous));
+        // Update our diagnosis after the replacement.
+        // - If we had no errors/warnings before, we can just use the replaced
+        //   diagnosis
+        // - Or, if our replacement has errors _and_ warnings, we can use that
+        // - Otherwise, we need to update based on all of the children _outside_
+        //   the replaced range in case we replaced the erroneous children
+        let replaced_diagnosis = Diagnosis::any(replacement);
+        if !self.diagnosis.either() || replaced_diagnosis.both() {
+            self.diagnosis = replaced_diagnosis;
+        } else {
+            self.diagnosis = replaced_diagnosis.or(Diagnosis::or(
+                Diagnosis::any(&self.children[..range.start]),
+                Diagnosis::any(&self.children[range.end..]),
+            ));
+        }
 
         // Perform the replacement.
         self.children
@@ -655,7 +740,7 @@ impl InnerNode {
     ) {
         self.len = self.len + new_len - prev_len;
         self.descendants = self.descendants + new_descendants - prev_descendants;
-        self.erroneous = self.children.iter().any(SyntaxNode::erroneous);
+        self.diagnosis = Diagnosis::any(&self.children);
     }
 }
 
@@ -670,14 +755,51 @@ impl Debug for InnerNode {
     }
 }
 
-/// A syntactical error.
+/// Whether a node has diagnostic errors and/or warnings in it or its children.
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash)]
+pub struct Diagnosis {
+    pub errors: bool,
+    pub warnings: bool,
+}
+
+impl Diagnosis {
+    /// Whether there were errors or warnings.
+    pub fn either(self) -> bool {
+        self.errors | self.warnings
+    }
+
+    /// Whether there were both errors and warnings.
+    pub fn both(self) -> bool {
+        self.errors & self.warnings
+    }
+
+    /// Apply the `OR` of both fields separately.
+    pub fn or(mut self, other: Self) -> Self {
+        self.errors |= other.errors;
+        self.warnings |= other.warnings;
+        self
+    }
+
+    /// Whether any node in the given slice has errors or warnings.
+    fn any(slice: &[SyntaxNode]) -> Self {
+        slice
+            .iter()
+            .map(SyntaxNode::diagnosis)
+            .fold(Self::default(), Self::or)
+    }
+}
+
+/// A syntactical error or warning. This is mainly used by converting it to a
+/// `SourceDiagnostic` during evaluation.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct SyntaxError {
-    /// The node's span.
+pub struct SyntaxDiagnostic {
+    /// `true` if the diagnostic is an error, `false` if it's a warning.
+    pub is_error: bool,
+    /// The span targeted by the diagnostic.
     pub span: Span,
-    /// The error message.
+    /// The main diagnostic message.
     pub message: EcoString,
-    /// Additional hints to the user, indicating how this error could be avoided
+    /// Additional hints to the user indicating how this issue could be avoided
     /// or worked around.
     pub hints: EcoVec<EcoString>,
 }
@@ -688,7 +810,7 @@ struct ErrorNode {
     /// The source text of the node.
     text: EcoString,
     /// The syntax error.
-    error: SyntaxError,
+    error: SyntaxDiagnostic,
 }
 
 impl ErrorNode {
@@ -696,7 +818,12 @@ impl ErrorNode {
     fn new(message: EcoString, text: EcoString) -> Self {
         Self {
             text,
-            error: SyntaxError { span: Span::detached(), message, hints: eco_vec![] },
+            error: SyntaxDiagnostic {
+                is_error: true,
+                span: Span::detached(),
+                message,
+                hints: eco_vec![],
+            },
         }
     }
 
@@ -721,6 +848,62 @@ impl Debug for ErrorNode {
             }
             out.finish()
         }
+    }
+}
+
+/// A warning message wrapped around a node in the tree.
+///
+/// Warnings transparently wrap another node and do not have spans or text of
+/// their own. This means their child cannot be directly found or mutated, only
+/// affected _through_ the warning, usually via the [`SyntaxNode::get`] and
+/// [`SyntaxNode::get_mut`] methods.
+#[derive(Clone, Eq, PartialEq, Hash)]
+struct WarningWrapper {
+    /// The wrapped syntax node.
+    child: SyntaxNode,
+    /// The warning message.
+    message: EcoString,
+    /// Additional hints to the user indicating how this warning could be
+    /// avoided or worked around.
+    hints: EcoVec<EcoString>,
+}
+
+impl WarningWrapper {
+    /// Wrap an existing syntax node in a warning node.
+    fn new(child: SyntaxNode, message: EcoString) -> Self {
+        Self { child, message, hints: eco_vec![] }
+    }
+
+    /// Produce the syntax diagnostic for a warning.
+    fn diagnostic(&self) -> SyntaxDiagnostic {
+        SyntaxDiagnostic {
+            is_error: false,
+            span: self.child.span(),
+            message: self.message.clone(),
+            hints: self.hints.clone(),
+        }
+    }
+
+    /// Whether the two warnings are the same apart from spans.
+    fn spanless_eq(&self, other: &Self) -> bool {
+        self.message == other.message
+            && self.hints == other.hints
+            && self.child.spanless_eq(&other.child)
+    }
+}
+
+impl Debug for WarningWrapper {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "Warning: ")?;
+        // Use `debug_set` instead of `debug_struct` so we don't have to add a
+        // field name when outputting the child.
+        let mut out = f.debug_set();
+        out.entry(&debug(|f| write!(f, "message: {:?}", self.message)));
+        for hint in &self.hints {
+            out.entry(&debug(|f| write!(f, "hint: {hint:?}")));
+        }
+        out.entry(&self.child);
+        out.finish()
     }
 }
 
@@ -784,7 +967,7 @@ impl<'a> LinkedNode<'a> {
             return Some(self.clone());
         }
 
-        if let Node::Inner(inner) = &self.0 {
+        if let Node::Inner(inner) = self.node.node() {
             // The parent of a subtree has a smaller span number than all of its
             // descendants. Therefore, we can bail out early if the target span's
             // number is smaller than our number.
@@ -792,6 +975,8 @@ impl<'a> LinkedNode<'a> {
                 return None;
             }
 
+            // Use `self.children()`, not `inner.children()` to preserve being
+            // in a `LinkedNode`.
             let mut children = self.children().peekable();
             while let Some(child) = children.next() {
                 // Every node in this child's subtree has a smaller span number than
@@ -1164,6 +1349,22 @@ Markup: 2 [
         message: \"the character `#` is not valid in code\",
         hint: \"the preceding hash is causing this to parse in code mode\",
         hint: \"try escaping the preceding hash: `\\\\#`\",
+    },
+]"
+        );
+        // A warning with a hint:
+        assert_eq!(
+            format!("{:#?}", crate::parse("**")),
+            "\
+Markup: 2 [
+    Warning: {
+        message: \"no text within stars\",
+        hint: \"using multiple consecutive stars (e.g. **) has no additional effect\",
+        Strong: 2 [
+            Star: \"*\",
+            Markup: 0,
+            Star: \"*\",
+        ],
     },
 ]"
         );

--- a/crates/typst-syntax/src/node.rs
+++ b/crates/typst-syntax/src/node.rs
@@ -26,7 +26,7 @@ enum NodeKind {
 impl SyntaxNode {
     /// Create a new leaf node.
     pub fn leaf(kind: SyntaxKind, text: impl Into<EcoString>) -> Self {
-        Self(NodeKind::Leaf(LeafNode::new(kind, text)))
+        Self(NodeKind::Leaf(LeafNode::new(kind, text.into())))
     }
 
     /// Create a new inner node with children.
@@ -34,9 +34,36 @@ impl SyntaxNode {
         Self(NodeKind::Inner(Arc::new(InnerNode::new(kind, children))))
     }
 
-    /// Create a new error node.
-    pub fn error(error: SyntaxError, text: impl Into<EcoString>) -> Self {
-        Self(NodeKind::Error(Arc::new(ErrorNode::new(error, text))))
+    /// Create a new error node with a user-presentable message for the given
+    /// text. Note that the message is the first argument, and the text causing
+    /// the error is the second argument.
+    pub fn error(message: impl Into<EcoString>, text: impl Into<EcoString>) -> Self {
+        Self(NodeKind::Error(Arc::new(ErrorNode::new(message.into(), text.into()))))
+    }
+
+    /// Add a user-presentable hint to an existing error. Panics if this is not
+    /// an error node.
+    #[track_caller]
+    pub fn hint(&mut self, hint: impl Into<EcoString>) {
+        match &mut self.0 {
+            NodeKind::Leaf(_) | NodeKind::Inner(_) => {
+                panic!("expected an error node")
+            }
+            NodeKind::Error(err) => Arc::make_mut(err).error.hints.push(hint.into()),
+        }
+    }
+
+    /// Add multiple hints while building an error. Panics if this is not an
+    /// error.
+    #[track_caller]
+    pub fn with_hints(mut self, hints: impl IntoIterator<Item = EcoString>) -> Self {
+        match &mut self.0 {
+            NodeKind::Leaf(_) | NodeKind::Inner(_) => {
+                panic!("expected an error node")
+            }
+            NodeKind::Error(err) => Arc::make_mut(err).error.hints.extend(hints),
+        }
+        self
     }
 
     /// Create a dummy node of the given kind.
@@ -71,9 +98,9 @@ impl SyntaxNode {
     /// The byte length of the node in the source text.
     pub fn len(&self) -> usize {
         match &self.0 {
-            NodeKind::Leaf(leaf) => leaf.len(),
+            NodeKind::Leaf(leaf) => leaf.text.len(),
             NodeKind::Inner(inner) => inner.len,
-            NodeKind::Error(err) => err.len(),
+            NodeKind::Error(err) => err.text.len(),
         }
     }
 
@@ -151,13 +178,6 @@ impl SyntaxNode {
         vec
     }
 
-    /// Add a user-presentable hint if this is an error node.
-    pub fn hint(&mut self, hint: impl Into<EcoString>) {
-        if let NodeKind::Error(node) = &mut self.0 {
-            Arc::make_mut(node).hint(hint);
-        }
-    }
-
     /// Set a synthetic span for the node and all its descendants.
     pub fn synthesize(&mut self, span: Span) {
         self.synthesize_with(0, &mut |_| span);
@@ -183,12 +203,12 @@ impl SyntaxNode {
         f: &mut impl FnMut(Range<usize>) -> Span,
     ) {
         match &mut self.0 {
-            NodeKind::Leaf(leaf) => leaf.span = f(offset..offset + leaf.len()),
+            NodeKind::Leaf(leaf) => leaf.span = f(offset..offset + leaf.text.len()),
             NodeKind::Inner(inner) => {
                 Arc::make_mut(inner).synthesize_with_impl(offset, f)
             }
             NodeKind::Error(err) => {
-                Arc::make_mut(err).error.span = f(offset..offset + err.len())
+                Arc::make_mut(err).error.span = f(offset..offset + err.text.len())
             }
         }
     }
@@ -222,7 +242,7 @@ impl SyntaxNode {
     pub(super) fn convert_to_error(&mut self, message: impl Into<EcoString>) {
         if !self.kind().is_error() {
             let text = std::mem::take(self).into_text();
-            *self = SyntaxNode::error(SyntaxError::new(message), text);
+            *self = SyntaxNode::error(message.into(), text);
         }
     }
 
@@ -380,14 +400,9 @@ struct LeafNode {
 impl LeafNode {
     /// Create a new leaf node.
     #[track_caller]
-    fn new(kind: SyntaxKind, text: impl Into<EcoString>) -> Self {
+    fn new(kind: SyntaxKind, text: EcoString) -> Self {
         debug_assert!(!kind.is_error());
-        Self { kind, text: text.into(), span: Span::detached() }
-    }
-
-    /// The byte length of the node in the source text.
-    fn len(&self) -> usize {
-        self.text.len()
+        Self { kind, text, span: Span::detached() }
     }
 
     /// Whether the two leaf nodes are the same apart from spans.
@@ -657,6 +672,18 @@ impl Debug for InnerNode {
     }
 }
 
+/// A syntactical error.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct SyntaxError {
+    /// The node's span.
+    pub span: Span,
+    /// The error message.
+    pub message: EcoString,
+    /// Additional hints to the user, indicating how this error could be avoided
+    /// or worked around.
+    pub hints: EcoVec<EcoString>,
+}
+
 /// An error node in the untyped syntax tree.
 #[derive(Clone, Eq, PartialEq, Hash)]
 struct ErrorNode {
@@ -667,24 +694,19 @@ struct ErrorNode {
 }
 
 impl ErrorNode {
-    /// Create new error node.
-    fn new(error: SyntaxError, text: impl Into<EcoString>) -> Self {
-        Self { text: text.into(), error }
+    /// Create a new error node.
+    fn new(message: EcoString, text: EcoString) -> Self {
+        Self {
+            text,
+            error: SyntaxError { span: Span::detached(), message, hints: eco_vec![] },
+        }
     }
 
-    /// The byte length of the node in the source text.
-    fn len(&self) -> usize {
-        self.text.len()
-    }
-
-    /// Add a user-presentable hint to this error node.
-    fn hint(&mut self, hint: impl Into<EcoString>) {
-        self.error.hints.push(hint.into());
-    }
-
-    /// Whether the two leaf nodes are the same apart from spans.
+    /// Whether the two error nodes are the same apart from spans.
     fn spanless_eq(&self, other: &Self) -> bool {
-        self.text == other.text && self.error.spanless_eq(&other.error)
+        self.text == other.text
+            && self.error.message == other.error.message
+            && self.error.hints == other.error.hints
     }
 }
 
@@ -701,34 +723,6 @@ impl Debug for ErrorNode {
             }
             out.finish()
         }
-    }
-}
-
-/// A syntactical error.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct SyntaxError {
-    /// The node's span.
-    pub span: Span,
-    /// The error message.
-    pub message: EcoString,
-    /// Additional hints to the user, indicating how this error could be avoided
-    /// or worked around.
-    pub hints: EcoVec<EcoString>,
-}
-
-impl SyntaxError {
-    /// Create a new detached syntax error.
-    pub fn new(message: impl Into<EcoString>) -> Self {
-        Self {
-            span: Span::detached(),
-            message: message.into(),
-            hints: eco_vec![],
-        }
-    }
-
-    /// Whether the two errors are the same apart from spans.
-    fn spanless_eq(&self, other: &Self) -> bool {
-        self.message == other.message && self.hints == other.hints
     }
 }
 

--- a/crates/typst-syntax/src/node.rs
+++ b/crates/typst-syntax/src/node.rs
@@ -11,104 +11,152 @@ use crate::{FileId, RangeMapper, Span, SyntaxKind, SyntaxMode};
 
 /// A node in the untyped syntax tree.
 #[derive(Clone, Eq, PartialEq, Hash)]
-pub struct SyntaxNode(NodeWrapper);
-
-/// A transparent wrapper around an actual node which allows us to add data,
-/// currently just warning messages, without increasing the size of `Node`.
-#[derive(Clone, Eq, PartialEq, Hash)]
-enum NodeWrapper {
-    /// An actual node in the syntax tree.
-    Node(Node),
-    /// A warning message wrapped directly around another node.
-    Warning(Arc<WarningWrapper>),
+pub struct SyntaxNode {
+    /// The underlying node data, potentially with wrapped warning messages.
+    data: Node,
+    /// The node's span, at the top-level to guarantee efficient access.
+    span: Span,
+    // We would love to move the `SyntaxKind` up here as well, but keeping it in
+    // `Node` saves 8 bytes :/
 }
 
-/// The internal representations of a node in the syntax tree.
+/// The data for nodes in the tree, plus their [`SyntaxKind`]. May actually be a
+/// warning message wrapping a child [`Node`].
+///
+/// Contains the [`SyntaxKind`] at the top-level for efficient access. This
+/// requires being careful when mutating the kind, as warnings store this type
+/// as their child, which duplicates the kind. Deduplicating the syntax kinds
+/// would require a whole other enum type, and makes mutable access too painful.
+///
+/// The only other invariant for syntax kinds is that error nodes always contain
+/// [`SyntaxKind::Error`], but leaf and inner nodes never do. The syntax kind of
+/// a warning depends on what it wraps.
+///
+/// The simplest way to get the underlying data by descending into the children
+/// of warnings is via a loop and match like below. The [`SyntaxNode::node_ref`]
+/// helper does this for the by-reference case, but mutation is usually more
+/// involved, so only gets the [`SyntaxNode::inner_and_span_mut`] helper.
+/// ```ignore
+/// let mut data = &mut node.data;
+/// let value = loop {
+///     match data {
+///         Leaf(_, _) | Inner(_, _) | Error(_, _) => break "value",
+///         Warning(warn, _) => data = &mut Arc::make_mut(warn).child,
+///     }
+/// };
+/// ```
 #[derive(Clone, Eq, PartialEq, Hash)]
 enum Node {
-    /// A leaf node containing text.
-    Leaf(LeafNode),
-    /// A reference-counted inner node containing an array of children.
-    Inner(Arc<InnerNode>),
-    /// An error node containing an error message for some text.
-    Error(Arc<ErrorNode>),
+    Leaf(EcoString, SyntaxKind),
+    Inner(Arc<InnerNode>, SyntaxKind),
+    Error(Arc<ErrorNode>, SyntaxKind),
+    Warning(Arc<WarningWrapper>, SyntaxKind),
+}
+
+/// Data attached to a node, accessed by reference via [`SyntaxNode::node_ref`].
+enum NodeRef<'a> {
+    Leaf(&'a EcoString),
+    Inner(&'a Arc<InnerNode>),
+    Error(&'a Arc<ErrorNode>),
 }
 
 impl SyntaxNode {
-    /// Get the underlying node, descending past warnings.
-    fn node(mut self: &Self) -> &Node {
+    /// Access the underlying node data by reference, descending past warnings.
+    fn node_ref(&self) -> NodeRef<'_> {
+        let mut data = &self.data;
         loop {
-            match &self.0 {
-                NodeWrapper::Node(node) => break node,
-                NodeWrapper::Warning(warn) => self = &warn.child,
+            match data {
+                Node::Leaf(text, _) => break NodeRef::Leaf(text),
+                Node::Inner(inner, _) => break NodeRef::Inner(inner),
+                Node::Error(err, _) => break NodeRef::Error(err),
+                Node::Warning(warn, _) => data = &warn.child,
             }
         }
     }
 
-    /// Get the underlying node mutably, descending past warnings.
-    fn node_mut(mut self: &mut Self) -> &mut Node {
+    /// Access an inner node and the node's overall span mutably, descending
+    /// past warnings. If this only returned the `&mut InnerNode`, the caller
+    /// wouldn't be able to also get a mutable reference to the span since the
+    /// inner node would borrow mutably from `self`.
+    fn inner_and_span_mut(&mut self) -> Option<(&mut InnerNode, &mut Span)> {
+        let mut data = &mut self.data;
         loop {
-            match &mut self.0 {
-                NodeWrapper::Node(node) => break node,
-                NodeWrapper::Warning(warn) => self = &mut Arc::make_mut(warn).child,
+            match data {
+                Node::Leaf(_, _) | Node::Error(_, _) => break None,
+                Node::Inner(inner, _) => {
+                    break Some((Arc::make_mut(inner), &mut self.span));
+                }
+                Node::Warning(warn, _) => data = &mut Arc::make_mut(warn).child,
             }
         }
     }
 
-    /// Get the hints for an error or warning mutably.
-    #[track_caller]
-    fn hints_mut(&mut self) -> &mut EcoVec<EcoString> {
-        match &mut self.0 {
-            NodeWrapper::Node(Node::Leaf(_) | Node::Inner(_)) => {
-                panic!("expected an error or warning")
-            }
-            NodeWrapper::Node(Node::Error(err)) => &mut Arc::make_mut(err).hints,
-            NodeWrapper::Warning(warn) => &mut Arc::make_mut(warn).hints,
+    /// Access the hints for an error or warning mutably.
+    fn hints_mut(&mut self) -> Option<&mut EcoVec<EcoString>> {
+        match &mut self.data {
+            Node::Leaf(_, _) | Node::Inner(_, _) => None,
+            Node::Error(err, _) => Some(&mut Arc::make_mut(err).hints),
+            Node::Warning(warn, _) => Some(&mut Arc::make_mut(warn).hints),
         }
     }
 }
 
 impl SyntaxNode {
     /// Create a new leaf node.
+    #[track_caller]
     pub fn leaf(kind: SyntaxKind, text: impl Into<EcoString>) -> Self {
-        Self(NodeWrapper::Node(Node::Leaf(LeafNode::new(kind, text.into()))))
+        debug_assert!(!kind.is_error());
+        Self {
+            data: Node::Leaf(text.into(), kind),
+            span: Span::detached(),
+        }
     }
 
     /// Create a new inner node with children.
+    #[track_caller]
     pub fn inner(kind: SyntaxKind, children: Vec<SyntaxNode>) -> Self {
-        Self(NodeWrapper::Node(Node::Inner(Arc::new(InnerNode::new(kind, children)))))
+        debug_assert!(!kind.is_error());
+        Self {
+            data: Node::Inner(Arc::new(InnerNode::new(children)), kind),
+            span: Span::detached(),
+        }
     }
 
     /// Create a new error node with a user-presentable message for the given
     /// text. Note that the message is the first argument, and the text causing
     /// the error is the second argument.
     pub fn error(message: impl Into<EcoString>, text: impl Into<EcoString>) -> Self {
-        Self(NodeWrapper::Node(Node::Error(Arc::new(ErrorNode::new(
-            message.into(),
-            text.into(),
-        )))))
+        Self {
+            data: Node::Error(
+                Arc::new(ErrorNode::new(message.into(), text.into())),
+                SyntaxKind::Error,
+            ),
+            span: Span::detached(),
+        }
     }
 
     /// Add a warning message to an existing node.
     pub fn warn(&mut self, message: impl Into<EcoString>) {
-        *self = Self(NodeWrapper::Warning(Arc::new(WarningWrapper::new(
-            std::mem::take(self),
-            message.into(),
-        ))));
+        let kind = self.kind();
+        let child = std::mem::replace(&mut self.data, Node::Leaf(EcoString::new(), kind));
+        let warn = Arc::new(WarningWrapper::new(child, message.into()));
+        self.data = Node::Warning(warn, kind);
     }
 
     /// Add a user-presentable hint to an existing error or warning. Panics if
     /// this is not an error or warning.
     #[track_caller]
     pub fn hint(&mut self, hint: impl Into<EcoString>) {
-        self.hints_mut().push(hint.into());
+        let hints = self.hints_mut().expect("expected an error or warning");
+        hints.push(hint.into());
     }
 
     /// Add multiple hints while building an error or warning. Panics if this is
     /// not an error or warning.
     #[track_caller]
-    pub fn with_hints(mut self, hints: impl IntoIterator<Item = EcoString>) -> Self {
-        self.hints_mut().extend(hints);
+    pub fn with_hints(mut self, new_hints: impl IntoIterator<Item = EcoString>) -> Self {
+        let hints = self.hints_mut().expect("expected an error or warning");
+        hints.extend(new_hints);
         self
     }
 
@@ -120,19 +168,19 @@ impl SyntaxNode {
         if kind.is_error() {
             panic!("cannot create error placeholder");
         }
-        Self(NodeWrapper::Node(Node::Leaf(LeafNode {
-            kind,
-            text: EcoString::new(),
+        Self {
+            data: Node::Leaf(EcoString::new(), kind),
             span: Span::detached(),
-        })))
+        }
     }
 
     /// The type of the node.
     pub fn kind(&self) -> SyntaxKind {
-        match self.node() {
-            Node::Leaf(leaf) => leaf.kind,
-            Node::Inner(inner) => inner.kind,
-            Node::Error(_) => SyntaxKind::Error,
+        match self.data {
+            Node::Leaf(_, kind)
+            | Node::Inner(_, kind)
+            | Node::Error(_, kind)
+            | Node::Warning(_, kind) => kind,
         }
     }
 
@@ -143,20 +191,16 @@ impl SyntaxNode {
 
     /// The byte length of the node in the source text.
     pub fn len(&self) -> usize {
-        match self.node() {
-            Node::Leaf(leaf) => leaf.text.len(),
-            Node::Inner(inner) => inner.len,
-            Node::Error(err) => err.text.len(),
+        match self.node_ref() {
+            NodeRef::Leaf(text) => text.len(),
+            NodeRef::Inner(inner) => inner.len,
+            NodeRef::Error(err) => err.text.len(),
         }
     }
 
     /// The span of the node.
     pub fn span(&self) -> Span {
-        match self.node() {
-            Node::Leaf(leaf) => leaf.span,
-            Node::Inner(inner) => inner.span,
-            Node::Error(err) => err.span,
-        }
+        self.span
     }
 
     /// The text of the node if it is a leaf or error node.
@@ -164,10 +208,10 @@ impl SyntaxNode {
     /// Returns the empty string if this is an inner node.
     pub fn text(&self) -> &EcoString {
         static EMPTY: EcoString = EcoString::new();
-        match self.node() {
-            Node::Leaf(leaf) => &leaf.text,
-            Node::Inner(_) => &EMPTY,
-            Node::Error(err) => &err.text,
+        match self.node_ref() {
+            NodeRef::Leaf(text) => text,
+            NodeRef::Inner(_) => &EMPTY,
+            NodeRef::Error(err) => &err.text,
         }
     }
 
@@ -177,29 +221,29 @@ impl SyntaxNode {
     pub fn into_text(self) -> EcoString {
         // This isn't fully efficient for warnings, but the efficient
         // version is more complicated to read/write due to partial moves.
-        match self.0 {
-            NodeWrapper::Node(Node::Leaf(leaf)) => leaf.text,
-            NodeWrapper::Node(Node::Error(err)) => err.text.clone(),
-            NodeWrapper::Node(Node::Inner(_)) | NodeWrapper::Warning(_) => {
-                let mut text = EcoString::with_capacity(self.len());
+        match self.data {
+            Node::Leaf(text, _) => text,
+            Node::Error(err, _) => err.text.clone(),
+            Node::Inner(_, _) | Node::Warning(_, _) => {
+                let mut buffer = EcoString::with_capacity(self.len());
                 self.traverse(|node| {
-                    match node.node() {
-                        Node::Leaf(leaf) => text.push_str(&leaf.text),
-                        Node::Inner(_) => {}
-                        Node::Error(err) => text.push_str(&err.text),
+                    match node.node_ref() {
+                        NodeRef::Leaf(text) => buffer.push_str(text),
+                        NodeRef::Inner(_) => {}
+                        NodeRef::Error(err) => buffer.push_str(&err.text),
                     }
                     node.children()
                 });
-                text
+                buffer
             }
         }
     }
 
     /// The node's children.
     pub fn children(&self) -> std::slice::Iter<'_, SyntaxNode> {
-        match self.node() {
-            Node::Leaf(_) | Node::Error(_) => [].iter(),
-            Node::Inner(inner) => inner.children.iter(),
+        match self.node_ref() {
+            NodeRef::Leaf(_) | NodeRef::Error(_) => [].iter(),
+            NodeRef::Inner(inner) => inner.children.iter(),
         }
     }
 
@@ -210,16 +254,14 @@ impl SyntaxNode {
     /// This can be used to determine whether [`Self::errors_and_warnings`] will
     /// return an empty vector without traversing the tree if it will not.
     pub fn diagnosis(&self) -> Diagnosis {
-        match &self.0 {
-            NodeWrapper::Node(Node::Leaf(_)) => Diagnosis::default(),
-            NodeWrapper::Node(Node::Inner(inner)) => inner.diagnosis,
-            NodeWrapper::Node(Node::Error(_)) => {
-                Diagnosis { errors: true, warnings: false }
-            }
-            NodeWrapper::Warning(warn) => Diagnosis {
-                errors: warn.child.diagnosis().errors,
-                warnings: true,
-            },
+        let diagnosis = match self.node_ref() {
+            NodeRef::Leaf(_) => Diagnosis::default(),
+            NodeRef::Inner(inner) => inner.diagnosis,
+            NodeRef::Error(_) => Diagnosis { errors: true, warnings: false },
+        };
+        match &self.data {
+            Node::Warning(_, _) => Diagnosis { warnings: true, errors: diagnosis.errors },
+            _ => diagnosis,
         }
     }
 
@@ -227,20 +269,23 @@ impl SyntaxNode {
     pub fn errors_and_warnings(&self) -> (Vec<SyntaxDiagnostic>, Vec<SyntaxDiagnostic>) {
         let mut errors = Vec::new();
         let mut warnings = Vec::new();
-        self.traverse(|node| match &node.0 {
-            NodeWrapper::Node(Node::Inner(inner)) if inner.diagnosis.either() => {
-                inner.children.iter()
-            }
-            NodeWrapper::Node(Node::Inner(_) | Node::Leaf(_)) => [].iter(),
-            NodeWrapper::Node(Node::Error(err)) => {
-                errors.push(err.diagnostic());
-                [].iter()
-            }
-            NodeWrapper::Warning(warn) => {
-                warnings.push(warn.diagnostic());
-                // We traverse into the wrapped child of the warning in case
-                // that child is itself a warning.
-                std::slice::from_ref(&warn.child).iter()
+        self.traverse(|node| {
+            let mut data = &node.data;
+            loop {
+                match data {
+                    Node::Inner(inner, _) if inner.diagnosis.either() => {
+                        break inner.children.iter();
+                    }
+                    Node::Leaf(_, _) | Node::Inner(_, _) => break [].iter(),
+                    Node::Error(err, _) => {
+                        errors.push(err.diagnostic(node.span));
+                        break [].iter();
+                    }
+                    Node::Warning(warn, _) => {
+                        warnings.push(warn.diagnostic(node.span));
+                        data = &warn.child;
+                    }
+                }
             }
         });
         (errors, warnings)
@@ -270,34 +315,37 @@ impl SyntaxNode {
         mut offset: usize,
         f: &mut impl FnMut(Range<usize>) -> Span,
     ) {
-        match self.node_mut() {
-            Node::Leaf(leaf) => leaf.span = f(offset..offset + leaf.text.len()),
-            Node::Inner(inner) => {
-                let inner = Arc::make_mut(inner);
-                inner.span = f(offset..offset + inner.len);
-                inner.upper = inner.span.number();
-                for child in &mut inner.children {
-                    child.synthesize_with(offset, f);
-                    offset += child.len();
-                }
-            }
-            Node::Error(err) => {
-                Arc::make_mut(err).span = f(offset..offset + err.text.len());
+        self.span = f(offset..offset + self.len());
+        if let Some((inner, span)) = self.inner_and_span_mut() {
+            inner.upper = span.number();
+            for child in &mut inner.children {
+                child.synthesize_with(offset, f);
+                offset += child.len();
             }
         }
     }
 
     /// Whether the two syntax nodes are the same apart from spans.
     pub fn spanless_eq(&self, other: &Self) -> bool {
-        match (&self.0, &other.0) {
-            (NodeWrapper::Node(a), NodeWrapper::Node(b)) => match (a, b) {
-                (Node::Leaf(a), Node::Leaf(b)) => a.spanless_eq(b),
-                (Node::Inner(a), Node::Inner(b)) => a.spanless_eq(b),
-                (Node::Error(a), Node::Error(b)) => a.spanless_eq(b),
-                _ => false,
-            },
-            (NodeWrapper::Warning(a), NodeWrapper::Warning(b)) => a.spanless_eq(b),
-            _ => false,
+        self.kind() == other.kind() && {
+            let mut data_a = &self.data;
+            let mut data_b = &other.data;
+            loop {
+                match (data_a, data_b) {
+                    (Node::Leaf(a, _), Node::Leaf(b, _)) => break a == b,
+                    (Node::Inner(a, _), Node::Inner(b, _)) => {
+                        break a.spanless_eq(b);
+                    }
+                    (Node::Error(a, _), Node::Error(b, _)) => break a == b,
+                    (Node::Warning(a, _), Node::Warning(b, _))
+                        if a.message == b.message && a.hints == b.hints =>
+                    {
+                        data_a = &a.child;
+                        data_b = &b.child;
+                    }
+                    _ => break false,
+                }
+            }
         }
     }
 }
@@ -305,14 +353,29 @@ impl SyntaxNode {
 impl SyntaxNode {
     /// Convert the child to another kind.
     ///
-    /// Don't use this for converting to an error!
+    /// Panics if trying to convert to or from an error.
     #[track_caller]
-    pub(super) fn convert_to_kind(&mut self, kind: SyntaxKind) {
-        debug_assert!(!kind.is_error());
-        match self.node_mut() {
-            Node::Leaf(leaf) => leaf.kind = kind,
-            Node::Inner(inner) => Arc::make_mut(inner).kind = kind,
-            Node::Error(_) => panic!("cannot convert error"),
+    pub(super) fn convert_to_kind(&mut self, new_kind: SyntaxKind) {
+        if new_kind.is_error() {
+            panic!("cannot convert to an error, use `convert_to_error` instead");
+        } else if self.kind().is_error() {
+            // `.kind()` checks both errors and warnings that wrap errors.
+            panic!("cannot convert an error to a different kind");
+        }
+        // Must assign through warnings as well, since they duplicate the kind.
+        let mut data = &mut self.data;
+        loop {
+            match data {
+                Node::Leaf(_, kind) | Node::Inner(_, kind) => {
+                    *kind = new_kind;
+                    break;
+                }
+                Node::Error(_, _) => unreachable!(),
+                Node::Warning(warn, kind) => {
+                    *kind = new_kind;
+                    data = &mut Arc::make_mut(warn).child;
+                }
+            }
         }
     }
 
@@ -349,17 +412,13 @@ impl SyntaxNode {
         within: Range<u64>,
     ) -> NumberingResult {
         if within.start >= within.end {
-            return Err(Unnumberable);
+            Err(Unnumberable)
+        } else if let Some((inner, span)) = self.inner_and_span_mut() {
+            inner.numberize(span, id, None, within)
+        } else {
+            self.span = Span::from_number(id, (within.start + within.end) / 2).unwrap();
+            Ok(())
         }
-
-        let mid = Span::from_number(id, (within.start + within.end) / 2).unwrap();
-        match self.node_mut() {
-            Node::Leaf(leaf) => leaf.span = mid,
-            Node::Inner(inner) => Arc::make_mut(inner).numberize(id, None, within)?,
-            Node::Error(err) => Arc::make_mut(err).span = mid,
-        }
-
-        Ok(())
     }
 
     /// Traverse the tree in-order, calling `f` on each node and recursing on
@@ -381,28 +440,29 @@ impl SyntaxNode {
 
     /// Whether this is a leaf node.
     pub(super) fn is_leaf(&self) -> bool {
-        matches!(self.node(), Node::Leaf(_))
+        matches!(self.node_ref(), NodeRef::Leaf(_))
         // TODO: Should we also treat non-empty errors as leaves?
     }
 
     /// Whether this is an inner node.
     pub(super) fn is_inner(&self) -> bool {
-        matches!(self.node(), Node::Inner(_))
+        matches!(self.node_ref(), NodeRef::Inner(_))
     }
 
     /// The number of descendants, including the node itself.
     pub(super) fn descendants(&self) -> usize {
-        match self.node() {
-            Node::Leaf(_) | Node::Error(_) => 1,
-            Node::Inner(inner) => inner.descendants,
+        match self.node_ref() {
+            NodeRef::Leaf(_) | NodeRef::Error(_) => 1,
+            NodeRef::Inner(inner) => inner.descendants,
         }
     }
 
     /// The node's children, mutably.
     pub(super) fn children_mut(&mut self) -> &mut [SyntaxNode] {
-        match self.node_mut() {
-            Node::Leaf(_) | Node::Error(_) => &mut [],
-            Node::Inner(inner) => &mut Arc::make_mut(inner).children,
+        if let Some((inner, _)) = self.inner_and_span_mut() {
+            &mut inner.children
+        } else {
+            &mut []
         }
     }
 
@@ -414,11 +474,10 @@ impl SyntaxNode {
         range: Range<usize>,
         replacement: Vec<SyntaxNode>,
     ) -> NumberingResult {
-        match self.node_mut() {
-            Node::Leaf(_) | Node::Error(_) => Ok(()),
-            Node::Inner(inner) => {
-                Arc::make_mut(inner).replace_children(range, replacement)
-            }
+        if let Some((inner, span)) = self.inner_and_span_mut() {
+            inner.replace_children(span, range, replacement)
+        } else {
+            Ok(())
         }
     }
 
@@ -430,34 +489,33 @@ impl SyntaxNode {
         prev_descendants: usize,
         new_descendants: usize,
     ) {
-        match self.node_mut() {
-            Node::Leaf(_) | Node::Error(_) => {}
-            Node::Inner(inner) => Arc::make_mut(inner).update_parent(
-                prev_len,
-                new_len,
-                prev_descendants,
-                new_descendants,
-            ),
+        if let Some((inner, _)) = self.inner_and_span_mut() {
+            inner.update_parent(prev_len, new_len, prev_descendants, new_descendants)
         }
     }
 
     /// The upper bound of assigned numbers in this subtree.
     pub(super) fn upper(&self) -> u64 {
-        match self.node() {
-            Node::Leaf(leaf) => leaf.span.number() + 1,
-            Node::Inner(inner) => inner.upper,
-            Node::Error(err) => err.span.number() + 1,
+        match self.node_ref() {
+            NodeRef::Leaf(_) | NodeRef::Error(_) => self.span.number() + 1,
+            NodeRef::Inner(inner) => inner.upper,
         }
     }
 }
 
 impl Debug for SyntaxNode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.data.fmt(f)
+    }
+}
+
+impl Debug for Node {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match &self.0 {
-            NodeWrapper::Node(Node::Leaf(leaf)) => leaf.fmt(f),
-            NodeWrapper::Node(Node::Inner(inner)) => inner.fmt(f),
-            NodeWrapper::Node(Node::Error(err)) => err.fmt(f),
-            NodeWrapper::Warning(warn) => warn.fmt(f),
+        match self {
+            Node::Leaf(text, kind) => write!(f, "{kind:?}: {text:?}"),
+            Node::Inner(inner, kind) => inner.debug_fmt(f, *kind),
+            Node::Error(err, _) => err.fmt(f),
+            Node::Warning(warn, _) => warn.fmt(f),
         }
     }
 }
@@ -468,48 +526,11 @@ impl Default for SyntaxNode {
     }
 }
 
-/// A leaf node in the untyped syntax tree.
-#[derive(Clone, Eq, PartialEq, Hash)]
-struct LeafNode {
-    /// What kind of node this is (each kind would have its own struct in a
-    /// strongly typed AST).
-    kind: SyntaxKind,
-    /// The source text of the node.
-    text: EcoString,
-    /// The node's span.
-    span: Span,
-}
-
-impl LeafNode {
-    /// Create a new leaf node.
-    #[track_caller]
-    fn new(kind: SyntaxKind, text: EcoString) -> Self {
-        debug_assert!(!kind.is_error());
-        Self { kind, text, span: Span::detached() }
-    }
-
-    /// Whether the two leaf nodes are the same apart from spans.
-    fn spanless_eq(&self, other: &Self) -> bool {
-        self.kind == other.kind && self.text == other.text
-    }
-}
-
-impl Debug for LeafNode {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{:?}: {:?}", self.kind, self.text)
-    }
-}
-
 /// An inner node in the untyped syntax tree.
 #[derive(Clone, Eq, PartialEq, Hash)]
 struct InnerNode {
-    /// What kind of node this is (each kind would have its own struct in a
-    /// strongly typed AST).
-    kind: SyntaxKind,
     /// The byte length of the node in the source.
     len: usize,
-    /// The node's span.
-    span: Span,
     /// The number of nodes in the whole subtree, including this node.
     descendants: usize,
     /// Whether this node or any of its children contain an error/warning
@@ -522,11 +543,8 @@ struct InnerNode {
 }
 
 impl InnerNode {
-    /// Create a new inner node with the given kind and children.
-    #[track_caller]
-    fn new(kind: SyntaxKind, children: Vec<SyntaxNode>) -> Self {
-        debug_assert!(!kind.is_error());
-
+    /// Create a new inner node with the given children.
+    fn new(children: Vec<SyntaxNode>) -> Self {
         let mut len = 0;
         let mut descendants = 1;
         let mut diagnosis = Diagnosis::default();
@@ -537,21 +555,14 @@ impl InnerNode {
             diagnosis = diagnosis.or(child.diagnosis());
         }
 
-        Self {
-            kind,
-            len,
-            span: Span::detached(),
-            descendants,
-            diagnosis,
-            upper: 0,
-            children,
-        }
+        Self { len, descendants, diagnosis, upper: 0, children }
     }
 
     /// Assign span numbers `within` an interval to this node's subtree or just
     /// a `range` of its children.
     fn numberize(
         &mut self,
+        span: &mut Span,
         id: FileId,
         range: Option<Range<usize>>,
         within: Range<u64>,
@@ -582,7 +593,7 @@ impl InnerNode {
         let mut start = within.start;
         if range.is_none() {
             let end = start + stride;
-            self.span = Span::from_number(id, (start + end) / 2).unwrap();
+            *span = Span::from_number(id, (start + end) / 2).unwrap();
             self.upper = within.end;
             start = end;
         }
@@ -600,8 +611,7 @@ impl InnerNode {
 
     /// Whether the two inner nodes are the same apart from spans.
     fn spanless_eq(&self, other: &Self) -> bool {
-        self.kind == other.kind
-            && self.len == other.len
+        self.len == other.len
             && self.descendants == other.descendants
             && self.diagnosis == other.diagnosis
             && self.children.len() == other.children.len()
@@ -617,10 +627,11 @@ impl InnerNode {
     /// May have mutated the children if it returns `Err(_)`.
     fn replace_children(
         &mut self,
+        span: &mut Span,
         mut range: Range<usize>,
         replacement: Vec<SyntaxNode>,
     ) -> NumberingResult {
-        let Some(id) = self.span.id() else { return Err(Unnumberable) };
+        let Some(id) = span.id() else { return Err(Unnumberable) };
         let mut replacement_range = 0..replacement.len();
 
         // Trim off common prefix.
@@ -695,7 +706,7 @@ impl InnerNode {
                 .start
                 .checked_sub(1)
                 .and_then(|i| self.children.get(i))
-                .map_or(self.span.number() + 1, |child| child.upper());
+                .map_or(span.number() + 1, |child| child.upper());
 
             // The upper bound for renumbering is either
             // - the span number of the first child after the to-be-renumbered
@@ -709,7 +720,7 @@ impl InnerNode {
 
             // Try to renumber.
             let within = start_number..end_number;
-            if self.numberize(id, Some(renumber), within).is_ok() {
+            if self.numberize(span, id, Some(renumber), within).is_ok() {
                 return Ok(());
             }
 
@@ -736,11 +747,10 @@ impl InnerNode {
         self.descendants = self.descendants + new_descendants - prev_descendants;
         self.diagnosis = Diagnosis::any(&self.children);
     }
-}
 
-impl Debug for InnerNode {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{:?}: {}", self.kind, self.len)?;
+    /// Format the inner node with its `SyntaxKind` for debugging.
+    fn debug_fmt(&self, f: &mut Formatter, kind: SyntaxKind) -> fmt::Result {
+        write!(f, "{kind:?}: {}", self.len)?;
         if !self.children.is_empty() {
             f.write_str(" ")?;
             f.debug_list().entries(&self.children).finish()?;
@@ -803,8 +813,6 @@ pub struct SyntaxDiagnostic {
 struct ErrorNode {
     /// The source text of the node.
     text: EcoString,
-    /// The span targeted by the error.
-    span: Span,
     /// The error message.
     message: EcoString,
     /// Additional hints to the user indicating how this error could be avoided
@@ -815,29 +823,16 @@ struct ErrorNode {
 impl ErrorNode {
     /// Create a new error node.
     fn new(message: EcoString, text: EcoString) -> Self {
-        Self {
-            text,
-            span: Span::detached(),
-            message,
-            hints: eco_vec![],
-        }
+        Self { text, message, hints: eco_vec![] }
     }
-
     /// Produce the syntax diagnostic for an error.
-    fn diagnostic(&self) -> SyntaxDiagnostic {
+    fn diagnostic(&self, span: Span) -> SyntaxDiagnostic {
         SyntaxDiagnostic {
             is_error: true,
-            span: self.span,
+            span,
             message: self.message.clone(),
             hints: self.hints.clone(),
         }
-    }
-
-    /// Whether the two error nodes are the same apart from spans.
-    fn spanless_eq(&self, other: &Self) -> bool {
-        self.text == other.text
-            && self.message == other.message
-            && self.hints == other.hints
     }
 }
 
@@ -861,12 +856,12 @@ impl Debug for ErrorNode {
 ///
 /// Warnings transparently wrap another node and do not have spans or text of
 /// their own. This means their child cannot be directly found or mutated, only
-/// affected _through_ the warning, usually via the [`SyntaxNode::get`] and
-/// [`SyntaxNode::get_mut`] methods.
+/// affected _through_ the warning, usually via the [`SyntaxNode::node_ref`] and
+/// [`SyntaxNode::inner_and_span_mut`] methods.
 #[derive(Clone, Eq, PartialEq, Hash)]
 struct WarningWrapper {
-    /// The wrapped syntax node.
-    child: SyntaxNode,
+    /// The wrapped node data.
+    child: Node,
     /// The warning message.
     message: EcoString,
     /// Additional hints to the user indicating how this warning could be
@@ -876,25 +871,18 @@ struct WarningWrapper {
 
 impl WarningWrapper {
     /// Wrap an existing syntax node in a warning node.
-    fn new(child: SyntaxNode, message: EcoString) -> Self {
+    fn new(child: Node, message: EcoString) -> Self {
         Self { child, message, hints: eco_vec![] }
     }
 
     /// Produce the syntax diagnostic for a warning.
-    fn diagnostic(&self) -> SyntaxDiagnostic {
+    fn diagnostic(&self, span: Span) -> SyntaxDiagnostic {
         SyntaxDiagnostic {
             is_error: false,
-            span: self.child.span(),
+            span,
             message: self.message.clone(),
             hints: self.hints.clone(),
         }
-    }
-
-    /// Whether the two warnings are the same apart from spans.
-    fn spanless_eq(&self, other: &Self) -> bool {
-        self.message == other.message
-            && self.hints == other.hints
-            && self.child.spanless_eq(&other.child)
     }
 }
 
@@ -973,13 +961,10 @@ impl<'a> LinkedNode<'a> {
             return Some(self.clone());
         }
 
-        if let Node::Inner(inner) = self.node.node() {
+        if self.is_inner() && self.span().number() < span.number() {
             // The parent of a subtree has a smaller span number than all of its
             // descendants. Therefore, we can bail out early if the target span's
             // number is smaller than our number.
-            if span.number() < inner.span.number() {
-                return None;
-            }
 
             // Use `self.children()`, not `inner.children()` to preserve being
             // in a `LinkedNode`.

--- a/crates/typst-syntax/src/node.rs
+++ b/crates/typst-syntax/src/node.rs
@@ -114,10 +114,10 @@ impl SyntaxNode {
 
     /// Create a dummy node of the given kind.
     ///
-    /// Panics if `kind` is `SyntaxKind::Error`.
+    /// Panics if `kind` is [`SyntaxKind::Error`].
     #[track_caller]
     pub const fn placeholder(kind: SyntaxKind) -> Self {
-        if matches!(kind, SyntaxKind::Error) {
+        if kind.is_error() {
             panic!("cannot create error placeholder");
         }
         Self(NodeWrapper::Node(Node::Leaf(LeafNode {

--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -7,7 +7,7 @@ use typst_utils::{default_math_class, defer};
 use unicode_math_class::MathClass;
 
 use crate::set::{SyntaxSet, syntax_set};
-use crate::{Lexer, SyntaxError, SyntaxKind, SyntaxMode, SyntaxNode, ast, set};
+use crate::{Lexer, SyntaxKind, SyntaxMode, SyntaxNode, ast, set};
 
 // Picked by gut feeling.
 const MAX_DEPTH: u32 = 256;
@@ -1786,8 +1786,7 @@ impl<'s> Parser<'s> {
         let from = from.0.min(to);
         let text: EcoString =
             self.nodes.drain(from..to).map(SyntaxNode::into_text).collect();
-        self.nodes
-            .insert(from, SyntaxNode::error(SyntaxError::new(message), text));
+        self.nodes.insert(from, SyntaxNode::error(message.into(), text));
     }
 
     /// Parse within the [`SyntaxMode`] for subsequent tokens (does not change the
@@ -2021,8 +2020,7 @@ impl Parser<'_> {
     /// Produce an error that the given `thing` was expected at the position
     /// of the marker `m`.
     fn expected_at(&mut self, m: Marker, thing: &str) {
-        let error =
-            SyntaxNode::error(SyntaxError::new(eco_format!("expected {thing}")), "");
+        let error = SyntaxNode::error(eco_format!("expected {thing}"), "");
         self.nodes.insert(m.0, error);
     }
 

--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -139,8 +139,14 @@ fn strong(p: &mut Parser) {
         let m = p.marker();
         p.assert(SyntaxKind::Star);
         markup(p, false, true, syntax_set!(Star, RightBracket, End));
-        p.expect_closing_delimiter(m, SyntaxKind::Star);
+        let had_closing = p.expect_closing_delimiter(m, SyntaxKind::Star);
         p.wrap(m, SyntaxKind::Strong);
+        if had_closing && p[m].len() == 2 {
+            p[m].warn("no text within stars");
+            let hint = "using multiple consecutive stars (e.g. **) has no \
+                        additional effect";
+            p[m].hint(hint);
+        }
     });
 }
 
@@ -150,8 +156,14 @@ fn emph(p: &mut Parser) {
         let m = p.marker();
         p.assert(SyntaxKind::Underscore);
         markup(p, false, true, syntax_set!(Underscore, RightBracket, End));
-        p.expect_closing_delimiter(m, SyntaxKind::Underscore);
+        let had_closing = p.expect_closing_delimiter(m, SyntaxKind::Underscore);
         p.wrap(m, SyntaxKind::Emph);
+        if had_closing && p[m].len() == 2 {
+            p[m].warn("no text within underscores");
+            let hint = "using multiple consecutive underscores (e.g. __) has no \
+                        additional effect";
+            p[m].hint(hint);
+        }
     });
 }
 
@@ -1983,10 +1995,12 @@ impl Parser<'_> {
     /// Consume the given closing delimiter or produce an error for the matching
     /// opening delimiter at `open`.
     #[track_caller]
-    fn expect_closing_delimiter(&mut self, open: Marker, kind: SyntaxKind) {
-        if !self.eat_if(kind) {
+    fn expect_closing_delimiter(&mut self, open: Marker, kind: SyntaxKind) -> bool {
+        let at = self.eat_if(kind);
+        if !at {
             self.nodes[open.0].convert_to_error("unclosed delimiter");
         }
+        at
     }
 
     /// Produce an error that the given `thing` was expected. If the parser is


### PR DESCRIPTION
This PR allows us to add warning messages to the syntax tree generated when parsing, and it moves the warnings for `**` and `__` to the parser.

Since warnings do not act like errors in stopping the evaluation of the file, I've chosen to implement them as transparent wrappers around existing syntax nodes, accessible only via the `errors_and_warnings` method on `SyntaxNode`. This method was expanded from the `errors` method, and required adding a new `Erroneous` struct to differentiate between errors and warnings instead of just having a single `bool` for errors. And I renamed `SyntaxError` to `SyntaxDiagnostic` and gave it a boolean to distinguish the two (no enum because it felt weird to have a pure duplicate of `diag::Severity` housed in `typst-syntax`).

Also, the debug output for warnings inspired the new debug output for errors, but is a bit weirder since warnings directly contain a child node. LMK if anyone has thoughts on improving the debug outputs, or if we should just radically alter them at a later time.

The first four commits help prepare for the addition of warnings:
- The first commit adds a test for the `Debug` impl of `SyntaxNode` which we should've had a _long_ time ago
- The second updates the `Debug` impl for error nodes to include hints, but falls back to a shorter version if the error only contains a message (no text or hints)
- The third renames `ErrorNode` variables so that we can call errors `err` and warnings `warn` since calling both `node` would be confusing
- Finally, the fourth commit makes a few larger changes to remove/simplify a number of the private methods on structs in `node.rs` that I thought deserved it. This notably includes removing the `SyntaxError::new` method in favor of just having `SyntaxNode::error` take a message as a string to create errors (since `SyntaxError` is renaming to `SyntaxDiagnostic` and because I just prefer `SyntaxNode::error` taking a string)

Then the fifth commit adds warnings themselves.

Note that I am also planning on separately adding an abstraction for attaching sub-ranges to diagnostics. This would allow warnings and errors to target ranges of text that aren't necessarily contained directly by a Span in the syntax tree, greatly increasing the utility of syntax warnings (since this PR otherwise has little real benefit). However I am still working on that, but I wanted to push this set of changes now since they are ready to review.
