### PR TITLE
Enable splitting more of typst-library into separate crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3067,6 +3067,7 @@ dependencies = [
  "typst-html",
  "typst-layout",
  "typst-library",
+ "typst-loading",
  "typst-macros",
  "typst-realize",
  "typst-syntax",
@@ -3345,10 +3346,8 @@ dependencies = [
  "az",
  "bitflags 2.11.1",
  "bumpalo",
- "ciborium",
  "codex",
  "comemo",
- "csv",
  "ecow",
  "either",
  "flate2",
@@ -3376,13 +3375,11 @@ dependencies = [
  "rustc-hash",
  "rustybuzz",
  "serde",
- "serde_json",
  "serde_yaml",
  "siphasher",
  "smallvec",
  "syntect",
  "time",
- "toml",
  "ttf-parser",
  "two-face",
  "typed-arena",
@@ -3400,6 +3397,23 @@ dependencies = [
  "utf8_iter",
  "wasmi",
  "xmlwriter",
+]
+
+[[package]]
+name = "typst-loading"
+version = "0.14.2"
+dependencies = [
+ "az",
+ "ciborium",
+ "csv",
+ "ecow",
+ "roxmltree 0.21.1",
+ "serde_json",
+ "serde_yaml",
+ "toml",
+ "typst-library",
+ "typst-syntax",
+ "typst-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ typst-ide = { path = "crates/typst-ide", version = "0.14.2" }
 typst-kit = { path = "crates/typst-kit", version = "0.14.2", default-features = false }
 typst-layout = { path = "crates/typst-layout", version = "0.14.2" }
 typst-library = { path = "crates/typst-library", version = "0.14.2" }
+typst-loading = { path = "crates/typst-loading", version = "0.14.2" }
 typst-macros = { path = "crates/typst-macros", version = "0.14.2" }
 typst-pdf = { path = "crates/typst-pdf", version = "0.14.2" }
 typst-realize = { path = "crates/typst-realize", version = "0.14.2" }

--- a/crates/typst-library/Cargo.toml
+++ b/crates/typst-library/Cargo.toml
@@ -22,10 +22,8 @@ arrayvec = { workspace = true }
 az = { workspace = true }
 bitflags = { workspace = true }
 bumpalo = { workspace = true }
-ciborium = { workspace = true }
 codex = { workspace = true }
 comemo = { workspace = true }
-csv = { workspace = true }
 ecow = { workspace = true }
 either = { workspace = true }
 flate2 = { workspace = true }
@@ -53,13 +51,11 @@ rust_decimal = { workspace = true }
 rustc-hash = { workspace = true }
 rustybuzz = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 siphasher = { workspace = true }
 smallvec = { workspace = true }
 syntect = { workspace = true }
 time = { workspace = true }
-toml = { workspace = true }
 ttf-parser = { workspace = true }
 two-face = { workspace = true }
 typed-arena = { workspace = true }

--- a/crates/typst-library/src/lib.rs
+++ b/crates/typst-library/src/lib.rs
@@ -345,9 +345,8 @@ fn global(
 
     global.define("math", math);
     global.define("pdf", self::pdf::module(features));
-    if features.is_enabled(Feature::Html) {
-        global.define("html", (routines.html_module)());
-    }
+
+    (routines.register_globals)(&mut global, features);
 
     prelude(&mut global);
 

--- a/crates/typst-library/src/loading/mod.rs
+++ b/crates/typst-library/src/loading/mod.rs
@@ -1,27 +1,9 @@
 //! Data loading.
 
-#[path = "cbor.rs"]
-mod cbor_;
-#[path = "csv.rs"]
-mod csv_;
-#[path = "json.rs"]
-mod json_;
 #[path = "read.rs"]
 mod read_;
-#[path = "toml.rs"]
-mod toml_;
-#[path = "xml.rs"]
-mod xml_;
-#[path = "yaml.rs"]
-mod yaml_;
 
-pub use self::cbor_::*;
-pub use self::csv_::*;
-pub use self::json_::*;
 pub use self::read_::*;
-pub use self::toml_::*;
-pub use self::xml_::*;
-pub use self::yaml_::*;
 
 use comemo::Tracked;
 use typst_syntax::{FileId, Spanned};
@@ -34,12 +16,6 @@ use crate::foundations::{Bytes, OneOrMultiple, PathOrStr, Scope, Str, cast};
 pub(super) fn define(global: &mut Scope) {
     global.start_category(crate::Category::DataLoading);
     global.define_func::<read>();
-    global.define_func::<csv>();
-    global.define_func::<json>();
-    global.define_func::<toml>();
-    global.define_func::<yaml>();
-    global.define_func::<cbor>();
-    global.define_func::<xml>();
     global.reset_category();
 }
 

--- a/crates/typst-library/src/model/bibliography.rs
+++ b/crates/typst-library/src/model/bibliography.rs
@@ -22,7 +22,7 @@ use typst_utils::{
 
 use crate::World;
 use crate::diag::{
-    At, HintedStrResult, HintedString, LoadError, LoadResult, LoadedWithin,
+    At, HintedStrResult, HintedString, LineCol, LoadError, LoadResult, LoadedWithin,
     ReportTextPos, SourceDiagnostic, SourceResult, StrResult, bail, error, warning,
 };
 use crate::engine::{Engine, Route, Sink, Traced};
@@ -36,7 +36,7 @@ use crate::introspection::{
     QueryIntrospection,
 };
 use crate::layout::{BlockElem, Em, HElem, PadElem};
-use crate::loading::{DataSource, Load, LoadSource, Loaded, format_yaml_error};
+use crate::loading::{DataSource, Load, LoadSource, Loaded};
 use crate::model::{
     CitationForm, CiteElem, CiteGroup, Destination, DirectLinkElem, FootnoteElem,
     HeadingElem, LinkElem, Url,
@@ -479,6 +479,19 @@ fn decode_library(loaded: &Loaded) -> SourceResult<Library> {
             _ => Err(format_yaml_error(haya_err)).within(loaded),
         }
     }
+}
+
+/// Format the user-facing YAML error message.
+fn format_yaml_error(error: serde_yaml::Error) -> LoadError {
+    let pos = error
+        .location()
+        .map(|loc| {
+            let line_col = LineCol::one_based(loc.line(), loc.column());
+            let range = loc.index()..loc.index();
+            ReportTextPos::full(range, line_col)
+        })
+        .unwrap_or_default();
+    LoadError::text(pos, "failed to parse YAML", error)
 }
 
 /// Format a BibLaTeX loading error.

--- a/crates/typst-library/src/routines.rs
+++ b/crates/typst-library/src/routines.rs
@@ -8,14 +8,14 @@ use typst_utils::LazyHash;
 use crate::diag::SourceResult;
 use crate::engine::{Engine, Route, Sink, Traced};
 use crate::foundations::{
-    Args, Closure, Content, Context, Func, Module, NativeRuleMap, Scope, StyleChain,
-    Styles, Value,
+    Args, Closure, Content, Context, Func, NativeRuleMap, Scope, StyleChain, Styles,
+    Value,
 };
 use crate::introspection::{Introspector, Locator, SplitLocator};
 use crate::layout::{Frame, Region};
 use crate::model::DocumentInfo;
 use crate::visualize::Color;
-use crate::{Library, World};
+use crate::{Features, Library, World};
 
 /// Defines the `Routines` struct.
 macro_rules! routines {
@@ -50,6 +50,12 @@ macro_rules! routines {
 routines! {
     /// Creates the map with the built-in show rules.
     fn rules() -> NativeRuleMap
+
+    /// Register non-core elements
+    fn register_globals(
+        global: &mut Scope,
+        features: &Features,
+    ) -> ()
 
     /// Evaluates a string as code and return the resulting value.
     fn eval_string(
@@ -96,9 +102,6 @@ routines! {
         styles: StyleChain,
         region: Region,
     ) -> SourceResult<Frame>
-
-    /// Constructs the `html` module.
-    fn html_module() -> Module
 
     /// Returns the body of a MathML `HtmlElem`, if the content is one.
     fn html_mathml_body<'a>(

--- a/crates/typst-loading/Cargo.toml
+++ b/crates/typst-loading/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "typst-loading"
+version.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+categories.workspace = true
+keywords.workspace = true
+readme.workspace = true
+
+[dependencies]
+typst-library = { workspace = true }
+typst-syntax = { workspace = true }
+typst-utils = { workspace = true }
+az = { workspace = true }
+ciborium = { workspace = true }
+csv = { workspace = true }
+ecow = { workspace = true }
+roxmltree = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+toml = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/typst-loading/src/cbor.rs
+++ b/crates/typst-loading/src/cbor.rs
@@ -2,10 +2,10 @@ use ciborium::de::Error;
 use ecow::eco_format;
 use typst_syntax::Spanned;
 
-use crate::diag::{At, LoadError, LoadedWithin, SourceResult};
-use crate::engine::Engine;
-use crate::foundations::{Bytes, Value, func, scope};
-use crate::loading::{DataSource, Load};
+use typst_library::diag::{At, LoadError, LoadedWithin, SourceResult};
+use typst_library::engine::Engine;
+use typst_library::foundations::{Bytes, Value, func, scope};
+use typst_library::loading::{DataSource, Load};
 
 /// Reads structured data from a CBOR file.
 ///

--- a/crates/typst-loading/src/csv.rs
+++ b/crates/typst-loading/src/csv.rs
@@ -1,10 +1,12 @@
 use az::SaturatingAs;
 use typst_syntax::Spanned;
 
-use crate::diag::{LineCol, LoadError, LoadedWithin, ReportTextPos, SourceResult, bail};
-use crate::engine::Engine;
-use crate::foundations::{Array, Dict, IntoValue, Type, Value, cast, func};
-use crate::loading::{DataSource, Load};
+use typst_library::diag::{
+    LineCol, LoadError, LoadedWithin, ReportTextPos, SourceResult, bail,
+};
+use typst_library::engine::Engine;
+use typst_library::foundations::{Array, Dict, IntoValue, Type, Value, cast, func};
+use typst_library::loading::{DataSource, Load};
 
 /// Reads structured data from a CSV file.
 ///

--- a/crates/typst-loading/src/json.rs
+++ b/crates/typst-loading/src/json.rs
@@ -1,10 +1,10 @@
 use ecow::eco_format;
 use typst_syntax::Spanned;
 
-use crate::diag::{At, LineCol, LoadError, LoadedWithin, SourceResult, bail};
-use crate::engine::Engine;
-use crate::foundations::{Str, Value, func, scope};
-use crate::loading::{DataSource, Load};
+use typst_library::diag::{At, LineCol, LoadError, LoadedWithin, SourceResult, bail};
+use typst_library::engine::Engine;
+use typst_library::foundations::{Str, Value, func, scope};
+use typst_library::loading::{DataSource, Load};
 
 /// Reads structured data from a JSON file.
 ///

--- a/crates/typst-loading/src/lib.rs
+++ b/crates/typst-loading/src/lib.rs
@@ -1,0 +1,35 @@
+//! Data loading.
+
+#[path = "cbor.rs"]
+mod cbor_;
+#[path = "csv.rs"]
+mod csv_;
+#[path = "json.rs"]
+mod json_;
+#[path = "toml.rs"]
+mod toml_;
+#[path = "xml.rs"]
+mod xml_;
+#[path = "yaml.rs"]
+mod yaml_;
+
+pub use self::cbor_::*;
+pub use self::csv_::*;
+pub use self::json_::*;
+pub use self::toml_::*;
+pub use self::xml_::*;
+pub use self::yaml_::*;
+
+use typst_library::foundations::Scope;
+
+/// Hook up the `data-loading` definitions for more complicated file formats.
+pub fn register(global: &mut Scope) {
+    global.start_category(typst_library::Category::DataLoading);
+    global.define_func::<csv>();
+    global.define_func::<json>();
+    global.define_func::<toml>();
+    global.define_func::<yaml>();
+    global.define_func::<cbor>();
+    global.define_func::<xml>();
+    global.reset_category();
+}

--- a/crates/typst-loading/src/toml.rs
+++ b/crates/typst-loading/src/toml.rs
@@ -1,10 +1,10 @@
 use ecow::eco_format;
 use typst_syntax::Spanned;
 
-use crate::diag::{At, LoadError, LoadedWithin, ReportTextPos, SourceResult};
-use crate::engine::Engine;
-use crate::foundations::{Dict, Str, func, scope};
-use crate::loading::{DataSource, Load};
+use typst_library::diag::{At, LoadError, LoadedWithin, ReportTextPos, SourceResult};
+use typst_library::engine::Engine;
+use typst_library::foundations::{Dict, Str, func, scope};
+use typst_library::loading::{DataSource, Load};
 
 /// Reads structured data from a TOML file.
 ///

--- a/crates/typst-loading/src/xml.rs
+++ b/crates/typst-loading/src/xml.rs
@@ -1,10 +1,10 @@
 use roxmltree::ParsingOptions;
 use typst_syntax::Spanned;
 
-use crate::diag::{LoadError, LoadedWithin, SourceResult, format_xml_like_error};
-use crate::engine::Engine;
-use crate::foundations::{Array, Dict, IntoValue, Str, Value, dict, func};
-use crate::loading::{DataSource, Load};
+use typst_library::diag::{LoadError, LoadedWithin, SourceResult, format_xml_like_error};
+use typst_library::engine::Engine;
+use typst_library::foundations::{Array, Dict, IntoValue, Str, Value, dict, func};
+use typst_library::loading::{DataSource, Load};
 
 /// Reads structured data from an XML file.
 ///

--- a/crates/typst-loading/src/yaml.rs
+++ b/crates/typst-loading/src/yaml.rs
@@ -1,10 +1,12 @@
 use ecow::eco_format;
 use typst_syntax::Spanned;
 
-use crate::diag::{At, LineCol, LoadError, LoadedWithin, ReportTextPos, SourceResult};
-use crate::engine::Engine;
-use crate::foundations::{Str, Value, func, scope};
-use crate::loading::{DataSource, Load};
+use typst_library::diag::{
+    At, LineCol, LoadError, LoadedWithin, ReportTextPos, SourceResult,
+};
+use typst_library::engine::Engine;
+use typst_library::foundations::{Str, Value, func, scope};
+use typst_library::loading::{DataSource, Load};
 
 /// Reads structured data from a YAML file.
 ///
@@ -121,7 +123,7 @@ impl yaml {
 }
 
 /// Format the user-facing YAML error message.
-pub fn format_yaml_error(error: serde_yaml::Error) -> LoadError {
+fn format_yaml_error(error: serde_yaml::Error) -> LoadError {
     let pos = error
         .location()
         .map(|loc| {

--- a/crates/typst-macros/src/scope.rs
+++ b/crates/typst-macros/src/scope.rs
@@ -67,7 +67,7 @@ pub fn scope(stream: TokenStream, item: syn::Item) -> Result<TokenStream> {
                     )?;
 
                     let mut deprecation =
-                        quote! { crate::foundations::Deprecation::new() };
+                        quote! { ::typst_library::foundations::Deprecation::new() };
 
                     if let Some(message) = args.iter().find_map(|pair| {
                         pair.path.is_ident("message").then_some(&pair.value)

--- a/crates/typst/Cargo.toml
+++ b/crates/typst/Cargo.toml
@@ -17,6 +17,7 @@ typst-eval = { workspace = true }
 typst-html = { workspace = true }
 typst-layout = { workspace = true }
 typst-library = { workspace = true }
+typst-loading = { workspace = true }
 typst-macros = { workspace = true }
 typst-realize = { workspace = true }
 typst-syntax = { workspace = true }

--- a/crates/typst/src/lib.rs
+++ b/crates/typst/src/lib.rs
@@ -50,7 +50,7 @@ use typst_library::diag::{
 };
 use typst_library::engine::{Engine, Route, Sink, Traced};
 use typst_library::foundations::{
-    NativeRuleMap, Output, StyleChain, Styles, Target, TargetElem, Value,
+    NativeRuleMap, Output, Scope, StyleChain, Styles, Target, TargetElem, Value,
 };
 use typst_library::introspection::{
     EmptyIntrospector, ITER_NAMES, Introspector, MAX_ITERS,
@@ -304,6 +304,12 @@ impl LibraryExt for Library {
     }
 }
 
+fn register_globals(global: &mut Scope, features: &Features) {
+    if features.is_enabled(Feature::Html) {
+        global.define("html", typst_html::module());
+    }
+}
+
 /// Defines implementation of various Typst compiler routines as a table of
 /// function pointers.
 ///
@@ -315,11 +321,11 @@ static ROUTINES: LazyLock<Routines> = LazyLock::new(|| Routines {
         typst_html::register(&mut rules);
         rules
     },
+    register_globals,
     eval_string: typst_eval::eval_string,
     eval_closure: typst_eval::eval_closure,
     realize: typst_realize::realize,
     layout_frame: typst_layout::layout_frame,
-    html_module: typst_html::module,
     html_mathml_body: typst_html::html_mathml_body,
     html_span_filled: typst_html::html_span_filled,
 });

--- a/crates/typst/src/lib.rs
+++ b/crates/typst/src/lib.rs
@@ -305,6 +305,7 @@ impl LibraryExt for Library {
 }
 
 fn register_globals(global: &mut Scope, features: &Features) {
+    typst_loading::register(global);
     if features.is_enabled(Feature::Html) {
         global.define("html", typst_html::module());
     }


### PR DESCRIPTION
For the dutch kiesraad's use of typst, there is a desire to reduce the number of dependencies used by typst. This PR is meant as an illustration for how this reduction can be achieved by splitting some of the functionality in typst-library into their own crates. The first commit provides the ground work for making these splits possible, and the second commit shows how this can be applied by splitting of the loading of advanced data formats into its own crate.

Library users of typst get the benefit of reduced dependencies by depending on the individual crates. This requires some small duplications of code from the main typst crate on their end, but as this crate is small that duplication will be limited and is deemed acceptable, at least by the kiesraad.

On the other hand, the typst project does not have to deal with feature flags and the combinatorial explosion of trying to ensure everything works with some subset of flags enabled. The dependency structure of the crates will inherently enforce that the split-off parts of the code base will function independently by making use of the split-off functionality in typst-library and typst-render impossible by default.

As a side benefit, work in the split-off crates will likely have shorter compile-test cycle times, as fewer crates will have to be recompiled for changes in those crates as compared to changes to typst-library.