### PR TITLE
Adjust block promotion of `display: contents` elements

### DIFF
--- a/crates/typst-html/src/convert.rs
+++ b/crates/typst-html/src/convert.rs
@@ -436,16 +436,14 @@ fn make_block_level(node: &mut HtmlNode) -> Result<(), Unblockable> {
             property::Display::None
             | property::Display::Block
             | property::Display::Table
-            | property::Display::ListItem,
+            | property::Display::ListItem
+            | property::Display::Contents,
         ) => None,
 
         // These must be promoted to `block`.
-        None
-        | Some(
-            property::Display::Inline
-            | property::Display::InlineBlock
-            | property::Display::Contents,
-        ) => Some(property::Display::Block),
+        None | Some(property::Display::Inline | property::Display::InlineBlock) => {
+            Some(property::Display::Block)
+        }
 
         // These can't be promoted. They are instead wrapped in a `<div>`.
         _ => return Err(Unblockable),

--- a/tests/ref/html/hashes.txt
+++ b/tests/ref/html/hashes.txt
@@ -7,7 +7,7 @@ a845db3f6f6d466d683136b703f44cf6 basic-table
 1e0f40cc69e2d5efa0590d9c17fec0a6 bibliography-no-title
 805860e9a2d6bc7f9e466517c058eeec block-block-html
 805860e9a2d6bc7f9e466517c058eeec block-box-html
-7e781b26371016fd463430fa3aead840 block-display-html
+2771d670b32a96e330e3db46aebd5f5b block-display-html
 ffa25d90e2baac1e02b03a60cae89720 block-html-block
 3c77f2f38c8f3fa6c90b1beb10c5d722 block-html-frame
 56e9ac9cf5876bc5ebbdd43b1a640a99 block-html-inline

--- a/tests/suite/layout/container.typ
+++ b/tests/suite/layout/container.typ
@@ -356,7 +356,7 @@ Paragraph B
 #block(html.li())     // display: list-item -> nothing
 #block(html.span())   // display: inline -> block
 #block(html.input())  // display: inline-block -> block
-#block(html.slot())   // display: contents -> block
+#block(html.slot())   // display: contents -> nothing
 #block(html.ruby())   // display: ruby -> wrapped in div
 
 --- block-invalid-html html ---


### PR DESCRIPTION
The only HTML element that defaults to `display: contents` is `<slot>`. When I write `#block(html.slot())`, then I probably just want the slot to not be grouped into a paragraph, rather than getting a `style="display: block"` put onto it. Essentially, we can't predict how it will render, so it's better to not make any assumptions. The blockiness will likely come from whatever is planned for the slot.