### PR TITLE
Request standard library from `World` once upfront

### DIFF
--- a/crates/typst-bundle/src/lib.rs
+++ b/crates/typst-bundle/src/lib.rs
@@ -29,10 +29,10 @@ use typst_library::introspection::{
 use typst_library::model::{
     AssetElem, Document, DocumentElem, DocumentFormat, DocumentInfo, PagedFormat,
 };
-use typst_library::routines::{Arenas, Pair, RealizationKind, Routines};
-use typst_library::{Feature, World};
+use typst_library::routines::{Arenas, Pair, RealizationKind};
+use typst_library::{Feature, Library, World};
 use typst_syntax::VirtualPath;
-use typst_utils::Protected;
+use typst_utils::{LazyHash, Protected};
 
 /// A collection of files resulting from compilation.
 ///
@@ -124,8 +124,8 @@ pub fn bundle(
     styles: StyleChain,
 ) -> SourceResult<Bundle> {
     bundle_impl(
-        engine.routines,
         engine.world,
+        engine.library,
         engine.introspector.into_raw(),
         engine.traced,
         TrackedMut::reborrow_mut(&mut engine.sink),
@@ -139,8 +139,8 @@ pub fn bundle(
 #[comemo::memoize]
 #[allow(clippy::too_many_arguments)]
 fn bundle_impl(
-    routines: &Routines,
     world: Tracked<dyn World + '_>,
+    library: &LazyHash<Library>,
     introspector: Tracked<dyn Introspector + '_>,
     traced: Tracked<Traced>,
     sink: TrackedMut<Sink>,
@@ -151,7 +151,7 @@ fn bundle_impl(
     let introspector = Protected::from_raw(introspector);
     let mut locator = Locator::root().split();
     let mut engine = Engine {
-        routines,
+        library,
         world,
         introspector,
         traced,
@@ -165,7 +165,7 @@ fn bundle_impl(
     let styles = StyleChain::new(&styles);
 
     let arenas = Arenas::default();
-    let children = (engine.routines.realize)(
+    let children = (engine.library.routines.realize)(
         RealizationKind::Bundle,
         &mut engine,
         &mut locator,
@@ -318,7 +318,7 @@ fn compile_document<'a>(
             )
         }
         DocumentFormat::Html => {
-            if !engine.world.library().features.is_enabled(Feature::Html) {
+            if !engine.library.features.is_enabled(Feature::Html) {
                 bail!(
                     document.span(),
                     "html export is only available when the `html` feature is enabled";

--- a/crates/typst-cli/src/eval.rs
+++ b/crates/typst-cli/src/eval.rs
@@ -84,12 +84,13 @@ fn evaluate_expression(
     world: &dyn World,
     introspector: &dyn Introspector,
 ) -> SourceResult<Value> {
+    let library = world.library();
     eval_string(
-        &typst::ROUTINES,
         world.track(),
+        library,
         sink.track_mut(),
         introspector.track(),
-        Context::new(None, Some(StyleChain::new(&world.library().styles))).track(),
+        Context::new(None, Some(StyleChain::new(&library.styles))).track(),
         &expression,
         Span::detached(),
         SyntaxMode::Code,

--- a/crates/typst-cli/src/query.rs
+++ b/crates/typst-cli/src/query.rs
@@ -71,8 +71,8 @@ fn retrieve(
     introspector: &dyn Introspector,
 ) -> HintedStrResult<Vec<Content>> {
     let selector = eval_string(
-        &typst::ROUTINES,
         world.track(),
+        world.library(),
         // TODO: propagate warnings
         Sink::new().track_mut(),
         EmptyIntrospector.track(),

--- a/crates/typst-eval/src/call.rs
+++ b/crates/typst-eval/src/call.rs
@@ -1,6 +1,5 @@
 use comemo::{Tracked, TrackedMut};
 use ecow::{EcoString, EcoVec, eco_format};
-use typst_library::World;
 use typst_library::diag::{
     At, HintedStrResult, HintedString, SourceResult, Trace, Tracepoint, bail, error,
 };
@@ -11,7 +10,7 @@ use typst_library::foundations::{
 };
 use typst_library::introspection::Introspector;
 use typst_library::math::LrElem;
-use typst_library::routines::Routines;
+use typst_library::{Library, World};
 use typst_syntax::ast::{self, AstNode};
 use typst_syntax::{Span, Spanned, SyntaxNode};
 use typst_utils::{LazyHash, Protected};
@@ -586,8 +585,8 @@ impl Eval for ast::Closure<'_> {
 pub fn eval_closure(
     func: &Func,
     closure: &LazyHash<Closure>,
-    routines: &Routines,
     world: Tracked<dyn World + '_>,
+    library: &LazyHash<Library>,
     introspector: Tracked<dyn Introspector + '_>,
     traced: Tracked<Traced>,
     sink: TrackedMut<Sink>,
@@ -614,7 +613,7 @@ pub fn eval_closure(
     // Prepare the engine.
     let introspector = Protected::from_raw(introspector);
     let engine = Engine {
-        routines,
+        library,
         world,
         introspector,
         traced,

--- a/crates/typst-eval/src/import.rs
+++ b/crates/typst-eval/src/import.rs
@@ -235,8 +235,8 @@ fn import_file(engine: &mut Engine, id: FileId, span: Span) -> SourceResult<Modu
 
     // Evaluate the file.
     eval(
-        engine.routines,
         engine.world,
+        engine.library,
         engine.traced,
         TrackedMut::reborrow_mut(&mut engine.sink),
         engine.route.track(),

--- a/crates/typst-eval/src/lib.rs
+++ b/crates/typst-eval/src/lib.rs
@@ -24,22 +24,21 @@ use self::binding::*;
 use self::methods::*;
 
 use comemo::{Track, Tracked, TrackedMut};
-use typst_library::World;
 use typst_library::diag::{SourceResult, bail};
 use typst_library::engine::{Engine, Route, Sink, Traced};
 use typst_library::foundations::{Context, Module, NativeElement, Scope, Scopes, Value};
 use typst_library::introspection::{EmptyIntrospector, Introspector};
 use typst_library::math::EquationElem;
-use typst_library::routines::Routines;
+use typst_library::{Library, World};
 use typst_syntax::{Source, Span, SyntaxMode, ast, parse, parse_code, parse_math};
-use typst_utils::Protected;
+use typst_utils::{LazyHash, Protected};
 
 /// Evaluate a source file and return the resulting module.
 #[comemo::memoize]
 #[typst_macros::time(name = "eval", span = source.root().span())]
 pub fn eval(
-    routines: &Routines,
     world: Tracked<dyn World + '_>,
+    library: &LazyHash<Library>,
     traced: Tracked<Traced>,
     sink: TrackedMut<Sink>,
     route: Tracked<Route>,
@@ -54,7 +53,7 @@ pub fn eval(
     // Prepare the engine.
     let introspector = EmptyIntrospector;
     let engine = Engine {
-        routines,
+        library,
         world,
         introspector: Protected::new(introspector.track()),
         traced,
@@ -64,7 +63,7 @@ pub fn eval(
 
     // Prepare VM.
     let context = Context::none();
-    let scopes = Scopes::new(Some(world.library()));
+    let scopes = Scopes::new(Some(library));
     let root = source.root();
     let mut vm = Vm::new(engine, context.track(), scopes, root.span());
 
@@ -95,8 +94,8 @@ pub fn eval(
 #[comemo::memoize]
 #[allow(clippy::too_many_arguments)]
 pub fn eval_string(
-    routines: &Routines,
     world: Tracked<dyn World + '_>,
+    library: &LazyHash<Library>,
     sink: TrackedMut<Sink>,
     introspector: Tracked<dyn Introspector + '_>,
     context: Tracked<Context>,
@@ -122,7 +121,7 @@ pub fn eval_string(
     // Prepare the engine.
     let traced = Traced::default();
     let engine = Engine {
-        routines,
+        library,
         world,
         introspector: Protected::new(introspector),
         traced: traced.track(),
@@ -131,7 +130,7 @@ pub fn eval_string(
     };
 
     // Prepare VM.
-    let scopes = Scopes::new(Some(world.library()));
+    let scopes = Scopes::new(Some(library));
     let mut vm = Vm::new(engine, context, scopes, root.span());
     vm.scopes.scopes.push(scope);
 

--- a/crates/typst-html/src/convert.rs
+++ b/crates/typst-html/src/convert.rs
@@ -140,7 +140,7 @@ fn handle(
     } else if let Some(elem) = child.to_packed::<FrameElem>() {
         let locator = converter.locator.next(&elem.span());
         let style = TargetElem::target.set(Target::Paged).wrap();
-        let frame = (converter.engine.routines.layout_frame)(
+        let frame = (converter.engine.library.routines.layout_frame)(
             converter.engine,
             &elem.body,
             locator,

--- a/crates/typst-html/src/document.rs
+++ b/crates/typst-html/src/document.rs
@@ -1,6 +1,5 @@
 use comemo::{Track, Tracked, TrackedMut};
 use ecow::{EcoVec, eco_vec};
-use typst_library::World;
 use typst_library::diag::{SourceResult, bail, error};
 use typst_library::engine::{Engine, Route, Sink, Traced};
 use typst_library::foundations::{Content, NativeElement, StyleChain, Styles};
@@ -8,9 +7,10 @@ use typst_library::introspection::{
     Introspector, Locator, LocatorLink, QueryIntrospection,
 };
 use typst_library::model::{DocumentInfo, FootnoteContainer, FootnoteMarker};
-use typst_library::routines::{Arenas, RealizationKind, Routines};
+use typst_library::routines::{Arenas, RealizationKind};
+use typst_library::{Library, World};
 use typst_syntax::Span;
-use typst_utils::Protected;
+use typst_utils::{LazyHash, Protected};
 
 use crate::convert::{ConversionLevel, Whitespace};
 use crate::{HtmlDocument, HtmlElement, HtmlNode, attr, css, tag};
@@ -26,8 +26,8 @@ pub fn html_document(
     styles: StyleChain,
 ) -> SourceResult<HtmlDocument> {
     html_document_impl(
-        engine.routines,
         engine.world,
+        engine.library,
         engine.introspector.into_raw(),
         engine.traced,
         TrackedMut::reborrow_mut(&mut engine.sink),
@@ -41,8 +41,8 @@ pub fn html_document(
 #[comemo::memoize]
 #[allow(clippy::too_many_arguments)]
 fn html_document_impl(
-    routines: &Routines,
     world: Tracked<dyn World + '_>,
+    library: &LazyHash<Library>,
     introspector: Tracked<dyn Introspector + '_>,
     traced: Tracked<Traced>,
     sink: TrackedMut<Sink>,
@@ -51,8 +51,8 @@ fn html_document_impl(
     styles: StyleChain,
 ) -> SourceResult<HtmlDocument> {
     let mut document = html_document_common(
-        routines,
         world,
+        library,
         introspector,
         traced,
         sink,
@@ -80,8 +80,8 @@ pub fn html_document_for_bundle(
     styles: StyleChain,
 ) -> SourceResult<HtmlDocument> {
     html_document_for_bundle_impl(
-        engine.routines,
         engine.world,
+        engine.library,
         engine.introspector.into_raw(),
         engine.traced,
         TrackedMut::reborrow_mut(&mut engine.sink),
@@ -96,8 +96,8 @@ pub fn html_document_for_bundle(
 #[comemo::memoize]
 #[allow(clippy::too_many_arguments)]
 fn html_document_for_bundle_impl(
-    routines: &Routines,
     world: Tracked<dyn World + '_>,
+    library: &LazyHash<Library>,
     introspector: Tracked<dyn Introspector + '_>,
     traced: Tracked<Traced>,
     sink: TrackedMut<Sink>,
@@ -108,8 +108,8 @@ fn html_document_for_bundle_impl(
 ) -> SourceResult<HtmlDocument> {
     let link = LocatorLink::new(locator);
     html_document_common(
-        routines,
         world,
+        library,
         introspector,
         traced,
         sink,
@@ -124,8 +124,8 @@ fn html_document_for_bundle_impl(
 /// `html_document_for_bundle`.
 #[allow(clippy::too_many_arguments)]
 fn html_document_common(
-    routines: &Routines,
     world: Tracked<dyn World + '_>,
+    library: &LazyHash<Library>,
     introspector: Tracked<dyn Introspector + '_>,
     traced: Tracked<Traced>,
     sink: TrackedMut<Sink>,
@@ -137,7 +137,7 @@ fn html_document_common(
     let introspector = Protected::from_raw(introspector);
     let mut locator = locator.split();
     let mut engine = Engine {
-        routines,
+        library,
         world,
         introspector,
         traced,
@@ -158,7 +158,7 @@ fn html_document_common(
     info.populate(styles);
     info.populate_locale(styles);
 
-    let children = (engine.routines.realize)(
+    let children = (engine.library.routines.realize)(
         RealizationKind::HtmlDocument { info: &mut info },
         &mut engine,
         &mut locator,

--- a/crates/typst-html/src/fragment.rs
+++ b/crates/typst-html/src/fragment.rs
@@ -1,13 +1,13 @@
 use comemo::{Track, Tracked, TrackedMut};
 use ecow::EcoVec;
-use typst_library::World;
 use typst_library::diag::{At, SourceResult};
 use typst_library::engine::{Engine, Route, Sink, Traced};
 use typst_library::foundations::{Content, StyleChain};
 use typst_library::introspection::{Introspector, Locator, LocatorLink, SplitLocator};
-use typst_library::routines::{Arenas, FragmentKind, Pair, RealizationKind, Routines};
+use typst_library::routines::{Arenas, FragmentKind, Pair, RealizationKind};
 use typst_library::text::SmartQuoter;
-use typst_utils::Protected;
+use typst_library::{Library, World};
+use typst_utils::{LazyHash, Protected};
 
 use crate::HtmlNode;
 use crate::convert::{ConversionLevel, Whitespace};
@@ -23,8 +23,8 @@ pub fn html_block_fragment(
     whitespace: Whitespace,
 ) -> SourceResult<EcoVec<HtmlNode>> {
     html_block_fragment_impl(
-        engine.routines,
         engine.world,
+        engine.library,
         engine.introspector.into_raw(),
         engine.traced,
         TrackedMut::reborrow_mut(&mut engine.sink),
@@ -40,8 +40,8 @@ pub fn html_block_fragment(
 #[comemo::memoize]
 #[allow(clippy::too_many_arguments)]
 fn html_block_fragment_impl(
-    routines: &Routines,
     world: Tracked<dyn World + '_>,
+    library: &LazyHash<Library>,
     introspector: Tracked<dyn Introspector + '_>,
     traced: Tracked<Traced>,
     sink: TrackedMut<Sink>,
@@ -55,7 +55,7 @@ fn html_block_fragment_impl(
     let link = LocatorLink::new(locator);
     let mut locator = Locator::link(&link).split();
     let mut engine = Engine {
-        routines,
+        library,
         world,
         introspector,
         traced,
@@ -118,7 +118,7 @@ fn realize_fragment<'a>(
     content: &'a Content,
     styles: StyleChain<'a>,
 ) -> SourceResult<Vec<Pair<'a>>> {
-    (engine.routines.realize)(
+    (engine.library.routines.realize)(
         RealizationKind::HtmlFragment {
             // We ignore the `FragmentKind` because we handle both uniformly.
             kind: &mut FragmentKind::Block,

--- a/crates/typst-ide/src/utils.rs
+++ b/crates/typst-ide/src/utils.rs
@@ -21,7 +21,7 @@ where
     let traced = Traced::default();
     let mut sink = Sink::new();
     let mut engine = Engine {
-        routines: &typst::ROUTINES,
+        library: world.library(),
         world: world.upcast().track(),
         introspector: Protected::new(introspector.track()),
         traced: traced.track(),

--- a/crates/typst-layout/src/flow/collect.rs
+++ b/crates/typst-layout/src/flow/collect.rs
@@ -5,7 +5,6 @@ use std::hash::Hash;
 use bumpalo::Bump;
 use bumpalo::boxed::Box as BumpBox;
 use comemo::{Track, Tracked, TrackedMut};
-use typst_library::World;
 use typst_library::diag::{SourceResult, bail, warning};
 use typst_library::engine::{Engine, Route, Sink, Traced};
 use typst_library::foundations::{Packed, Resolve, Smart, StyleChain};
@@ -18,9 +17,10 @@ use typst_library::layout::{
     Ratio, Region, Regions, Rel, Size, Sizing, Spacing, VElem,
 };
 use typst_library::model::ParElem;
-use typst_library::routines::{Pair, Routines};
+use typst_library::routines::Pair;
 use typst_library::text::TextElem;
-use typst_utils::{Protected, SliceExt};
+use typst_library::{Library, World};
+use typst_utils::{LazyHash, Protected, SliceExt};
 
 use super::{FlowMode, layout_multi_block, layout_single_block};
 use crate::inline::ParSituation;
@@ -394,8 +394,8 @@ impl SingleChild<'_> {
             // Vertical expansion is only kept if this block is the only child.
             region.expand.y &= self.alone;
             layout_single_impl(
-                engine.routines,
                 engine.world,
+                engine.library,
                 engine.introspector.into_raw(),
                 engine.traced,
                 TrackedMut::reborrow_mut(&mut engine.sink),
@@ -413,8 +413,8 @@ impl SingleChild<'_> {
 #[comemo::memoize]
 #[allow(clippy::too_many_arguments)]
 fn layout_single_impl(
-    routines: &Routines,
     world: Tracked<dyn World + '_>,
+    library: &LazyHash<Library>,
     introspector: Tracked<dyn Introspector + '_>,
     traced: Tracked<Traced>,
     sink: TrackedMut<Sink>,
@@ -428,7 +428,7 @@ fn layout_single_impl(
     let link = LocatorLink::new(locator);
     let locator = Locator::link(&link);
     let mut engine = Engine {
-        routines,
+        library,
         world,
         introspector,
         traced,
@@ -494,8 +494,8 @@ impl<'a> MultiChild<'a> {
             // Vertical expansion is only kept if this block is the only child.
             regions.expand.y &= self.alone;
             layout_multi_impl(
-                engine.routines,
                 engine.world,
+                engine.library,
                 engine.introspector.into_raw(),
                 engine.traced,
                 TrackedMut::reborrow_mut(&mut engine.sink),
@@ -513,8 +513,8 @@ impl<'a> MultiChild<'a> {
 #[comemo::memoize]
 #[allow(clippy::too_many_arguments)]
 fn layout_multi_impl(
-    routines: &Routines,
     world: Tracked<dyn World + '_>,
+    library: &LazyHash<Library>,
     introspector: Tracked<dyn Introspector + '_>,
     traced: Tracked<Traced>,
     sink: TrackedMut<Sink>,
@@ -528,7 +528,7 @@ fn layout_multi_impl(
     let link = LocatorLink::new(locator);
     let locator = Locator::link(&link);
     let mut engine = Engine {
-        routines,
+        library,
         world,
         introspector,
         traced,

--- a/crates/typst-layout/src/flow/mod.rs
+++ b/crates/typst-layout/src/flow/mod.rs
@@ -14,7 +14,6 @@ use bumpalo::Bump;
 use comemo::{Track, Tracked, TrackedMut};
 use ecow::EcoVec;
 use rustc_hash::FxHashSet;
-use typst_library::World;
 use typst_library::diag::{At, SourceDiagnostic, SourceResult, bail};
 use typst_library::engine::{Engine, Route, Sink, Traced};
 use typst_library::foundations::{Content, Packed, Resolve, StyleChain};
@@ -27,9 +26,10 @@ use typst_library::layout::{
 };
 use typst_library::model::{FootnoteElem, FootnoteEntry, LineNumberingScope, ParLine};
 use typst_library::pdf::ArtifactKind;
-use typst_library::routines::{Arenas, FragmentKind, Pair, RealizationKind, Routines};
+use typst_library::routines::{Arenas, FragmentKind, Pair, RealizationKind};
 use typst_library::text::TextElem;
-use typst_utils::{NonZeroExt, Numeric, Protected};
+use typst_library::{Library, World};
+use typst_utils::{LazyHash, NonZeroExt, Numeric, Protected};
 
 use self::block::{layout_multi_block, layout_single_block};
 use self::collect::{
@@ -61,8 +61,8 @@ pub fn layout_fragment(
     regions: Regions,
 ) -> SourceResult<Fragment> {
     layout_fragment_impl(
-        engine.routines,
         engine.world,
+        engine.library,
         engine.introspector.into_raw(),
         engine.traced,
         TrackedMut::reborrow_mut(&mut engine.sink),
@@ -89,8 +89,8 @@ pub fn layout_columns(
     regions: Regions,
 ) -> SourceResult<Fragment> {
     layout_fragment_impl(
-        engine.routines,
         engine.world,
+        engine.library,
         engine.introspector.into_raw(),
         engine.traced,
         TrackedMut::reborrow_mut(&mut engine.sink),
@@ -108,8 +108,8 @@ pub fn layout_columns(
 #[comemo::memoize]
 #[allow(clippy::too_many_arguments)]
 fn layout_fragment_impl(
-    routines: &Routines,
     world: Tracked<dyn World + '_>,
+    library: &LazyHash<Library>,
     introspector: Tracked<dyn Introspector + '_>,
     traced: Tracked<Traced>,
     sink: TrackedMut<Sink>,
@@ -132,7 +132,7 @@ fn layout_fragment_impl(
     let link = LocatorLink::new(locator);
     let mut locator = Locator::link(&link).split();
     let mut engine = Engine {
-        routines,
+        library,
         world,
         introspector,
         traced,
@@ -144,7 +144,7 @@ fn layout_fragment_impl(
 
     let mut kind = FragmentKind::Block;
     let arenas = Arenas::default();
-    let children = (engine.routines.realize)(
+    let children = (engine.library.routines.realize)(
         RealizationKind::LayoutFragment { kind: &mut kind },
         &mut engine,
         &mut locator,

--- a/crates/typst-layout/src/inline/mod.rs
+++ b/crates/typst-layout/src/inline/mod.rs
@@ -12,7 +12,6 @@ pub use self::box_::layout_box;
 pub use self::shaping::{SharedShapingContext, create_shape_plan, get_font_and_covers};
 
 use comemo::{Track, Tracked, TrackedMut};
-use typst_library::World;
 use typst_library::diag::SourceResult;
 use typst_library::engine::{Engine, Route, Sink, Traced};
 use typst_library::foundations::{Packed, Smart, StyleChain};
@@ -22,9 +21,10 @@ use typst_library::model::{
     EnumElem, FirstLineIndent, JustificationLimits, Linebreaks, ListElem, ParElem,
     ParLine, ParLineMarker, TermsElem,
 };
-use typst_library::routines::{Arenas, Pair, RealizationKind, Routines};
+use typst_library::routines::{Arenas, Pair, RealizationKind};
 use typst_library::text::{Costs, Lang, TextElem};
-use typst_utils::{Numeric, Protected, SliceExt};
+use typst_library::{Library, World};
+use typst_utils::{LazyHash, Numeric, Protected, SliceExt};
 
 use self::collect::{Item, Segment, SpanMapper, collect};
 use self::deco::decorate;
@@ -52,8 +52,8 @@ pub fn layout_par(
 ) -> SourceResult<Fragment> {
     layout_par_impl(
         elem,
-        engine.routines,
         engine.world,
+        engine.library,
         engine.introspector.into_raw(),
         engine.traced,
         TrackedMut::reborrow_mut(&mut engine.sink),
@@ -71,8 +71,8 @@ pub fn layout_par(
 #[allow(clippy::too_many_arguments)]
 fn layout_par_impl(
     elem: &Packed<ParElem>,
-    routines: &Routines,
     world: Tracked<dyn World + '_>,
+    library: &LazyHash<Library>,
     introspector: Tracked<dyn Introspector + '_>,
     traced: Tracked<Traced>,
     sink: TrackedMut<Sink>,
@@ -87,7 +87,7 @@ fn layout_par_impl(
     let link = LocatorLink::new(locator);
     let mut locator = Locator::link(&link).split();
     let mut engine = Engine {
-        routines,
+        library,
         world,
         introspector,
         traced,
@@ -96,7 +96,7 @@ fn layout_par_impl(
     };
 
     let arenas = Arenas::default();
-    let children = (engine.routines.realize)(
+    let children = (engine.library.routines.realize)(
         RealizationKind::LayoutPar,
         &mut engine,
         &mut locator,

--- a/crates/typst-layout/src/pages/mod.rs
+++ b/crates/typst-layout/src/pages/mod.rs
@@ -6,7 +6,6 @@ mod run;
 
 use comemo::{Track, Tracked, TrackedMut};
 use ecow::EcoVec;
-use typst_library::World;
 use typst_library::diag::SourceResult;
 use typst_library::engine::{Engine, Route, Sink, Traced};
 use typst_library::foundations::{Content, StyleChain};
@@ -15,8 +14,9 @@ use typst_library::introspection::{
 };
 use typst_library::layout::{FrameItem, Point};
 use typst_library::model::DocumentInfo;
-use typst_library::routines::{Arenas, Pair, RealizationKind, Routines};
-use typst_utils::Protected;
+use typst_library::routines::{Arenas, Pair, RealizationKind};
+use typst_library::{Library, World};
+use typst_utils::{LazyHash, Protected};
 
 use self::collect::{Item, collect};
 use self::finalize::finalize;
@@ -36,8 +36,8 @@ pub fn layout_document(
     styles: StyleChain,
 ) -> SourceResult<PagedDocument> {
     layout_document_impl(
-        engine.routines,
         engine.world,
+        engine.library,
         engine.introspector.into_raw(),
         engine.traced,
         TrackedMut::reborrow_mut(&mut engine.sink),
@@ -51,8 +51,8 @@ pub fn layout_document(
 #[comemo::memoize]
 #[allow(clippy::too_many_arguments)]
 fn layout_document_impl(
-    routines: &Routines,
     world: Tracked<dyn World + '_>,
+    library: &LazyHash<Library>,
     introspector: Tracked<dyn Introspector + '_>,
     traced: Tracked<Traced>,
     sink: TrackedMut<Sink>,
@@ -61,7 +61,7 @@ fn layout_document_impl(
     styles: StyleChain,
 ) -> SourceResult<PagedDocument> {
     layout_document_common(
-        routines,
+        library,
         world,
         introspector,
         traced,
@@ -82,8 +82,8 @@ pub fn layout_document_for_bundle(
     styles: StyleChain,
 ) -> SourceResult<PagedDocument> {
     layout_document_for_bundle_impl(
-        engine.routines,
         engine.world,
+        engine.library,
         engine.introspector.into_raw(),
         engine.traced,
         TrackedMut::reborrow_mut(&mut engine.sink),
@@ -98,8 +98,8 @@ pub fn layout_document_for_bundle(
 #[comemo::memoize]
 #[allow(clippy::too_many_arguments)]
 fn layout_document_for_bundle_impl(
-    routines: &Routines,
     world: Tracked<dyn World + '_>,
+    library: &LazyHash<Library>,
     introspector: Tracked<dyn Introspector + '_>,
     traced: Tracked<Traced>,
     sink: TrackedMut<Sink>,
@@ -110,7 +110,7 @@ fn layout_document_for_bundle_impl(
 ) -> SourceResult<PagedDocument> {
     let link = LocatorLink::new(locator);
     layout_document_common(
-        routines,
+        library,
         world,
         introspector,
         traced,
@@ -126,7 +126,7 @@ fn layout_document_for_bundle_impl(
 /// `layout_document_for_bundle`.
 #[allow(clippy::too_many_arguments)]
 fn layout_document_common(
-    routines: &Routines,
+    library: &LazyHash<Library>,
     world: Tracked<dyn World + '_>,
     introspector: Tracked<dyn Introspector + '_>,
     traced: Tracked<Traced>,
@@ -139,7 +139,7 @@ fn layout_document_common(
     let introspector = Protected::from_raw(introspector);
     let mut locator = locator.split();
     let mut engine = Engine {
-        routines,
+        library,
         world,
         introspector,
         traced,
@@ -157,7 +157,7 @@ fn layout_document_common(
     info.populate(styles);
     info.populate_locale(styles);
 
-    let mut children = (engine.routines.realize)(
+    let mut children = (engine.library.routines.realize)(
         RealizationKind::LayoutDocument { info: &mut info },
         &mut engine,
         &mut locator,

--- a/crates/typst-layout/src/pages/run.rs
+++ b/crates/typst-layout/src/pages/run.rs
@@ -1,5 +1,4 @@
 use comemo::{Track, Tracked, TrackedMut};
-use typst_library::World;
 use typst_library::diag::SourceResult;
 use typst_library::engine::{Engine, Route, Sink, Traced};
 use typst_library::foundations::{
@@ -15,10 +14,11 @@ use typst_library::layout::{
 };
 use typst_library::model::Numbering;
 use typst_library::pdf::ArtifactKind;
-use typst_library::routines::{Pair, Routines};
+use typst_library::routines::Pair;
 use typst_library::text::{LocalName, TextElem};
 use typst_library::visualize::Paint;
-use typst_utils::{Numeric, Protected};
+use typst_library::{Library, World};
+use typst_utils::{LazyHash, Numeric, Protected};
 
 use crate::flow::{FlowMode, layout_flow};
 
@@ -59,8 +59,8 @@ pub fn layout_page_run(
     initial: StyleChain,
 ) -> SourceResult<Vec<LayoutedPage>> {
     layout_page_run_impl(
-        engine.routines,
         engine.world,
+        engine.library,
         engine.introspector.into_raw(),
         engine.traced,
         TrackedMut::reborrow_mut(&mut engine.sink),
@@ -75,8 +75,8 @@ pub fn layout_page_run(
 #[comemo::memoize]
 #[allow(clippy::too_many_arguments)]
 fn layout_page_run_impl(
-    routines: &Routines,
     world: Tracked<dyn World + '_>,
+    library: &LazyHash<Library>,
     introspector: Tracked<dyn Introspector + '_>,
     traced: Tracked<Traced>,
     sink: TrackedMut<Sink>,
@@ -89,7 +89,7 @@ fn layout_page_run_impl(
     let link = LocatorLink::new(locator);
     let mut locator = Locator::link(&link).split();
     let mut engine = Engine {
-        routines,
+        library,
         world,
         introspector,
         traced,

--- a/crates/typst-layout/src/rules.rs
+++ b/crates/typst-layout/src/rules.rs
@@ -268,7 +268,7 @@ const HEADING_RULE: ShowFn<HeadingElem> = |elem, engine, styles| {
             // We don't have a locator for the numbering here, so we just
             // use the measurement infrastructure for now.
             let link = LocatorLink::measure(location, span);
-            let size = (engine.routines.layout_frame)(
+            let size = (engine.library.routines.layout_frame)(
                 engine,
                 &numbering,
                 Locator::link(&link),

--- a/crates/typst-library/src/engine.rs
+++ b/crates/typst-library/src/engine.rs
@@ -7,21 +7,23 @@ use ecow::EcoVec;
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use rustc_hash::FxHashSet;
 use typst_syntax::{FileId, Span};
-use typst_utils::Protected;
+use typst_utils::{LazyHash, Protected};
 
-use crate::World;
 use crate::diag::{HintedStrResult, SourceDiagnostic, SourceResult, StrResult, bail};
 use crate::foundations::{Styles, Value};
 use crate::introspection::{Introspect, Introspection, Introspector};
-use crate::routines::Routines;
+use crate::{Library, World};
 
 /// Holds all data needed during compilation.
 pub struct Engine<'a> {
-    /// Defines implementation of various Typst compiler routines as a table of
-    /// function pointers.
-    pub routines: &'a Routines,
     /// The compilation environment.
     pub world: Tracked<'a, dyn World + 'a>,
+    /// Definition of Typst's standard library.
+    ///
+    /// Can be accessed via `world.library()`, but we fetch it once upfront
+    /// because it's accessed so frequently and we want to avoid the overhead of
+    /// the tracked call.
+    pub library: &'a LazyHash<Library>,
     /// Provides access to information about the document.
     pub introspector: Protected<Tracked<'a, dyn Introspector + 'a>>,
     /// May hold a span that is currently under inspection.
@@ -61,7 +63,7 @@ impl Engine<'_> {
         F: Fn(&mut Engine, T) -> U + Send + Sync,
     {
         let Engine {
-            world, introspector, traced, ref route, routines, ..
+            world, introspector, traced, ref route, library, ..
         } = *self;
 
         // We collect into a vector and then call `into_par_iter` instead of
@@ -79,7 +81,7 @@ impl Engine<'_> {
                     traced,
                     sink: sink.track_mut(),
                     route: route.clone(),
-                    routines,
+                    library,
                 };
                 (f(&mut engine, value), sink)
             })

--- a/crates/typst-library/src/foundations/func.rs
+++ b/crates/typst-library/src/foundations/func.rs
@@ -326,11 +326,11 @@ impl Func {
                 args.finish()?;
                 Ok(Value::Content(value))
             }
-            FuncInner::Closure(closure) => (engine.routines.eval_closure)(
+            FuncInner::Closure(closure) => (engine.library.routines.eval_closure)(
                 self,
                 closure,
-                engine.routines,
                 engine.world,
+                engine.library,
                 engine.introspector.into_raw(),
                 engine.traced,
                 TrackedMut::reborrow_mut(&mut engine.sink),

--- a/crates/typst-library/src/foundations/mod.rs
+++ b/crates/typst-library/src/foundations/mod.rs
@@ -301,9 +301,9 @@ pub fn eval(
         scope.bind(key.into(), Binding::new(value, span));
     }
 
-    (engine.routines.eval_string)(
-        engine.routines,
+    (engine.library.routines.eval_string)(
         engine.world,
+        engine.library,
         TrackedMut::reborrow_mut(&mut engine.sink),
         // We create a new, detached introspector for string evaluation. Passing
         // the real introspector should not have any consequences with

--- a/crates/typst-library/src/introspection/convergence.rs
+++ b/crates/typst-library/src/introspection/convergence.rs
@@ -12,7 +12,6 @@ use crate::World;
 use crate::diag::{SourceDiagnostic, warning};
 use crate::engine::{Engine, Route, Sink, Traced};
 use crate::introspection::Introspector;
-use crate::routines::Routines;
 
 pub const MAX_ITERS: usize = 5;
 pub const ITER_NAMES: &[&str] =
@@ -25,13 +24,12 @@ const INSTANCES: usize = MAX_ITERS + 1;
 #[typst_macros::time(name = "analyze introspections")]
 pub fn analyze(
     world: Tracked<dyn World + '_>,
-    routines: &Routines,
     introspectors: [&dyn Introspector; INSTANCES],
     introspections: &[Introspection],
 ) -> EcoVec<SourceDiagnostic> {
     let mut sink = Sink::new();
     for introspection in introspections {
-        if let Some(warning) = introspection.0.diagnose(world, routines, introspectors) {
+        if let Some(warning) = introspection.0.diagnose(world, introspectors) {
             sink.warn(warning);
         }
     }
@@ -167,7 +165,6 @@ trait Bounds: Debug + Send + Sync + Any + 'static {
     fn diagnose(
         &self,
         world: Tracked<dyn World + '_>,
-        routines: &Routines,
         introspectors: [&dyn Introspector; INSTANCES],
     ) -> Option<SourceDiagnostic>;
     fn dyn_eq(&self, other: &Introspection) -> bool;
@@ -181,13 +178,11 @@ where
     fn diagnose(
         &self,
         world: Tracked<dyn World + '_>,
-        routines: &Routines,
         introspectors: [&dyn Introspector; INSTANCES],
     ) -> Option<SourceDiagnostic> {
-        let history =
-            History::compute(world, routines, introspectors, |engine, introspector| {
-                self.introspect(engine, introspector)
-            });
+        let history = History::compute(world, introspectors, |engine, introspector| {
+            self.introspect(engine, introspector)
+        });
         (!history.converged()).then(|| self.diagnose(&history))
     }
 
@@ -221,7 +216,6 @@ impl<'a, T> History<'a, T> {
     /// Computes the value for each introspector with an ad-hoc engine.
     fn compute(
         world: Tracked<dyn World + '_>,
-        routines: &Routines,
         introspectors: [&'a dyn Introspector; INSTANCES],
         f: impl Fn(&mut Engine, Tracked<'a, dyn Introspector + '_>) -> T,
     ) -> Self {
@@ -230,12 +224,12 @@ impl<'a, T> History<'a, T> {
             let traced = Traced::default();
             let mut sink = Sink::new();
             let mut engine = Engine {
+                library: world.library(),
                 world,
                 introspector: Protected::new(tracked),
                 traced: traced.track(),
                 sink: sink.track_mut(),
                 route: Route::default(),
-                routines,
             };
             (introspector, f(&mut engine, tracked))
         }))

--- a/crates/typst-library/src/introspection/counter.rs
+++ b/crates/typst-library/src/introspection/counter.rs
@@ -7,9 +7,8 @@ use comemo::{Track, Tracked, TrackedMut};
 use ecow::{EcoString, EcoVec, eco_format, eco_vec};
 use smallvec::{SmallVec, smallvec};
 use typst_syntax::Span;
-use typst_utils::{NonZeroExt, Protected};
+use typst_utils::{LazyHash, NonZeroExt, Protected};
 
-use crate::World;
 use crate::diag::{At, HintedStrResult, SourceDiagnostic, SourceResult, bail, warning};
 use crate::engine::{Engine, Route, Sink, Traced};
 use crate::foundations::{
@@ -24,7 +23,7 @@ use crate::introspection::{
 use crate::layout::{Frame, FrameItem, PageElem};
 use crate::math::EquationElem;
 use crate::model::{FigureElem, FootnoteElem, HeadingElem, Numbering, NumberingPattern};
-use crate::routines::Routines;
+use crate::{Library, World};
 
 /// Counts through pages, elements, and more.
 ///
@@ -897,8 +896,8 @@ fn sequence(
     sequence_impl(
         counter,
         selector,
-        engine.routines,
         engine.world,
+        engine.library,
         introspector,
         engine.traced,
         TrackedMut::reborrow_mut(&mut engine.sink),
@@ -912,15 +911,15 @@ fn sequence(
 fn sequence_impl(
     counter: &Counter,
     selector: &Selector,
-    routines: &Routines,
     world: Tracked<dyn World + '_>,
+    library: &LazyHash<Library>,
     introspector: Tracked<dyn Introspector + '_>,
     traced: Tracked<Traced>,
     sink: TrackedMut<Sink>,
     route: Tracked<Route>,
 ) -> SourceResult<EcoVec<(CounterState, NonZeroUsize)>> {
     let mut engine = Engine {
-        routines,
+        library,
         world,
         introspector: Protected::from_raw(introspector),
         traced,

--- a/crates/typst-library/src/introspection/state.rs
+++ b/crates/typst-library/src/introspection/state.rs
@@ -1,9 +1,8 @@
 use comemo::{Track, Tracked, TrackedMut};
 use ecow::{EcoString, EcoVec, eco_format, eco_vec};
 use typst_syntax::Span;
-use typst_utils::Protected;
+use typst_utils::{LazyHash, Protected};
 
-use crate::World;
 use crate::diag::{At, SourceDiagnostic, SourceResult, bail, warning};
 use crate::engine::{Engine, Route, Sink, Traced};
 use crate::foundations::{
@@ -11,7 +10,7 @@ use crate::foundations::{
     Selector, Str, Value, cast, elem, func, scope, select_where, ty,
 };
 use crate::introspection::{History, Introspect, Introspector, Locatable, Location};
-use crate::routines::Routines;
+use crate::{Library, World};
 
 /// Manages stateful parts of your document.
 ///
@@ -461,8 +460,8 @@ fn sequence(
 ) -> SourceResult<EcoVec<Value>> {
     sequence_impl(
         state,
-        engine.routines,
         engine.world,
+        engine.library,
         introspector,
         engine.traced,
         TrackedMut::reborrow_mut(&mut engine.sink),
@@ -474,15 +473,15 @@ fn sequence(
 #[comemo::memoize]
 fn sequence_impl(
     state: &State,
-    routines: &Routines,
     world: Tracked<dyn World + '_>,
+    library: &LazyHash<Library>,
     introspector: Tracked<dyn Introspector + '_>,
     traced: Tracked<Traced>,
     sink: TrackedMut<Sink>,
     route: Tracked<Route>,
 ) -> SourceResult<EcoVec<Value>> {
     let mut engine = Engine {
-        routines,
+        library,
         world,
         introspector: Protected::from_raw(introspector),
         traced,

--- a/crates/typst-library/src/layout/measure.rs
+++ b/crates/typst-library/src/layout/measure.rs
@@ -93,7 +93,7 @@ pub fn measure(
     let locator = Locator::link(&link);
     let style = TargetElem::target.set(Target::Paged).wrap();
 
-    let frame = (engine.routines.layout_frame)(
+    let frame = (engine.library.routines.layout_frame)(
         engine,
         &content,
         locator,

--- a/crates/typst-library/src/lib.rs
+++ b/crates/typst-library/src/lib.rs
@@ -157,6 +157,9 @@ impl<T: World + ?Sized> WorldExt for T {
 /// - `Library::builder().build()` if you want to customize the library
 #[derive(Debug, Clone, Hash)]
 pub struct Library {
+    /// Defines implementation of various Typst compiler routines as a table of
+    /// function pointers.
+    pub routines: &'static Routines,
     /// The module that contains the definitions that are available everywhere.
     pub global: Module,
     /// The module that contains the definitions available in math mode.
@@ -211,6 +214,7 @@ impl LibraryBuilder {
         let inputs = self.inputs.unwrap_or_default();
         let global = global(self.routines, math.clone(), inputs, &self.features);
         Library {
+            routines: self.routines,
             global: global.clone(),
             math,
             styles: Styles::new(),

--- a/crates/typst-library/src/math/ir/resolve.rs
+++ b/crates/typst-library/src/math/ir/resolve.rs
@@ -129,7 +129,7 @@ impl<'a, 'v, 'e> MathResolver<'a, 'v, 'e> {
         content: &'a Content,
         styles: StyleChain<'a>,
     ) -> SourceResult<()> {
-        let pairs = (self.engine.routines.realize)(
+        let pairs = (self.engine.library.routines.realize)(
             RealizationKind::Math,
             self.engine,
             &mut self.locator,

--- a/crates/typst-library/src/model/bibliography.rs
+++ b/crates/typst-library/src/model/bibliography.rs
@@ -39,7 +39,6 @@ use crate::model::{
     CitationForm, CiteGroup, Destination, DirectLinkElem, FootnoteElem, HeadingElem,
     LinkElem, Url,
 };
-use crate::routines::Routines;
 use crate::text::{Lang, LocalName, Region, SmallcapsElem, SubElem, SuperElem, TextElem};
 
 /// A bibliography / reference listing.
@@ -555,7 +554,7 @@ impl Works {
     pub fn generate(engine: &mut Engine, span: Span) -> SourceResult<Arc<Works>> {
         let bibliography = BibliographyElem::find(engine, span).at(span)?;
         let groups = engine.introspect(CiteGroupIntrospection(span));
-        Self::generate_impl(engine.routines, engine.world, bibliography, groups).at(span)
+        Self::generate_impl(engine.world, bibliography, groups).at(span)
     }
 
     /// Generate all citations and the whole bibliography, given an existing
@@ -566,18 +565,17 @@ impl Works {
     ) -> SourceResult<Arc<Works>> {
         let span = bibliography.span();
         let groups = engine.introspect(CiteGroupIntrospection(span));
-        Self::generate_impl(engine.routines, engine.world, bibliography, groups).at(span)
+        Self::generate_impl(engine.world, bibliography, groups).at(span)
     }
 
     /// The internal implementation of [`Works::generate`].
     #[comemo::memoize]
     fn generate_impl(
-        routines: &Routines,
         world: Tracked<dyn World + '_>,
         bibliography: Packed<BibliographyElem>,
         groups: EcoVec<Content>,
     ) -> StrResult<Arc<Works>> {
-        let mut generator = Generator::new(routines, world, bibliography, groups)?;
+        let mut generator = Generator::new(world, bibliography, groups)?;
         let rendered = generator.drive();
         let works = generator.display(&rendered)?;
         Ok(Arc::new(works))
@@ -635,8 +633,6 @@ impl Introspect for CiteGroupIntrospection {
 
 /// Context for generating the bibliography.
 struct Generator<'a> {
-    /// The routines that are used to evaluate mathematical material in citations.
-    routines: &'a Routines,
     /// The world that is used to evaluate mathematical material in citations.
     world: Tracked<'a, dyn World + 'a>,
     /// The document's bibliography.
@@ -677,14 +673,12 @@ struct CiteInfo {
 impl<'a> Generator<'a> {
     /// Create a new generator.
     fn new(
-        routines: &'a Routines,
         world: Tracked<'a, dyn World + 'a>,
         bibliography: Packed<BibliographyElem>,
         groups: EcoVec<Content>,
     ) -> StrResult<Self> {
         let infos = Vec::with_capacity(groups.len());
         Ok(Self {
-            routines,
             world,
             bibliography,
             groups,
@@ -841,7 +835,6 @@ impl<'a> Generator<'a> {
             };
 
             let renderer = ElemRenderer {
-                routines: self.routines,
                 world: self.world,
                 span: info.span,
                 supplement: &supplement,
@@ -891,7 +884,6 @@ impl<'a> Generator<'a> {
         let mut output = vec![];
         for (k, item) in rendered.items.iter().enumerate() {
             let renderer = ElemRenderer {
-                routines: self.routines,
                 world: self.world,
                 span: self.bibliography.span(),
                 supplement: &|_| None,
@@ -936,8 +928,6 @@ impl<'a> Generator<'a> {
 
 /// Renders hayagriva elements into content.
 struct ElemRenderer<'a> {
-    /// The routines that is used to evaluate mathematical material in citations.
-    routines: &'a Routines,
     /// The world that is used to evaluate mathematical material.
     world: Tracked<'a, dyn World + 'a>,
     /// The span that is attached to all of the resulting content.
@@ -1050,9 +1040,10 @@ impl ElemRenderer<'_> {
 
     /// Display math.
     fn display_math(&self, math: &str) -> Content {
-        (self.routines.eval_string)(
-            self.routines,
+        let library = self.world.library();
+        (library.routines.eval_string)(
             self.world,
+            library,
             // TODO: propagate warnings
             Sink::new().track_mut(),
             EmptyIntrospector.track(),

--- a/crates/typst-library/src/model/outline.rs
+++ b/crates/typst-library/src/model/outline.rs
@@ -780,8 +780,14 @@ fn measure_prefix(
 ) -> SourceResult<Abs> {
     let pod = Region::new(Axes::splat(Abs::inf()), Axes::splat(false));
     let link = LocatorLink::measure(loc, span);
-    Ok((engine.routines.layout_frame)(engine, prefix, Locator::link(&link), styles, pod)?
-        .width())
+    Ok((engine.library.routines.layout_frame)(
+        engine,
+        prefix,
+        Locator::link(&link),
+        styles,
+        pod,
+    )?
+    .width())
 }
 
 /// Compute the base indent and hanging indent for an auto-indented outline

--- a/crates/typst-library/src/routines.rs
+++ b/crates/typst-library/src/routines.rs
@@ -5,7 +5,6 @@ use comemo::{Tracked, TrackedMut};
 use typst_syntax::{Span, SyntaxMode};
 use typst_utils::LazyHash;
 
-use crate::World;
 use crate::diag::SourceResult;
 use crate::engine::{Engine, Route, Sink, Traced};
 use crate::foundations::{
@@ -16,6 +15,7 @@ use crate::introspection::{Introspector, Locator, SplitLocator};
 use crate::layout::{Frame, Region};
 use crate::model::DocumentInfo;
 use crate::visualize::Color;
+use crate::{Library, World};
 
 /// Defines the `Routines` struct.
 macro_rules! routines {
@@ -52,8 +52,8 @@ macro_rules! routines {
 routines! {
     /// Evaluates a string as code and return the resulting value.
     fn eval_string(
-        routines: &Routines,
         world: Tracked<dyn World + '_>,
+        library: &LazyHash<Library>,
         sink: TrackedMut<Sink>,
         introspector: Tracked<dyn Introspector + '_>,
         context: Tracked<Context>,
@@ -67,8 +67,8 @@ routines! {
     fn eval_closure(
         func: &Func,
         closure: &LazyHash<Closure>,
-        routines: &Routines,
         world: Tracked<dyn World + '_>,
+        library: &LazyHash<Library>,
         introspector: Tracked<dyn Introspector + '_>,
         traced: Tracked<Traced>,
         sink: TrackedMut<Sink>,

--- a/crates/typst-library/src/text/raw.rs
+++ b/crates/typst-library/src/text/raw.rs
@@ -355,7 +355,7 @@ impl Synthesize for Packed<RawElem> {
         engine: &mut Engine,
         styles: StyleChain,
     ) -> SourceResult<()> {
-        let seq = self.highlight(engine.routines, styles);
+        let seq = self.highlight(engine.library.routines, styles);
         self.lines = Some(seq);
         Ok(())
     }

--- a/crates/typst-library/src/visualize/tiling.rs
+++ b/crates/typst-library/src/visualize/tiling.rs
@@ -5,7 +5,6 @@ use ecow::{EcoString, eco_format};
 use typst_syntax::{Span, Spanned};
 use typst_utils::{LazyHash, Numeric};
 
-use crate::World;
 use crate::diag::{SourceResult, bail};
 use crate::engine::Engine;
 use crate::foundations::{Content, Repr, Smart, StyleChain, func, scope, ty};
@@ -191,13 +190,11 @@ impl Tiling {
         let region = size.unwrap_or_else(|| Axes::splat(Abs::inf()));
 
         // Layout the tiling.
-        let world = engine.world;
-        let library = world.library();
         let locator = Locator::root();
-        let styles = StyleChain::new(&library.styles);
+        let styles = StyleChain::new(&engine.library.styles);
         let pod = Region::new(region, Axes::splat(false));
         let mut frame =
-            (engine.routines.layout_frame)(engine, &body, locator, styles, pod)?;
+            (engine.library.routines.layout_frame)(engine, &body, locator, styles, pod)?;
 
         // Set the size of the frame if the size is enforced.
         if let Smart::Custom(size) = size {

--- a/crates/typst-realize/src/lib.rs
+++ b/crates/typst-realize/src/lib.rs
@@ -510,7 +510,7 @@ fn verdict<'a>(
     // If we found no user-defined rule, also consider the built-in show rule.
     if step.is_none() {
         let target = styles.get(TargetElem::target);
-        if let Some(rule) = engine.routines.rules.get(target, elem) {
+        if let Some(rule) = engine.library.routines.rules.get(target, elem) {
             step = Some(ShowStep::Builtin(rule));
         }
     }

--- a/crates/typst/src/lib.rs
+++ b/crates/typst/src/lib.rs
@@ -101,13 +101,13 @@ fn compile_impl<T: Output>(
     traced: Tracked<Traced>,
     sink: &mut Sink,
 ) -> SourceResult<T> {
+    let library = world.library();
     match T::target() {
         Target::Paged => {}
-        Target::Html => warn_or_error_for_html(world, sink)?,
-        Target::Bundle => warn_or_error_for_bundle(world, sink)?,
+        Target::Html => warn_or_error_for_html(&library.features, sink)?,
+        Target::Bundle => warn_or_error_for_bundle(&library.features, sink)?,
     }
 
-    let library = world.library();
     let base = StyleChain::new(&library.styles);
     let target = TargetElem::target.set(T::target()).wrap();
     let styles = base.chain(&target);
@@ -121,8 +121,8 @@ fn compile_impl<T: Output>(
 
     // First evaluate the main source file into a module.
     let content = typst_eval::eval(
-        &ROUTINES,
         world,
+        library,
         traced,
         sink.track_mut(),
         Route::default().track(),
@@ -145,12 +145,12 @@ fn compile_impl<T: Output>(
 
         let mut subsink = Sink::new();
         let mut engine = Engine {
+            library,
             world,
             introspector: Protected::new(introspector.track_with(&constraint)),
             traced,
             sink: subsink.track_mut(),
             route: Route::default(),
-            routines: &ROUTINES,
         };
 
         document = T::create(&mut engine, &content, styles)?;
@@ -170,7 +170,6 @@ fn compile_impl<T: Output>(
 
             let warnings = typst_library::introspection::analyze(
                 world,
-                &ROUTINES,
                 introspectors,
                 subsink.introspections(),
             );
@@ -245,12 +244,9 @@ fn hint_invalid_main_file(
 }
 
 /// HTML export will warn or error depending on whether the feature flag is enabled.
-fn warn_or_error_for_html(
-    world: Tracked<dyn World + '_>,
-    sink: &mut Sink,
-) -> SourceResult<()> {
+fn warn_or_error_for_html(features: &Features, sink: &mut Sink) -> SourceResult<()> {
     const ISSUE: &str = "https://github.com/typst/typst/issues/5512";
-    if world.library().features.is_enabled(Feature::Html) {
+    if features.is_enabled(Feature::Html) {
         sink.warn(warning!(
             Span::detached(),
             "html export is under active development and incomplete";
@@ -271,11 +267,8 @@ fn warn_or_error_for_html(
 
 /// Bundle export will warn or error depending on whether the feature flag is
 /// enabled.
-fn warn_or_error_for_bundle(
-    world: Tracked<dyn World + '_>,
-    sink: &mut Sink,
-) -> SourceResult<()> {
-    if world.library().features.is_enabled(Feature::Bundle) {
+fn warn_or_error_for_bundle(features: &Features, sink: &mut Sink) -> SourceResult<()> {
+    if features.is_enabled(Feature::Bundle) {
         sink.warn(warning!(
             Span::detached(),
             "bundle export is experimental";
@@ -315,7 +308,7 @@ impl LibraryExt for Library {
 /// function pointers.
 ///
 /// This is essentially dynamic linking and done to allow for crate splitting.
-pub static ROUTINES: LazyLock<Routines> = LazyLock::new(|| Routines {
+static ROUTINES: LazyLock<Routines> = LazyLock::new(|| Routines {
     rules: {
         let mut rules = NativeRuleMap::new();
         typst_layout::register(&mut rules);

--- a/tests/src/run.rs
+++ b/tests/src/run.rs
@@ -824,10 +824,10 @@ mod eval {
     use comemo::{Track, Tracked};
     use ecow::EcoVec;
     use rustc_hash::FxHashSet;
+    use typst::World;
     use typst::diag::{SourceDiagnostic, SourceResult, Warned};
     use typst::engine::{Route, Sink, Traced};
     use typst::foundations::Content;
-    use typst::{ROUTINES, World};
 
     pub fn eval(world: &dyn World) -> Warned<SourceResult<Content>> {
         let mut sink = Sink::new();
@@ -848,8 +848,8 @@ mod eval {
 
         // First evaluate the main source file into a module.
         let content = typst_eval::eval(
-            &ROUTINES,
             world,
+            world.library(),
             traced,
             sink.track_mut(),
             Route::default().track(),


### PR DESCRIPTION
Stores the standard library in the `Engine` so that it can be used across the whole compilation without always invoking a tracked call. It's not like the standard library is changing during compilation, so a tracked call is a bit pointless. This is in preparation for a [followup PR](https://github.com/typst/typst/pull/8216) that allows overriding native show rules and requires access to the `Library` in realization (where I wanted to avoid adding yet another `world.library()` tracked call).

A nice side effect of this change is that the `ROUTINES` static can now be private as it's implicitly threaded into compilation through the `LibraryBuilder`.