### PR TITLE
Support for overriding native show rules

### DIFF
--- a/crates/typst-library/src/foundations/styles.rs
+++ b/crates/typst-library/src/foundations/styles.rs
@@ -5,7 +5,8 @@ use std::{mem, ptr};
 
 use comemo::Tracked;
 use ecow::{EcoString, EcoVec, eco_vec};
-use rustc_hash::FxHashMap;
+use indexmap::IndexMap;
+use rustc_hash::FxBuildHasher;
 use smallvec::SmallVec;
 use typst_syntax::Span;
 use typst_utils::LazyHash;
@@ -982,8 +983,9 @@ fn block_wrong_type(func: Element, id: u8, value: &Block) -> ! {
 }
 
 /// Holds native show rules.
+#[derive(Debug, Clone)]
 pub struct NativeRuleMap {
-    rules: FxHashMap<(Element, Target), NativeShowRule>,
+    rules: IndexMap<(Element, Target), NativeShowRule, FxBuildHasher>,
 }
 
 /// The signature of a native show rule.
@@ -1005,7 +1007,7 @@ impl NativeRuleMap {
             |_, _, _| Ok(Content::empty())
         }
 
-        let mut rules = Self { rules: FxHashMap::default() };
+        let mut rules = Self { rules: IndexMap::default() };
 
         for target in [Target::Paged, Target::Html, Target::Bundle] {
             // ContextElem is as special as SequenceElem and StyledElem and
@@ -1035,11 +1037,26 @@ impl NativeRuleMap {
     /// Registers a rule for a target.
     ///
     /// Panics if a rule already exists for this target-element combination.
+    #[track_caller]
     pub fn register<T: NativeElement>(&mut self, target: Target, f: ShowFn<T>) {
         let res = self.rules.insert((T::ELEM, target), NativeShowRule::new(f));
         if res.is_some() {
             panic!(
                 "duplicate native show rule for `{}` on {target:?} target",
+                T::ELEM.name()
+            )
+        }
+    }
+
+    /// Replaces a rule for a target.
+    ///
+    /// Panics if no rule exists for this target-element combination.
+    #[track_caller]
+    pub fn replace<T: NativeElement>(&mut self, target: Target, f: ShowFn<T>) {
+        let res = self.rules.insert((T::ELEM, target), NativeShowRule::new(f));
+        if res.is_none() {
+            panic!(
+                "no existing native show rule for `{}` on {target:?} target",
                 T::ELEM.name()
             )
         }
@@ -1058,13 +1075,22 @@ impl Default for NativeRuleMap {
     }
 }
 
+impl Hash for NativeRuleMap {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write_usize(self.rules.len());
+        for item in &self.rules {
+            item.hash(state);
+        }
+    }
+}
+
 pub use rule::NativeShowRule;
 
 mod rule {
     use super::*;
 
     /// The show rule for a native element.
-    #[derive(Copy, Clone)]
+    #[derive(Copy, Clone, Hash)]
     pub struct NativeShowRule {
         /// The element to which this rule applies.
         elem: Element,
@@ -1103,6 +1129,12 @@ mod rule {
 
             // Safety: We just checked that the element is of the correct type.
             unsafe { (self.f)(content, engine, styles) }
+        }
+    }
+
+    impl Debug for NativeShowRule {
+        fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+            f.pad("NativeShowRule(..)")
         }
     }
 }

--- a/crates/typst-library/src/lib.rs
+++ b/crates/typst-library/src/lib.rs
@@ -34,7 +34,7 @@ use typst_utils::{LazyHash, SmallBitSet};
 
 use crate::diag::FileResult;
 use crate::foundations::{
-    Array, Binding, Bytes, Datetime, Dict, Duration, Module, Scope, Styles,
+    Array, Binding, Bytes, Datetime, Dict, Duration, Module, NativeRuleMap, Scope, Styles,
 };
 use crate::layout::{Alignment, Dir};
 use crate::routines::Routines;
@@ -156,6 +156,7 @@ impl<T: World + ?Sized> WorldExt for T {
 /// - `Library::default()` for a standard configuration
 /// - `Library::builder().build()` if you want to customize the library
 #[derive(Debug, Clone, Hash)]
+#[non_exhaustive]
 pub struct Library {
     /// Defines implementation of various Typst compiler routines as a table of
     /// function pointers.
@@ -167,6 +168,8 @@ pub struct Library {
     /// The default style properties (for page size, font selection, and
     /// everything else configurable via set and show rules).
     pub styles: Styles,
+    /// The built-in show rules.
+    pub rules: NativeRuleMap,
     /// The standard library as a value. Used to provide the `std` module.
     pub std: Binding,
     /// In-development features that were enabled.
@@ -218,6 +221,7 @@ impl LibraryBuilder {
             global: global.clone(),
             math,
             styles: Styles::new(),
+            rules: (self.routines.rules)(),
             std: Binding::detached(global),
             features: self.features,
         }

--- a/crates/typst-library/src/routines.rs
+++ b/crates/typst-library/src/routines.rs
@@ -29,8 +29,6 @@ macro_rules! routines {
         /// This is essentially dynamic linking and done to allow for crate
         /// splitting.
         pub struct Routines {
-            /// Native show rules.
-            pub rules: NativeRuleMap,
             $(
                 $(#[$attr])*
                 pub $name: $(for<$($time),*>)? fn ($($args)*) -> $ret
@@ -50,6 +48,9 @@ macro_rules! routines {
 }
 
 routines! {
+    /// Creates the map with the built-in show rules.
+    fn rules() -> NativeRuleMap
+
     /// Evaluates a string as code and return the resulting value.
     fn eval_string(
         world: Tracked<dyn World + '_>,

--- a/crates/typst-realize/src/lib.rs
+++ b/crates/typst-realize/src/lib.rs
@@ -510,7 +510,7 @@ fn verdict<'a>(
     // If we found no user-defined rule, also consider the built-in show rule.
     if step.is_none() {
         let target = styles.get(TargetElem::target);
-        if let Some(rule) = engine.library.routines.rules.get(target, elem) {
+        if let Some(rule) = engine.library.rules.get(target, elem) {
             step = Some(ShowStep::Builtin(rule));
         }
     }

--- a/crates/typst/src/lib.rs
+++ b/crates/typst/src/lib.rs
@@ -309,7 +309,7 @@ impl LibraryExt for Library {
 ///
 /// This is essentially dynamic linking and done to allow for crate splitting.
 static ROUTINES: LazyLock<Routines> = LazyLock::new(|| Routines {
-    rules: {
+    rules: || {
         let mut rules = NativeRuleMap::new();
         typst_layout::register(&mut rules);
         typst_html::register(&mut rules);


### PR DESCRIPTION
This allows consumers of the Typst crates to define their own native Rust-based show rules instead of having to rely on the built-in ones.