### PR TITLE
Add trailing / to requests in bundle index.html

### DIFF
--- a/crates/typst-kit/src/server.rs
+++ b/crates/typst-kit/src/server.rs
@@ -161,10 +161,18 @@ fn handle(req: Request, reload: bool, bucket: &Arc<RouterBucket>) -> io::Result<
 
 /// Handles for the `/` route. Serves the compiled HTML.
 fn handle_body(req: Request, reload: bool, mut body: HttpBody) -> io::Result<()> {
+    // requests for index.html without trailing / should be redirected for
+    // adding /, e.g. /foo -> /foo/, because otherwise relative links on the
+    // page doesn't work
+    let mut should_redirect_index = false;
     let (data, mime) = match &mut body {
         HttpBody::Html(html) => {
             if reload {
                 inject_live_reload_script(html);
+            }
+            let url = req.url();
+            if !url.ends_with(".html") && !url.ends_with("/") {
+                should_redirect_index = true;
             }
             (html.as_bytes(), Some("text/html"))
         }
@@ -175,8 +183,14 @@ fn handle_body(req: Request, reload: bool, mut body: HttpBody) -> io::Result<()>
     if let Some(mime) = mime {
         headers.push(Header::from_bytes("Content-Type", mime).unwrap());
     }
+    let code = if should_redirect_index {
+        headers.push(Header::from_bytes("location", req.url().to_owned() + "/").unwrap());
+        307
+    } else {
+        200
+    };
 
-    req.respond(Response::new(StatusCode(200), headers, data, Some(data.len()), None))
+    req.respond(Response::new(StatusCode(code), headers, data, Some(data.len()), None))
 }
 
 /// Handler for the `/__events` route.


### PR DESCRIPTION
When `index.html` is opened in browser, and url doesn't end with `/`, relative links doesn't work correctly. Example (link resolution is the same in JS):

```js
console.log(new URL("article", "https://example.org/foo/").href)
// https://example.org/foo/article

console.log(new URL("article", "https://example.org/foo").href)
// https://example.org/article
```

[MDN](https://developer.mozilla.org/en-US/docs/Web/API/URL_API/Resolving_relative_references#current_directory_relative)

Repro:

```typ
#document("index.html")[
    #link("foo", "foo")
]
#document("foo/index.html")[
    this link is invalid:
    #link("bar.html", "bar")

    when current url is `/foo` (not `/foo/`), link points to `/bar.html`
]
#document("foo/bar.html")[
    bar
]
```

tested in chrome and firefox