### PR TITLE
Escape potentially dangerous characters before printing user-provided strings

### DIFF
--- a/crates/typst-library/src/foundations/mod.rs
+++ b/crates/typst-library/src/foundations/mod.rs
@@ -81,6 +81,7 @@ pub use {
 use comemo::{Track, TrackedMut};
 use ecow::EcoString;
 use typst_syntax::{RootedPath, Spanned, SyntaxMode};
+use typst_utils::escape_user_string;
 
 use crate::diag::{SourceResult, StrResult, bail};
 use crate::engine::Engine;
@@ -149,7 +150,7 @@ pub fn panic(
                 msg.push_str(", ");
             }
             match value {
-                Value::Str(s) => msg.push_str(s),
+                Value::Str(s) => msg.push_str(escape_user_string(s).as_ref()),
                 _ => msg.push_str(&value.repr()),
             }
         }
@@ -179,7 +180,7 @@ pub fn assert(
 ) -> StrResult<NoneValue> {
     if !condition {
         if let Some(message) = message {
-            bail!("assertion failed: {message}");
+            bail!("assertion failed: {}", escape_user_string(&message).as_ref());
         } else {
             bail!("assertion failed");
         }
@@ -210,7 +211,10 @@ impl assert {
     ) -> StrResult<NoneValue> {
         if left != right {
             if let Some(message) = message {
-                bail!("equality assertion failed: {message}");
+                bail!(
+                    "equality assertion failed: {}",
+                    escape_user_string(&message).as_ref()
+                );
             } else {
                 bail!(
                     "equality assertion failed: value {} was not equal to {}",
@@ -243,7 +247,10 @@ impl assert {
     ) -> StrResult<NoneValue> {
         if left == right {
             if let Some(message) = message {
-                bail!("inequality assertion failed: {message}");
+                bail!(
+                    "inequality assertion failed: {}",
+                    escape_user_string(&message).as_ref()
+                );
             } else {
                 bail!(
                     "inequality assertion failed: value {} was equal to {}",

--- a/crates/typst-library/src/foundations/mod.rs
+++ b/crates/typst-library/src/foundations/mod.rs
@@ -150,7 +150,7 @@ pub fn panic(
                 msg.push_str(", ");
             }
             match value {
-                Value::Str(s) => msg.push_str(escape_user_string(s).as_ref()),
+                Value::Str(s) => msg.push_str(&escape_user_string(s)),
                 _ => msg.push_str(&value.repr()),
             }
         }
@@ -180,7 +180,8 @@ pub fn assert(
 ) -> StrResult<NoneValue> {
     if !condition {
         if let Some(message) = message {
-            bail!("assertion failed: {}", escape_user_string(&message).as_ref());
+            let escaped = escape_user_string(&message);
+            bail!("assertion failed: {escaped}");
         } else {
             bail!("assertion failed");
         }
@@ -211,10 +212,8 @@ impl assert {
     ) -> StrResult<NoneValue> {
         if left != right {
             if let Some(message) = message {
-                bail!(
-                    "equality assertion failed: {}",
-                    escape_user_string(&message).as_ref()
-                );
+                let escaped = escape_user_string(&message);
+                bail!("equality assertion failed: {escaped}");
             } else {
                 bail!(
                     "equality assertion failed: value {} was not equal to {}",
@@ -247,10 +246,8 @@ impl assert {
     ) -> StrResult<NoneValue> {
         if left == right {
             if let Some(message) = message {
-                bail!(
-                    "inequality assertion failed: {}",
-                    escape_user_string(&message).as_ref()
-                );
+                let escaped = escape_user_string(&message);
+                bail!("inequality assertion failed: {escaped}");
             } else {
                 bail!(
                     "inequality assertion failed: value {} was equal to {}",

--- a/crates/typst-utils/src/lib.rs
+++ b/crates/typst-utils/src/lib.rs
@@ -30,6 +30,7 @@ pub use self::version_::{TypstVersion, display_commit, version};
 #[doc(hidden)]
 pub use once_cell;
 
+use std::borrow::Cow;
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::Hash;
 use std::iter::{Chain, Flatten, Rev};
@@ -491,26 +492,12 @@ fn is_dangerous_character(c: char) -> bool {
 ///
 /// This replaces potentially dangerous characters with the REPLACEMENT
 /// CHARACTER.
-pub fn escape_user_string<'a>(s: &'a str) -> impl AsRef<str> + 'a {
-    enum Escaped<'a> {
-        Original(&'a str),
-        Modified(String),
-    }
-
-    impl<'a> AsRef<str> for Escaped<'a> {
-        fn as_ref(&self) -> &str {
-            match self {
-                Self::Original(s) => s,
-                Self::Modified(s) => s.as_ref(),
-            }
-        }
-    }
-
+pub fn escape_user_string(s: &str) -> Cow<'_, str> {
     if !s.contains(is_dangerous_character) {
-        Escaped::Original(s)
+        Cow::Borrowed(s)
     } else {
         // We replace dangerous characters with the REPLACEMENT CHARACTER.
         // https://www.unicode.org/charts/PDF/UFFF0.pdf
-        Escaped::Modified(s.replace(is_dangerous_character, "\u{FFFD}"))
+        Cow::Owned(s.replace(is_dangerous_character, "\u{FFFD}"))
     }
 }

--- a/crates/typst-utils/src/lib.rs
+++ b/crates/typst-utils/src/lib.rs
@@ -472,3 +472,45 @@ macro_rules! display_possible_values {
         }
     };
 }
+
+/// Tests whether a Unicode character is a "dangerous" character that should  be
+/// escaped when printing a user-provided string.
+///
+/// The following characters are considered dangerous characters for this
+/// purpose:
+/// - C0 controls and DELETE from the [C0 Controls and Basic Latin] block
+/// - C1 controls from the [C1 Controls and Latin-1 Supplement] block
+///
+/// [C0 Controls and Basic Latin]: https://www.unicode.org/charts/PDF/U0000.pdf
+/// [C1 Controls and Latin-1 Supplement]: https://www.unicode.org/charts/PDF/U0080.pdf
+fn is_dangerous_character(c: char) -> bool {
+    matches!(c, '\u{0000}'..='\u{001F}' | '\u{007F}' | '\u{0080}'..='\u{009F}')
+}
+
+/// Escapes a user-provided string to be displayed in the terminal.
+///
+/// This replaces potentially dangerous characters with the REPLACEMENT
+/// CHARACTER.
+pub fn escape_user_string<'a>(s: &'a str) -> impl AsRef<str> + 'a {
+    enum Escaped<'a> {
+        Original(&'a str),
+        Modified(String),
+    }
+
+    impl<'a> AsRef<str> for Escaped<'a> {
+        fn as_ref(&self) -> &str {
+            match self {
+                Self::Original(s) => s,
+                Self::Modified(s) => s.as_ref(),
+            }
+        }
+    }
+
+    if !s.contains(is_dangerous_character) {
+        Escaped::Original(s)
+    } else {
+        // We replace dangerous characters with the REPLACEMENT CHARACTER.
+        // https://www.unicode.org/charts/PDF/UFFF0.pdf
+        Escaped::Modified(s.replace(is_dangerous_character, "\u{FFFD}"))
+    }
+}

--- a/tests/suite/foundations/assert.typ
+++ b/tests/suite/foundations/assert.typ
@@ -38,3 +38,18 @@
 #assert(5 > 3)
 #assert.eq(15, 15)
 #assert.ne(10, 12)
+
+--- assert-message-escaped eval ---
+// `assert` should escape escape characters.
+// Error: 2-73 assertion failed: �[2JAre they � escaped?�
+#assert(false, message: "\u{001B}[2JAre they \u{009C} escaped?\u{007F}")
+
+--- assert-eq-message-escaped eval ---
+// `assert.eq` should escape escape characters.
+// Error: 2-75 equality assertion failed: �[2JAre they � escaped?�
+#assert.eq(1, 2, message: "\u{001B}[2JAre they \u{009C} escaped?\u{007F}")
+
+--- assert-ne-message-escaped eval ---
+// `assert.ne` should escape escape characters.
+// Error: 2-75 inequality assertion failed: �[2JAre they � escaped?�
+#assert.ne(1, 1, message: "\u{001B}[2JAre they \u{009C} escaped?\u{007F}")

--- a/tests/suite/foundations/panic.typ
+++ b/tests/suite/foundations/panic.typ
@@ -17,7 +17,7 @@
 
 --- panic-multiline eval ---
 // Test panic with a multiline string.
-// Error: 1:2-2:7 panicked with: oops\noops\noops
+// Error: 1:2-2:7 panicked with: oops�oops�oops
 #panic("oops\noops
 oops")
 
@@ -30,3 +30,8 @@ oops")
 --- issue-5219-panic-escaped-quotes eval ---
 // Error: 2-42 panicked with: use an identifier like "math"
 #panic("use an identifier like \"math\"")
+
+--- panic-escape-characters eval ---
+// `panic` should escape escape characters.
+// Error: 2-56 panicked with: �[2JAre they � escaped?�
+#panic("\u{001B}[2JAre they \u{009C} escaped?\u{007F}")


### PR DESCRIPTION
Following the concern expressed in https://github.com/typst/typst/pull/8211#pullrequestreview-4230670199, this PR replaces potentially dangerous characters with the REPLACEMENT CHARACTER in user-provided strings. The following characters are considered dangerous characters for this purpose:
- C0 controls and DELETE from the [C0 Controls and Basic Latin] block
- C1 controls from the [C1 Controls and Latin-1 Supplement] block

[C0 Controls and Basic Latin]: https://www.unicode.org/charts/PDF/U0000.pdf
[C1 Controls and Latin-1 Supplement]: https://www.unicode.org/charts/PDF/U0080.pdf

We could also add BiDi control characters to this list, but I think this is fine for now.

Below is a prototype of an panic message a package could print to mislead a user into executing arbitrary code:

```typ
#let clear-screen = "\u{001B}[2J"
#let move-cursor-to-top-left = "\u{001B}[H"
#let red = "\u{001B}[31m"
#let reset = "\u{001B}[0m"
#let message = "Typst warning: One of your packages contains a security issue. Update it as soon as possible by executing the following command:\n\t~/.cache/typst/packages/preview/whatever/1.0.0/security-update\n\n"
#let security = clear-screen + move-cursor-to-top-left + red + message + reset

#assert(false, message: security)
```

Result (without colors):

```
Typst warning: One of your packages contains a security issue. Update it as soon as possible by executing the following command:
        ~/.cache/typst/packages/preview/whatever/1.0.0/security-update

  ┌─ /whatever
  │
7 │ #assert(false, message: security)
  │  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```