### PR TITLE
Fix PR link in 0.14 changelog

### DIFF
--- a/docs/content/changelog/0.14.0.typ
+++ b/docs/content/changelog/0.14.0.typ
@@ -77,7 +77,7 @@ PDF export was fully rewritten to use the new #link("https://github.com/LaurenzV
 - Reduced amount of `<g>` grouping elements that are generated #pr(6247)
 
 = PNG export <png-export>
-- Fixed crash when @text.size[text size] is negative #pr(5940)
+- Fixed crash when @text.size[text size] is negative #pr(7004)
 
 = Visualize <visualize>
 - Added support for using PDFs as @image[images] using the new #link("https://github.com/LaurenzV/hayro")[`hayro`] library. PDFs will be embedded directly in PDF export, rasterized in PNG export, and turned into SVGs in SVG and HTML export. _(Thanks to #gh("LaurenzV") for creating hayro!)_ #pr(6623)


### PR DESCRIPTION
Checked with:

```sh
# in docs/content/changelog
echo '*' > .gitignore
rg '#pr\(\d+\)' --only-matching --no-filename --no-ignore | rg '\d+' --only-matching | sort | uniq > prs.txt
echo "TOKEN" > token
./check.sh
```

<details><summary>check.sh</summary>
<p>

```sh
#!/usr/bin/env bash

YELLOW="\e[0;33m"
GREEN="\e[0;32m"
RED="\e[0;31m"
RESET="\e[0m"

function log() { >&2 echo -e "$@"; }
function warn() { log "$YELLOW" "$@" "$RESET"; }
function error() { log "$RED" "$@" "$RESET"; }
function good() { log "$GREEN" "$@" "$RESET"; }

token="$(cat token)"
function request() {
  pr="$1"
  log sending request, pr = "$pr"
  resp="$(curl -L --silent \
    -H "Accept: application/vnd.github+json" \
    -H "Authorization: Bearer $token" \
    -H "X-GitHub-Api-Version: 2026-03-10" \
    "https://api.github.com/repos/typst/typst/pulls/$pr")"
  id="$(echo "$resp" | jq -r .id)"
  msg="$(echo "$resp" | jq -r .message)"
  log id is "$id"
  log msg is "$msg"
  if [[ "$id" == "null" ]]; then
    if [[ "$msg" == "Not Found" ]]; then
      # is issue, not pr
      return 1
    fi
    error error: "$resp"
    return 2
  fi
  return 0
}

prs="$(cat prs.txt)"
for pr in $prs; do
  request "$pr"
  res="$?"
  if [[ "$res" == "1" ]]; then
    warn is issue
    echo "$pr" >> issues.txt
  elif [[ "$res" == "2" ]]; then
    error error occured
    exit 1
  else
    good is pr
    echo "$pr" >> handled.txt
  fi
done
```

</p>
</details> 