### PR TITLE
Bump MSRV to 1.92 and Rust in CI to 1.95

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           sudo dpkg --add-architecture i386
           sudo apt update
           sudo apt install -y gcc-multilib g++-multilib libssl-dev:i386 pkg-config:i386
-      - uses: dtolnay/rust-toolchain@f941e41d00837ee686f9d4575861485df1f7a655 # Rust 1.91.0
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:
           targets: ${{ matrix.bits == 32 && 'i686-unknown-linux-gnu' || '' }}
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - uses: dtolnay/rust-toolchain@f941e41d00837ee686f9d4575861485df1f7a655 # Rust 1.91.0
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - uses: dtolnay/rust-toolchain@f941e41d00837ee686f9d4575861485df1f7a655 # Rust 1.91.0
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
       - run: cargo docit compile --format website --deny-warnings
       - run: cargo docit compile --format pdf --deny-warnings
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - uses: dtolnay/rust-toolchain@9710f9012180ecfb08dcfc878269be6dc6f1d80e # Rust 1.89.0
+      - uses: dtolnay/rust-toolchain@b5826f8eb73f40ac7c19ef631dce17a9680f8129 # 1.92.0
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
       - run: cargo check --workspace
 
@@ -125,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: nightly-2025-10-28
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
@@ -137,7 +137,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           components: miri
           toolchain: nightly-2025-10-28

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-    - uses: dtolnay/rust-toolchain@f941e41d00837ee686f9d4575861485df1f7a655 # Rust 1.91.0
+    - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
       with:
         target: ${{ matrix.target }}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 
 [workspace.package]
 version = "0.14.2"
-rust-version = "1.89" # also change in ci.yml
+rust-version = "1.92" # also change in ci.yml
 authors = ["The Typst Project Developers"]
 edition = "2024"
 homepage = "https://typst.app"

--- a/crates/typst-eval/src/code.rs
+++ b/crates/typst-eval/src/code.rs
@@ -247,7 +247,7 @@ impl Eval for ast::Array<'_> {
                     Value::None => {}
                     Value::Array(array) => {
                         all_dict_spreads = false;
-                        vec.extend(array.into_iter())
+                        vec.extend(array);
                     }
                     v @ Value::Dict(_)
                         if all_dict_spreads
@@ -301,7 +301,7 @@ impl Eval for ast::Dict<'_> {
                 }
                 ast::DictItem::Spread(spread) => match spread.expr().eval(vm)? {
                     Value::None => {}
-                    Value::Dict(dict) => map.extend(dict.into_iter()),
+                    Value::Dict(dict) => map.extend(dict),
                     v => bail!(spread.span(), "cannot spread {} into dictionary", v.ty()),
                 },
             }

--- a/crates/typst-kit/src/downloader.rs
+++ b/crates/typst-kit/src/downloader.rs
@@ -309,8 +309,7 @@ impl Display for Progress {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let len = self.samples.len();
         let sum: usize = self.samples.iter().sum();
-        let bytes_per_period =
-            if len > 0 { sum / len } else { self.content_len.unwrap_or(0) };
+        let bytes_per_period = sum.checked_div(len).or(self.content_len).unwrap_or(0);
 
         let frequency: usize = Duration::from_secs(1)
             .as_nanos()

--- a/crates/typst-layout/src/grid/rowspans.rs
+++ b/crates/typst-layout/src/grid/rowspans.rs
@@ -174,7 +174,7 @@ impl GridLayouter<'_> {
         for ((i, (finished, header_dy)), frame) in self
             .finished
             .iter_mut()
-            .chain(current_region.into_iter())
+            .chain(current_region)
             .zip(finished_header_rows)
             .skip(first_region)
             .enumerate()

--- a/crates/typst-layout/src/math/mod.rs
+++ b/crates/typst-layout/src/math/mod.rs
@@ -139,10 +139,9 @@ pub fn layout_equation_block(
         let mut last_first_pos = Point::zero();
         let mut regions = regions;
 
-        loop {
-            // Keep track of the position of the first row in this region,
-            // so that the offset can be reverted later.
-            let Some(&(_, first_pos)) = rows.peek() else { break };
+        // Keep track of the position of the first row in this region,
+        // so that the offset can be reverted later.
+        while let Some(&(_, first_pos)) = rows.peek() {
             last_first_pos = first_pos;
 
             let mut frames = vec![];


### PR DESCRIPTION
Since krilla has bumped its MSRV to 1.92, we'll have to bump it sooner or later anyways.