### PR TITLE
Documentation symbol list improvements including submodule support

### DIFF
--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -1497,10 +1497,9 @@ p + .symbol-grid {
   gap: 16px;
 }
 
-.symbol-flyout .info .accent {
-  display: flex;
-  align-items: center;
-  gap: 4px;
+.symbol-flyout .info .accent > img {
+  top: 0.15em;
+  position: relative;
 }
 
 .symbol-flyout button + .remark {

--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -1476,18 +1476,20 @@ p + .symbol-grid {
 }
 
 .symbol-flyout button.copy {
-  top: 1px;
-  margin-inline-start: 2px;
-}
-
-.symbol-flyout button.copy {
-  padding: 2px;
+  top: 0.2em;
+  margin-inline-start: 0.15em;
+  padding: 0px;
   background: none;
   border: 0px;
   width: unset;
   box-shadow: none;
   display: inline-block;
   position: relative;
+  cursor: pointer;
+}
+
+.symbol-flyout button.copy > img {
+  display: block;
 }
 
 .symbol-flyout .info {

--- a/docs/assets/docs.js
+++ b/docs/assets/docs.js
@@ -467,7 +467,9 @@ function setUpSymbolFlyout(symbolGrid) {
     ".info .sym-deprecation .text",
   );
   /** @type {HTMLElement | null} */
-  const foName = flyout.querySelector(".sym-name code");
+  const foName = flyout.querySelector(".info .sym-name");
+  /** @type {HTMLElement | null} */
+  const foNameCode = flyout.querySelector(".info .sym-name code");
   /** @type {HTMLElement | null} */
   const foUnicName = flyout.querySelector(".info .unic-name");
   /** @type {HTMLElement | null} */
@@ -533,8 +535,8 @@ function setUpSymbolFlyout(symbolGrid) {
     item.ariaHasPopup = "true";
     flyoutOpenId = item.id;
     flyout.style.display = "block";
-    const name = item.id.replace(/^symbol-/, "");
     const deprecation = item.dataset.deprecation;
+    const codexName = item.dataset.codexName;
     const unicName = item.dataset.unicName;
     const latexName = item.dataset.latexName;
     const codepoint = item.dataset.value?.charCodeAt(0) ?? 0;
@@ -563,7 +565,12 @@ function setUpSymbolFlyout(symbolGrid) {
       foDeprecationText.textContent = deprecation.replaceAll("`", "");
     }
 
-    foName.textContent = name;
+    if (codexName) {
+      foName.style.display = "block";
+      foNameCode.textContent = codexName;
+    } else {
+      foName.style.display = "none";
+    }
     foUnicName.textContent = unicName ?? "";
     foCodepoint.textContent = codepointText;
     foAccent.style.display = accent ? null : "none";
@@ -585,7 +592,7 @@ function setUpSymbolFlyout(symbolGrid) {
       foMathClass.style.display = "none";
     }
 
-    const nameListener = () => copyText(name);
+    const nameListener = () => copyText(codexName);
     foCopySymNameBtn.addEventListener("click", nameListener);
     listeners.push({ target: foCopySymNameBtn, listener: nameListener });
 
@@ -988,7 +995,7 @@ function searchSymbols(symbols, query) {
   for (const element of symbols) {
     let hit = false;
     for (const s of [
-      element.id.replace(/^symbol-/, ""),
+      element.dataset.codexName,
       element.dataset.unicName,
       element.dataset.latexName,
       element.dataset.value,

--- a/docs/assets/docs.js
+++ b/docs/assets/docs.js
@@ -482,8 +482,6 @@ function setUpSymbolFlyout(symbolGrid) {
   const foCodepoint = flyout.querySelector(".info .codepoint .value");
   /** @type {HTMLElement | null} */
   const foAccent = flyout.querySelector(".info .accent");
-  /** @type {HTMLImageElement | null} */
-  const foAccentIcon = flyout.querySelector(".info .accent img");
   /** @type {HTMLElement | null} */
   const foVariantsBox = flyout.querySelector(".variants-box");
   /** @type {HTMLElement | null} */
@@ -568,9 +566,7 @@ function setUpSymbolFlyout(symbolGrid) {
     foName.textContent = name;
     foUnicName.textContent = unicName ?? "";
     foCodepoint.textContent = codepointText;
-    foAccent.style.display = accent ? "block" : "none";
-    foAccentIcon.src = accent ? checkIconSrc : closeIconSrc;
-    foAccentIcon.setAttribute("alt", accent ? "Yes" : "No");
+    foAccent.style.display = accent ? null : "none";
     foShorthand.style.display =
       shorthand && shorthand.length > 0 ? "block" : "none";
     foShorthandCode.textContent = shorthand ?? "";

--- a/docs/assets/docs.js
+++ b/docs/assets/docs.js
@@ -999,6 +999,7 @@ function searchSymbols(symbols, query) {
       element.dataset.unicName,
       element.dataset.latexName,
       element.dataset.value,
+      element.dataset.keywords,
       element.dataset.shorthand,
       element.dataset.mathShorthand,
     ]) {

--- a/docs/assets/docs.js
+++ b/docs/assets/docs.js
@@ -724,7 +724,13 @@ async function setUpGlobalSearch() {
     const items = matches.map((hit) => {
       const item = index.items[hit];
       let url = item.route;
-      if (item.kind == "Symbols") {
+      if (
+        item.kind == "Symbols" &&
+        !"symbols".startsWith(query.toLowerCase()) &&
+        !"emojis".startsWith(query.toLowerCase())
+      ) {
+        // Prefill the symbol list search box unless the user searched for
+        // something like "symbols", "sym", or "emoji".
         url += "?query=" + query;
       }
       const li = document.createElement("li");

--- a/docs/components/base.typ
+++ b/docs/components/base.typ
@@ -1,4 +1,4 @@
-// Definies utilites and basic components.
+// Defines utilities and basic components.
 
 #import "system.typ": colors, sizes
 
@@ -96,7 +96,7 @@
   is-short-state.update(false)
 }
 
-// Contraints content to a maximum width and/or height.
+// Constrains content to a maximum width and/or height.
 #let constrain(width: none, height: none, body) = layout(size => block(
   ..if width != none { (width: calc.min(size.width, width)) },
   ..if height != none { (height: calc.min(size.height, height)) },

--- a/docs/components/category.typ
+++ b/docs/components/category.typ
@@ -152,7 +152,7 @@
 
   {
     show heading: it => {
-      // The expression `figure.caption` is ambigious. It's both an element and
+      // The expression `figure.caption` is ambiguous. It's both an element and
       // a contextual parameter access. This is really a language-level problem
       // but reflects in linking ambiguity in the docs. To avoid a linking
       // error, we simply prefer the element always.

--- a/docs/content/reference/library/symbols.typ
+++ b/docs/content/reference/library/symbols.typ
@@ -27,6 +27,14 @@
   "\u{200F}": "rlm",
 )
 
+// Additional keywords for some symbols. Used to improve symbol search.
+#let symbol-keywords = (
+  "ħ": ("hbar",),
+  "⇒": ("implies",),
+  "⟹": ("implies",),
+  "⇔": ("iff",),
+)
+
 // Human-facing names of the math classes.
 #let math-class-names = (
   "normal": "Normal",
@@ -130,6 +138,7 @@
     data-codex-name: if not shorthand { name },
     data-unic-name: stdx.unicode-name(value),
     data-latex-name: stdx.latex-name(value),
+    data-keywords: symbol-keywords.at(value, default: ()).join(" ", default: ""),
     data-value: value,
     data-accent: if stdx.is-accent(value) { "true" },
     data-alternates: alternates.join(" ", default: none),

--- a/docs/content/reference/library/symbols.typ
+++ b/docs/content/reference/library/symbols.typ
@@ -74,7 +74,6 @@
         html.p(class: "sym-name", {
           [Name: ]
           html.code()
-          [ ]
           copy-button()
         })
         html.p(class: "codepoint", {
@@ -83,13 +82,11 @@
             class: "typ-escape",
             "\\u{" + html.span(class: "value") + "}",
           )
-          [ ]
           copy-button()
         })
         html.p(class: "shorthand", {
           [Shorthand: ]
           html.code(class: "typ-escape")
-          [ ]
           copy-button()
           html.span(class: "remark")
         })

--- a/docs/content/reference/library/symbols.typ
+++ b/docs/content/reference/library/symbols.typ
@@ -76,6 +76,12 @@
           html.code()
           copy-button()
         })
+        html.p(class: "shorthand", {
+          [Shorthand: ]
+          html.code(class: "typ-escape")
+          copy-button()
+          html.span(class: "remark")
+        })
         html.p(class: "codepoint", {
           [Escape: ]
           html.code(
@@ -83,12 +89,6 @@
             "\\u{" + html.span(class: "value") + "}",
           )
           copy-button()
-        })
-        html.p(class: "shorthand", {
-          [Shorthand: ]
-          html.code(class: "typ-escape")
-          copy-button()
-          html.span(class: "remark")
         })
         html.p(class: "accent", {
           [Accent: ]
@@ -118,31 +118,16 @@
 // One list entry in a symbol list or cell in a symbol grid.
 #let symbol-entry(
   name,
-  info,
-  prefix,
-  variant,
   value,
   deprecation,
-  title: auto,
+  alternates,
+  shorthand: false,
 ) = {
-  let complete(variant) = {
-    if prefix != none {
-      prefix + "."
-    }
-    name
-    if variant != "" {
-      "." + variant
-    }
-  }
-
-  let full = complete(variant)
-  let alternates = info
-    .variants
-    .map(((variant, ..)) => complete(variant))
-    .filter(v => v != full)
-
   let attrs = (
-    id: "symbol-" + full,
+    // This can possibly produce IDs that are not valid CSS identifiers, but we
+    // don't need that so this is fine.
+    id: "symbol-" + name,
+    data-codex-name: if not shorthand { name },
     data-unic-name: stdx.unicode-name(value),
     data-latex-name: stdx.latex-name(value),
     data-value: value,
@@ -161,36 +146,30 @@
   let body = symbol-overrides.at(value, default: value)
 
   context if target() == "paged" {
-   let style = if value in symbol-overrides {
+    let style = if value in symbol-overrides {
       (fill: colors.dark-gray.shade-10, weight: 500, style: "italic")
     }
     box(width: 5em, h(1fr) + text(font: symbol-fonts, ..style, body) + h(1em))
     let wrapper = if deprecation != none { strike } else { it => it }
-    if title == auto {
-      wrapper(raw(full))
+    if shorthand {
+      text(fill: colors.text.syntax.teal, wrapper(raw(name)))
     } else {
-      text(fill: colors.text.syntax.teal, wrapper(raw(title)))
+      wrapper(raw(name))
     }
   } else {
-    let title = title
-    let named = title == auto
-    if named {
-      let sep
-      title = for part in full.split(".") {
-        sep
-        part
-        sep = "." + html.wbr()
-      }
-    }
-
     html.elem(
       "li",
       attrs: attrs.pairs().filter(p => p.last() != none).to-dict(),
       html.button({
         html.span(class: "sym", body)
         html.code(
-          ..if not named { (class: "typ-escape") },
-          title,
+          ..if shorthand { (class: "typ-escape") },
+          if not shorthand {
+            show ".": it => it + html.wbr()
+            name
+          } else {
+            name
+          },
         )
       }),
     )
@@ -198,7 +177,7 @@
 }
 
 // Computes the entries to display in a symbol list / grid.
-#let symbol-list-entries(mod, prefix, shorthands) = {
+#let symbol-list-entries(mod, prefix) = {
   let entries = ()
   for (name, s) in dictionary(mod) {
     if type(s) == module {
@@ -207,7 +186,7 @@
       } else {
         prefix + "." + name
       }
-      entries += symbol-list-entries(s, nested-prefix, shorthands)
+      entries += symbol-list-entries(s, nested-prefix)
       continue
     }
 
@@ -219,23 +198,27 @@
         deprecation = binding.deprecation.message
       }
 
-      let title = auto
-      if shorthands != none {
-        let short = shorthands.at(value, default: none)
-        if short == none or deprecation != none {
-          continue
+      let complete(v) = {
+        if prefix != none {
+          prefix + "."
         }
-        title = short
+        name
+        if v != "" {
+          "." + v
+        }
       }
 
+      let full-name = complete(variant)
+      let alternates = info
+        .variants
+        .map(((variant, ..)) => complete(variant))
+        .filter(v => v != full-name)
+
       entries.push(symbol-entry(
-        name,
-        info,
-        prefix,
-        variant,
+        full-name,
         value,
         deprecation,
-        title: title,
+        alternates,
       ))
     }
   }
@@ -246,8 +229,7 @@
 //
 // Any page containing this should also contain a single `flyout-template()` in
 // website export.
-#let symbol-list(mod, shorthands: none, emoji: false) = {
-  let entries = symbol-list-entries(mod, none, shorthands)
+#let symbol-list(entries, emoji: false) = {
   context if target() == "paged" {
     columns(2, list(..entries, marker: none))
   } else {
@@ -256,6 +238,26 @@
       entries.join(),
     )
   }
+}
+
+// A list / grid of symbols with their names.
+#let symbol-name-list(mod, emoji: false) = {
+  let entries = symbol-list-entries(mod, none)
+  symbol-list(entries, emoji: emoji)
+}
+
+// A list / grid of symbols with their shorthands.
+#let symbol-shorthand-list(shorthands) = {
+  let entries = shorthands.pairs().map(((value, shorthand)) => {
+    symbol-entry(
+      shorthand,
+      value,
+      none,
+      (),
+      shorthand: true,
+    )
+  })
+  symbol-list(entries)
 }
 
 #docs-category(
@@ -273,10 +275,10 @@
   You can deactivate a shorthand's interpretation by escaping any of its characters. If you escape a single character in a shorthand, the remaining unescaped characters may form a different shorthand.
 
   == Within Markup Mode <within-markup-mode>
-  #symbol-list(sym, shorthands: stdx.shorthands.markup)
+  #symbol-shorthand-list(stdx.shorthands.markup)
 
   == Within Math Mode <within-math-mode>
-  #symbol-list(sym, shorthands: stdx.shorthands.math)
+  #symbol-shorthand-list(stdx.shorthands.math)
 
   #context if target() == "html" {
     flyout-template()
@@ -294,7 +296,7 @@
         search-box(id: "symbol-search", placeholder: "Search in symbols")
       })
     }
-    symbol-list(mod, emoji: emoji)
+    symbol-name-list(mod, emoji: emoji)
     context if target() == "html" {
       flyout-template()
     }

--- a/docs/content/reference/library/symbols.typ
+++ b/docs/content/reference/library/symbols.typ
@@ -246,6 +246,9 @@
 }
 
 // A list / grid of symbols.
+//
+// Any page containing this should also contain a single `flyout-template()` in
+// website export.
 #let symbol-list(mod, shorthands: none, emoji: false) = {
   let entries = symbol-list-entries(mod, none, shorthands)
   context if target() == "paged" {
@@ -255,7 +258,6 @@
       class: classnames("symbol-grid", emoji: emoji),
       entries.join(),
     )
-    flyout-template()
   }
 }
 
@@ -278,6 +280,10 @@
 
   == Within Math Mode <within-math-mode>
   #symbol-list(sym, shorthands: stdx.shorthands.math)
+
+  #context if target() == "html" {
+    flyout-template()
+  }
 ]
 
 #let symbols-section(..args, mod: none, emoji: false, body) = docs-section(
@@ -292,6 +298,9 @@
       })
     }
     symbol-list(mod, emoji: emoji)
+    context if target() == "html" {
+      flyout-template()
+    }
   },
 )
 

--- a/docs/content/reference/library/symbols.typ
+++ b/docs/content/reference/library/symbols.typ
@@ -1,6 +1,6 @@
 #import "../../../components/index.typ": (
   classnames, colors, docs-category, docs-section, fonts, icon,
-  paged-heading-offset, search-box, ty-pill, use-icon,
+  paged-heading-offset, prose-styling, search-box, ty-pill, use-icon,
 )
 
 // Symbols that are not rendered as themselves because they would be invisible.
@@ -287,7 +287,7 @@
   ..args,
   kind: "Symbols",
   {
-    body
+    prose-styling(body)
     context if target() == "html" {
       html.div(class: "symbol-hint", {
         par[Click on a #ty-pill(symbol) to copy it to the clipboard.]

--- a/docs/content/reference/library/symbols.typ
+++ b/docs/content/reference/library/symbols.typ
@@ -122,15 +122,20 @@
 #let symbol-entry(
   name,
   info,
+  prefix,
   variant,
   value,
   deprecation,
   title: auto,
 ) = {
-  let complete(variant) = if variant == "" {
+  let complete(variant) = {
+    if prefix != none {
+      prefix + "."
+    }
     name
-  } else {
-    name + "." + variant
+    if variant != "" {
+      "." + variant
+    }
   }
 
   let full = complete(variant)
@@ -195,13 +200,19 @@
   }
 }
 
-// A list / grid of symbols.
-#let symbol-list(mod, shorthands: none, emoji: false) = {
+// Computes the entries to display in a symbol list / grid.
+#let symbol-list-entries(mod, prefix, shorthands) = {
   let entries = ()
   for (name, s) in dictionary(mod) {
-    // TODO: Submodules are not yet handled
-    // (they weren't in the non-Typst docs either).
-    if type(s) == module { continue }
+    if type(s) == module {
+      let nested-prefix = if prefix == none {
+        name
+      } else {
+        prefix + "." + name
+      }
+      entries += symbol-list-entries(s, nested-prefix, shorthands)
+      continue
+    }
 
     let info = stdx.describe(s)
     let binding = stdx.binding(mod, name)
@@ -223,6 +234,7 @@
       entries.push(symbol-entry(
         name,
         info,
+        prefix,
         variant,
         value,
         deprecation,
@@ -230,7 +242,12 @@
       ))
     }
   }
+  entries
+}
 
+// A list / grid of symbols.
+#let symbol-list(mod, shorthands: none, emoji: false) = {
+  let entries = symbol-list-entries(mod, none, shorthands)
   context if target() == "paged" {
     columns(2, list(..entries, marker: none))
   } else {

--- a/docs/content/reference/library/symbols.typ
+++ b/docs/content/reference/library/symbols.typ
@@ -92,7 +92,7 @@
         })
         html.p(class: "accent", {
           [Accent: ]
-          icon(16, "close", "")
+          icon(16, "check", "Yes")
         })
         html.p(class: "math-class", {
           [Math Class: ]


### PR DESCRIPTION
This contains multiple improvements to the symbol list / grid in the documentation, including support for submodules.

Commits are independent so I can remove one if necessary.

Regarding submodule support, there is no indication that, e.g., `gender` refers to a submodule in `gender.female`. I am not sure how to indicate that in a concise way, especially in the PDF version.

Fixes https://github.com/typst/typst/issues/8245.
Closes https://github.com/typst/typst/issues/8270.
Closes https://github.com/typst/typst/issues/8274.