### PR TITLE
Add Auto Font Downloading Support via Google Fonts

### DIFF
--- a/crates/typst-cli/Cargo.toml
+++ b/crates/typst-cli/Cargo.toml
@@ -66,6 +66,7 @@ features = [
     "datetime",
     "emit-diagnostics",
     "system-downloader",
+    "font-downloader",
     "watcher",
     "timer",
 ]

--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -479,6 +479,10 @@ pub struct FontArgs {
     #[cfg(feature = "embedded-fonts")]
     #[arg(long, env = "TYPST_IGNORE_EMBEDDED_FONTS")]
     pub ignore_embedded_fonts: bool,
+
+    /// Automatically download missing fonts during compilation
+    #[arg(long, env = "TYPST_AUTO_DOWNLOAD_FONTS")]
+    pub auto_download_fonts: bool,
 }
 
 /// Arguments for the HTTP server.

--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -2,7 +2,7 @@ use std::ffi::OsStr;
 use std::path::Path;
 
 use chrono::{DateTime, Datelike, Timelike, Utc};
-use ecow::eco_format;
+use ecow::{EcoString, eco_format};
 use parking_lot::RwLock;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use typst::diag::{
@@ -77,6 +77,8 @@ pub struct CompileConfig {
     /// The export cache for images, used for caching output files in `typst
     /// watch` sessions with images.
     pub export_cache: ExportCache,
+    /// Whether to automatically download missing fonts.
+    pub auto_download_fonts: bool,
     /// Server for `typst watch` to HTML.
     #[cfg(feature = "http-server")]
     pub server: Option<HttpServer>,
@@ -236,6 +238,7 @@ impl CompileConfig {
             diagnostic_format: args.process.diagnostic_format,
             open: args.open.clone(),
             export_cache: ExportCache::new(),
+            auto_download_fonts: args.world.font.auto_download_fonts,
             deps,
             deps_format,
             #[cfg(feature = "http-server")]
@@ -257,7 +260,13 @@ pub fn compile_once(
         Status::Compiling.print(config).unwrap();
     }
 
-    let Warned { output, mut warnings } = compile_and_export(world, config);
+    let first = compile_and_export(world, config);
+
+    // Two-pass font auto-download: if the first pass reported missing font
+    // families and --auto-download-fonts is set, download them then recompile
+    // once so that the output uses the real fonts.
+    let Warned { output, mut warnings } =
+        maybe_download_fonts_and_recompile(world, config, first);
 
     // Add static warnings (for deprecated CLI flags and such).
     for warning in config.warnings.iter() {
@@ -304,6 +313,73 @@ pub fn compile_once(
     }
 
     Ok(())
+}
+
+/// If the first-pass result contains "unknown font family" warnings and
+/// `--auto-download-fonts` is set, attempts to download the missing families
+/// and recompile. Returns the second-pass result if any fonts were newly
+/// downloaded, otherwise returns the original first-pass result unchanged.
+fn maybe_download_fonts_and_recompile(
+    world: &mut SystemWorld,
+    config: &mut CompileConfig,
+    result: Warned<SourceResult<Vec<Output>>>,
+) -> Warned<SourceResult<Vec<Output>>> {
+    if !config.auto_download_fonts {
+        return result;
+    }
+
+    let missing: Vec<String> = result
+        .warnings
+        .iter()
+        .filter_map(extract_missing_font_family)
+        .collect();
+
+    if missing.is_empty() {
+        return result;
+    }
+
+    let (any_downloaded, font_warnings) = download_fonts(&missing);
+    let mut result = if any_downloaded {
+        world.rebuild_font_store();
+        compile_and_export(world, config)
+    } else {
+        result
+    };
+    for msg in font_warnings {
+        result.warnings.push(SourceDiagnostic::warning(Span::detached(), msg));
+    }
+    result
+}
+
+/// Extracts the font family name from an "unknown font family: X" diagnostic.
+fn extract_missing_font_family(diag: &SourceDiagnostic) -> Option<String> {
+    diag.message
+        .as_str()
+        .strip_prefix("unknown font family: ")
+        .map(str::to_owned)
+}
+
+/// Downloads all found font `families` into the platform cache directory.
+/// Returns whether any family was newly downloaded and a list of warning
+/// messages for families that failed to download.
+fn download_fonts(families: &[String]) -> (bool, Vec<EcoString>) {
+    use typst_kit::font_downloader::{FontDownloadError, FontDownloader};
+
+    let downloader = FontDownloader::new(crate::download::downloader());
+
+    let mut any_downloaded = false;
+    let mut warnings = Vec::new();
+    for family in families {
+        match downloader.download_family(family) {
+            Ok(_) => any_downloaded = true,
+            Err(FontDownloadError::NoVariantsFound(_)) => {}
+            Err(e) => {
+                warnings.push(eco_format!("could not download font \"{family}\": {e}"))
+            }
+        }
+    }
+
+    (any_downloaded, warnings)
 }
 
 /// Compile and then export the document.

--- a/crates/typst-cli/src/download.rs
+++ b/crates/typst-cli/src/download.rs
@@ -25,7 +25,8 @@ pub fn downloader() -> impl Downloader {
         } else if let Some(&s @ "release") = key.downcast_ref::<&str>() {
             Some(s.into())
         } else {
-            None
+            key.downcast_ref::<String>()
+                .map(|name| eco_format!("font \"{name}\""))
         };
         PrintProgress(name)
     })

--- a/crates/typst-cli/src/fonts.rs
+++ b/crates/typst-cli/src/fonts.rs
@@ -2,6 +2,7 @@ use std::any::Any;
 use std::path::Path;
 
 use typst::text::FontVariant;
+use typst_kit::font_downloader::FontDownloader;
 use typst_kit::fonts::{self, FontPath, FontStore};
 
 use crate::args::{FontArgs, FontsCommand};
@@ -38,6 +39,9 @@ pub fn discover_fonts(args: &FontArgs) -> FontStore {
 
     if !args.ignore_system_fonts {
         fonts.extend(fonts::system());
+        if let Some(cache) = FontDownloader::default_cache_dir().filter(|p| p.exists()) {
+            fonts.extend(fonts::scan(&cache));
+        }
     }
 
     #[cfg(feature = "embedded-fonts")]

--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
-use std::sync::LazyLock;
+use std::sync::{LazyLock, OnceLock};
 
 use ecow::{EcoString, eco_format};
 use typst::diag::{FileError, FileResult};
@@ -18,7 +18,7 @@ use typst_kit::files::{FileLoader, FileStore, FsRoot};
 use typst_kit::fonts::FontStore;
 use typst_kit::packages::SystemPackages;
 
-use crate::args::{Feature, Input, ProcessArgs, WorldArgs};
+use crate::args::{Feature, FontArgs, Input, ProcessArgs, WorldArgs};
 
 /// A world that provides access to the operating system.
 pub struct SystemWorld {
@@ -26,8 +26,10 @@ pub struct SystemWorld {
     workdir: Option<PathBuf>,
     /// Typst's standard library.
     library: LazyHash<Library>,
-    /// Metadata about discovered fonts and lazily loaded fonts.
-    fonts: LazyLock<FontStore, Box<dyn Fn() -> FontStore + Send + Sync>>,
+    /// Lazily initialised font store. Separating the args from the cell
+    /// lets us reborrow both fields independently in `fonts()`.
+    fonts: OnceLock<FontStore>,
+    font_args: FontArgs,
     /// Maps file ids to source files and buffers.
     files: FileStore<SystemFiles>,
     /// The current datetime if requested. This is stored here to ensure it is
@@ -75,9 +77,8 @@ impl SystemWorld {
         Ok(Self {
             workdir: std::env::current_dir().ok(),
             library: LazyHash::new(library),
-            fonts: LazyLock::new(Box::new(|| {
-                crate::fonts::discover_fonts(&world_args.font)
-            })),
+            fonts: OnceLock::new(),
+            font_args: world_args.font.clone(),
             files: FileStore::new(SystemFiles::new(input, world_args)?),
             now,
         })
@@ -105,11 +106,26 @@ impl SystemWorld {
         self.now.reset();
     }
 
+    /// Returns a reference to the font store, initialising it on first call.
+    fn fonts(&self) -> &FontStore {
+        // Explicit field borrows avoid a self-referential borrow when the
+        // closure captures both `self.fonts` and `self.font_args`.
+        let args = &self.font_args;
+        self.fonts.get_or_init(|| crate::fonts::discover_fonts(args))
+    }
+
     /// Forcibly scan fonts instead of doing it lazily upon the first access.
     ///
     /// Does nothing if the fonts were already scanned.
     pub fn scan_fonts(&mut self) {
-        LazyLock::force(&self.fonts);
+        let _ = self.fonts();
+    }
+
+    /// Rebuilds the font store after new fonts have been downloaded.
+    pub fn rebuild_font_store(&mut self) {
+        let _ = self.fonts.take();
+        let store = crate::fonts::discover_fonts(&self.font_args);
+        self.fonts.set(store).ok();
     }
 }
 
@@ -119,7 +135,7 @@ impl World for SystemWorld {
     }
 
     fn book(&self) -> &LazyHash<FontBook> {
-        self.fonts.book()
+        self.fonts().book()
     }
 
     fn main(&self) -> FileId {
@@ -135,7 +151,7 @@ impl World for SystemWorld {
     }
 
     fn font(&self, index: usize) -> Option<Font> {
-        self.fonts.font(index)
+        self.fonts().font(index)
     }
 
     fn today(&self, offset: Option<Duration>) -> Option<Datetime> {

--- a/crates/typst-kit/Cargo.toml
+++ b/crates/typst-kit/Cargo.toml
@@ -86,6 +86,9 @@ timer = []
 # Enables live-reloading HTTP serving via `server::HttpServer`.
 http-server = ["dep:tiny_http", "dep:infer"]
 
+# Enables automatic font downloading.
+font-downloader = ["dep:dirs", "system-downloader"]
+
 # Whether to vendor OpenSSL for the `system-downloader`. Not applicable to
 # Windows and macOS build.
 vendor-openssl = ["openssl/vendored"]

--- a/crates/typst-kit/src/downloader.rs
+++ b/crates/typst-kit/src/downloader.rs
@@ -176,6 +176,9 @@ impl Downloader for SystemDownloader {
         builder = builder.tls_connector(Arc::new(connector));
 
         let response = builder.build().get(url).call().map_err(|err| match err {
+            ureq::Error::Status(400, _) => {
+                io::Error::new(io::ErrorKind::InvalidInput, err)
+            }
             ureq::Error::Status(404, _) => io::Error::new(io::ErrorKind::NotFound, err),
             err => io::Error::other(err),
         })?;

--- a/crates/typst-kit/src/font_downloader.rs
+++ b/crates/typst-kit/src/font_downloader.rs
@@ -1,0 +1,167 @@
+//! Automatic font downloading.
+
+use std::fmt;
+use std::io;
+use std::path::PathBuf;
+
+use crate::downloader::Downloader;
+
+pub struct FontDownloader {
+    downloader: Box<dyn Downloader>,
+}
+
+#[cfg(feature = "font-downloader")]
+impl FontDownloader {
+    pub fn new(downloader: impl Downloader + 'static) -> Self {
+        Self { downloader: Box::new(downloader) }
+    }
+
+    /// Returns the platform-specific default cache directory for downloaded fonts:
+    /// - Linux:   `~/.cache/typst/fonts/google/`
+    /// - macOS:   `~/Library/Caches/typst/fonts/google/`
+    /// - Windows: `%LOCALAPPDATA%\typst\fonts\google\`
+    pub fn default_cache_dir() -> Option<PathBuf> {
+        dirs::cache_dir().map(|d| d.join("typst/fonts/google"))
+    }
+
+    /// Downloads all available variants of `family` into the platform cache directory.
+    ///
+    /// Returns the paths of all font files.
+    pub fn download_family(
+        &self,
+        family: &str,
+    ) -> Result<Vec<PathBuf>, FontDownloadError> {
+        let cache_dir = Self::default_cache_dir().ok_or(FontDownloadError::NoCacheDir)?;
+        let family_dir = cache_dir.join(family_slug(family));
+
+        let css = self.fetch_css(family)?;
+        let urls = font_urls_from_css(&css);
+
+        if urls.is_empty() {
+            return Err(FontDownloadError::NoVariantsFound(family.to_owned()));
+        }
+
+        let mut paths = Vec::new();
+        let mut first = true;
+        for url in urls {
+            let filename =
+                url_filename(&url).ok_or(FontDownloadError::CssParseFailure)?;
+            let dest = family_dir.join(filename);
+
+            if dest.exists() {
+                paths.push(dest);
+                continue;
+            }
+
+            // ProgressDownloader doesn't really work for our case since we make many
+            // separate downloads per font, so just show first download instead.
+            let data = if first {
+                first = false;
+                std::fs::create_dir_all(&family_dir)?;
+                self.downloader
+                    .download(&family.to_owned(), &url)
+                    .map_err(FontDownloadError::Http)?
+            } else {
+                self.downloader.download(&(), &url).map_err(FontDownloadError::Http)?
+            };
+
+            // Atomic write
+            let tmp = dest.with_file_name(format!("{filename}.tmp"));
+            std::fs::write(&tmp, &data)?;
+            std::fs::rename(&tmp, &dest)?;
+
+            paths.push(dest);
+        }
+
+        Ok(paths)
+    }
+
+    fn fetch_css(&self, family: &str) -> Result<String, FontDownloadError> {
+        let encoded = family.replace(' ', "+");
+        let url = format!(
+            "https://fonts.googleapis.com/css2?family={encoded}:\
+             ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;\
+             1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900\
+             &display=swap"
+        );
+
+        let bytes = self.downloader.download(&(), &url).map_err(|e| {
+            // Google Fonts returns 400 Bad Request for invalid family names
+            if e.kind() == io::ErrorKind::InvalidInput {
+                FontDownloadError::NoVariantsFound(family.to_owned())
+            } else {
+                FontDownloadError::Http(e)
+            }
+        })?;
+
+        String::from_utf8(bytes).map_err(|_| FontDownloadError::CssParseFailure)
+    }
+}
+
+/// Errors that can occur while downloading a font family.
+#[derive(Debug)]
+pub enum FontDownloadError {
+    /// A network error fetching the CSS index or a font file.
+    Http(io::Error),
+    /// The CSS response from Google Fonts could not be parsed.
+    CssParseFailure,
+    /// Google Fonts returned no font variants for the given family name.
+    NoVariantsFound(String),
+    /// A filesystem I/O error.
+    Io(io::Error),
+    /// The platform cache directory could not be determined.
+    NoCacheDir,
+}
+
+impl fmt::Display for FontDownloadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Http(e) => write!(f, "network error: {e}"),
+            Self::CssParseFailure => {
+                write!(f, "could not parse Google Fonts CSS response")
+            }
+            Self::NoVariantsFound(name) => {
+                write!(f, "no variants found for font family '{name}' on Google Fonts")
+            }
+            Self::Io(e) => write!(f, "I/O error: {e}"),
+            Self::NoCacheDir => write!(f, "could not determine font cache directory"),
+        }
+    }
+}
+
+impl From<io::Error> for FontDownloadError {
+    fn from(e: io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+/// Extracts font file URLs from Google Fonts CSS response.
+fn font_urls_from_css(css: &str) -> Vec<String> {
+    let mut urls = Vec::new();
+    let mut rest = css;
+    while let Some(start) = rest.find("url(") {
+        rest = &rest[start + 4..];
+        let Some(end) = rest.find(')') else { break };
+        let inner = rest[..end].trim().trim_matches(|c| c == '"' || c == '\'');
+        let after = rest[end + 1..].trim_start();
+        if after.starts_with("format('truetype')") && !inner.is_empty() {
+            urls.push(inner.to_owned());
+        }
+        rest = &rest[end + 1..];
+    }
+    urls
+}
+
+fn url_filename(url: &str) -> Option<&str> {
+    url.rsplit('/').next().filter(|s| !s.is_empty())
+}
+
+/// Converts family name to slug suitable for filesystem, e.g. "Open Sans" -> "open-sans".
+fn family_slug(family: &str) -> String {
+    family
+        .chars()
+        .map(|c| if c.is_alphanumeric() { c.to_ascii_lowercase() } else { '-' })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_owned()
+}

--- a/crates/typst-kit/src/lib.rs
+++ b/crates/typst-kit/src/lib.rs
@@ -24,6 +24,8 @@
 //!   [`diagnostics::emit`].
 //! - `system-downloader`: Enables network requests via
 //!   [`downloader::SystemDownloader`].
+//! - `font-downloader`: Enables automatic font downloading via
+//!   [`font_downloader::FontDownloader`].
 //! - `watcher`: Enables file system watching via [`watcher::Watcher`].
 //! - `timer`: Enables performance tracing via [`timer::Timer`].
 //! - `http-server`: Enables a live-reloading HTTP serving via [`server::HttpServer`].
@@ -42,6 +44,7 @@
         feature = "emit-diagnostics",
         feature = "datetime",
         feature = "system-downloader",
+        feature = "font-downloader",
         feature = "watcher",
         feature = "timer",
         feature = "http-server",
@@ -53,6 +56,7 @@ pub mod datetime;
 pub mod diagnostics;
 pub mod downloader;
 pub mod files;
+pub mod font_downloader;
 pub mod fonts;
 pub mod packages;
 pub mod server;

--- a/crates/typst-library/src/text/font/book.rs
+++ b/crates/typst-library/src/text/font/book.rs
@@ -55,7 +55,7 @@ impl FontBook {
 
     /// Returns true if the book contains a font family with the given name.
     pub fn contains_family(&self, family: &str) -> bool {
-        self.families.contains_key(family)
+        self.families.contains_key(&family.to_lowercase())
     }
 
     /// An ordered iterator over all font families this book knows and the
@@ -72,18 +72,16 @@ impl FontBook {
     }
 
     /// Try to find a font from the given `family` that matches the given
-    /// `variant` as closely as possible.
-    ///
-    /// The `family` should be all lowercase.
+    /// `variant` as closely as possible. The lookup is case-insensitive.
     pub fn select(&self, family: &str, variant: FontVariant) -> Option<usize> {
-        let ids = self.families.get(family)?;
+        let ids = self.families.get(&family.to_lowercase())?;
         self.find_best_variant(None, variant, ids.iter().copied())
     }
 
     /// Iterate over all variants of a family.
     pub fn select_family(&self, family: &str) -> impl Iterator<Item = usize> + '_ {
         self.families
-            .get(family)
+            .get(&family.to_lowercase())
             .map(|vec| vec.as_slice())
             .unwrap_or_default()
             .iter()

--- a/crates/typst-library/src/text/mod.rs
+++ b/crates/typst-library/src/text/mod.rs
@@ -845,7 +845,7 @@ impl PlainText for Packed<TextElem> {
     }
 }
 
-/// A lowercased font family like "arial".
+/// A font family like `"Arial"`.
 #[derive(Debug, Clone, PartialEq, Hash)]
 pub struct FontFamily {
     // The name of the font family
@@ -862,10 +862,10 @@ impl FontFamily {
 
     /// Create a font family by name and optional Unicode coverage.
     pub fn with_coverage(string: &str, covers: Option<Covers>) -> Self {
-        Self { name: string.to_lowercase().into(), covers }
+        Self { name: string.into(), covers }
     }
 
-    /// The lowercased family name.
+    /// The family name.
     pub fn as_str(&self) -> &str {
         &self.name
     }

--- a/crates/typst-library/src/visualize/image/svg.rs
+++ b/crates/typst-library/src/visualize/image/svg.rs
@@ -228,7 +228,7 @@ impl FontResolver<'_> {
                 _ => None,
             })
             .chain(self.families.iter().copied())
-            .filter_map(|named| self.book.select(&named.to_lowercase(), variant))
+            .filter_map(|named| self.book.select(named, variant))
             .find_map(|index| self.get_or_load(index, db))
     }
 

--- a/tests/suite/math/text.typ
+++ b/tests/suite/math/text.typ
@@ -65,7 +65,7 @@ $ cal(P)_i (X) * cal(C)_1 $
 $ x + y = z $
 
 --- math-font-error paged ---
-// Warning: 37-51 unknown font family: cambria math
+// Warning: 37-51 unknown font family: Cambria Math
 #show math.equation: set text(font: "Cambria Math", fallback: false)
 // Error: 1-39 no font could be found
 $ brace.stroked.l -1 brace.stroked.r $

--- a/tests/suite/text/edge.typ
+++ b/tests/suite/text/edge.typ
@@ -5,13 +5,13 @@
 #set text(size: 8pt)
 
 #let try(top, bottom) = rect(inset: 0pt, fill: conifer)[
-  // Warning: 19-34 unknown font family: ibm plex mono
+  // Warning: 19-34 unknown font family: IBM Plex Mono
   #set text(font: "IBM Plex Mono", top-edge: top, bottom-edge: bottom)
   From #top to #bottom
 ]
 
 #let try-bounds(top, bottom) = rect(inset: 0pt, fill: conifer)[
-  // Warning: 19-34 unknown font family: ibm plex mono
+  // Warning: 19-34 unknown font family: IBM Plex Mono
   #set text(font: "IBM Plex Mono", top-edge: top, bottom-edge: bottom)
   #top to #bottom: "yay, Typst"
 ]

--- a/tests/suite/text/font.typ
+++ b/tests/suite/text/font.typ
@@ -185,15 +185,15 @@ The number 123.
 --- text-font-covers-reflection paged empty ---
 // reflect "latin-in-cjk" covers
 #set text(font: (name: "Ubuntu", covers: "latin-in-cjk"))
-#context test(text.font, (name: "ubuntu", covers: "latin-in-cjk"))
+#context test(text.font, (name: "Ubuntu", covers: "latin-in-cjk"))
 
 // reflect regex covers
 #set text(font: (name: "Ubuntu", covers: regex("\d")))
-#context test(text.font, (name: "ubuntu", covers: regex("\d")))
+#context test(text.font, (name: "Ubuntu", covers: regex("\d")))
 
 // reflect font list with covers
 #set text(font: ((name: "Ubuntu", covers: regex("\d")), "IBM Plex Serif"))
-#context test(text.font, ((name: "ubuntu", covers: regex("\d")), "ibm plex serif"))
+#context test(text.font, ((name: "Ubuntu", covers: regex("\d")), "IBM Plex Serif"))
 
 --- issue-5262-text-negative-size paged ---
 #set text(-1pt)


### PR DESCRIPTION
Implements #6590.

Downloads fonts from Google Fonts and stores them in the cache directory (`cache_dir/fonts/google/{font-family}/.ttfs`). This feature is implemented as **opt-in**. typst will not attempt to download from Google Fonts unless you add the `--auto-download-fonts` flag. Once the fonts are downloaded to the cache, they are considered system fonts (and therefore can be excluded using `--ignore-system-fonts`, and are loaded before compilation along with system installed fonts).

Because font loading is currently all done prior to compiling, instead of completely refactoring font loading to allow it during compilation, I let the full compilation complete, then check for font not found warnings. If there are any of these warnings, then we attempt to fetch them from Google Fonts, and if any fonts are successfully fetched we recompile. Is this the most efficient approach? Probably not. However, this double compilation shouldn't trigger often since once a font is downloaded it will be considered a system font, and if it isn't found in Google Fonts then nothing is recompiled.

Also, Google Font's API is case sensitive, so I pushed the lowercase normalization of font family names down into FontBook. This does alter the warning messages to show user-provided-case names instead of lowercase family names.