### PR TITLE
Make `target` available without feature flags

### DIFF
--- a/crates/typst-cli/tests/smoke.rs
+++ b/crates/typst-cli/tests/smoke.rs
@@ -231,6 +231,13 @@ fn test_tracepoints() {
         .must_contain("*Slightly unusual…*");
 }
 
+#[test]
+fn test_target_available() {
+    let project = tempfs();
+    let main = project.write("main.typ", "#context target()");
+    exec().arg("compile").arg(&main).must_succeed();
+}
+
 /// Executes a command with the Typst CLI.
 fn exec() -> Command {
     Command::new(env!("CARGO_BIN_EXE_typst"))

--- a/crates/typst-library/src/foundations/mod.rs
+++ b/crates/typst-library/src/foundations/mod.rs
@@ -86,10 +86,9 @@ use crate::diag::{SourceResult, StrResult, bail};
 use crate::engine::Engine;
 use crate::introspection::EmptyIntrospector;
 use crate::routines::SpanMode;
-use crate::{Feature, Features};
 
 /// Hook up all `foundations` definitions.
-pub(super) fn define(global: &mut Scope, inputs: Dict, features: &Features) {
+pub(super) fn define(global: &mut Scope, inputs: Dict) {
     global.start_category(crate::Category::Foundations);
     global.define_type::<bool>();
     global.define_type::<i64>();
@@ -117,9 +116,7 @@ pub(super) fn define(global: &mut Scope, inputs: Dict, features: &Features) {
     global.define_func::<assert>();
     global.define_func::<eval>();
     global.define_func::<plugin>();
-    if features.is_enabled(Feature::Html) || features.is_enabled(Feature::Bundle) {
-        global.define_func::<target>();
-    }
+    global.define_func::<target>();
     global.define("calc", calc::module());
     global.define("sys", sys::module(inputs));
     global.reset_category();

--- a/crates/typst-library/src/foundations/target.rs
+++ b/crates/typst-library/src/foundations/target.rs
@@ -92,21 +92,18 @@ pub struct TargetElem {
 
 /// Returns the current export target.
 ///
-/// This function returns either
-/// - `{"paged"}` (for PDF, PNG, and SVG export), or
-/// - `{"html"}` (for HTML export).
-///
-/// The design of this function is not yet finalized and for this reason it is
-/// guarded behind the `html` and `bundle` features (enabling either one makes
-/// the function available). Visit the @html[HTML documentation page] for more
-/// details.
+/// This function returns
+/// - `{"paged"}` in @pdf[PDF], @reference:png[PNG], and
+///   @reference:svg[SVG] export, or within an @html.frame[HTML frame]
+/// - `{"html"}` in @html[HTML] export
+/// - `{"bundle"}` in @reference:bundle[Bundle] export
 ///
 /// = When to use it <when-to-use-it>
-/// This function allows you to format your document properly across both HTML
-/// and paged export targets. It should primarily be used in templates and show
-/// rules, rather than directly in content. This way, the document's contents
-/// can be fully agnostic to the export target and content can be shared between
-/// PDF and HTML export.
+/// This function allows you to format your document properly across the paged,
+/// HTML, and multi file export targets. It should primarily be used in
+/// templates and show rules, rather than directly in content. This way, the
+/// document's contents can be fully agnostic to the export target and content
+/// can be shared between different export targets.
 ///
 /// = Varying targets <varying-targets>
 /// This function is @reference:context[contextual] as the target can vary

--- a/crates/typst-library/src/lib.rs
+++ b/crates/typst-library/src/lib.rs
@@ -328,7 +328,7 @@ fn global(
 ) -> Module {
     let mut global = Scope::deduplicating();
 
-    self::foundations::define(&mut global, inputs, features);
+    self::foundations::define(&mut global, inputs);
     self::model::define(&mut global, features);
     self::text::define(&mut global);
     self::layout::define(&mut global);


### PR DESCRIPTION
The `target` function was guarded behind the `html` feature (or, since recently, alternatively, the `bundle` feature) because its design is not finalized and it's essentially also experimental. I would say this was a reasonable course of action at the time, but now I would agree with some voices that it's holding the ecosystem back a bit since packages can't add support for HTML export without forcing `--features html` upon their users.

While I still believe that the design is likely to be superseded, we can deal with this when the time comes without breaking packages using the [planned compatibility mechanism](https://laurmaedje.github.io/posts/evolving-typst/). In case the mechanism superseding it does not involve the identifier `target`, even a normal deprecation might suffice. If a new design was just around a corner, I would think that we should wait for it, but that isn't really the case.

Closes https://github.com/typst/typst/issues/8229.