### PR TITLE
Within selector for introspection

### DIFF
--- a/crates/typst-library/src/foundations/selector.rs
+++ b/crates/typst-library/src/foundations/selector.rs
@@ -197,6 +197,9 @@ impl Selector {
 
     /// Returns a modified selector that will only match elements that occur
     /// before the first match of `end`.
+    ///
+    /// _Note:_ This selector is currently only supported with introspection
+    /// functions, not in show rules.
     #[func]
     pub fn before(
         self,
@@ -217,6 +220,9 @@ impl Selector {
 
     /// Returns a modified selector that will only match elements that occur
     /// after the first match of `start`.
+    ///
+    /// _Note:_ This selector is currently only supported with introspection
+    /// functions, not in show rules.
     #[func]
     pub fn after(
         self,
@@ -232,6 +238,61 @@ impl Selector {
             selector: Arc::new(self),
             start: Arc::new(start.0),
             inclusive,
+        }
+    }
+
+    /// Returns a modified selector that will only match elements that are
+    /// contained within any elements matching the `ancestor` selector.
+    ///
+    /// #example(
+    ///   title: "Finding strong elements in lists",
+    ///   ```
+    ///   *Strong emphasis* that does not count.
+    ///
+    ///   - An *important* word
+    ///   - Another *key* word
+    ///
+    ///   Strong elements in lists:
+    ///   #context {
+    ///     query(selector(strong).within(list))
+    ///       .map(it => it.body)
+    ///       .join[, ]
+    ///   }
+    ///   ```
+    /// )
+    ///
+    /// This can also be used in combination with @here to find all matches of a
+    /// selector within a @reference:context[context] expression. This can be
+    /// quite useful to have an introspection return results local to some
+    /// component you are building.
+    ///
+    /// #example(
+    ///   title: "Counting elements locally in a context block",
+    ///   ```
+    ///   #let count(sel, body) = context {
+    ///     let n = query(selector(sel).within(here())).len()
+    ///     [#body (#n matches)]
+    ///   }
+    ///
+    ///   - #count(emph)[Has _two_ matching _elements_]
+    ///   - #count(strong)[Has *one* matching element]
+    ///   ```
+    /// )
+    ///
+    /// _Note:_ This selector is currently only supported with introspection
+    /// functions, not in show rules.
+    #[func]
+    pub fn within(
+        self,
+        /// Only matches of `self` that are descendants of any element matching
+        /// this selector will be included in the output.
+        ///
+        /// An element is not considered its own ancestor.
+        ancestor: LocatableSelector,
+    ) -> Selector {
+        Selector::Within {
+            selector: Arc::new(self),
+            ancestor: Arc::new(ancestor.0),
         }
     }
 }
@@ -460,9 +521,14 @@ impl FromValue for ShowableSelector {
                 | Selector::Location(_)
                 | Selector::Can(_)
                 | Selector::Before { .. }
-                | Selector::After { .. }
-                | Selector::Within { .. } => {
+                | Selector::After { .. } => {
                     bail!("this selector cannot be used with show")
+                }
+                Selector::Within { .. } => {
+                    bail!(
+                        "this selector cannot currently be used with show";
+                        hint: "support for this is planned for the future";
+                    )
                 }
             }
             Ok(())

--- a/docs/components/footnote.typ
+++ b/docs/components/footnote.typ
@@ -6,7 +6,7 @@
 // Creates a listing of all footnotes that are descendants of the element
 // with the location `scope`.
 #let footnote-container(scope) = context {
-  let notes = query(stdx.selector-within(footnote, scope))
+  let notes = query(selector(footnote).within(scope))
   if notes.len() == 0 { return }
   html.elem("section", attrs: (role: "doc-endnotes"), {
     for note in notes {

--- a/docs/components/nav.typ
+++ b/docs/components/nav.typ
@@ -131,19 +131,14 @@
 #let nav-on-this-page(scope) = context {
   let items = ()
 
-  let titles = query(stdx.selector-within(
-    selector.and(title, <summary>),
-    scope,
-  ))
+  let titles = query(selector.and(title, <summary>).within(scope))
   if titles.len() > 0 {
     let dest = titles.first().location()
     items.push((dest: dest, level: 1, body: [Summary]))
   }
 
-  items += query(stdx.selector-within(
-    heading.where(outlined: true),
-    scope,
-  )).map(m => (dest: m.location(), level: m.level, body: m.body))
+  items += query(heading.where(outlined: true).within(scope))
+    .map(m => (dest: m.location(), level: m.level, body: m.body))
 
   if items.len() == 0 { return }
 

--- a/docs/src/world.rs
+++ b/docs/src/world.rs
@@ -1,5 +1,5 @@
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, LazyLock};
+use std::sync::LazyLock;
 
 use az::SaturatingAs;
 use comemo::{Track, TrackedMut};
@@ -7,9 +7,8 @@ use ecow::{EcoString, eco_format};
 use typst::diag::{At, FileError, FileResult, SourceResult, StrResult, bail};
 use typst::engine::Engine;
 use typst::foundations::{
-    Binding, Bytes, Context, Datetime, Dict, Duration, IntoValue, Label,
-    LocatableSelector, Module, NativeElement, PathOrStr, Repr, Scope, Selector, ShowFn,
-    Str, Target, Value, array, elem, func,
+    Binding, Bytes, Context, Datetime, Dict, Duration, IntoValue, Label, Module,
+    NativeElement, PathOrStr, Repr, Scope, ShowFn, Str, Target, Value, array, elem, func,
 };
 use typst::introspection::{EmptyIntrospector, MetadataElem};
 use typst::model::{Destination, EarlyLinkResolver, LinkElem, ResolvedLink};
@@ -215,7 +214,6 @@ fn stdx_module() -> Module {
     scope.define_elem::<ConfigElem>();
     scope.define_func::<read_dev_asset>();
     scope.define_func::<read_font>();
-    scope.define_func::<selector_within>();
     scope.define_func::<eval_mapped>();
     scope.define_func::<crate::live::docs_in_source>();
     scope.define_func::<crate::example::compile_example>();
@@ -259,16 +257,6 @@ fn read_font(post_script_name: EcoString) -> StrResult<Bytes> {
         })
         .map(|font| font.data().clone())
         .ok_or("unknown font")?)
-}
-
-/// This exists just because the within selector is not yet publicly exposed.
-/// It can be removed once it is.
-#[func]
-fn selector_within(selector: LocatableSelector, ancestor: LocatableSelector) -> Selector {
-    Selector::Within {
-        selector: Arc::new(selector.0),
-        ancestor: Arc::new(ancestor.0),
-    }
 }
 
 /// Evaluates a string of Typst markup with mapped spans.

--- a/tests/src/world.rs
+++ b/tests/src/world.rs
@@ -2,15 +2,13 @@ use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::sync::Arc;
 
 use comemo::Tracked;
 use typst::diag::{At, FileError, FileResult, SourceResult, StrResult, bail};
 use typst::engine::Engine;
 use typst::foundations::{
-    Array, Bytes, Content, Context, Datetime, Duration, IntoValue, LocatableSelector,
-    NativeElement, NoneValue, Packed, Repr, Selector, Smart, StyleChain, Value, elem,
-    func,
+    Array, Bytes, Content, Context, Datetime, Duration, IntoValue, NativeElement,
+    NoneValue, Packed, Repr, Smart, StyleChain, Value, elem, func,
 };
 use typst::introspection::Locator;
 use typst::layout::{Abs, BlockElem, Fragment, Margin, PageElem, Regions};
@@ -180,7 +178,6 @@ fn library() -> Library {
     lib.global.scope_mut().define_func::<test_repr>();
     lib.global.scope_mut().define_func::<print>();
     lib.global.scope_mut().define_func::<lines>();
-    lib.global.scope_mut().define_func::<selector_within>();
     lib.global.scope_mut().define_func::<bounds>();
     lib.global
         .scope_mut()
@@ -244,16 +241,6 @@ fn lines(
         .collect::<SourceResult<Array>>()?
         .join(Some('\n'.into_value()), None, None)
         .at(span)
-}
-
-/// This exists just to test `within` selectors (which are already used
-/// internally) while they are not yet publicly exposed.
-#[func]
-fn selector_within(selector: LocatableSelector, ancestor: LocatableSelector) -> Selector {
-    Selector::Within {
-        selector: Arc::new(selector.0),
-        ancestor: Arc::new(ancestor.0),
-    }
 }
 
 /// Display boundaries and the baseline around some content's frames.

--- a/tests/suite/introspection/query.typ
+++ b/tests/suite/introspection/query.typ
@@ -202,10 +202,6 @@
 )
 
 --- query-within paged html bundle ---
-// The within selector is not yet publicly exposed, but already used internally,
-// so it's good to have some tests. Since it's not yet in the public API, we
-// have a test-runner specific `selector-within` "polyfill" instead.
-
 // We also want to test in bundle mode to ensure the inner introspector
 // correctly forwards the stuff.
 #show: it => context if target() == "bundle" {
@@ -232,38 +228,38 @@ What's *up* with *you?*
   #let loc = here()
   *Local* bold *text*
   #test-selector(
-    selector-within(strong, loc),
+    selector(strong).within(loc),
     ([Local], [text]),
   )
 ]
 
 #test-selector(
-  selector-within(strong, par),
+  selector(strong).within(par),
   ([up], [you?], [Local], [text]),
 )
 
 #test-selector(
-  selector-within(strong, selector.or(heading, emph, figure)),
+  selector(strong).within(selector.or(heading, emph, figure)),
   ([there], [nice], [rect]),
 )
 
 #test-selector(
-  selector-within(selector-within(strong, emph), heading),
+  selector(strong).within(emph).within(heading),
   ([there],),
 )
 
 #test-selector(
-  selector-within(selector-within(strong, heading), emph),
+  selector(strong).within(heading).within(emph),
   ([there],),
 )
 
 #test-selector(
-  selector-within(strong, selector-within(heading, emph)),
+  selector(strong).within(selector(heading).within(emph)),
   (),
 )
 
 #test-selector(
-  selector-within(emph, quote),
+  selector.within(emph, quote),
   ([Hello],),
 )
 
@@ -286,9 +282,9 @@ What's *up* with *you?*
   = 5
 ] <b>
 
-#test-selector(selector-within(heading, table), ([2], [3]))
-#test-selector(selector-within(heading, <a>), ([1], [2], [3]))
-#test-selector(selector-within(heading, <b>), ([4], [5]))
+#test-selector(selector.within(heading, table), ([2], [3]))
+#test-selector(selector.within(heading, <a>), ([1], [2], [3]))
+#test-selector(selector.within(heading, <b>), ([4], [5]))
 
 --- query-within-inverted paged empty ---
 // Test a case where the ancestor is fully contained in one of the children.
@@ -298,7 +294,7 @@ What's *up* with *you?*
   m(<b>)
   m(<c>)
 })
-#context test(query(selector-within(strong, <b>)), ())
+#context test(query(selector.within(strong, <b>)), ())
 
 --- query-bundle-logical-order bundle ---
 #metadata(1)

--- a/tests/suite/styling/show.typ
+++ b/tests/suite/styling/show.typ
@@ -261,6 +261,11 @@ I am *strong*, I am _emphasized_, and I am #[special<special>].
 // Error: 7-41 this selector cannot be used with show
 #show heading.where(level: 1).or("more"): set text(red)
 
+--- show-selector-within eval ---
+// Error: 7-33 this selector cannot currently be used with show
+// Hint: 7-33 support for this is planned for the future
+#show selector(emph).within(par): set text(red)
+
 --- show-delayed-error paged ---
 // Error: 21-34 panicked with: hey1
 #show heading: _ => panic("hey1")


### PR DESCRIPTION
This selector is super useful, so I don't want to hold it back even though it's currently only supported in introspections, not in show rules. It's the same as `before` and `after` in this regard, but unlike these, it can be supported in show rules in the future.

Closes https://github.com/typst/typst/issues/1926. The show rule part will be tracked in https://github.com/typst/typst/issues/8251.