### PR TITLE
Add sub-ranges for diagnostics and hints

### DIFF
--- a/crates/typst-eval/src/lib.rs
+++ b/crates/typst-eval/src/lib.rs
@@ -24,7 +24,7 @@ use self::binding::*;
 use self::methods::*;
 
 use comemo::{Track, Tracked, TrackedMut};
-use typst_library::diag::{SourceResult, bail};
+use typst_library::diag::{At, SourceResult, bail};
 use typst_library::engine::{Engine, Route, Sink, Traced};
 use typst_library::foundations::{Context, Module, NativeElement, Scope, Scopes, Value};
 use typst_library::introspection::{EmptyIntrospector, Introspector};
@@ -120,7 +120,9 @@ pub fn eval_string(
     match spans {
         SpanMode::Uniform(span) if span.is_detached() => {}
         SpanMode::Uniform(span) => root.synthesize(span),
-        SpanMode::Mapped { id, mapper } => root.synthesize_mapped(id, mapper),
+        SpanMode::Mapped { id, mapper, mapper_error_span } => {
+            root.synthesize_mapped(id, mapper).at(mapper_error_span)?;
+        }
     }
 
     // Check for errors or warnings in the syntax tree before evaluating it.

--- a/crates/typst-ide/src/definition.rs
+++ b/crates/typst-ide/src/definition.rs
@@ -1,5 +1,5 @@
 use typst::foundations::{AsOutput, Label, Selector, Value};
-use typst::syntax::{LinkedNode, Side, Source, Span, ast};
+use typst::syntax::{FileId, LinkedNode, Side, Source, Span, ast};
 use typst::utils::PicoStr;
 
 use crate::utils::globals;
@@ -13,6 +13,8 @@ use crate::{
 pub enum Definition {
     /// The item is defined at the given span.
     Span(Span),
+    /// The item is the entire included/imported file.
+    File(FileId),
     /// The item is defined in the standard library.
     Std(Value),
 }
@@ -65,8 +67,7 @@ pub fn definition(
                 return None;
             };
             let id = module.file_id()?;
-            let span = Span::from_range(id, 0..0);
-            return Some(Definition::Span(span));
+            return Some(Definition::File(id));
         }
 
         // Try to jump to the referenced content.
@@ -101,6 +102,7 @@ mod tests {
 
     trait ResponseExt {
         fn must_be_at(&self, path: &str, range: Range<usize>) -> &Self;
+        fn must_be_file(&self, path: &str) -> &Self;
         fn must_be_value(&self, value: impl IntoValue) -> &Self;
     }
 
@@ -114,6 +116,17 @@ mod tests {
                     assert_eq!(range, Some(expected));
                 }
                 _ => panic!("expected span definition"),
+            }
+            self
+        }
+
+        #[track_caller]
+        fn must_be_file(&self, path: &str) -> &Self {
+            match self.1 {
+                Some(Definition::File(file_id)) => {
+                    assert_eq!(file_id.vpath().get_without_slash(), path);
+                }
+                _ => panic!("expected file definition"),
             }
             self
         }
@@ -167,14 +180,14 @@ mod tests {
     fn test_definition_import() {
         let world = TestWorld::new("#import \"other.typ\" as o: x")
             .with_source("other.typ", "#let x = 1");
-        test(&world, 14, Side::Before).must_be_at("other.typ", 0..0);
+        test(&world, 14, Side::Before).must_be_file("other.typ");
     }
 
     #[test]
     fn test_definition_include() {
         let world = TestWorld::new("#include \"other.typ\"")
             .with_source("other.typ", "Hello there");
-        test(&world, 14, Side::Before).must_be_at("other.typ", 0..0);
+        test(&world, 14, Side::Before).must_be_file("other.typ");
     }
 
     #[test]

--- a/crates/typst-ide/src/jump.rs
+++ b/crates/typst-ide/src/jump.rs
@@ -49,6 +49,7 @@ impl JumpFromDocument for HtmlDocument {}
 
 mod jump_from_document_sealed {
     use typst::introspection::{HtmlPosition, InnerHtmlPosition, PagedPosition};
+    use typst::syntax::SyntaxKind;
     use typst_html::{HtmlDocument, HtmlNode, HtmlSliceExt};
     use typst_layout::PagedDocument;
 
@@ -175,9 +176,8 @@ mod jump_from_document_sealed {
             let span = current_node.span();
             let id = span.id()?;
             let source = world.source(id).ok()?;
-            let ast_node = source.find(span);
-            let is_text_node =
-                ast_node.is_some_and(|x| x.is::<typst::syntax::ast::Text>());
+            let ast_node = source.find(span)?;
+            let is_text_node = ast_node.kind() == SyntaxKind::Text;
 
             if let (HtmlNode::Frame(frame), Some(InnerHtmlPosition::Frame(point))) =
                 (current_node, &position.details())
@@ -185,7 +185,7 @@ mod jump_from_document_sealed {
                 return jump_from_click_in_frame(world, self, &frame.inner, *point);
             }
 
-            let source_range = source.range(span)?;
+            let source_range = ast_node.range();
             Some(Jump::File(
                 id,
                 source_range.start

--- a/crates/typst-kit/src/diagnostics.rs
+++ b/crates/typst-kit/src/diagnostics.rs
@@ -13,7 +13,7 @@ use ecow::eco_format;
 use termcolor::{Color, ColorSpec, WriteColor};
 use typst_library::World;
 use typst_library::diag::{FileError, Severity, SourceDiagnostic, Tracepoint};
-use typst_syntax::{FileId, Lines, Source, Span, SpanKind, Spanned};
+use typst_syntax::{DiagSpan, DiagSpanKind, FileId, Lines, Source, Spanned};
 
 type CodespanResult<T> = Result<T, CodespanError>;
 type CodespanError = codespan_reporting::files::Error;
@@ -155,16 +155,16 @@ struct WorldFiles<'a> {
 impl WorldFiles<'_> {
     /// Determine the byte range of a span, also remembering the source file
     /// for future line / column lookups.
-    fn range(&mut self, span: Span) -> Option<Range<usize>> {
-        match span.get() {
-            SpanKind::Detached => None,
-            SpanKind::Number { id, num } => {
+    fn range(&mut self, span: impl Into<DiagSpan>) -> Option<Range<usize>> {
+        match span.into().get() {
+            DiagSpanKind::Detached => None,
+            DiagSpanKind::Number { id, num, sub_range } => {
                 let source = self.world.source(id).ok()?;
-                let range = source.range(num);
+                let range = source.range(num, sub_range);
                 self.sources.entry(id).or_insert(source);
                 range
             }
-            SpanKind::Range { id: _, range } => Some(range),
+            DiagSpanKind::Range { id: _, range } => Some(range),
         }
     }
 

--- a/crates/typst-kit/src/diagnostics.rs
+++ b/crates/typst-kit/src/diagnostics.rs
@@ -13,7 +13,7 @@ use ecow::eco_format;
 use termcolor::{Color, ColorSpec, WriteColor};
 use typst_library::World;
 use typst_library::diag::{FileError, Severity, SourceDiagnostic, Tracepoint};
-use typst_syntax::{FileId, Lines, Source, Span, Spanned};
+use typst_syntax::{FileId, Lines, Source, Span, SpanKind, Spanned};
 
 type CodespanResult<T> = Result<T, CodespanError>;
 type CodespanError = codespan_reporting::files::Error;
@@ -156,13 +156,16 @@ impl WorldFiles<'_> {
     /// Determine the byte range of a span, also remembering the source file
     /// for future line / column lookups.
     fn range(&mut self, span: Span) -> Option<Range<usize>> {
-        span.range().or_else(|| {
-            let id = span.id()?;
-            let source = self.world.source(id).ok()?;
-            let range = source.range(span);
-            self.sources.entry(id).or_insert(source);
-            range
-        })
+        match span.get() {
+            SpanKind::Detached => None,
+            SpanKind::Number { id, num } => {
+                let source = self.world.source(id).ok()?;
+                let range = source.range(num);
+                self.sources.entry(id).or_insert(source);
+                range
+            }
+            SpanKind::Range { id: _, range } => Some(range),
+        }
     }
 
     /// Lookup line metadata for a file by id. If a source file was remembered,

--- a/crates/typst-kit/src/diagnostics.rs
+++ b/crates/typst-kit/src/diagnostics.rs
@@ -9,7 +9,6 @@ use std::ops::Range;
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use codespan_reporting::files::Files;
 use codespan_reporting::term;
-use ecow::eco_format;
 use termcolor::{Color, ColorSpec, WriteColor};
 use typst_library::World;
 use typst_library::diag::{FileError, Severity, SourceDiagnostic, Tracepoint};
@@ -63,7 +62,7 @@ pub fn emit<'a>(
                 .hints
                 .iter()
                 .filter(|s| s.span.is_detached())
-                .map(|s| (eco_format!("hint: {}", s.v)).into())
+                .map(|s| format!("hint: {}", s.v))
                 .collect(),
         )
         .with_labels(

--- a/crates/typst-kit/src/timer.rs
+++ b/crates/typst-kit/src/timer.rs
@@ -101,7 +101,7 @@ fn resolve_span<W: World>(world: &W, span: Span) -> Option<(String, u32)> {
         SpanKind::Detached => return None,
         SpanKind::Number { id, num } => {
             let source = world.source(id).ok()?;
-            let range = source.range(num)?;
+            let range = source.range(num, None)?;
             let line = source.lines().byte_to_line(range.start)?;
             (id, line)
         }

--- a/crates/typst-kit/src/timer.rs
+++ b/crates/typst-kit/src/timer.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 
 use typst_library::World;
 use typst_library::diag::{StrResult, bail};
-use typst_syntax::Span;
+use typst_syntax::{Span, SpanKind};
 
 /// Allows to record timings of function executions.
 pub struct Timer {
@@ -54,14 +54,11 @@ impl Timer {
 
     /// Records all timings in `f` and writes them to disk as JSON compatible
     /// with Chrome's tracing tool.
-    pub fn record<W, T>(
+    pub fn record<W: World, T>(
         &mut self,
         world: &mut W,
         f: impl FnOnce(&mut W) -> T,
-    ) -> StrResult<T>
-    where
-        W: World,
-    {
+    ) -> StrResult<T> {
         let Some(path) = &self.path else {
             return Ok(f(world));
         };
@@ -99,21 +96,20 @@ impl Timer {
 }
 
 /// Turns a span into a (file, line) pair.
-fn resolve_span<W>(world: &W, span: Span) -> Option<(String, u32)>
-where
-    W: World,
-{
-    let id = span.id()?;
-    let line = match span.range() {
-        Some(range) => {
+fn resolve_span<W: World>(world: &W, span: Span) -> Option<(String, u32)> {
+    let (id, line) = match span.get() {
+        SpanKind::Detached => return None,
+        SpanKind::Number { id, num } => {
+            let source = world.source(id).ok()?;
+            let range = source.range(num)?;
+            let line = source.lines().byte_to_line(range.start)?;
+            (id, line)
+        }
+        SpanKind::Range { id, range } => {
             let file = world.file(id).ok()?;
             let lines = file.lines().ok()?;
-            lines.byte_to_line(range.start)?
-        }
-        None => {
-            let source = world.source(id).ok()?;
-            let range = source.range(span)?;
-            source.lines().byte_to_line(range.start)?
+            let line = lines.byte_to_line(range.start)?;
+            (id, line)
         }
     };
     Some((format!("{id:?}"), line as u32 + 1))

--- a/crates/typst-library/src/diag.rs
+++ b/crates/typst-library/src/diag.rs
@@ -17,7 +17,7 @@ use std::string::FromUtf8Error;
 use az::SaturatingAs;
 use comemo::Tracked;
 use typst_syntax::package::{PackageSpec, PackageVersion};
-use typst_syntax::{Lines, Span, Spanned, SyntaxDiagnostic, VirtualRoot};
+use typst_syntax::{DiagSpan, Lines, Span, Spanned, SyntaxDiagnostic, VirtualRoot};
 use utf8_iter::ErrorReportingUtf8Chars;
 
 use crate::engine::Engine;
@@ -301,8 +301,9 @@ impl<T> Warned<T> {
 pub struct SourceDiagnostic {
     /// Whether the diagnostic is an error or a warning.
     pub severity: Severity,
-    /// The span of the relevant node in the source code.
-    pub span: Span,
+    /// The span of a relevant node in a Typst source file or the relevant byte
+    /// range of an external file.
+    pub span: DiagSpan,
     /// A diagnostic message describing the problem.
     pub message: EcoString,
     /// The trace of function calls leading to the problem.
@@ -328,10 +329,10 @@ pub enum Severity {
 
 impl SourceDiagnostic {
     /// Create a new, bare error.
-    pub fn error(span: Span, message: impl Into<EcoString>) -> Self {
+    pub fn error(span: impl Into<DiagSpan>, message: impl Into<EcoString>) -> Self {
         Self {
             severity: Severity::Error,
-            span,
+            span: span.into(),
             trace: eco_vec![],
             message: message.into(),
             hints: eco_vec![],
@@ -339,10 +340,10 @@ impl SourceDiagnostic {
     }
 
     /// Create a new, bare warning.
-    pub fn warning(span: Span, message: impl Into<EcoString>) -> Self {
+    pub fn warning(span: impl Into<DiagSpan>, message: impl Into<EcoString>) -> Self {
         Self {
             severity: Severity::Warning,
-            span,
+            span: span.into(),
             trace: eco_vec![],
             message: message.into(),
             hints: eco_vec![],
@@ -838,14 +839,14 @@ fn load_err_in_text(
     match loaded.source.v {
         LoadSource::Path(file_id) => {
             if let Some(range) = pos.range(&lines) {
-                let span = Span::from_range(file_id, range);
+                let span = DiagSpan::from_range(file_id, range);
                 return SourceDiagnostic::error(span, message);
             }
 
             // Either `ReportPos::None` was provided, or resolving the range
             // from the line/column failed. If present report the possibly
             // wrong line/column in the error message anyway.
-            let span = Span::from_range(file_id, 0..loaded.data.len());
+            let span = DiagSpan::from_range(file_id, 0..loaded.data.len());
             if let Some(pair) = pos.line_col(&lines) {
                 message.pop();
                 let (line, col) = pair.numbers();

--- a/crates/typst-library/src/diag.rs
+++ b/crates/typst-library/src/diag.rs
@@ -310,12 +310,12 @@ pub struct SourceDiagnostic {
     pub trace: EcoVec<Spanned<Tracepoint>>,
     /// Additional hints to the user.
     ///
-    /// - When the span is detached, these are generic hints. The CLI renders
-    ///   them as a list at the bottom, each prefixed with `hint: `.
+    /// - When the span is `None`, these are generic hints. The CLI renders them
+    ///   as a list at the bottom, each prefixed with `hint: `.
     ///
     /// - When a span is given, the hint is related to a secondary piece of code
     ///   and will be annotated at that code.
-    pub hints: EcoVec<Spanned<EcoString>>,
+    pub hints: EcoVec<Spanned<EcoString, DiagSpan>>,
 }
 
 /// The severity of a [`SourceDiagnostic`].
@@ -356,8 +356,12 @@ impl SourceDiagnostic {
     }
 
     /// Adds a single hint specific to a source code location to the diagnostic.
-    pub fn spanned_hint(&mut self, hint: impl Into<EcoString>, span: Span) {
-        self.hints.push(Spanned::new(hint.into(), span));
+    pub fn spanned_hint(
+        &mut self,
+        hint: impl Into<EcoString>,
+        span: impl Into<DiagSpan>,
+    ) {
+        self.hints.push(Spanned::new(hint.into(), span.into()));
     }
 
     /// Adds a single hint to the diagnostic.
@@ -367,7 +371,11 @@ impl SourceDiagnostic {
     }
 
     /// Adds a single hint specific to a source code location to the diagnostic.
-    pub fn with_spanned_hint(mut self, hint: impl Into<EcoString>, span: Span) -> Self {
+    pub fn with_spanned_hint(
+        mut self,
+        hint: impl Into<EcoString>,
+        span: impl Into<DiagSpan>,
+    ) -> Self {
         self.spanned_hint(hint, span);
         self
     }
@@ -393,7 +401,7 @@ impl From<SyntaxDiagnostic> for SourceDiagnostic {
             span,
             message,
             trace: eco_vec![],
-            hints: hints.into_iter().map(Spanned::detached).collect(),
+            hints,
         }
     }
 }

--- a/crates/typst-library/src/lib.rs
+++ b/crates/typst-library/src/lib.rs
@@ -29,7 +29,7 @@ pub mod visualize;
 use std::ops::{Deref, Range};
 
 use serde::{Deserialize, Serialize};
-use typst_syntax::{FileId, Source, Span, SpanKind};
+use typst_syntax::{DiagSpan, DiagSpanKind, FileId, Source};
 use typst_utils::{LazyHash, SmallBitSet};
 
 use crate::diag::FileResult;
@@ -140,15 +140,17 @@ pub trait WorldExt {
     /// Get the byte range for a span.
     ///
     /// Returns `None` if the `Span` does not point into any file.
-    fn range(&self, span: Span) -> Option<Range<usize>>;
+    fn range(&self, span: impl Into<DiagSpan>) -> Option<Range<usize>>;
 }
 
 impl<T: World + ?Sized> WorldExt for T {
-    fn range(&self, span: Span) -> Option<Range<usize>> {
-        match span.get() {
-            SpanKind::Detached => None,
-            SpanKind::Number { id, num } => self.source(id).ok()?.range(num),
-            SpanKind::Range { id: _, range } => Some(range),
+    fn range(&self, span: impl Into<DiagSpan>) -> Option<Range<usize>> {
+        match span.into().get() {
+            DiagSpanKind::Detached => None,
+            DiagSpanKind::Number { id, num, sub_range } => {
+                self.source(id).ok()?.range(num, sub_range)
+            }
+            DiagSpanKind::Range { id: _, range } => Some(range),
         }
     }
 }

--- a/crates/typst-library/src/lib.rs
+++ b/crates/typst-library/src/lib.rs
@@ -29,7 +29,7 @@ pub mod visualize;
 use std::ops::{Deref, Range};
 
 use serde::{Deserialize, Serialize};
-use typst_syntax::{FileId, Source, Span};
+use typst_syntax::{FileId, Source, Span, SpanKind};
 use typst_utils::{LazyHash, SmallBitSet};
 
 use crate::diag::FileResult;
@@ -145,7 +145,11 @@ pub trait WorldExt {
 
 impl<T: World + ?Sized> WorldExt for T {
     fn range(&self, span: Span) -> Option<Range<usize>> {
-        span.range().or_else(|| self.source(span.id()?).ok()?.range(span))
+        match span.get() {
+            SpanKind::Detached => None,
+            SpanKind::Number { id, num } => self.source(id).ok()?.range(num),
+            SpanKind::Range { id: _, range } => Some(range),
+        }
     }
 }
 

--- a/crates/typst-library/src/routines.rs
+++ b/crates/typst-library/src/routines.rs
@@ -144,6 +144,9 @@ pub enum SpanMode<'a> {
         /// the file holding the original text and the evaluated text is the
         /// derived one.
         mapper: &'a RangeMapper,
+        /// A span to associate with errors that occur due to issues with the
+        /// mapper.
+        mapper_error_span: Span,
     },
 }
 

--- a/crates/typst-syntax/src/lib.rs
+++ b/crates/typst-syntax/src/lib.rs
@@ -30,7 +30,9 @@ pub use self::path::{
     FileId, PathError, RootedPath, VirtualPath, VirtualRoot, VirtualizeError,
 };
 pub use self::source::Source;
-pub use self::span::{RangeMapper, Span, SpanKind, SpanNumber, Spanned};
+pub use self::span::{
+    DiagSpan, DiagSpanKind, RangeMapper, Span, SpanKind, SpanNumber, Spanned, SubRange,
+};
 
 use self::lexer::Lexer;
 use self::parser::{reparse_block, reparse_markup};

--- a/crates/typst-syntax/src/lib.rs
+++ b/crates/typst-syntax/src/lib.rs
@@ -30,7 +30,7 @@ pub use self::path::{
     FileId, PathError, RootedPath, VirtualPath, VirtualRoot, VirtualizeError,
 };
 pub use self::source::Source;
-pub use self::span::{RangeMapper, Span, Spanned};
+pub use self::span::{RangeMapper, Span, SpanKind, SpanNumber, Spanned};
 
 use self::lexer::Lexer;
 use self::parser::{reparse_block, reparse_markup};

--- a/crates/typst-syntax/src/node.rs
+++ b/crates/typst-syntax/src/node.rs
@@ -1,3 +1,4 @@
+use std::cell::LazyCell;
 use std::fmt::{self, Debug, Display, Formatter};
 use std::ops::{Deref, Range};
 use std::rc::Rc;
@@ -7,7 +8,10 @@ use ecow::{EcoString, EcoVec, eco_format, eco_vec};
 use typst_utils::debug;
 
 use crate::kind::ModeAfter;
-use crate::{FileId, RangeMapper, Span, SpanKind, SpanNumber, SyntaxKind, SyntaxMode};
+use crate::{
+    DiagSpan, FileId, RangeMapper, Span, SpanKind, SpanNumber, SubRange, SyntaxKind,
+    SyntaxMode,
+};
 
 /// A node in the untyped syntax tree.
 #[derive(Clone, Eq, PartialEq, Hash)]
@@ -139,7 +143,24 @@ impl SyntaxNode {
     pub fn warn(&mut self, message: impl Into<EcoString>) {
         let kind = self.kind();
         let child = std::mem::replace(&mut self.data, Node::Leaf(EcoString::new(), kind));
-        let warn = Arc::new(WarningWrapper::new(child, message.into()));
+        let warn = Arc::new(WarningWrapper::new(child, None, message.into()));
+        self.data = Node::Warning(warn, kind);
+    }
+
+    /// Add a warning around this node at a particular sub-range of the node's
+    /// text. Panics if the range is empty or exceeds the length of the wrapped
+    /// text.
+    #[track_caller]
+    pub fn warn_at(
+        &mut self,
+        Range { start, end }: Range<usize>,
+        message: impl Into<EcoString>,
+    ) {
+        assert!(end <= self.len()); // This isn't checked by `SubRange::new`.
+        let sub_range = SubRange::new(start, end).expect("a valid sub-range");
+        let kind = self.kind();
+        let child = std::mem::replace(&mut self.data, Node::Leaf(EcoString::new(), kind));
+        let warn = Arc::new(WarningWrapper::new(child, Some(sub_range), message.into()));
         self.data = Node::Warning(warn, kind);
     }
 
@@ -293,7 +314,8 @@ impl SyntaxNode {
 
     /// Set a synthetic span for the node and all its descendants.
     pub fn synthesize(&mut self, span: Span) {
-        self.synthesize_with(0, &|_, _| span);
+        // Sub-ranges are removed since the overall range is not accurate.
+        self.synthesize_with(0, &|_, _| span, &|_, sub_range| *sub_range = None);
     }
 
     /// Set a raw range span for each node.
@@ -316,26 +338,54 @@ impl SyntaxNode {
                 mapper.total_len(),
             ));
         }
-        self.synthesize_with(0, &|offset, len| {
-            Span::from_range(id, mapper.map(offset..offset + len))
-        });
+        self.synthesize_with(
+            0,
+            &|offset, len| Span::from_range(id, mapper.map(offset..offset + len)),
+            &|offset, sub_range| {
+                if let Some(sr) = sub_range {
+                    *sr = mapper.map_sub_range(offset, *sr);
+                }
+            },
+        );
         Ok(())
     }
 
-    /// Set a custom span for each node given its offset and length.
+    /// Set a custom span for each node given its offset and length, and update
+    /// any sub-ranges based on their offset.
     ///
     /// Should be called with `offset = 0` on the root node.
     fn synthesize_with(
         &mut self,
         mut offset: usize,
         map_span: &impl Fn(usize, usize) -> Span,
+        update_sub_range: &impl Fn(usize, &mut Option<SubRange>),
     ) {
-        self.span = map_span(offset, self.len());
-        if let Some((inner, span)) = self.inner_and_span_mut() {
-            inner.upper = span.number();
-            for child in &mut inner.children {
-                child.synthesize_with(offset, map_span);
-                offset += child.len();
+        let mut data = &mut self.data;
+        loop {
+            match data {
+                Node::Leaf(leaf, _) => {
+                    self.span = map_span(offset, leaf.len());
+                    break;
+                }
+                Node::Inner(inner, _) => {
+                    let inner = Arc::make_mut(inner);
+                    self.span = map_span(offset, inner.len);
+                    inner.upper = self.span.number();
+                    for child in &mut inner.children {
+                        child.synthesize_with(offset, map_span, update_sub_range);
+                        offset += child.len();
+                    }
+                    break;
+                }
+                Node::Error(err, _) => {
+                    self.span = map_span(offset, err.text.len());
+                    break;
+                }
+                Node::Warning(warn, _) => {
+                    let warn = Arc::make_mut(warn);
+                    update_sub_range(offset, &mut warn.sub_range);
+                    data = &mut warn.child;
+                }
             }
         }
     }
@@ -816,7 +866,7 @@ pub struct SyntaxDiagnostic {
     /// `true` if the diagnostic is an error, `false` if it's a warning.
     pub is_error: bool,
     /// The span targeted by the diagnostic.
-    pub span: Span,
+    pub span: DiagSpan,
     /// The main diagnostic message.
     pub message: EcoString,
     /// Additional hints to the user indicating how this issue could be avoided
@@ -845,7 +895,7 @@ impl ErrorNode {
     fn diagnostic(&self, span: Span) -> SyntaxDiagnostic {
         SyntaxDiagnostic {
             is_error: true,
-            span,
+            span: span.into(),
             message: self.message.clone(),
             hints: self.hints.clone(),
         }
@@ -878,6 +928,11 @@ impl Debug for ErrorNode {
 struct WarningWrapper {
     /// The wrapped node data.
     child: Node,
+    /// A relative sub-range for targeting text not grouped by an existing span.
+    ///
+    /// Warnings may need to target a range of text that isn't actually grouped
+    /// by the syntax tree, this sub-range can select that text.
+    sub_range: Option<SubRange>,
     /// The warning message.
     message: EcoString,
     /// Additional hints to the user indicating how this warning could be
@@ -887,15 +942,15 @@ struct WarningWrapper {
 
 impl WarningWrapper {
     /// Wrap an existing syntax node in a warning node.
-    fn new(child: Node, message: EcoString) -> Self {
-        Self { child, message, hints: eco_vec![] }
+    fn new(child: Node, sub_range: Option<SubRange>, message: EcoString) -> Self {
+        Self { child, sub_range, message, hints: eco_vec![] }
     }
 
     /// Produce the syntax diagnostic for a warning.
     fn diagnostic(&self, span: Span) -> SyntaxDiagnostic {
         SyntaxDiagnostic {
             is_error: false,
-            span,
+            span: DiagSpan::from_span(span, self.sub_range),
             message: self.message.clone(),
             hints: self.hints.clone(),
         }
@@ -904,13 +959,31 @@ impl WarningWrapper {
 
 impl Debug for WarningWrapper {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let full_text = LazyCell::new(|| {
+            let data = self.child.clone();
+            let temp_node = SyntaxNode { data, span: Span::detached() };
+            temp_node.into_text()
+        });
+        let debug_field = |field, message, sub_range: Option<SubRange>| {
+            // Inner closure has `move`, so need to explicitly capture by ref.
+            let full_text = &full_text;
+            debug(move |f| {
+                if let Some(sr) = sub_range {
+                    let selected = &full_text[sr.to_relative()];
+                    write!(f, "{field} @({selected:?}): {message:?}")
+                } else {
+                    write!(f, "{field}: {message:?}")
+                }
+            })
+        };
+
         write!(f, "Warning: ")?;
         // Use `debug_set` instead of `debug_struct` so we don't have to add a
         // field name when outputting the child.
         let mut out = f.debug_set();
-        out.entry(&debug(|f| write!(f, "message: {:?}", self.message)));
+        out.entry(&debug_field("message", &self.message, self.sub_range));
         for hint in &self.hints {
-            out.entry(&debug(|f| write!(f, "hint: {hint:?}")));
+            out.entry(&debug_field("hint", hint, None));
         }
         out.entry(&self.child);
         out.finish()
@@ -1396,6 +1469,32 @@ Markup: 2 [
             Star: \"*\",
             Markup: 0,
             Star: \"*\",
+        ],
+    },
+]"
+        );
+    }
+
+    #[test]
+    fn test_debug_sub_range() {
+        // An example warning for text at a sub-range:
+        let mut root = crate::parse("= =head");
+        let heading_body = &mut root.children_mut()[0];
+        heading_body.warn_at(0..3, "equal space equal!");
+        heading_body.hint("try equal equal space?");
+        assert_eq!(
+            format!("{root:#?}"),
+            "\
+Markup: 7 [
+    Warning: {
+        message @(\"= =\"): \"equal space equal!\",
+        hint: \"try equal equal space?\",
+        Heading: 7 [
+            HeadingMarker: \"=\",
+            Space: \" \",
+            Markup: 5 [
+                Text: \"=head\",
+            ],
         ],
     },
 ]"

--- a/crates/typst-syntax/src/node.rs
+++ b/crates/typst-syntax/src/node.rs
@@ -9,8 +9,8 @@ use typst_utils::debug;
 
 use crate::kind::ModeAfter;
 use crate::{
-    DiagSpan, FileId, RangeMapper, Span, SpanKind, SpanNumber, SubRange, SyntaxKind,
-    SyntaxMode,
+    DiagSpan, FileId, RangeMapper, Span, SpanKind, SpanNumber, Spanned, SubRange,
+    SyntaxKind, SyntaxMode,
 };
 
 /// A node in the untyped syntax tree.
@@ -96,7 +96,7 @@ impl SyntaxNode {
     }
 
     /// Access the hints for an error or warning mutably.
-    fn hints_mut(&mut self) -> Option<&mut EcoVec<EcoString>> {
+    fn hints_mut(&mut self) -> Option<&mut EcoVec<(EcoString, Option<SubRange>)>> {
         match &mut self.data {
             Node::Leaf(_, _) | Node::Inner(_, _) => None,
             Node::Error(err, _) => Some(&mut Arc::make_mut(err).hints),
@@ -169,7 +169,23 @@ impl SyntaxNode {
     #[track_caller]
     pub fn hint(&mut self, hint: impl Into<EcoString>) {
         let hints = self.hints_mut().expect("expected an error or warning");
-        hints.push(hint.into());
+        hints.push((hint.into(), None));
+    }
+
+    /// Add a user-presentable hint to an existing error or warning at a
+    /// sub-range of the text. Panics if the range is empty or exceeds the
+    /// length of the wrapped text. Panics if this is not an error or warning
+    /// node.
+    #[track_caller]
+    pub fn hint_at(
+        &mut self,
+        Range { start, end }: Range<usize>,
+        hint: impl Into<EcoString>,
+    ) {
+        assert!(end <= self.len()); // This isn't checked by `SubRange::new`.
+        let sub_range = SubRange::new(start, end).expect("a valid sub-range");
+        let hints = self.hints_mut().expect("expected an error or warning");
+        hints.push((hint.into(), Some(sub_range)));
     }
 
     /// Add multiple hints while building an error or warning. Panics if this is
@@ -177,7 +193,8 @@ impl SyntaxNode {
     #[track_caller]
     pub fn with_hints(mut self, new_hints: impl IntoIterator<Item = EcoString>) -> Self {
         let hints = self.hints_mut().expect("expected an error or warning");
-        hints.extend(new_hints);
+        let iter = new_hints.into_iter().map(|h| (h, None));
+        hints.extend(iter);
         self
     }
 
@@ -378,12 +395,19 @@ impl SyntaxNode {
                     break;
                 }
                 Node::Error(err, _) => {
+                    let err = Arc::make_mut(err);
+                    for (_hint, sub_range) in err.hints.make_mut() {
+                        update_sub_range(offset, sub_range);
+                    }
                     self.span = map_span(offset, err.text.len());
                     break;
                 }
                 Node::Warning(warn, _) => {
                     let warn = Arc::make_mut(warn);
                     update_sub_range(offset, &mut warn.sub_range);
+                    for (_hint, sub_range) in warn.hints.make_mut() {
+                        update_sub_range(offset, sub_range);
+                    }
                     data = &mut warn.child;
                 }
             }
@@ -871,7 +895,7 @@ pub struct SyntaxDiagnostic {
     pub message: EcoString,
     /// Additional hints to the user indicating how this issue could be avoided
     /// or worked around.
-    pub hints: EcoVec<EcoString>,
+    pub hints: EcoVec<Spanned<EcoString, DiagSpan>>,
 }
 
 /// An error node in the untyped syntax tree.
@@ -883,7 +907,7 @@ struct ErrorNode {
     message: EcoString,
     /// Additional hints to the user indicating how this error could be avoided
     /// or worked around.
-    hints: EcoVec<EcoString>,
+    hints: EcoVec<(EcoString, Option<SubRange>)>,
 }
 
 impl ErrorNode {
@@ -891,13 +915,14 @@ impl ErrorNode {
     fn new(message: EcoString, text: EcoString) -> Self {
         Self { text, message, hints: eco_vec![] }
     }
+
     /// Produce the syntax diagnostic for an error.
     fn diagnostic(&self, span: Span) -> SyntaxDiagnostic {
         SyntaxDiagnostic {
             is_error: true,
             span: span.into(),
             message: self.message.clone(),
-            hints: self.hints.clone(),
+            hints: build_diagnostic_hints(span, &self.hints),
         }
     }
 }
@@ -910,8 +935,14 @@ impl Debug for ErrorNode {
             let mut out = f.debug_struct("Error:");
             out.field("text", &self.text);
             out.field("message", &self.message);
-            for hint in &self.hints {
-                out.field("hint", hint);
+            for (hint, sub_range) in &self.hints {
+                let field = if let Some(sub_range) = sub_range {
+                    let selected = &self.text[sub_range.to_relative()];
+                    &format!("hint @({selected:?})")
+                } else {
+                    "hint"
+                };
+                out.field(field, hint);
             }
             out.finish()
         }
@@ -937,7 +968,7 @@ struct WarningWrapper {
     message: EcoString,
     /// Additional hints to the user indicating how this warning could be
     /// avoided or worked around.
-    hints: EcoVec<EcoString>,
+    hints: EcoVec<(EcoString, Option<SubRange>)>,
 }
 
 impl WarningWrapper {
@@ -952,7 +983,7 @@ impl WarningWrapper {
             is_error: false,
             span: DiagSpan::from_span(span, self.sub_range),
             message: self.message.clone(),
-            hints: self.hints.clone(),
+            hints: build_diagnostic_hints(span, &self.hints),
         }
     }
 }
@@ -982,12 +1013,30 @@ impl Debug for WarningWrapper {
         // field name when outputting the child.
         let mut out = f.debug_set();
         out.entry(&debug_field("message", &self.message, self.sub_range));
-        for hint in &self.hints {
-            out.entry(&debug_field("hint", hint, None));
+        for (hint, sub_range) in &self.hints {
+            out.entry(&debug_field("hint", hint, *sub_range));
         }
         out.entry(&self.child);
         out.finish()
     }
+}
+
+/// Map a vector of hints with optional sub-ranges to one with optional
+/// diagnostic spans derived from a parent span.
+fn build_diagnostic_hints(
+    parent_span: Span,
+    hints: &EcoVec<(EcoString, Option<SubRange>)>,
+) -> EcoVec<Spanned<EcoString, DiagSpan>> {
+    hints
+        .iter()
+        .map(|(message, sub_range)| {
+            let msg = message.clone();
+            match *sub_range {
+                Some(sr) => Spanned::new(msg, DiagSpan::from_span(parent_span, Some(sr))),
+                None => Spanned::detached(msg),
+            }
+        })
+        .collect()
 }
 
 /// A syntax node in a context.
@@ -1496,6 +1545,32 @@ Markup: 7 [
                 Text: \"=head\",
             ],
         ],
+    },
+]"
+        );
+
+        // An example for hints at sub-ranges:
+        let mut root = crate::parse("<unclosed");
+        let node = &mut root.children_mut()[0];
+        // Hint on the "unclosed label" error:
+        node.hint_at(0..1, "greater");
+        node.hint_at(3..8, "open!");
+        // Adding a warning with hints around the error:
+        node.warn_at(3..9, "opened?");
+        node.hint_at(0..9, "full text"); // no special treatment
+        assert_eq!(
+            format!("{root:#?}"),
+            "\
+Markup: 9 [
+    Warning: {
+        message @(\"closed\"): \"opened?\",
+        hint @(\"<unclosed\"): \"full text\",
+        Error: {
+            text: \"<unclosed\",
+            message: \"unclosed label\",
+            hint @(\"<\"): \"greater\",
+            hint @(\"close\"): \"open!\",
+        },
     },
 ]"
         );

--- a/crates/typst-syntax/src/node.rs
+++ b/crates/typst-syntax/src/node.rs
@@ -7,7 +7,7 @@ use ecow::{EcoString, EcoVec, eco_format, eco_vec};
 use typst_utils::debug;
 
 use crate::kind::ModeAfter;
-use crate::{FileId, RangeMapper, Span, SyntaxKind, SyntaxMode};
+use crate::{FileId, RangeMapper, Span, SpanKind, SpanNumber, SyntaxKind, SyntaxMode};
 
 /// A node in the untyped syntax tree.
 #[derive(Clone, Eq, PartialEq, Hash)]
@@ -431,7 +431,8 @@ impl SyntaxNode {
         } else if let Some((inner, span)) = self.inner_and_span_mut() {
             inner.numberize(span, id, None, within)
         } else {
-            self.span = Span::from_number(id, (within.start + within.end) / 2).unwrap();
+            self.span =
+                Span::from_number(id, SpanNumber((within.start + within.end) / 2));
             Ok(())
         }
     }
@@ -608,7 +609,7 @@ impl InnerNode {
         let mut start = within.start;
         if range.is_none() {
             let end = start + stride;
-            *span = Span::from_number(id, (start + end) / 2).unwrap();
+            *span = Span::from_number(id, SpanNumber((start + end) / 2));
             self.upper = within.end;
             start = end;
         }
@@ -971,16 +972,29 @@ impl<'a> LinkedNode<'a> {
     }
 
     /// Find a descendant with the given span.
-    pub fn find(&self, span: Span) -> Option<LinkedNode<'a>> {
-        if self.span() == span {
+    pub fn find(&self, span: Span) -> Option<Self> {
+        match span.get() {
+            SpanKind::Detached => None,
+            SpanKind::Number { id: _, num } => self.find_number(num),
+            SpanKind::Range { id: _, range } => self.find_range(range.start, range.end),
+        }
+    }
+
+    /// Find the descendant whose span number matches the given number.
+    ///
+    /// This relies on the ordering guarantees of numbered spans:
+    /// - The number of a parent is smaller than the numbers of all its children
+    /// - The numbers of sibling nodes always increase from left to right
+    pub(crate) fn find_number(&self, target: SpanNumber) -> Option<Self> {
+        let number = self.span().number();
+        if number == target.0 {
             return Some(self.clone());
         }
 
-        if self.is_inner() && self.span().number() < span.number() {
-            // The parent of a subtree has a smaller span number than all of its
-            // descendants. Therefore, we can bail out early if the target span's
-            // number is smaller than our number.
-
+        // The parent of a subtree has a smaller span number than all of its
+        // descendants. Therefore, we can bail out early if the target span's
+        // number is smaller than our number.
+        if self.node.is_inner() && number < target.0 {
             // Use `self.children()`, not `inner.children()` to preserve being
             // in a `LinkedNode`.
             let mut children = self.children().peekable();
@@ -988,16 +1002,28 @@ impl<'a> LinkedNode<'a> {
                 // Every node in this child's subtree has a smaller span number than
                 // the next sibling. Therefore we only need to recurse if the next
                 // sibling's span number is larger than the target span's number.
-                if children
-                    .peek()
-                    .is_none_or(|next| next.span().number() > span.number())
-                    && let Some(found) = child.find(span)
+                if children.peek().is_none_or(|next| next.span().number() > target.0)
+                    && let Some(found) = child.find_number(target)
                 {
                     return Some(found);
                 }
             }
         }
 
+        None
+    }
+
+    /// Find the descendant whose byte range matches the given range exactly.
+    pub(crate) fn find_range(&self, start: usize, end: usize) -> Option<Self> {
+        if start == self.offset && end == self.offset + self.len() {
+            return Some(self.clone());
+        }
+        for child in self.children() {
+            // Descend into the single child which fully covers the range.
+            if child.offset <= start && end <= child.offset + child.len() {
+                return child.find_range(start, end);
+            }
+        }
         None
     }
 

--- a/crates/typst-syntax/src/node.rs
+++ b/crates/typst-syntax/src/node.rs
@@ -293,33 +293,48 @@ impl SyntaxNode {
 
     /// Set a synthetic span for the node and all its descendants.
     pub fn synthesize(&mut self, span: Span) {
-        self.synthesize_with(0, &mut |_| span);
+        self.synthesize_with(0, &|_, _| span);
     }
 
     /// Set a raw range span for each node.
     ///
     /// The range is determined by mapping the node's ranges through the given
     /// `mapper`.
-    pub fn synthesize_mapped(&mut self, id: FileId, mapper: &RangeMapper) {
-        self.synthesize_with(0, &mut |range| match mapper.map(range) {
-            Some(mapped) => Span::from_range(id, mapped),
-            None => Span::detached(),
+    ///
+    /// Returns an error with the mapper's length if it was shorter than the
+    /// length of the source text.
+    pub fn synthesize_mapped(
+        &mut self,
+        id: FileId,
+        mapper: &RangeMapper,
+    ) -> Result<(), EcoString> {
+        if self.len() > mapper.total_len() {
+            // TODO: Should we error if not exactly equal?
+            return Err(eco_format!(
+                "text length ({}) is greater than mapper length ({})",
+                self.len(),
+                mapper.total_len(),
+            ));
+        }
+        self.synthesize_with(0, &|offset, len| {
+            Span::from_range(id, mapper.map(offset..offset + len))
         });
+        Ok(())
     }
 
-    /// Set a custom span for each node gives its range.
+    /// Set a custom span for each node given its offset and length.
     ///
     /// Should be called with `offset = 0` on the root node.
     fn synthesize_with(
         &mut self,
         mut offset: usize,
-        f: &mut impl FnMut(Range<usize>) -> Span,
+        map_span: &impl Fn(usize, usize) -> Span,
     ) {
-        self.span = f(offset..offset + self.len());
+        self.span = map_span(offset, self.len());
         if let Some((inner, span)) = self.inner_and_span_mut() {
             inner.upper = span.number();
             for child in &mut inner.children {
-                child.synthesize_with(offset, f);
+                child.synthesize_with(offset, map_span);
                 offset += child.len();
             }
         }

--- a/crates/typst-syntax/src/source.rs
+++ b/crates/typst-syntax/src/source.rs
@@ -9,11 +9,12 @@ use typst_utils::LazyHash;
 use crate::lines::Lines;
 use crate::reparser::reparse;
 use crate::{
-    FileId, LinkedNode, RootedPath, Span, SpanNumber, SyntaxNode, VirtualPath,
+    FileId, LinkedNode, RootedPath, Span, SpanNumber, SubRange, SyntaxNode, VirtualPath,
     VirtualRoot, parse,
 };
 
-/// A source file.
+/// A Typst source file containing the full source text, a mapping from byte
+/// indices to lines/columns, and the parsed syntax tree.
 ///
 /// All line and column indices start at zero, just like byte indices. Only for
 /// user-facing display, you should add 1 to them.
@@ -120,12 +121,24 @@ impl Source {
         LinkedNode::new(self.root()).find(span)
     }
 
-    /// Get the byte range for a given span number in this file.
+    /// Get the byte range for the given span number (and optional sub-range) in
+    /// this file.
     ///
     /// The main way to get a [`SpanNumber`] is by unpacking a span with
     /// [`Span::get`], but it's likely easier to use `WorldExt::range` instead.
-    pub fn range(&self, num: SpanNumber) -> Option<Range<usize>> {
-        Some(LinkedNode::new(self.root()).find_number(num)?.range())
+    pub fn range(
+        &self,
+        num: SpanNumber,
+        sub_range: Option<SubRange>,
+    ) -> Option<Range<usize>> {
+        let overall = LinkedNode::new(self.root()).find_number(num)?.range();
+        if let Some(sub_range) = sub_range {
+            let range = sub_range.to_absolute(overall.start);
+            assert!(range.end <= overall.end);
+            Some(range)
+        } else {
+            Some(overall)
+        }
     }
 }
 
@@ -138,5 +151,32 @@ impl Debug for Source {
 impl AsRef<str> for Source {
     fn as_ref(&self) -> &str {
         self.text()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Source;
+    use crate::{LinkedNode, Side, Span, SubRange};
+
+    #[test]
+    fn test_source_sub_ranges() {
+        let text = "= head <label>";
+        let source = Source::detached(text);
+        let get = |span: Span, sub_range| {
+            let num = crate::SpanNumber(span.number());
+            &text[source.range(num, sub_range).unwrap()]
+        };
+        let head = LinkedNode::new(source.root()).leaf_at(2, Side::After).unwrap().span();
+        assert_eq!(get(head, None), "head");
+        assert_eq!(get(head, SubRange::new(1, 3)), "ea");
+        assert_eq!(get(head, SubRange::new(0, 1)), "h");
+        assert_eq!(get(head, SubRange::new(0, 4)), "head");
+        assert_eq!(get(head, SubRange::new(3, 4)), "d");
+        let root = source.root().span();
+        assert_eq!(get(root, None), text);
+        assert_eq!(get(root, SubRange::new(3, 10)), "ead <la");
+        assert_eq!(get(root, SubRange::new(0, 10)), "= head <la");
+        assert_eq!(get(root, SubRange::new(3, 14)), "ead <label>");
     }
 }

--- a/crates/typst-syntax/src/source.rs
+++ b/crates/typst-syntax/src/source.rs
@@ -9,7 +9,8 @@ use typst_utils::LazyHash;
 use crate::lines::Lines;
 use crate::reparser::reparse;
 use crate::{
-    FileId, LinkedNode, RootedPath, Span, SyntaxNode, VirtualPath, VirtualRoot, parse,
+    FileId, LinkedNode, RootedPath, Span, SpanNumber, SyntaxNode, VirtualPath,
+    VirtualRoot, parse,
 };
 
 /// A source file.
@@ -113,16 +114,18 @@ impl Source {
     ///
     /// Returns `None` if the span does not point into this source file.
     pub fn find(&self, span: Span) -> Option<LinkedNode<'_>> {
+        if span.id() != Some(self.id()) {
+            return None;
+        }
         LinkedNode::new(self.root()).find(span)
     }
 
-    /// Get the byte range for the given span in this file.
+    /// Get the byte range for a given span number in this file.
     ///
-    /// Returns `None` if the span does not point into this source file.
-    ///
-    /// Typically, it's easier to use `WorldExt::range` instead.
-    pub fn range(&self, span: Span) -> Option<Range<usize>> {
-        Some(self.find(span)?.range())
+    /// The main way to get a [`SpanNumber`] is by unpacking a span with
+    /// [`Span::get`], but it's likely easier to use `WorldExt::range` instead.
+    pub fn range(&self, num: SpanNumber) -> Option<Range<usize>> {
+        Some(LinkedNode::new(self.root()).find_number(num)?.range())
     }
 }
 

--- a/crates/typst-syntax/src/span.rs
+++ b/crates/typst-syntax/src/span.rs
@@ -1,37 +1,53 @@
 use std::fmt::{self, Debug, Formatter};
-use std::num::{NonZeroU16, NonZeroU64};
+use std::num::{NonZeroU16, NonZeroU32, NonZeroU64};
 use std::ops::Range;
 
 use ecow::{EcoString, eco_format};
 
 use crate::FileId;
 
-/// Defines a range in a file.
+/// Defines a range of text in a Typst source file.
 ///
-/// This is used throughout the compiler to track which source section an
-/// element stems from or an error applies to.
+/// Spans are used throughout the compiler to track which source section an
+/// element stems from or an error/warning applies to. Errors and warnings use
+/// the [`DiagSpan`] type which can contain either a normal span or a range
+/// targeting a location in a non-Typst file, such as a JSON parsing error.
 ///
-/// - The [`.id()`](Self::id) function can be used to get the `FileId` for the
+/// - The [`.id()`](Self::id) method can be used to get the [`FileId`] for the
 ///   span and, by extension, its file system path.
 /// - The `WorldExt::range` function can be used to map the span to a
 ///   `Range<usize>`.
 ///
-/// This type takes up 8 bytes and is copyable and null-optimized (i.e.
-/// `Option<Span>` also takes 8 bytes).
+/// This type is stored compactly in 8 bytes, and is copyable and null-optimized
+/// (i.e. `Option<Span>` also takes 8 bytes), but can be expanded for easier
+/// usage into the [`SpanKind`] enum via [`Self::get()`].
 ///
-/// Spans come in two flavors: Numbered spans and raw range spans. The
-/// `WorldExt::range` function automatically handles both cases, yielding a
-/// `Range<usize>`.
+/// Spans internally distinguish between four kinds of values, these are
+/// accessible as the [`SpanKind`] or [`DiagSpanKind`] enums via the
+/// [`Span::get`] or [`DiagSpan::get`] methods.
+/// 1. They can be detached, originating from nowhere or from the compiler
+///    itself.
+/// 2. They can be numbered values, corresponding to a node in a Typst source
+///    file's concrete syntax tree. These are the most common span type and are
+///    explained more below.
+/// 3. They can be raw range spans, containing a range of two indices that came
+///    from parsing a text as Typst syntax. The file itself is not necessarily a
+///    Typst source file. The maximum value for the start/end of these ranges is
+///    `2^23-1`, larger values will be saturated.
+/// 4. They can be an external start index, used for diagnostics on externally
+///    loaded text files. These are only accessible as part of a [`DiagSpan`]
+///    which also contains the end index. The maximum value for the start/end of
+///    these ranges is `2^46-1`, larger values will be saturated.
 ///
 /// # Numbered spans
 /// Typst source files use _numbered spans._ Rather than using byte ranges,
-/// which shift a lot as you type, each AST node gets a unique number.
+/// which shift a lot as you type, each syntax tree node gets a unique number.
 ///
 /// During editing, the span numbers stay mostly stable, even for nodes behind
-/// an insertion. This is not true for simple ranges as they would shift. Spans
-/// can be used as inputs to memoized functions without hurting cache
-/// performance when text is inserted somewhere in the document other than the
-/// end.
+/// an insertion. This is not true for simple ranges as they would shift. This
+/// allows spans to be used as inputs to memoized functions without hurting
+/// cache performance when text is inserted somewhere in the document other than
+/// the end.
 ///
 /// Span numbers are ordered in the syntax tree to enable quickly finding the
 /// node of a known span:
@@ -43,11 +59,6 @@ use crate::FileId;
 /// the span numbers for node A and _all of A's children_ are less than node B's
 /// span number, and the numbers for node C and all of C's children are greater
 /// than B's span number.
-///
-/// # Raw range spans
-/// Non Typst-files use raw ranges instead of numbered spans. The maximum
-/// encodable value for start and end is 2^23-1. Larger values will be
-/// saturated.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Span(NonZeroU64);
 
@@ -78,19 +89,23 @@ impl Span {
     /// The value reserved for the detached span.
     const DETACHED: Self = Self(NonZeroU64::new(1).unwrap());
 
-    /// Data layout:
+    /// The span's internal data is laid out with the high 16 bits as the file
+    /// id and the low 48 bits as the span number:
     /// | 16 bits file id | 48 bits number |
     ///
-    /// Number =
-    /// - 1 means detached
-    /// - 2..2^47-1 is a numbered span
-    /// - 2^47..2^48-1 is a raw range span. To retrieve it, you must subtract
-    ///   `RANGE_BASE` and then use shifting/bitmasking to extract the
-    ///   components.
+    /// Possible values for the span number are:
+    /// - always non-zero
+    /// - Detached: 1 (file id is 0, otherwise non-zero)
+    /// - Typst source file:           2 ..= 2^47-1      (one 47-bit number)
+    /// - External file start:      2^47 ..= 2^47+2^46-1 (one 46-bit number)
+    /// - Internal range span: 2^47+2^46 ..= 2^48-1      (two 23-bit numbers)
     const NUMBER_BITS: usize = 48;
+    const RANGE_BITS: usize = 46;
     const FILE_ID_SHIFT: usize = Self::NUMBER_BITS;
     const NUMBER_MASK: u64 = (1 << Self::NUMBER_BITS) - 1;
-    const RANGE_BASE: u64 = Self::FULL.end;
+    const EXTERNAL_BASE: u64 = Self::FULL.end;
+    const EXTERNAL_VALUE_MAX: u64 = (1 << Self::RANGE_BITS) - 1;
+    const RANGE_BASE: u64 = Self::EXTERNAL_BASE + (1 << Self::RANGE_BITS);
     const RANGE_VALUE_BITS: usize = 23;
     const RANGE_VALUE_MAX: u64 = (1 << Self::RANGE_VALUE_BITS) - 1;
 
@@ -110,7 +125,7 @@ impl Span {
     ///
     /// If one of the range's parts exceeds the maximum value of `2^23-1`, it is
     /// saturated.
-    pub const fn from_range(id: FileId, range: Range<usize>) -> Self {
+    pub(crate) const fn from_range(id: FileId, range: Range<usize>) -> Self {
         let start = saturate(range.start, Self::RANGE_VALUE_MAX);
         let end = saturate(range.end, Self::RANGE_VALUE_MAX);
         let number = (start << Self::RANGE_VALUE_BITS) | end;
@@ -189,10 +204,161 @@ impl Span {
     }
 }
 
+/// The span of a diagnostic message. Either from a Typst source file or from a
+/// loaded external file.
+///
+/// Typst source spans may additionally contain a sub-range targeting just part
+/// of the overall range of the span.
+///
+/// When storing an external file range, the maximum value of the start/end is
+/// `2^46-1`, larger values are saturated.
+///
+/// This type is stored compactly in 16 bytes and null-optimized, but can be
+/// expanded for easier usage as the [`DiagSpanKind`] enum via [`Self::get()`].
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub struct DiagSpan {
+    span: Span,
+    extra: u64,
+}
+
+/// The possible kinds of a diagnostic span.
+#[derive(Debug)]
+pub enum DiagSpanKind {
+    /// A span that does not point into any file.
+    Detached,
+    /// A numbered span with an optional sub-range.
+    Number { id: FileId, num: SpanNumber, sub_range: Option<SubRange> },
+    /// A raw byte range in a file.
+    Range { id: FileId, range: Range<usize> },
+}
+
+impl DiagSpan {
+    /// Create a new diagnostic span from an external file's byte range instead
+    /// of an internal span.
+    ///
+    /// If either of the range's parts exceeds the maximum value of `2^46-1`, it
+    /// will be saturated.
+    pub fn from_range(id: FileId, range: Range<usize>) -> Self {
+        let start = saturate(range.start, Span::EXTERNAL_VALUE_MAX);
+        let end = saturate(range.end, Span::EXTERNAL_VALUE_MAX);
+        Self {
+            span: Span::pack(id, Span::EXTERNAL_BASE + start),
+            extra: end,
+        }
+    }
+
+    /// Create a new diagnostic span from a source span and optional sub-range.
+    ///
+    /// The preferred interface for converting a [`Span`] into [`DiagSpan`] is
+    /// using `span.into()`, which calls this with `sub_range: None`.
+    pub fn from_span(span: Span, sub_range: Option<SubRange>) -> Self {
+        let extra = sub_range.map_or(0, |SubRange { start, end }| {
+            ((start as u64) << 32) | (end.get() as u64)
+        });
+        Self { span, extra }
+    }
+
+    /// The id of the file the span points into.
+    ///
+    /// Returns `None` if the span is detached.
+    pub fn id(self) -> Option<FileId> {
+        self.span.id()
+    }
+
+    /// Unpack the diagnostic span into the variants of a [`DiagSpanKind`] for
+    /// easier use.
+    ///
+    /// To access a range, you may want to use `WorldExt::range` instead.
+    pub fn get(self) -> DiagSpanKind {
+        let DiagSpan { span, extra } = self;
+        match span.get() {
+            SpanKind::Detached => DiagSpanKind::Detached,
+            SpanKind::Number { id, num } => {
+                if let Some(start) = num.0.checked_sub(Span::EXTERNAL_BASE) {
+                    // This `checked_sub` must come after the internal range
+                    // check from `span.get()`.
+                    let start = start as usize;
+                    let end = extra as usize;
+                    DiagSpanKind::Range { id, range: start..end }
+                } else {
+                    let sub_range = {
+                        let start = (extra >> 32) as u32;
+                        let end = NonZeroU32::new(extra as u32); // `as` truncates
+                        end.map(|end| SubRange { start, end })
+                    };
+                    DiagSpanKind::Number { id, num, sub_range }
+                }
+            }
+            SpanKind::Range { id, range } => {
+                if let Some(end) = NonZeroU32::new(extra as u32) {
+                    let start = (extra >> 32) as u32;
+                    let sub_range = SubRange { start, end };
+                    let range = sub_range.to_absolute(range.start);
+                    DiagSpanKind::Range { id, range }
+                } else {
+                    DiagSpanKind::Range { id, range }
+                }
+            }
+        }
+    }
+}
+
+impl From<Span> for DiagSpan {
+    fn from(span: Span) -> Self {
+        Self::from_span(span, None)
+    }
+}
+
 /// Saturate a value at a given maximum. Can't use `.min()` since it isn't
 /// stable in const :/
 const fn saturate(value: usize, max: u64) -> u64 {
     if value as u64 > max { max } else { value as u64 }
+}
+
+/// A non-empty range targeting a smaller part of a spanned section of text.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub struct SubRange {
+    start: u32,
+    end: NonZeroU32,
+}
+
+impl SubRange {
+    /// Create a new sub-range. The given start and end must create a non-empty
+    /// range.
+    ///
+    /// If start or end are above a `2^32-1`, they will be saturated.
+    pub fn new(start: usize, end: usize) -> Option<Self> {
+        if start < end {
+            Some(Self {
+                start: to_u32_saturated(start),
+                // (0 <= start) && (start < end) --> (end != 0)
+                end: NonZeroU32::new(to_u32_saturated(end)).unwrap(),
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Convert to a normal range relative to the spanned range.
+    pub fn to_relative(self) -> Range<usize> {
+        Range {
+            start: self.start as usize,
+            end: self.end.get() as usize,
+        }
+    }
+
+    /// Convert to a normal range at an offset.
+    pub fn to_absolute(self, offset: usize) -> Range<usize> {
+        Range {
+            start: self.start as usize + offset,
+            end: self.end.get() as usize + offset,
+        }
+    }
+}
+
+// Convert a `usize` to a `u32` by saturating at `u32::MAX`.
+fn to_u32_saturated(value: usize) -> u32 {
+    value.try_into().unwrap_or(u32::MAX)
 }
 
 /// A value with a span locating it in the source code.
@@ -321,6 +487,17 @@ impl RangeMapper {
         }
     }
 
+    /// Map a relative sub-range at an offset to a new sub-range. If the
+    /// sub-range spans over multiple segments, the gap between them will be
+    /// included in the new sub-range.
+    pub(crate) fn map_sub_range(&self, offset: usize, sub_range: SubRange) -> SubRange {
+        let range = sub_range.to_absolute(offset);
+        let new_offset = self.map_start(offset);
+        let start = self.map_start(range.start);
+        let end = self.map_end(range.end); // sub-ranges have `start < end`.
+        SubRange::new(start - new_offset, end - new_offset).unwrap()
+    }
+
     /// Map a single offset, preferring the second index if at a boundary.
     fn map_start(&self, offset: usize) -> usize {
         let idx = self.vec.partition_point(|&Mapping { old, new: _ }| old <= offset);
@@ -380,6 +557,54 @@ mod tests {
         roundtrip(177..233);
         roundtrip(0..8388607);
         roundtrip(8388606..8388607); // 2^23-2 .. 2^23-1
+    }
+
+    #[test]
+    fn test_diag_span_range() {
+        let file_id = FileId::from_raw(NonZeroU16::new(u16::MAX).unwrap());
+        let roundtrip = |range: Range<usize>| {
+            let span = DiagSpan::from_range(file_id, range.clone());
+            let DiagSpanKind::Range { id, range: actual } = span.get() else {
+                panic!("bad diagspan kind")
+            };
+            assert_eq!(id, file_id);
+            assert_eq!(actual, range);
+        };
+
+        roundtrip(0..0);
+        roundtrip(177..233);
+        roundtrip(0..8388607);
+        roundtrip(8388606..8388607); // 2^23-2 .. 2^23-1
+        roundtrip(8388608..8388609); // 2^23   .. 2^23+1
+        #[cfg(target_pointer_width = "64")]
+        roundtrip(70368744177662..70368744177663); // 2^46-2 .. 2^46-1
+    }
+
+    #[test]
+    fn test_sub_range_constructor() {
+        let max = u32::MAX as usize;
+        // valid
+        assert!(SubRange::new(0, 1).is_some());
+        assert!(SubRange::new(4, 5).is_some());
+        assert!(SubRange::new(0, max).is_some());
+        assert!(SubRange::new(0, max - 1).is_some());
+        assert!(SubRange::new(max - 1, max).is_some());
+        // invalid
+        assert!(SubRange::new(0, 0).is_none());
+        assert!(SubRange::new(5, 5).is_none());
+        assert!(SubRange::new(5, 4).is_none());
+        assert!(SubRange::new(max - 1, max - 1).is_none());
+        assert!(SubRange::new(max, max).is_none());
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn test_sub_range_saturating() {
+        // Values saturate at 2^32-1
+        let max = u32::MAX as usize;
+        let maxxed = SubRange::new(max, max + 1).unwrap();
+        assert_eq!(maxxed.start, maxxed.end.get());
+        assert_eq!(SubRange::new(1 << 47, 1 << 63), Some(maxxed));
     }
 
     #[test]
@@ -443,5 +668,36 @@ mod tests {
         assert_eq!(with_empty.map(1..1), 11..11);
         assert_eq!(with_empty.map(1..2), 21..22);
         assert_eq!(with_empty.map(2..2), 22..22);
+    }
+
+    #[test]
+    fn test_sub_range_mapping() {
+        let base = "01_23__45";
+        let ranges = [(0..2), (3..5), (7..9)];
+        let mapped = ranges.iter().map(|r| &base[r.clone()]).collect::<String>();
+        assert_eq!(mapped, "012345");
+        let m = RangeMapper::new(ranges).unwrap();
+
+        let map_at = |at: usize, sr: Option<SubRange>| {
+            let sub_range = sr.unwrap();
+            m.map_sub_range(at, sub_range).to_relative()
+        };
+
+        // Ranges within each section:
+        assert_eq!(map_at(0, SubRange::new(0, 1)), 0..1); // 0
+        assert_eq!(map_at(0, SubRange::new(2, 3)), 3..4); // 2
+        assert_eq!(map_at(0, SubRange::new(2, 4)), 3..5); // 23
+        assert_eq!(map_at(0, SubRange::new(4, 5)), 7..8); // 4
+        assert_eq!(map_at(1, SubRange::new(0, 1)), 0..1); // 1
+        assert_eq!(map_at(3, SubRange::new(0, 1)), 0..1); // 3
+        assert_eq!(map_at(4, SubRange::new(0, 2)), 0..2); // 45
+        // Across boundaries:
+        assert_eq!(map_at(1, SubRange::new(0, 2)), 0..3); // 12 -> 1_2
+        assert_eq!(map_at(0, SubRange::new(1, 3)), 1..4); // 12 -> 1_2
+        assert_eq!(map_at(3, SubRange::new(0, 2)), 0..4); // 34 -> 3__4
+        assert_eq!(map_at(0, SubRange::new(3, 5)), 4..8); // 34 -> 3__4
+        assert_eq!(map_at(1, SubRange::new(0, 4)), 0..7); // 1234 -> 1_23__4
+        assert_eq!(map_at(0, SubRange::new(1, 5)), 1..8); // 1234 -> 1_23__4
+        assert_eq!(map_at(0, SubRange::new(0, 6)), 0..9); // 012345 -> 01_23__45
     }
 }

--- a/crates/typst-syntax/src/span.rs
+++ b/crates/typst-syntax/src/span.rs
@@ -109,7 +109,7 @@ impl Span {
     const RANGE_VALUE_BITS: usize = 23;
     const RANGE_VALUE_MAX: u64 = (1 << Self::RANGE_VALUE_BITS) - 1;
 
-    /// Create a span that does not point into any file.
+    /// The detached span that does not point into any file.
     pub const fn detached() -> Self {
         Self::DETACHED
     }
@@ -233,6 +233,11 @@ pub enum DiagSpanKind {
 }
 
 impl DiagSpan {
+    /// The detached diagnostic span that does not point into any file.
+    pub const fn detached() -> Self {
+        Self { span: Span::DETACHED, extra: 0 }
+    }
+
     /// Create a new diagnostic span from an external file's byte range instead
     /// of an internal span.
     ///
@@ -258,11 +263,21 @@ impl DiagSpan {
         Self { span, extra }
     }
 
+    /// Whether the diagnostic span is detached.
+    pub const fn is_detached(self) -> bool {
+        self.span.0.get() == Span::DETACHED.0.get()
+    }
+
     /// The id of the file the span points into.
     ///
     /// Returns `None` if the span is detached.
     pub fn id(self) -> Option<FileId> {
         self.span.id()
+    }
+
+    /// Return `other` if `self` is detached and `self` otherwise.
+    pub fn or(self, other: Self) -> Self {
+        if self.is_detached() { other } else { self }
     }
 
     /// Unpack the diagnostic span into the variants of a [`DiagSpanKind`] for
@@ -363,42 +378,55 @@ fn to_u32_saturated(value: usize) -> u32 {
 
 /// A value with a span locating it in the source code.
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
-pub struct Spanned<T> {
+#[expect(private_bounds)]
+pub struct Spanned<T, S: Copy + SpanDetached = Span> {
     /// The spanned value.
     pub v: T,
     /// The value's location in source code.
-    pub span: Span,
+    pub span: S,
 }
 
-impl<T> Spanned<T> {
+#[expect(private_bounds)]
+impl<T, S: Copy + SpanDetached> Spanned<T, S> {
     /// Create a new instance from a value and its span.
-    pub const fn new(v: T, span: Span) -> Self {
+    pub const fn new(v: T, span: S) -> Self {
         Self { v, span }
     }
 
     /// Create a new instance with a span that does not point into any file.
     pub const fn detached(v: T) -> Self {
-        Self { v, span: Span::detached() }
+        Self { v, span: S::SPAN_DETACHED }
     }
 
     /// Convert from `&Spanned<T>` to `Spanned<&T>`
-    pub const fn as_ref(&self) -> Spanned<&T> {
+    pub const fn as_ref(&self) -> Spanned<&T, S> {
         Spanned { v: &self.v, span: self.span }
     }
 
     /// Map the value using a function.
-    pub fn map<F, U>(self, f: F) -> Spanned<U>
-    where
-        F: FnOnce(T) -> U,
-    {
+    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> Spanned<U, S> {
         Spanned { v: f(self.v), span: self.span }
     }
 }
 
-impl<T: Debug> Debug for Spanned<T> {
+impl<T: Debug, S: Copy + SpanDetached> Debug for Spanned<T, S> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         self.v.fmt(f)
     }
+}
+
+/// Allows generic access to the detached span. Only used to implement
+/// [`Spanned::detached`].
+trait SpanDetached {
+    const SPAN_DETACHED: Self;
+}
+
+impl SpanDetached for Span {
+    const SPAN_DETACHED: Self = Self::detached();
+}
+
+impl SpanDetached for DiagSpan {
+    const SPAN_DETACHED: Self = Self::detached();
 }
 
 /// Remaps ranges.

--- a/crates/typst-syntax/src/span.rs
+++ b/crates/typst-syntax/src/span.rs
@@ -33,24 +33,50 @@ use crate::FileId;
 /// performance when text is inserted somewhere in the document other than the
 /// end.
 ///
-/// Span ids are ordered in the syntax tree to enable quickly finding the node
-/// with some id:
-/// - The id of a parent is always smaller than the ids of any of its children.
-/// - The id of a node is always greater than any id in the subtrees of any left
-///   sibling and smaller than any id in the subtrees of any right sibling.
+/// Span numbers are ordered in the syntax tree to enable quickly finding the
+/// node of a known span:
+/// - The span number of a parent node is always smaller than the number of any
+///   of its children
+/// - The span numbers of sibling nodes always increase from left to right
+///
+/// Combining those guarantees, we have that for siblings in order [A, B, C],
+/// the span numbers for node A and _all of A's children_ are less than node B's
+/// span number, and the numbers for node C and all of C's children are greater
+/// than B's span number.
 ///
 /// # Raw range spans
 /// Non Typst-files use raw ranges instead of numbered spans. The maximum
-/// encodable value for start and end is 2^23. Larger values will be saturated.
+/// encodable value for start and end is 2^23-1. Larger values will be
+/// saturated.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Span(NonZeroU64);
+
+/// The unique number of a span within its [`Source`](crate::Source). Known to
+/// be within the range of `Span::FULL`.
+///
+/// This is mainly used externally as an input to the
+/// [`Source::range`](crate::Source::range) method for efficiently finding the
+/// byte range of a span.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct SpanNumber(pub(crate) u64);
+
+/// The possible kinds of span.
+#[derive(Debug)]
+pub enum SpanKind {
+    /// A span that does not point into any file.
+    Detached,
+    /// A numbered span.
+    Number { id: FileId, num: SpanNumber },
+    /// A raw byte range in a file.
+    Range { id: FileId, range: Range<usize> },
+}
 
 impl Span {
     /// The full range of numbers available for source file span numbering.
     pub(crate) const FULL: Range<u64> = 2..(1 << 47);
 
     /// The value reserved for the detached span.
-    const DETACHED: u64 = 1;
+    const DETACHED: Self = Self(NonZeroU64::new(1).unwrap());
 
     /// Data layout:
     /// | 16 bits file id | 48 bits number |
@@ -65,34 +91,29 @@ impl Span {
     const FILE_ID_SHIFT: usize = Self::NUMBER_BITS;
     const NUMBER_MASK: u64 = (1 << Self::NUMBER_BITS) - 1;
     const RANGE_BASE: u64 = Self::FULL.end;
-    const RANGE_PART_BITS: usize = 23;
-    const RANGE_PART_SHIFT: usize = Self::RANGE_PART_BITS;
-    const RANGE_PART_MASK: u64 = (1 << Self::RANGE_PART_BITS) - 1;
+    const RANGE_VALUE_BITS: usize = 23;
+    const RANGE_VALUE_MAX: u64 = (1 << Self::RANGE_VALUE_BITS) - 1;
 
     /// Create a span that does not point into any file.
     pub const fn detached() -> Self {
-        Self(NonZeroU64::new(Self::DETACHED).unwrap())
+        Self::DETACHED
     }
 
-    /// Create a new span from a file id and a number.
-    ///
-    /// Returns `None` if `number` is not contained in `FULL`.
-    pub(crate) const fn from_number(id: FileId, number: u64) -> Option<Self> {
-        if number < Self::FULL.start || number >= Self::FULL.end {
-            return None;
-        }
-        Some(Self::pack(id, number))
+    /// Create a new span from a [`FileId`] and a [`SpanNumber`].
+    pub(crate) const fn from_number(id: FileId, SpanNumber(number): SpanNumber) -> Self {
+        debug_assert!(Self::FULL.start <= number);
+        debug_assert!(number < Self::FULL.end);
+        Self::pack(id, number)
     }
 
     /// Create a new span from a raw byte range instead of a span number.
     ///
-    /// If one of the range's parts exceeds the maximum value (2^23), it is
+    /// If one of the range's parts exceeds the maximum value of `2^23-1`, it is
     /// saturated.
     pub const fn from_range(id: FileId, range: Range<usize>) -> Self {
-        let max = 1 << Self::RANGE_PART_BITS;
-        let start = if range.start > max { max } else { range.start } as u64;
-        let end = if range.end > max { max } else { range.end } as u64;
-        let number = (start << Self::RANGE_PART_SHIFT) | end;
+        let start = saturate(range.start, Self::RANGE_VALUE_MAX);
+        let end = saturate(range.end, Self::RANGE_VALUE_MAX);
+        let number = (start << Self::RANGE_VALUE_BITS) | end;
         Self::pack(id, Self::RANGE_BASE + number)
     }
 
@@ -115,7 +136,7 @@ impl Span {
 
     /// Whether the span is detached.
     pub const fn is_detached(self) -> bool {
-        self.0.get() == Self::DETACHED
+        self.0.get() == Self::DETACHED.0.get()
     }
 
     /// The id of the file the span points into.
@@ -135,17 +156,19 @@ impl Span {
         self.0.get() & Self::NUMBER_MASK
     }
 
-    /// Extract a raw byte range from the span, if it is a raw range span.
+    /// Unpack the span into the variants of a [`SpanKind`] for easier use.
     ///
-    /// Typically, you should use `WorldExt::range` instead.
-    pub const fn range(self) -> Option<Range<usize>> {
-        let Some(number) = self.number().checked_sub(Self::RANGE_BASE) else {
-            return None;
-        };
-
-        let start = (number >> Self::RANGE_PART_SHIFT) as usize;
-        let end = (number & Self::RANGE_PART_MASK) as usize;
-        Some(start..end)
+    /// To access a range, you may want to use `WorldExt::range` instead.
+    pub const fn get(self) -> SpanKind {
+        let Some(id) = self.id() else { return SpanKind::Detached };
+        let num = self.number();
+        if let Some(packed_range) = num.checked_sub(Self::RANGE_BASE) {
+            let start = (packed_range >> Self::RANGE_VALUE_BITS) as usize;
+            let end = (packed_range & Self::RANGE_VALUE_MAX) as usize;
+            SpanKind::Range { id, range: start..end }
+        } else {
+            SpanKind::Number { id, num: SpanNumber(num) }
+        }
     }
 
     /// Extract the raw underlying number.
@@ -164,6 +187,12 @@ impl Span {
             .find(|span| !span.is_detached())
             .unwrap_or(Span::detached())
     }
+}
+
+/// Saturate a value at a given maximum. Can't use `.min()` since it isn't
+/// stable in const :/
+const fn saturate(value: usize, max: u64) -> u64 {
+    if value as u64 > max { max } else { value as u64 }
 }
 
 /// A value with a span locating it in the source code.
@@ -318,42 +347,39 @@ impl RangeMapper {
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroU16;
-    use std::ops::Range;
-
-    use super::{RangeMapper, Span};
-    use crate::FileId;
+    use super::*;
 
     #[test]
     fn test_span_detached() {
         let span = Span::detached();
         assert!(span.is_detached());
         assert_eq!(span.id(), None);
-        assert_eq!(span.range(), None);
     }
 
     #[test]
     fn test_span_number_encoding() {
         let id = FileId::from_raw(NonZeroU16::new(5).unwrap());
-        let span = Span::from_number(id, 10).unwrap();
+        let span = Span::from_number(id, SpanNumber(10));
         assert_eq!(span.id(), Some(id));
         assert_eq!(span.number(), 10);
-        assert_eq!(span.range(), None);
     }
 
     #[test]
     fn test_span_range_encoding() {
-        let id = FileId::from_raw(NonZeroU16::new(u16::MAX).unwrap());
+        let file_id = FileId::from_raw(NonZeroU16::new(u16::MAX).unwrap());
         let roundtrip = |range: Range<usize>| {
-            let span = Span::from_range(id, range.clone());
-            assert_eq!(span.id(), Some(id));
-            assert_eq!(span.range(), Some(range));
+            let span = Span::from_range(file_id, range.clone());
+            let SpanKind::Range { id, range: actual } = span.get() else {
+                panic!("bad span kind")
+            };
+            assert_eq!(id, file_id);
+            assert_eq!(actual, range);
         };
 
         roundtrip(0..0);
         roundtrip(177..233);
         roundtrip(0..8388607);
-        roundtrip(8388606..8388607);
+        roundtrip(8388606..8388607); // 2^23-2 .. 2^23-1
     }
 
     #[test]

--- a/crates/typst-syntax/src/span.rs
+++ b/crates/typst-syntax/src/span.rs
@@ -1,7 +1,8 @@
-use std::cmp::Ordering;
 use std::fmt::{self, Debug, Formatter};
 use std::num::{NonZeroU16, NonZeroU64};
 use std::ops::Range;
+
+use ecow::{EcoString, eco_format};
 
 use crate::FileId;
 
@@ -213,7 +214,17 @@ impl<T: Debug> Debug for Spanned<T> {
 /// source file (for instance, Typst code in a doc comment with start-of-line
 /// slashes).
 #[derive(Hash)]
-pub struct RangeMapper(Vec<(usize, Range<usize>)>);
+pub struct RangeMapper {
+    vec: Vec<Mapping>,
+    total: usize,
+}
+
+/// A mapping from an old index to a new one, guarantees that `old <= new`.
+#[derive(Hash, Clone, Copy)]
+struct Mapping {
+    old: usize,
+    new: usize,
+}
 
 impl RangeMapper {
     /// Creates a new range mapper.
@@ -223,44 +234,85 @@ impl RangeMapper {
     ///
     /// Segments should be in order. (The start of a later range must not
     /// precede the end of an earlier range.)
-    pub fn new(segments: impl IntoIterator<Item = Range<usize>>) -> Self {
-        let mut cursor = 0;
-        Self(
-            segments
-                .into_iter()
-                .map(|segment| {
-                    let pair = (cursor, segment.clone());
-                    cursor += segment.len();
-                    pair
-                })
-                .collect(),
-        )
+    ///
+    /// Note that this representation implies that ranges can only ever increase
+    /// in their start position and length when mapped.
+    pub fn new(
+        segments: impl IntoIterator<Item = Range<usize>>,
+    ) -> Result<Self, EcoString> {
+        let mut map = Mapping { old: 0, new: 0 };
+        let vec = segments
+            .into_iter()
+            .map(|Range { start, end }| {
+                if start > end || map.new > start {
+                    return Err(eco_format!("invalid mapper segment: ({start}, {end})"));
+                }
+                map.new = start;
+                let segment_map = map;
+                map.old += end - start;
+                Ok(segment_map)
+            })
+            .collect::<Result<Vec<Mapping>, EcoString>>()?;
+
+        if vec.is_empty() {
+            Ok(Self { vec: vec![map], total: 0 })
+        } else {
+            Ok(Self { vec, total: map.old })
+        }
+    }
+
+    /// The total length of the original text.
+    pub(crate) fn total_len(&self) -> usize {
+        self.total
     }
 
     /// Maps a range in the derived text back to a range in the original text.
     /// If the range spans over multiple segments, the gap between the two
     /// segments will be included in the resulting range.
-    pub fn map(&self, range: Range<usize>) -> Option<Range<usize>> {
-        let start = self.map_offset(range.start)?;
-        let end = self.map_offset(range.end)?;
-        Some(start..end)
+    ///
+    /// Input ranges must have  `start <= end`, and the caller should have
+    /// verified that `end <= self.total`.
+    pub(crate) fn map(&self, range: Range<usize>) -> Range<usize> {
+        debug_assert!(range.start <= range.end);
+        if range.end == 0 {
+            // Handles the panic case of `map_end`.
+            let offset = self.vec[0].new;
+            offset..offset
+        } else if range.start == range.end {
+            // If start/end are at a boundary, map them to the first position,
+            // not the second.
+            let offset = self.map_end(range.start);
+            offset..offset
+        } else {
+            // We now know that `start < end`, so the values from `map_start`
+            // and `map_end` must be non-overlapping.
+            let start = self.map_start(range.start);
+            let end = self.map_end(range.end);
+            start..end
+        }
     }
 
-    fn map_offset(&self, offset: usize) -> Option<usize> {
-        let idx = self
-            .0
-            .binary_search_by(|(at, segment)| {
-                if offset < *at {
-                    Ordering::Greater
-                } else if offset <= at + segment.len() {
-                    Ordering::Equal
-                } else {
-                    Ordering::Less
-                }
-            })
-            .ok()?;
-        let (at, segment) = &self.0[idx];
-        Some(segment.start + (offset - at))
+    /// Map a single offset, preferring the second index if at a boundary.
+    fn map_start(&self, offset: usize) -> usize {
+        let idx = self.vec.partition_point(|&Mapping { old, new: _ }| old <= offset);
+        // Subtracting by 1 is valid: vec is non-empty, index 0 has `old == 0`,
+        // and `partition_point` returns the index of the first item to fail the
+        // predicate (or the length), which is not index 0, since `0 <= usize`
+        // is true for all usize.
+        let Mapping { old, new } = &self.vec[idx - 1];
+        new + (offset - old)
+    }
+
+    /// Map a single offset, preferring the first index if at a boundary.
+    ///
+    /// This will panic if `offset` is 0.
+    fn map_end(&self, offset: usize) -> usize {
+        debug_assert_ne!(offset, 0);
+        let idx = self.vec.partition_point(|&Mapping { old, new: _ }| old < offset);
+        // Unlike `map_start`, this can yield index 0 when `offset == 0`, making
+        // `idx - 1` potentially panicking.
+        let Mapping { old, new } = &self.vec[idx - 1];
+        new + (offset - old)
     }
 }
 
@@ -309,14 +361,61 @@ mod tests {
         let base = "-- Hello\n-- world\n";
         let ranges = [(3..9), (12..18)];
         let mapped = ranges.iter().map(|r| &base[r.clone()]).collect::<String>();
-        let m = RangeMapper::new(ranges);
+        let m = RangeMapper::new(ranges).unwrap();
 
         assert_eq!(mapped, "Hello\nworld\n");
-        assert_eq!(m.map(2..3), Some(5..6));
-        // FIXME: End range should prefer earlier segment.
-        // assert_eq!(m.map(4..6), Some(7..9));
-        assert_eq!(m.map(6..8), Some(12..14));
-        assert_eq!(m.map(8..11), Some(14..17));
-        assert_eq!(m.map(2..12), Some(5..18));
+        assert_eq!(m.map(2..3), 5..6); // l -> l
+        assert_eq!(m.map(4..6), (7..9)); // o\n -> o\n
+        assert_eq!(m.map(6..8), (12..14)); // wo -> wo
+        assert_eq!(m.map(8..11), (14..17)); // rld -> rld
+        assert_eq!(m.map(2..12), (5..18)); // llo\n-- world\n -> llo\n-- world\n
+
+        // Empty ranges on boundaries:
+        assert_eq!(m.map(0..0), (3..3));
+        assert_eq!(m.map(6..6), (9..9)); // maps to the left of the boundary
+        assert_eq!(m.map(12..12), (18..18));
+    }
+
+    /// Small exhaustive edge case tests for the range mapper
+    #[test]
+    fn test_range_mapper_exhaustive() {
+        let empty = RangeMapper::new([]).unwrap();
+        assert_eq!(empty.map(0..0), 0..0);
+
+        let exact = RangeMapper::new(Some(0..1)).unwrap();
+        assert_eq!(exact.map(0..0), 0..0);
+        assert_eq!(exact.map(0..1), 0..1);
+        assert_eq!(exact.map(1..1), 1..1);
+
+        let plus = RangeMapper::new(Some(10..11)).unwrap();
+        assert_eq!(plus.map(0..0), 10..10);
+        assert_eq!(plus.map(0..1), 10..11);
+        assert_eq!(plus.map(1..1), 11..11);
+
+        let disjoint = RangeMapper::new([(10..11), (21..22)]).unwrap();
+        assert_eq!(disjoint.map(0..0), 10..10);
+        assert_eq!(disjoint.map(0..1), 10..11);
+        assert_eq!(disjoint.map(0..2), 10..22);
+        assert_eq!(disjoint.map(1..1), 11..11);
+        assert_eq!(disjoint.map(1..2), 21..22);
+        assert_eq!(disjoint.map(2..2), 22..22);
+
+        // disjoint with interspersed empty ranges.
+        let with_empty = RangeMapper::new([
+            (10..10),
+            (10..11),
+            (11..11),
+            (16..16),
+            (21..21),
+            (21..22),
+            (22..22),
+        ])
+        .unwrap();
+        assert_eq!(with_empty.map(0..0), 10..10);
+        assert_eq!(with_empty.map(0..1), 10..11);
+        assert_eq!(with_empty.map(0..2), 10..22);
+        assert_eq!(with_empty.map(1..1), 11..11);
+        assert_eq!(with_empty.map(1..2), 21..22);
+        assert_eq!(with_empty.map(2..2), 22..22);
     }
 }

--- a/docs/src/example.rs
+++ b/docs/src/example.rs
@@ -137,9 +137,9 @@ fn create_source(
         }
     }
 
-    let mapper = RangeMapper::new(ranges);
+    let mapper = RangeMapper::new(ranges).at(raw.span())?;
     let mut root = typst::syntax::parse(&compile);
-    root.synthesize_mapped(file_id, &mapper);
+    root.synthesize_mapped(file_id, &mapper).at(raw.span())?;
 
     Ok(Source::with_root(file_id, compile, root))
 }

--- a/docs/src/world.rs
+++ b/docs/src/world.rs
@@ -274,7 +274,7 @@ fn eval_mapped(
     /// that describes where in the `path` file a specific segment of the `text`
     /// is. The segments defined by the ranges are consecutive pieces of `text`.
     /// The sum of all `end - start` in `ranges` is the length of the `text`.
-    ranges: Vec<RangePair>,
+    ranges: Spanned<Vec<RangePair>>,
     /// The syntactical mode in which the string is parsed.
     #[named]
     #[default(SyntaxMode::Code)]
@@ -291,7 +291,12 @@ fn eval_mapped(
     }
 
     let id = path.v.resolve_if_some(path.span.id()).at(path.span)?.intern();
-    let mapper = RangeMapper::new(ranges.into_iter().map(|p| p.0));
+    let mapper = RangeMapper::new(ranges.v.into_iter().map(|p| p.0)).at(ranges.span)?;
+    let spans = SpanMode::Mapped {
+        id,
+        mapper: &mapper,
+        mapper_error_span: ranges.span,
+    };
 
     typst_eval::eval_string(
         engine.world,
@@ -300,7 +305,7 @@ fn eval_mapped(
         EmptyIntrospector.track(),
         Context::none().track(),
         &text,
-        SpanMode::Mapped { id, mapper: &mapper },
+        spans,
         mode,
         scope,
     )

--- a/tests/src/notes.rs
+++ b/tests/src/notes.rs
@@ -15,7 +15,9 @@ use typst::foundations::Bytes;
 use typst::{World, WorldExt as _};
 use typst_kit::files::FileLoader as _;
 use typst_syntax::package::PackageVersion;
-use typst_syntax::{FileId, Lines, RootedPath, Source, Span, VirtualPath, VirtualRoot};
+use typst_syntax::{
+    DiagSpan, DiagSpanKind, FileId, Lines, RootedPath, Source, VirtualPath, VirtualRoot,
+};
 use unscanny::Scanner;
 
 use crate::collect::{FilePos, TestParseError, TestStages};
@@ -214,7 +216,7 @@ impl Note {
         kind: NoteKind,
         stage: TestStages,
         message: &EcoString,
-        span: Span,
+        span: DiagSpan,
         world: &TestWorld,
     ) -> Self {
         let range = if let Some(file) = span.id()
@@ -231,7 +233,7 @@ impl Note {
                 positions: start..end,
             }
         } else {
-            assert!(span.is_detached());
+            assert!(matches!(span.get(), DiagSpanKind::Detached));
             NoteRange::None
         };
 

--- a/tests/src/run.rs
+++ b/tests/src/run.rs
@@ -779,20 +779,16 @@ impl<'a> Runner<'a> {
         self.test.body.mark_seen_or_update(emitted_diag);
 
         // Check hints.
-        for Spanned { v: hint, span } in &diag.hints {
+        for &Spanned { v: ref hint, span } in &diag.hints {
             // HACK: This hint only gets emitted in debug builds, so filter it
             // out to make the test suite also pass for release builds.
             if hint == "set `RUST_BACKTRACE` to `1` or `full` to capture a backtrace" {
                 continue;
             }
 
-            let emitted_hint = Note::emitted(
-                NoteKind::Hint,
-                stage,
-                hint,
-                span.or(diag.span),
-                &self.world,
-            );
+            let hint_span = if span.is_detached() { diag.span } else { span.into() };
+            let emitted_hint =
+                Note::emitted(NoteKind::Hint, stage, hint, hint_span, &self.world);
             self.test.body.mark_seen_or_update(emitted_hint);
         }
     }

--- a/tests/src/run.rs
+++ b/tests/src/run.rs
@@ -779,14 +779,14 @@ impl<'a> Runner<'a> {
         self.test.body.mark_seen_or_update(emitted_diag);
 
         // Check hints.
-        for &Spanned { v: ref hint, span } in &diag.hints {
+        for Spanned { v: hint, span } in &diag.hints {
             // HACK: This hint only gets emitted in debug builds, so filter it
             // out to make the test suite also pass for release builds.
             if hint == "set `RUST_BACKTRACE` to `1` or `full` to capture a backtrace" {
                 continue;
             }
 
-            let hint_span = if span.is_detached() { diag.span } else { span.into() };
+            let hint_span = span.or(diag.span);
             let emitted_hint =
                 Note::emitted(NoteKind::Hint, stage, hint, hint_span, &self.world);
             self.test.body.mark_seen_or_update(emitted_hint);


### PR DESCRIPTION
This PR adds sub-ranges for diagnostics, although does not add any uses of them yet. A following PR will add warnings for raw syntax that will make use of sub-ranges and sub-ranges on hints.

This PR is dependent on #8188. The first new commit is "Don't use raw range spans for imported files in `definition.rs`"

**Why are sub-ranges necessary?**
When we assign spans to a concrete syntax tree, we assign targetable numbers that correspond to a range in the source. However, spans only exist on full nodes in the tree, and do not allow targeting parts of a node, or ranges of text across multiple nodes. Adding sub-ranges gives us much more flexibility to create good diagnostic messages that target exactly the desired text.

**Why not use raw-range spans instead?**
Sub-ranges are relative to the overall range for a span so they aren't invalidated when we insert new text into the syntax tree when parsing incrementally. Absolute raw-ranges would need to be searched for and globally updated on every reparse.

**What else changed?**
- The new interface in `synthesize_with` evolves a lot over all of the commits, although I am open to changing it. However, leaving `InnerNode::synthesize_with` as a separate function caused too many non-local changes, so I just inlined it to `synthesize_with`.
- I updated the `RangeMapper` quite a bit and notably removed the `Option` from the range return by using `partition_point` and returning a result on construction if any invariants weren't followed.
- I added the `SpanNumber` type that solely interacts with the `Source::range` since sub-ranges add a new way to produce ranges that would have made `Source::range` taking a whole `Span` easy to use incorrectly.
- `SpanNumber` also made it easier to distinguish the kinds of `LinkedNode::find` operation, and I made it work for raw-range spans.
- Of course, there needed to be a way to get a `SpanNumber`, and I settled on a `.get()` method returning the new unpacked `SpanKind` enum that can be explicitly matched against.
- Sub-ranges get their own type as `SubRange` and use a `NonZeroU32` for the end index for null-optimization and to ensure they are non-empty ranges. Most uses take an `Option<SubRange>` which is conviently produced by `SubRange::new` requiring a non-empty range.
- However, sub-ranges are not meant to be stored in the document content, so I added `DiagSpan` and `DiagSpanKind` to distinguish diagnostic spans with sub-ranges from normal spans.
- `DiagSpan` containing an extra 64 bits also allows us to store larger ranges than just 23 bits for externally loaded files by storing a 46-bit start index within the `Span` and another 46-bit end index in the extra space.
- And this comes with no compromise for raw-range span sizes except fixing a bug where the start index could be `2^23` instead of saturating at `2^23-1` like the end index.
- In the syntax tree, only warnings get sub-ranges since they wrap other nodes instead of encompassing a node entirely like errors.
- However in the final commit, both warnings and errors are allowed sub-ranges on hints.
