### PR TITLE
Implement `Debug` for `typst_kit::package` types

### DIFF
--- a/crates/typst-kit/src/downloader.rs
+++ b/crates/typst-kit/src/downloader.rs
@@ -376,8 +376,8 @@ fn format_seconds(duration: Duration) -> impl Display {
     typst_utils::display(move |f| write!(f, "{} s", duration.as_secs()))
 }
 
-// Acknowledgement:
-// The `RemoteReader` is closely modelled after rustup's `DownloadTracker`.
+// Acknowledgment:
+// The `RemoteReader` is closely modeled after rustup's `DownloadTracker`.
 // https://github.com/rust-lang/rustup/blob/master/src/cli/download_tracker.rs
 
 /// Keep track of this many download speed samples.

--- a/crates/typst-kit/src/packages.rs
+++ b/crates/typst-kit/src/packages.rs
@@ -1,5 +1,6 @@
 //! Package loading.
 
+use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 
 use ecow::eco_format;
@@ -30,6 +31,7 @@ use {
 /// With default configuration, this loads packages from the same sources as the
 /// CLI.
 #[cfg(feature = "system-packages")]
+#[derive(Debug)]
 pub struct SystemPackages {
     data: Option<FsPackages>,
     cache: Option<FsPackages>,
@@ -146,6 +148,7 @@ impl SystemPackages {
 /// - Top-level directories denote namespaces
 /// - Second-level directories denote packages
 /// - Third-level directories denote package versions
+#[derive(Debug)]
 pub struct FsPackages(PathBuf);
 
 impl FsPackages {
@@ -277,6 +280,7 @@ impl FsPackages {
 
 /// A temporary directory that is automatically cleaned up.
 #[cfg(feature = "universe-packages")]
+#[derive(Debug)]
 struct Tempdir(PathBuf);
 
 #[cfg(feature = "universe-packages")]
@@ -431,6 +435,15 @@ impl UniversePackages {
                 }
             })
             .map(AsRef::as_ref)
+    }
+}
+
+#[cfg(feature = "universe-packages")]
+impl Debug for UniversePackages {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Downloader")
+            .field("url", &self.url)
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/typst-kit/src/packages.rs
+++ b/crates/typst-kit/src/packages.rs
@@ -275,7 +275,7 @@ impl FsPackages {
     }
 }
 
-/// A temporary directory that is a automatically cleaned up.
+/// A temporary directory that is automatically cleaned up.
 #[cfg(feature = "universe-packages")]
 struct Tempdir(PathBuf);
 
@@ -308,7 +308,7 @@ impl AsRef<Path> for Tempdir {
 /// with the official Typst Universe package registry.
 #[cfg(feature = "universe-packages")]
 pub struct UniversePackages {
-    /// The url of the registry.
+    /// The URL of the registry.
     url: String,
     /// A downloader with which we can download from the registry.
     downloader: Box<dyn Downloader>,

--- a/crates/typst-kit/src/watcher.rs
+++ b/crates/typst-kit/src/watcher.rs
@@ -48,7 +48,7 @@ impl Watcher {
     ///
     /// All writes to the `output` path will be ignored.
     pub fn new(output: Option<PathBuf>) -> StrResult<Self> {
-        // Setup file watching.
+        // Set up file watching.
         let (tx, rx) = std::sync::mpsc::channel();
 
         // Set the poll interval to something more eager than the default. That


### PR DESCRIPTION
Stumbled across these when refactoring tytanic, ironically I likely won't use them because the typst-kit stuff now does most of what I wrote there. But these seem useful to me nontheless.