### PR TITLE
Revert raw language tag changes temporarily with warnings for re-enabling in the future

### DIFF
--- a/crates/typst-library/src/text/raw.rs
+++ b/crates/typst-library/src/text/raw.rs
@@ -31,13 +31,19 @@ use crate::visualize::Color;
 /// Raw text with optional syntax highlighting.
 ///
 /// Displays the text verbatim and in a monospace font. This is typically used
-/// to embed computer code into your document.
+/// to embed computer code into a document.
 ///
-/// Note that text given to this element cannot contain arbitrary formatting,
-/// such as `[*strong*]` or `[_emphasis_]`, as it is displayed verbatim. If
-/// you'd like to display any kind of content with a monospace font, instead of
-/// using @raw, you should change its font to a monospace font using the @text
-/// function.
+/// Text given to this element will ignore markup syntax, such as `[*strong*]`
+/// or `[_emphasis_]`, and will be displayed verbatim. If you would like to
+/// display content with a monospace font while still allowing markup syntax,
+/// instead of using @raw, you can explicitly set the text font to a monospace
+/// font with the @text.font parameter.
+///
+/// Raw elements are mainly produced with their @raw:syntax[dedicated syntax] by
+/// enclosing text with either one or three-plus backtick characters (``` ` ```)
+/// on both sides. When using three or more backticks, text immediately after
+/// the initial backticks will be treated as a @raw.lang[language tag] used for
+/// syntax highlighting, and the raw text begins after the first whitespace.
 ///
 /// = Example <example>
 /// ````example
@@ -60,32 +66,16 @@ use crate::visualize::Color;
 /// ````
 ///
 /// You can also construct a @raw element programmatically from a string (and
-/// provide the language tag via the optional @raw.lang[`lang`] argument).
+/// provide the language tag via the optional @raw.lang[`lang`] parameter).
 ///
 /// ```example
 /// #raw("fn " + "main() {}", lang: "rust")
 /// ```
 ///
-/// = Syntax <syntax>
-/// This function also has dedicated syntax. You can enclose text in 1 or 3+
-/// backticks (``` ` ```) to make it raw. Two backticks produce empty raw text.
-/// This works both in markup and code.
-///
-/// When you use three or more backticks, you can additionally specify a
-/// language tag for syntax highlighting directly after the opening backticks.
-/// Within raw blocks, everything (except for the language tag, if applicable)
-/// is rendered as is, in particular, there are no escape sequences.
-///
-/// The language tag ends at the first whitespace or backtick. If your text
-/// starts with something that looks like an identifier, but no syntax
-/// highlighting is needed, start the text with a single space (which will be
-/// trimmed) or use the single backtick syntax. If your text should start or end
-/// with a backtick, put a space before or after it (it will be trimmed).
-///
 /// If no syntax highlighting is available by default for your specified
 /// language tag (or if you want to override the built-in definition), you may
 /// provide a custom syntax specification file to the @raw.syntaxes[`syntaxes`]
-/// field.
+/// parameter.
 ///
 /// = Styling <styling>
 /// By default, the `raw` element uses the `DejaVu Sans Mono` font (included
@@ -114,15 +104,150 @@ use crate::visualize::Color;
 /// ````
 ///
 /// In addition, you can customize the syntax highlighting colors by setting a
-/// custom theme through the @raw.theme[`theme`] field.
+/// custom theme through the @raw.theme[`theme`] parameter.
 ///
 /// For complete customization of the appearance of a raw block, a show rule on
 /// @raw.line could be helpful, such as to add line numbers.
 ///
-/// Note that, in raw text, typesetting features like
+/// Note that in raw text, typesetting features like
 /// @text.hyphenate[hyphenation], @text.overhang[overhang],
-/// @text.cjk-latin-spacing[CJK-Latin spacing] (and @par.justify[justification]
-/// for @raw.block[raw blocks]) will be disabled by default.
+/// @text.cjk-latin-spacing[CJK-Latin spacing], and (for raw blocks)
+/// @par.justify[justification] will be disabled by default.
+///
+/// = Syntax <syntax>
+/// This function has dedicated syntax that produces a raw element in both
+/// markup and code mode. You can enclose text in one or three-plus backtick
+/// characters (``` ` ```) on both sides to make it raw. The number of backticks
+/// must be the same on both sides, and the enclosed text cannot contain a group
+/// of that many backticks in a row. Writing just two backticks (``` `` ```)
+/// produces empty raw text.
+///
+/// Notable differences from Markdown include that single backticks can enclose
+/// text spanning multiple lines without removing indentation, and that the
+/// three-plus backtick syntax still interprets language tags when used inline.
+///
+/// Raw text enclosed in _single_ backticks has no way to specify a language tag
+/// and is always treated as inline for use within a paragraph, i.e. the
+/// @raw.block[`block`] parameter is `{false}`.
+///
+/// Raw syntax using _three or more_ backticks has the following properties:
+///
+/// - *After the initial backticks, the raw block is only terminated by a
+///   sequence of the same number of backticks*
+///
+///   To include text containing a sequence of backticks, the initial and final
+///   backticks must have at least one more backtick than the sequence.
+///
+/// - *If the raw text contains a linebreak, it will be block-level, otherwise
+///   it will be inline*
+///
+///   This sets the @raw.block[`block`] parameter to `{true}` or `{false}`
+///   accordingly.
+///
+/// - *Text immediately after the initial backticks, up to the first whitespace,
+///   is treated as a _language tag_ used for syntax highlighting*
+///
+///   The specific rules for which text can be treated as the language tag are
+///   planned to change, and are @raw:language-tag-changes[explained in detail
+///   below.]
+///
+/// - *The initial and final lines have special trimming behavior*
+///
+///   For the initial line, if all characters following the initial backticks or
+///   language tag are whitespace, the entire line will be trimmed. However, if
+///   there are non-whitespace characters on that line, only a single space
+///   immediately following the initial backticks or language tag will be
+///   trimmed if present.
+///
+///   If the final line is entirely whitespace up to the closing backticks, it
+///   will be trimmed. Otherwise, if the last non-whitespace character of the
+///   final line is a backtick, then one space character will be trimmed from
+///   the end of the line if present.
+///
+/// - *Common indentation at the beginning of lines is trimmed*
+///
+///   Typst will remove initial whitespace at the beginning of lines in the raw
+///   text that is shared between all lines, i.e. common indentation. Although
+///   this excludes text on the line with the initial backticks.
+///
+///   Typst first finds the line with the fewest initial whitespace characters
+///   that contains some non-whitespace characters, including the line with the
+///   closing backticks. Then Typst trims characters from every line equal to
+///   the number of initial whitespace characters in that line. Lines which are
+///   only whitespace will remove the same number of characters until they are
+///   empty, but will keep any extra trailing whitespace.
+///
+///   #let code-point = "https://www.unicode.org/glossary/#code_point"
+///
+///   Note that this check treats tabs and spaces as equivalent characters for
+///   simplicity, and that it operates on numbers of #link(code-point)[Unicode
+///   code points], i.e. characters, not on byte lengths.
+///
+/// These properties of the three-plus backtick syntax allow for some use cases
+/// that may not be obvious:
+///
+/// - To write text containing a sequence of backticks, enclose it with one or
+///   more backticks than the sequence:
+///   ````` ```` enclosed```backticks```` `````
+///
+/// - To write text that starts or ends with a backtick, add a space inside the
+///   opening and closing backticks: ```` ``` `backticks` ``` ````
+///
+/// - To write inline text highlighted with a language tag, add a space between
+///   the language tag and the text ````rust ```rust fn main() {}``` ````
+///
+/// - To write inline text without any language tag, add a space after the
+///   initial backticks: ```` ``` text``` ```` or use the single backtick
+///   syntax: ``` `text` ```
+///
+/// == Embedding strings with raw syntax <embedding-strings>
+/// A common use-case for raw syntax is to embed data as strings with formatting
+/// by accessing the `.text` field on raw content to get the underlying string.
+/// This may also be paired with the @bytes constructor to convert the string to
+/// bytes.
+///
+/// ````example
+/// An inline YAML dictionary via `.text`
+///
+/// #yaml(bytes(
+///   ```yaml
+///   Magic:
+///     limited-by: Mana
+///   Pokémon:
+///     limited-by: Energy
+///   Yu-Gi-Oh:
+///     limited-by: false
+///   ```.text
+///   //  ^^^^ used as a string
+/// ))
+/// ````
+///
+/// == Language tag changes <language-tag-changes>
+///
+/// When using raw syntax with three or more backticks, text immediately after
+/// the initial backticks (up to the first whitespace) is treated as a
+/// @raw.lang[language tag]. However in the current version of Typst, only text
+/// that would be a valid Typst identifier is treated as the language tag. The
+/// first character not valid for an identifier will be interpreted as starting
+/// the raw text.
+///
+/// For example, in the current verion of Typst, if a raw block starts with
+/// `C++`, the identifier `C` will be the language tag, and the raw text will
+/// start with `++`. If a raw block starts with `++C`, it will have no language
+/// tag and the raw text will start with `++C`.
+///
+/// To use language tags that are not valid as identifiers in the current
+/// version of Typst, you must use the @raw.lang[`lang`] parameter, either by
+/// calling the constructor with a string: ```typ #raw("text", lang: "...")```,
+/// or by writing a set rule: ```typ #set raw(lang: "...")```.
+///
+/// In the next version of Typst, _all text_ up to the first whitespace or
+/// backtick will be treated as the language tag, allowing a wider character set
+/// for language tags. Tags including spaces or backticks will still need to be
+/// set manually via the @raw.lang[`lang`] parameter.
+///
+/// Typst will alert you if your raw blocks will be interpreted differently in
+/// the next Typst version by emitting a warning.
 #[elem(
     scope,
     title = "Raw Text / Code",
@@ -196,7 +321,10 @@ pub struct RawElem {
     #[default(false)]
     pub block: bool,
 
-    /// The language to syntax-highlight in.
+    /// The language to interpret the raw text as for syntax highlighting.
+    ///
+    /// In @html[HTML export], this sets the `data-lang` attribute of the
+    /// generated @html.code element.
     ///
     /// Apart from typical language tags known from Markdown, this supports the
     /// `{"typ"}`, `{"typc"}`, and `{"typm"}` tags for

--- a/crates/typst-syntax/src/lexer.rs
+++ b/crates/typst-syntax/src/lexer.rs
@@ -186,8 +186,7 @@ impl Lexer<'_> {
 /// Raw.
 impl Lexer<'_> {
     /// We parse entire raw segments in the lexer as a convenience to avoid
-    /// going to and from the parser for each raw section. See comments in
-    /// [`Self::blocky_raw`] and [`Self::inline_raw`] for specific details.
+    /// going to and from the parser for each raw section.
     fn raw(&mut self) -> (SyntaxKind, SyntaxNode) {
         let start = self.s.cursor() - 1;
 
@@ -221,31 +220,56 @@ impl Lexer<'_> {
         }
         let end = self.s.cursor();
 
-        let mut nodes = Vec::with_capacity(3); // Will have at least 3.
-
-        // A closure for pushing a node onto our raw vector. Assumes the caller
-        // will move the scanner to the next location at each step.
-        let mut prev_start = start;
-        let mut push_raw = |kind, s: &Scanner| {
-            nodes.push(SyntaxNode::leaf(kind, s.from(prev_start)));
-            prev_start = s.cursor();
-        };
+        let mut inner = Scanner::new(self.s.get(start + backticks..end - backticks));
+        let inner_len = inner.string().len();
 
         // Opening delimiter.
-        self.s.jump(start + backticks);
-        push_raw(SyntaxKind::RawDelim, &self.s);
+        let delim = SyntaxNode::leaf(SyntaxKind::RawDelim, self.s.from(end - backticks));
+        let mut nodes = vec![delim.clone()];
 
-        if backticks >= 3 {
-            self.blocky_raw(end - backticks, &mut push_raw);
+        let mut tag = None;
+        let mut diff_future_tag_len = None;
+        if delim.len() >= 3 {
+            (tag, diff_future_tag_len) = Self::raw_lang_tag(&mut inner);
+            if let Some(tag) = tag {
+                nodes.push(SyntaxNode::leaf(SyntaxKind::RawLang, tag));
+            }
+            Self::blocky_raw(&mut inner, &mut nodes);
         } else {
-            self.inline_raw(end - backticks, &mut push_raw);
+            Self::inline_raw(&mut inner, &mut nodes);
         }
 
         // Closing delimiter.
-        self.s.jump(end);
-        push_raw(SyntaxKind::RawDelim, &self.s);
+        nodes.push(delim);
 
-        (SyntaxKind::Raw, SyntaxNode::inner(SyntaxKind::Raw, nodes))
+        let mut raw = SyntaxNode::inner(SyntaxKind::Raw, nodes);
+
+        Self::add_raw_warnings(&mut raw, backticks, diff_future_tag_len, tag, inner_len);
+
+        (SyntaxKind::Raw, raw)
+    }
+
+    /// Lex the raw language tag into an optional string and return the length
+    /// of the future language tag if it will differ in the next version.
+    ///
+    /// See [`Self::add_raw_warnings`] for more.
+    fn raw_lang_tag<'a>(s: &mut Scanner<'a>) -> (Option<&'a str>, Option<usize>) {
+        let start = s.cursor();
+        let future_tag = s.eat_until(|c: char| c.is_whitespace() || c == '`');
+        if future_tag.is_empty() {
+            // Future tag is always longer than current tag, if empty, we have
+            // no current tag either.
+            return (None, None);
+        }
+        s.jump(start);
+        let tag = s.eat_if(is_id_start).then(|| {
+            s.eat_while(is_id_continue);
+            s.from(start)
+        });
+        let diff_future_tag_len = tag
+            .is_none_or(|tag| tag.len() != future_tag.len())
+            .then_some(future_tag.len());
+        (tag, diff_future_tag_len)
     }
 
     /// Raw blocks parse a language tag, have smart behavior for trimming
@@ -254,7 +278,7 @@ impl Lexer<'_> {
     /// below.
     ///
     /// ### The initial line:
-    /// - Text until the first whitespace or backtick is parsed as the language tag.
+    /// - The language tag is already handled above.
     /// - We check the rest of the line and if all characters are whitespace,
     ///   trim it. Otherwise we trim a single leading space if present.
     ///   - If more trimmed characters follow on future lines, they will be
@@ -276,18 +300,9 @@ impl Lexer<'_> {
     /// - Otherwise its text is kept like an inner line. However, if the last
     ///   non-whitespace character of the final line is a backtick, then one
     ///   ascii space (if present) is trimmed from the end.
-    fn blocky_raw<F>(&mut self, inner_end: usize, mut push_raw: F)
-    where
-        F: FnMut(SyntaxKind, &Scanner),
-    {
-        // Language tag.
-        let tag = self.s.eat_until(|c: char| c.is_whitespace() || c == '`');
-        if !tag.is_empty() {
-            push_raw(SyntaxKind::RawLang, &self.s);
-        }
-
-        // The rest of the function operates on the lines between the backticks.
-        let mut lines = split_newlines(self.s.to(inner_end));
+    fn blocky_raw(s: &mut Scanner, nodes: &mut Vec<SyntaxNode>) {
+        // The lines between the backticks.
+        let mut lines = split_newlines(s.after());
 
         // Determine dedent level.
         let dedent = lines
@@ -313,6 +328,14 @@ impl Lexer<'_> {
             }
         }
 
+        // A closure for pushing a leaf node and updating the cursor in one
+        // step.
+        let mut prev = s.cursor();
+        let mut push_leaf = |kind, s: &Scanner| {
+            nodes.push(SyntaxNode::leaf(kind, s.from(prev)));
+            prev = s.cursor();
+        };
+
         let mut lines = lines.into_iter();
 
         // Handle the first line: trim if all whitespace, or trim a single space
@@ -320,11 +343,11 @@ impl Lexer<'_> {
         // value.
         if let Some(first_line) = lines.next() {
             if first_line.chars().all(char::is_whitespace) {
-                self.s.advance(first_line.len());
+                s.advance(first_line.len());
                 // This is the only spot we advance the scanner, but don't
-                // immediately call `push_raw`. But the rest of the function
+                // immediately call `push_leaf`. But the rest of the function
                 // ensures we will always add this text to a `RawTrimmed` later.
-                debug_assert!(self.s.cursor() != inner_end);
+                debug_assert!(!s.done());
                 // A proof by cases follows:
                 // # First case: The loop runs
                 // If the loop runs, there must be a newline following, so
@@ -342,51 +365,120 @@ impl Lexer<'_> {
                 //    by the last line must include at least a newline, so
                 //    `cursor != inner_end` here.
             } else {
-                let line_end = self.s.cursor() + first_line.len();
-                if self.s.eat_if(' ') {
-                    // Trim a single space after the lang tag on the first line.
-                    push_raw(SyntaxKind::RawTrimmed, &self.s);
+                let line_end = s.cursor() + first_line.len();
+                if s.eat_if(' ') {
+                    // Trim a single space after the lang tag or backticks on
+                    // the first line.
+                    push_leaf(SyntaxKind::RawTrimmed, s);
                 }
                 // We know here that the rest of the line is non-empty.
-                self.s.jump(line_end);
-                push_raw(SyntaxKind::Text, &self.s);
+                s.jump(line_end);
+                push_leaf(SyntaxKind::Text, s);
             }
         }
 
         // Add lines.
         for line in lines {
             let offset: usize = line.chars().take(dedent).map(char::len_utf8).sum();
-            self.s.eat_newline();
-            self.s.advance(offset);
-            push_raw(SyntaxKind::RawTrimmed, &self.s);
-            self.s.advance(line.len() - offset);
-            push_raw(SyntaxKind::Text, &self.s);
+            s.eat_newline();
+            s.advance(offset);
+            push_leaf(SyntaxKind::RawTrimmed, s);
+            s.advance(line.len() - offset);
+            push_leaf(SyntaxKind::Text, s);
         }
 
         // Add final trimmed.
-        if self.s.cursor() < inner_end {
-            self.s.jump(inner_end);
-            push_raw(SyntaxKind::RawTrimmed, &self.s);
+        if !s.done() {
+            nodes.push(SyntaxNode::leaf(SyntaxKind::RawTrimmed, s.after()));
         }
     }
 
     /// Inline raw text is split on lines with non-newlines as `Text` kinds and
     /// newlines as `RawTrimmed`. Inline raw text does not dedent the text, all
     /// non-newline whitespace is kept.
-    fn inline_raw<F>(&mut self, inner_end: usize, mut push_raw: F)
-    where
-        F: FnMut(SyntaxKind, &Scanner),
-    {
-        while self.s.cursor() < inner_end {
-            if self.s.at(is_newline) {
-                push_raw(SyntaxKind::Text, &self.s);
-                self.s.eat_newline();
-                push_raw(SyntaxKind::RawTrimmed, &self.s);
+    fn inline_raw(s: &mut Scanner, nodes: &mut Vec<SyntaxNode>) {
+        let mut prev = s.cursor();
+        while !s.done() {
+            if s.at(is_newline) {
+                nodes.push(SyntaxNode::leaf(SyntaxKind::Text, s.from(prev)));
+                prev = s.cursor();
+                s.eat_newline();
+                nodes.push(SyntaxNode::leaf(SyntaxKind::RawTrimmed, s.from(prev)));
+                prev = s.cursor();
                 continue;
             }
-            self.s.eat();
+            s.eat();
         }
-        push_raw(SyntaxKind::Text, &self.s);
+        nodes.push(SyntaxNode::leaf(SyntaxKind::Text, s.from(prev)));
+    }
+
+    /// Add warnings if the raw language tag will differ in the next version of
+    /// Typst or if there is a language tag but the raw text is empty.
+    ///
+    /// Currently, we parse the language tag only up to the end of a valid
+    /// identifier or the first whitespace. So if we start with `C++`, the
+    /// identifier `C` will be the language tag, and the raw text will start
+    /// with `++`. If we start with `++C`, we will have no language tag and the
+    /// raw text will start with `++C`.
+    ///
+    /// In the next version of Typst, we will parse all text up to the first
+    /// whitespace or backtick, so tags like `C++` or `html.j2` or `$!#%@` can
+    /// be written without issue
+    ///
+    /// However, this may cause some documents relying on the behavior of raw
+    /// text starting like `C++` or `++C` to change, so we are giving a warning
+    /// for those cases.
+    fn add_raw_warnings(
+        raw: &mut SyntaxNode,
+        backticks: usize,
+        diff_future_tag_len: Option<usize>,
+        tag: Option<&str>,
+        inner_len: usize,
+    ) {
+        // Add a warning if the tag will differ in the next version.
+        if let Some(future_tag_len) = diff_future_tag_len {
+            let future_range = backticks..backticks + future_tag_len;
+            if let Some(tag) = tag {
+                raw.warn_at(
+                    future_range,
+                    "no whitespace between language tag and raw text",
+                );
+                raw.hint(eco_format!(
+                    "currently, Typst is treating `{tag}` as the language tag"
+                ));
+                raw.hint(
+                    "in the next version of Typst, this will change and we will treat \
+                        all text until the first whitespace as the language tag",
+                );
+                let tag_range = backticks..backticks + tag.len();
+                raw.hint_at(tag_range.clone(), eco_format!(
+                    "if the current behavior is correct, please add a space after `{tag}`"
+                ));
+                raw.hint_at(
+                    tag_range,
+                    "otherwise, add a space or newline after the initial backticks",
+                );
+            } else {
+                raw.warn_at(future_range, "no whitespace before raw text");
+                raw.hint(
+                    "in the next version of Typst, this text will be treated as \
+                        the language tag for this element",
+                );
+                raw.hint("to avoid this, add a space after the initial backticks");
+            }
+        } else if let Some(tag) = tag
+            && inner_len == tag.len()
+        {
+            // Empty with no tag/ws is only possible with exactly two backticks,
+            // which is handled by the caller.
+            raw.warn("empty raw text");
+            raw.hint(eco_format!("Typst is treating `{tag}` as the language tag"));
+            let tag_range = backticks..backticks + tag.len();
+            raw.hint_at(
+                tag_range,
+                "to treat this as text, add a space after the initial backticks",
+            );
+        }
     }
 }
 

--- a/crates/typst-syntax/src/lexer.rs
+++ b/crates/typst-syntax/src/lexer.rs
@@ -183,71 +183,8 @@ impl Lexer<'_> {
     }
 }
 
-/// Markup.
+/// Raw.
 impl Lexer<'_> {
-    fn markup(&mut self, start: usize, c: char) -> SyntaxKind {
-        match c {
-            '\\' => self.backslash(),
-            'h' if self.s.eat_if("ttp://") => self.link(),
-            'h' if self.s.eat_if("ttps://") => self.link(),
-            '<' if self.s.at(is_id_continue) => self.label(),
-            '@' if self.s.at(is_id_continue) => self.ref_marker(),
-
-            '.' if self.s.eat_if("..") => SyntaxKind::Shorthand,
-            '-' if self.s.eat_if("--") => SyntaxKind::Shorthand,
-            '-' if self.s.eat_if('-') => SyntaxKind::Shorthand,
-            '-' if self.s.eat_if('?') => SyntaxKind::Shorthand,
-            '-' if self.s.at(char::is_numeric) => SyntaxKind::Shorthand,
-            '*' if !self.in_word() => SyntaxKind::Star,
-            '_' if !self.in_word() => SyntaxKind::Underscore,
-
-            '#' => SyntaxKind::Hash,
-            '[' => SyntaxKind::LeftBracket,
-            ']' => SyntaxKind::RightBracket,
-            '\'' => SyntaxKind::SmartQuote,
-            '"' => SyntaxKind::SmartQuote,
-            '$' => SyntaxKind::Dollar,
-            '~' => SyntaxKind::Shorthand,
-            ':' => SyntaxKind::Colon,
-            '=' => {
-                self.s.eat_while('=');
-                if self.space_or_end() { SyntaxKind::HeadingMarker } else { self.text() }
-            }
-            '-' if self.space_or_end() => SyntaxKind::ListMarker,
-            '+' if self.space_or_end() => SyntaxKind::EnumMarker,
-            '/' if self.space_or_end() => SyntaxKind::TermMarker,
-            '0'..='9' => self.numbering(start),
-
-            _ => self.text(),
-        }
-    }
-
-    fn backslash(&mut self) -> SyntaxKind {
-        if self.s.eat_if("u{") {
-            let hex = self.s.eat_while(char::is_ascii_alphanumeric);
-            if !self.s.eat_if('}') {
-                return self.error("unclosed Unicode escape sequence");
-            }
-
-            if u32::from_str_radix(hex, 16)
-                .ok()
-                .and_then(std::char::from_u32)
-                .is_none()
-            {
-                return self.error(eco_format!("invalid Unicode codepoint: {hex}"));
-            }
-
-            return SyntaxKind::Escape;
-        }
-
-        if self.s.done() || self.s.at(char::is_whitespace) {
-            SyntaxKind::Linebreak
-        } else {
-            self.s.eat();
-            SyntaxKind::Escape
-        }
-    }
-
     /// We parse entire raw segments in the lexer as a convenience to avoid
     /// going to and from the parser for each raw section. See comments in
     /// [`Self::blocky_raw`] and [`Self::inline_raw`] for specific details.
@@ -450,6 +387,72 @@ impl Lexer<'_> {
             self.s.eat();
         }
         push_raw(SyntaxKind::Text, &self.s);
+    }
+}
+
+/// Markup.
+impl Lexer<'_> {
+    fn markup(&mut self, start: usize, c: char) -> SyntaxKind {
+        match c {
+            '\\' => self.backslash(),
+            'h' if self.s.eat_if("ttp://") => self.link(),
+            'h' if self.s.eat_if("ttps://") => self.link(),
+            '<' if self.s.at(is_id_continue) => self.label(),
+            '@' if self.s.at(is_id_continue) => self.ref_marker(),
+
+            '.' if self.s.eat_if("..") => SyntaxKind::Shorthand,
+            '-' if self.s.eat_if("--") => SyntaxKind::Shorthand,
+            '-' if self.s.eat_if('-') => SyntaxKind::Shorthand,
+            '-' if self.s.eat_if('?') => SyntaxKind::Shorthand,
+            '-' if self.s.at(char::is_numeric) => SyntaxKind::Shorthand,
+            '*' if !self.in_word() => SyntaxKind::Star,
+            '_' if !self.in_word() => SyntaxKind::Underscore,
+
+            '#' => SyntaxKind::Hash,
+            '[' => SyntaxKind::LeftBracket,
+            ']' => SyntaxKind::RightBracket,
+            '\'' => SyntaxKind::SmartQuote,
+            '"' => SyntaxKind::SmartQuote,
+            '$' => SyntaxKind::Dollar,
+            '~' => SyntaxKind::Shorthand,
+            ':' => SyntaxKind::Colon,
+            '=' => {
+                self.s.eat_while('=');
+                if self.space_or_end() { SyntaxKind::HeadingMarker } else { self.text() }
+            }
+            '-' if self.space_or_end() => SyntaxKind::ListMarker,
+            '+' if self.space_or_end() => SyntaxKind::EnumMarker,
+            '/' if self.space_or_end() => SyntaxKind::TermMarker,
+            '0'..='9' => self.numbering(start),
+
+            _ => self.text(),
+        }
+    }
+
+    fn backslash(&mut self) -> SyntaxKind {
+        if self.s.eat_if("u{") {
+            let hex = self.s.eat_while(char::is_ascii_alphanumeric);
+            if !self.s.eat_if('}') {
+                return self.error("unclosed Unicode escape sequence");
+            }
+
+            if u32::from_str_radix(hex, 16)
+                .ok()
+                .and_then(std::char::from_u32)
+                .is_none()
+            {
+                return self.error(eco_format!("invalid Unicode codepoint: {hex}"));
+            }
+
+            return SyntaxKind::Escape;
+        }
+
+        if self.s.done() || self.s.at(char::is_whitespace) {
+            SyntaxKind::Linebreak
+        } else {
+            self.s.eat();
+            SyntaxKind::Escape
+        }
     }
 
     fn link(&mut self) -> SyntaxKind {

--- a/tests/suite/text/raw.typ
+++ b/tests/suite/text/raw.typ
@@ -68,6 +68,147 @@ The keyword ```rust let```.
         B
     ```
 
+--- raw-empty-inline eval ---
+#let raw = ``
+#test(raw.text, "")
+#test(raw.block, false)
+
+--- raw-empty-spaces eval ---
+#let raw = ```   ```
+#test(raw.text, "")
+#test(raw.block, false)
+
+--- raw-empty-newlines eval ---
+#let raw = ```
+
+
+```
+#test(raw.text, "\n")
+#test(raw.block, true)
+
+--- raw-newlines-backtick eval ---
+#let raw = ```
+
+`
+
+```
+#test(raw.text, "\n`\n")
+#test(raw.block, true)
+
+--- raw-backtick eval ---
+#let raw = ``` ` ```
+#test(raw.text, "`")
+#test(raw.block, false)
+
+--- raw-lang-backtick eval ---
+#let raw = ```js ` ```
+#test(raw.lang, "js")
+#test(raw.text, "`")
+#test(raw.block, false)
+
+--- raw-lang-space eval ---
+// The language tag stops at a space.
+#let raw = ```js test ```
+#test(raw.lang, "js")
+#test(raw.text, "test ")
+#test(raw.block, false)
+
+--- raw-lang-newline eval ---
+// The language tag stops at a newline.
+#let raw = ```js
+test
+```
+#test(raw.lang, "js")
+#test(raw.text, "test")
+#test(raw.block, true)
+
+--- raw-blocky eval ---
+// The first line and the last line are ignored.
+#let raw = {
+```
+test
+```
+}
+#test(raw.text, "test")
+#test(raw.block, true)
+
+--- raw-blocky-dedent eval ---
+// A blocky raw should handle dedents.
+#let raw = {
+```
+test
+```
+}
+#test(raw.text, "test")
+#test(raw.block, true)
+
+--- raw-blocky-dedent-firstline eval ---
+// When there is content in the first line, we discard a single whitespace char.
+#let raw = ``` test
+  ```
+#test(raw.text, "test")
+#test(raw.block, true)
+
+--- raw-blocky-dedent-firstline2 eval ---
+// When there is content in the first line, we discard a single whitespace char.
+#let raw = ``` test
+```
+#test(raw.text, "test")
+#test(raw.block, true)
+
+--- raw-blocky-dedent-firstline3 eval ---
+// The first line is not affected by dedent, and the middle lines don't consider
+// the whitespace prefix of the first line.
+#let raw = ``` test
+     test2
+  ```
+#test(raw.text, "test\n   test2")
+#test(raw.block, true)
+
+--- raw-blocky-dedent-firstline4 eval ---
+// The first line is not affected by dedent, and the middle lines don't consider
+// the whitespace prefix of the first line.
+#let raw = ```     test
+  test2
+  ```
+#test(raw.text, "    test\ntest2")
+#test(raw.block, true)
+
+--- raw-blocky-dedent-lastline eval ---
+#let raw = ```
+  test
+ ```
+#test(raw.text, " test")
+#test(raw.block, true)
+
+--- raw-blocky-dedent-lastline2 eval ---
+#let raw = ```
+  test
+  ```
+#test(raw.text, "test")
+#test(raw.block, true)
+
+--- raw-blocky-tab eval ---
+#let raw = {
+```
+	test
+```
+}
+#test(raw.text, "\ttest")
+#test(raw.block, true)
+
+--- raw-blocky-tab-dedent eval ---
+// This one is a bit problematic because there is a trailing tab below "test"
+// which the editor constantly wants to remove.
+#let raw = eval("```\n\ttest\n  \n ```")
+#test(raw.text, "test\n ")
+#test(raw.block, true)
+
+--- raw-extra-first-line-ws eval ---
+#let raw = eval("```   \n```")
+#test(raw.text, "")
+#test(raw.block, true)
+
 --- raw-tab-size paged ---
 #set raw(tab-size: 8)
 
@@ -359,213 +500,6 @@ int main() {
   {% endfor %}
 </tbody>
 ```
-
---- raw-blocky eval ---
-// Test various raw parsing edge cases.
-
-#let empty = (
-  name: "empty",
-  input: ``,
-  text: "",
-  block: false,
-)
-
-#let empty-spaces = (
-  name: "empty-spaces",
-  input: ```   ```,
-  text: "",
-  block: false,
-)
-
-#let empty-newlines = (
-  name: "empty-newlines",
-  input: ```
-
-
-```,
-  text: "\n",
-  block: true,
-)
-
-#let newlines-backtick = (
-  name: "newlines-backtick",
-  input: ```
-
-`
-
-```,
-  text: "\n`\n",
-  block: true,
-)
-
-#let backtick = (
-  name: "backtick",
-  input: ``` ` ```,
-  text: "`",
-  block: false,
-)
-
-#let lang-backtick = (
-  name: "lang-backtick",
-  input: ```js ` ```,
-  lang: "js",
-  text: "`",
-  block: false,
-)
-
-// The language tag stops on space
-#let lang-space = (
-  name: "lang-space",
-  input: ```js test ```,
-  lang: "js",
-  text: "test ",
-  block: false,
-)
-
-// The language tag stops on newline
-#let lang-newline = (
-  name: "lang-newline",
-  input: ```js
-test
-```,
-  lang: "js",
-  text: "test",
-  block: true,
-)
-
-// The first line and the last line are ignored
-#let blocky = (
-  name: "blocky",
-  input: {
-```
-test
-```
-},
-  text: "test",
-  block: true,
-)
-
-// A blocky raw should handle dedents
-#let blocky-dedent = (
-  name: "blocky-dedent",
-  input: {
-```
- test
- ```
-  },
-  text: "test",
-  block: true,
-)
-
-// When there is content in the first line, it should exactly eat a whitespace char.
-#let blocky-dedent-firstline = (
-  name: "blocky-dedent-firstline",
-  input: ``` test
-  ```,
-  text: "test",
-  block: true,
-)
-
-// When there is content in the first line, it should exactly eat a whitespace char.
-#let blocky-dedent-firstline2 = (
-  name: "blocky-dedent-firstline2",
-  input: ``` test
-```,
-  text: "test",
-  block: true,
-)
-
-// The first line is not affected by dedent, and the middle lines don't consider the whitespace prefix of the first line.
-#let blocky-dedent-firstline3 = (
-  name: "blocky-dedent-firstline3",
-  input: ``` test
-     test2
-  ```,
-  text: "test\n   test2",
-  block: true,
-)
-
-// The first line is not affected by dedent, and the middle lines don't consider the whitespace prefix of the first line.
-#let blocky-dedent-firstline4 = (
-  name: "blocky-dedent-firstline4",
-  input: ```     test
-  test2
-  ```,
-  text: "    test\ntest2",
-  block: true,
-)
-
-#let blocky-dedent-lastline = (
-  name: "blocky-dedent-lastline",
-  input: ```
-  test
- ```,
-  text: " test",
-  block: true,
-)
-
-#let blocky-dedent-lastline2 = (
-  name: "blocky-dedent-lastline2",
-  input: ```
-  test
-   ```,
-  text: "test",
-  block: true,
-)
-
-#let blocky-tab = (
-  name: "blocky-tab",
-  input: {
-```
-	test
-```
-},
-  text: "\ttest",
-  block: true,
-)
-
-// This one is a bit problematic because there is a trailing tab below "test"
-// which the editor constantly wants to remove.
-#let blocky-tab-dedent = (
-  name: "blocky-tab-dedent",
-  input: eval("```\n\ttest\n  \n ```"),
-  text: "test\n ",
-  block: true,
-)
-
-#let extra-first-line-ws = (
-  name: "extra-first-line-ws",
-  input: eval("```   \n```"),
-  text: "",
-  block: true,
-)
-
-#let cases = (
-  empty,
-  empty-spaces,
-  empty-newlines,
-  newlines-backtick,
-  backtick,
-  lang-backtick,
-  lang-space,
-  lang-newline,
-  blocky,
-  blocky-dedent,
-  blocky-dedent-firstline,
-  blocky-dedent-firstline2,
-  blocky-dedent-firstline3,
-  blocky-dedent-lastline,
-  blocky-dedent-lastline2,
-  blocky-tab,
-  blocky-tab-dedent,
-  extra-first-line-ws,
-)
-
-#for c in cases {
-  let block = c.block
-  assert.eq(c.text, c.input.text, message: "in point " + c.name + ", expect " + repr(c.text) + ", got " + repr(c.input.text) + "")
-  assert.eq(block, c.input.block, message: "in point " + c.name + ", expect " + repr(block) + ", got " + repr(c.input.block) + "")
-}
 
 --- raw-html html ---
 This is ```typ *inline*```.

--- a/tests/suite/text/raw.typ
+++ b/tests/suite/text/raw.typ
@@ -138,6 +138,9 @@ test
 #test(raw.block, true)
 
 --- raw-lang-no-text eval ---
+// Warning: 12-22 empty raw text
+// Hint: 12-22 Typst is treating `lang` as the language tag
+// Hint: 15-19 to treat this as text, add a space after the initial backticks
 #let raw = ```lang```
 #test(raw.lang, "lang")
 #test(raw.text, "")
@@ -145,16 +148,25 @@ test
 
 --- raw-lang-non-ident eval ---
 // The language tag does not have to be a valid identifier.
+// Warning: 15-25 no whitespace between language tag and raw text
+// Hint: 15-19 if the current behavior is correct, please add a space after `lang`
+// Hint: 15-19 otherwise, add a space or newline after the initial backticks
+// Hint: 15-25 currently, Typst is treating `lang` as the language tag
+// Hint: 15-25 in the next version of Typst, this will change and we will treat all text until the first whitespace as the language tag
 #let raw = ```lang.tag++ test```
-#test(raw.lang, "lang.tag++")
-#test(raw.text, "test")
+#test(raw.lang, "lang")
+#test(raw.text, ".tag++ test")
 #test(raw.block, false)
 
 --- raw-lang-starts-non-ident eval ---
 // Test the language tag starting with non-identifier characters.
+// Warning: 15-31 no whitespace before raw text
+// Hint: 15-31 in the next version of Typst, this text will be treated as the language tag for this element
+// Hint: 15-31 to avoid this, add a space after the initial backticks
 #let raw = ```!@#$%^&*()_+lang test```
-#test(raw.lang, "!@#$%^&*()_+lang")
-#test(raw.text, "test")
+#test(raw.text, "!@#$%^&*()_+lang test")
+// Error: 11-15 field "lang" in raw is not known at this point
+#test(raw.lang, none)
 #test(raw.block, false)
 
 --- raw-blocky eval ---
@@ -523,8 +535,9 @@ int main() {
 
 --- raw-highlight-html-jinja2 paged ---
 #set page(width: auto)
+// FUTURE: Convert to raw syntax when we re-enable non-identifier language tags
 
-```html.j2
+#raw(block: true, lang: "html.j2", ```
 <tbody>
   {% for row in data.rows %}
   <tr>
@@ -534,7 +547,7 @@ int main() {
   </tr>
   {% endfor %}
 </tbody>
-```
+```.text)
 
 --- raw-html html ---
 This is ```typ *inline*```.

--- a/tests/suite/text/raw.typ
+++ b/tests/suite/text/raw.typ
@@ -101,26 +101,61 @@ The keyword ```rust let```.
 #test(raw.block, false)
 
 --- raw-lang-backtick eval ---
-#let raw = ```js ` ```
-#test(raw.lang, "js")
+#let raw = ```lang ` ```
+#test(raw.lang, "lang")
 #test(raw.text, "`")
+#test(raw.block, false)
+
+--- raw-lang-backtick-no-space eval ---
+// The language tag stops at a backtick even without whitespace.
+// TODO: Do we want this behavior? It was not discussed in #7337.
+#let raw = ```lang`test ` ```
+#test(raw.lang, "lang")
+#test(raw.text, "`test `")
 #test(raw.block, false)
 
 --- raw-lang-space eval ---
 // The language tag stops at a space.
-#let raw = ```js test ```
-#test(raw.lang, "js")
+#let raw = ```lang test ```
+#test(raw.lang, "lang")
 #test(raw.text, "test ")
+#test(raw.block, false)
+
+--- raw-lang--multi-space eval ---
+// The language tag only discards one space.
+#let raw = ```lang  test```
+#test(raw.lang, "lang")
+#test(raw.text, " test")
 #test(raw.block, false)
 
 --- raw-lang-newline eval ---
 // The language tag stops at a newline.
-#let raw = ```js
+#let raw = ```lang
 test
 ```
-#test(raw.lang, "js")
+#test(raw.lang, "lang")
 #test(raw.text, "test")
 #test(raw.block, true)
+
+--- raw-lang-no-text eval ---
+#let raw = ```lang```
+#test(raw.lang, "lang")
+#test(raw.text, "")
+#test(raw.block, false)
+
+--- raw-lang-non-ident eval ---
+// The language tag does not have to be a valid identifier.
+#let raw = ```lang.tag++ test```
+#test(raw.lang, "lang.tag++")
+#test(raw.text, "test")
+#test(raw.block, false)
+
+--- raw-lang-starts-non-ident eval ---
+// Test the language tag starting with non-identifier characters.
+#let raw = ```!@#$%^&*()_+lang test```
+#test(raw.lang, "!@#$%^&*()_+lang")
+#test(raw.text, "test")
+#test(raw.block, false)
 
 --- raw-blocky eval ---
 // The first line and the last line are ignored.


### PR DESCRIPTION
This PR temporarily reverts the change to raw language tag parsing from #7337 to the current (0.14) behavior for 0.15. But since the change from #7337 is still desireable (and should land in 0.16), I've added warnings to raw blocks whose language tag would differ with the new behavior so that users are aware of the change before the switch. See [my comment on the PR](https://github.com/typst/typst/pull/7337#issuecomment-4337833842) for more motivation.

This PR is dependent on #8254, which is further dependent on #8188.
The first new commit is **"Convert single `raw-blocky` test into multiple eval tests"**

Here is an example of how the new warning will render in the CLI:
(this makes use of both warning sub-ranges and sub-ranges on hints!)
```txt
warning: no whitespace between language tag and text
  ┌─ <stdin>:1:14
  │
1 │ #let raw = ```lang.tag++ test```
  │               ^^^^^^^^^^
  │               │
  │               if the current behavior is correct, please add a space after `lang`
  │               otherwise, add a space or newline after the initial backticks
  │
  = hint: currently, Typst is treating `lang` as the language tag
  = hint: in the next version of Typst, this will change and we will treat all text until
the first whitespace as the language tag
```

You can see more warning cases in `tests/suite/raw.typ`, which I cleaned up by splitting the monolithic `raw-blocky`into individual tests alongside some new tests for this behavior. I'm not happy that there are three distinct, but similar warnings messages for the different cases, but I think each does a reasonable job of explaining the context and offering suggestions.

I also rewrote and cleaned up the top-level `raw` documentation, including greatly expanding the Syntax section and adding new sections for the language tag changes and an example I felt was missing on embedding strings in code mode using `.text` on raw syntax.

<details><summary>
You can open this dropdown to see the new raw docs (minus example images)
</summary>
<table>
<td>

## `raw`
Raw text with optional syntax highlighting.

Displays the text verbatim and in a monospace font. This is typically used to embed computer code into a document.

Text given to this element will ignore markup syntax, such as `*strong*` or `_emphasis_`, and will be displayed verbatim. If you would like to display content with a monospace font while still allowing markup syntax, instead of using [`raw`](https://typst.app/docs/reference/text/raw/#syntax), you can explicitly set the text font to a monospace font with the [`text.font`](https://typst.app/docs/reference/text/text/#parameters-font) parameter.

Raw elements are mainly produced with their [dedicated syntax](https://typst.app/docs/reference/text/raw/#syntax) by enclosing text with either one or three-plus backtick characters (``` ` ```) on both sides. When using three or more backticks, text immediately after the initial backticks will be treated as a [language tag](https://typst.app/docs/reference/text/raw/#parameters-lang) used for syntax highlighting, and the raw text begins after the first whitespace.

## Example
````typ
Adding `rbx` to `rcx` gives
the desired result.

What is ```rust fn main()``` in Rust
would be ```c int main()``` in C.

```rust
fn main() {
    println!("Hello World!");
}
```

This has ``` `backticks` ``` in it
(but the spaces are trimmed). And
``` here``` the leading space is
also trimmed.
````

You can also construct a [`raw`](https://typst.app/docs/reference/text/raw/) element programmatically from a string (and provide the language tag via the optional [`lang`](https://typst.app/docs/reference/text/raw/#parameters-lang) parameter).

```typ
#raw("fn " + "main() {}", lang: "rust")
```

If no syntax highlighting is available by default for your specified language tag (or if you want to override the built-in definition), you may provide a custom syntax specification file to the [`syntaxes`](https://typst.app/docs/reference/text/raw/#parameters-syntaxes) parameter.

## Styling
By default, the `raw` element uses the `DejaVu Sans Mono` font (included with Typst), with a smaller font size of `0.8em` (that is, 80% of the global font size). This is because monospace fonts tend to be visually larger than non-monospace fonts.

You can customize these properties with show-set rules:

````typ
// Switch to Cascadia Code for both
// inline and block raw.
#show raw: set text(font: "Cascadia Code")

// Reset raw blocks to the same size as normal text,
// but keep inline raw at the reduced size.
#show raw.where(block: true): set text(1em / 0.8)

Now using the `Cascadia Code` font for raw text.
Here's some Python code. It looks larger now:

```py
def python():
  return 5 + 5
```
````

In addition, you can customize the syntax highlighting colors by setting a custom theme through the [`theme`](https://typst.app/docs/reference/text/raw/#parameters-theme) parameter.

For complete customization of the appearance of a raw block, a show rule on [`raw.line`](https://typst.app/docs/reference/text/raw/#definitions-line) could be helpful, such as to add line numbers.

Note that in raw text, typesetting features like [hyphenation](https://typst.app/docs/reference/text/text/#parameters-hyphenate), [overhang](https://typst.app/docs/reference/text/text/#parameters-overhang), [CJK-Latin spacing](https://typst.app/docs/reference/text/text/#parameters-cjk-latin-spacing), and (for raw blocks) [justification](https://typst.app/docs/reference/model/par/#parameters-justify) will be disabled by default.

## Syntax
This function has dedicated syntax that produces a raw element in both markup and code mode. You can enclose text in one or three-plus backtick characters (``` ` ```) on both sides to make it raw. The number of backticks must be the same on both sides, and the enclosed text cannot contain a group of that many backticks in a row. Writing just two backticks (``` `` ```) produces an empty raw element.

This is intended to be similar to syntax found in other markup languages like Markdown, but has some notably different behaviors which make it more flexible: writing two backticks in a row makes it easy to produce an empty raw element, single backticks can enclose text spanning multiple lines without removing indentation, and the three-plus backtick syntax still interprets language tags when used inline.

Raw text enclosed in _single_ backticks has no way to specify a language tag and is always treated as inline for use within a paragraph, i.e. the [`block`](https://typst.app/docs/reference/text/raw/#parameters-block) parameter is `false`. However, the text may span multiple lines and will include the line breaks and indentation verbatim in its content (this is similar to the behavior of [strings](https://typst.app/docs/reference/foundations/str/)).

Raw syntax using _three or more_ backticks is meant to be more flexible and has the following smart behaviors for including text and trimming whitespace:

- **The text starts after the initial set of backticks and only ends when it encounters a group of the same number of backticks**

    This allows for enclosing text which itself contains backticks, which you can do by increasing the number of enclosing backticks until they exceed the largest group of backticks in the text itself. To enclose text containing a group of three backticks, use four or more backticks on either side.

- **The raw element can be inline or block-level based on linebreaks**

    If the text inside three or more backticks contains a linebreak character, it will produce a block-level element. If the text does not, it will produce an inline element. This sets the [`block`](https://typst.app/docs/reference/text/raw/#parameters-block) parameter to `true` or `false` accordingly.

- **Text immediately after the initial backticks (up to the first whitespace) is treated as a "language tag" for interpreting the raw text as code in that language**

    If any non-whitespace text follows on the initial line, a single (ASCII) space may be added after the language tag or immediately after the initial backticks to avoid treating the following text as part of the language tag. This space will be trimmed from the raw text if present.

    The specific rules for which text can be treated as the language tag are planned to change, and are [explained in detail below.](https://typst.app/docs/reference/text/raw/#language-tag-changes)

- **Common indentation in the text is trimmed so raw syntax can be used directly at any indentation level**

    In particular, the line which has any non-whitespace characters (including the line containing the closing backticks) that contains the least amount of leading whitespace characters determines the number of characters trimmed from the beginning of every line. Lines which are only whitespace will remove the same number of characters until they are empty, but do keep extra trailing whitespace.

    Note that this check treats tabs and spaces as equivalent characters for simplicity, and that it operates on numbers of [Unicode code points](https://www.unicode.org/glossary/#code_point), i.e. characters, not on byte lengths.

- **The initial and final lines trim whitespace specially**

    If all characters on the the initial line following the initial backticks or language tag are whitespace, they are trimmed from the raw text. Otherwise a single space character (if present) will be trimmed immediately following the initial backticks or language tag.

    If the final line (up to the closing backticks) is entirely whitespace, it is trimmed from the raw text. Otherwise, if the last non-whitespace character of the final line is a backtick, then one space character (if present) will be trimmed from the end.

    Trimming single spaces allows writing content that starts or ends with a backtick by adding a space inside the enclosing backticks. Trimming a space from the start allows using a space to separate a language tag from content on the initial line or to avoid including a language tag at all.

### Embedding strings with raw syntax
A common use-case for raw syntax is to embed data as strings with formatting by accessing the `.text` field on raw content to get the underlying string. This may also be paired with the [`bytes`](https://typst.app/docs/reference/foundations/bytes/) constructor to convert the string to bytes.

````typ
An inline YAML dictionary via `.text`

#yaml(bytes(
  ```yaml
  Magic:
    limited-by: Mana
  Pokémon:
    limited-by: Energy
  Yu-Gi-Oh:
    limited-by: false
  ```.text
  //  ^^^^ used as a string
))
````

### Language tag changes

When using raw syntax with three or more backticks, text immediately after the initial backticks (up to the first whitespace) is treated as a [language tag](https://typst.app/docs/reference/text/raw/#parameters-lang). However in the current version of Typst, only text that would be a valid Typst identifier is treated as the language tag. So if a raw block starts with `C++`, the identifier `C` will be the language tag, and the raw text will start with `++`. If a raw block starts with `++C`, it will have no language tag and the raw text will start with `++C`.

If you do want to use something like `C++`, `++C`, or `html.j2` as a language tag in the current version, you will need to use the [`lang`](https://typst.app/docs/reference/text/raw/#parameters-lang) parameter and pass in the raw text as a string. This can be aided by using a `set` rule, or by writing a raw block with no tag and using `.text` to access the contents as a string, but it can still be annoying.

In the next version of Typst, _all text_ up to the first whitespace or backtick will be treated as the language tag, so tags like `C++` or `html.j2` or `$!#%@` can be written without issue. Although tags including spaces or backticks will still need to be set manually via the [`lang`](https://typst.app/docs/reference/text/raw/#parameters-lang) parameter.

However, this may cause some documents relying on the behavior of raw text starting like `C++` or `++C` to change, so we are giving a warning for those cases. To silence the warning and keep the current behavior, you can add a single space after the intended language tag or, if no tag is intended, after the initial backticks.

</td>
</table>
</details> 

Please comment if you have any feedback on the warning messages or documentation!
