### PR TITLE
Use math in docs!

### DIFF
--- a/crates/typst-library/src/foundations/calc.rs
+++ b/crates/typst-library/src/foundations/calc.rs
@@ -155,7 +155,7 @@ pub fn pow(
     }
 }
 
-/// Raises a value to some exponent of e.
+/// Raises a value to some exponent of $e$.
 ///
 /// ```example
 /// #calc.exp(1)
@@ -201,9 +201,9 @@ pub fn sqrt(
     Ok(value.v.float().sqrt())
 }
 
-/// Calculates the real nth root of a number.
+/// Calculates the real $n$#super[th] root of a number.
 ///
-/// If the number is negative, then n must be odd.
+/// If the number is negative, then $n$ must be odd.
 ///
 /// ```example
 /// #calc.root(16.0, 4) \
@@ -213,7 +213,7 @@ pub fn sqrt(
 pub fn root(
     /// The expression to take the root of.
     radicand: f64,
-    /// Which root of the radicand to take.
+    /// The value of $n$.
     index: Spanned<i64>,
 ) -> SourceResult<f64> {
     if index.v == 0 {
@@ -300,7 +300,7 @@ pub fn tan(
 /// ```
 #[func(title = "Arcsine")]
 pub fn asin(
-    /// The number whose arcsine to calculate. Must be between -1 and 1.
+    /// The number whose arcsine to calculate. Must be between $-1$ and $1$.
     value: Spanned<Num>,
 ) -> SourceResult<Angle> {
     let val = value.v.float();
@@ -318,7 +318,7 @@ pub fn asin(
 /// ```
 #[func(title = "Arccosine")]
 pub fn acos(
-    /// The number whose arccosine to calculate. Must be between -1 and 1.
+    /// The number whose arccosine to calculate. Must be between $-1$ and $1$.
     value: Spanned<Num>,
 ) -> SourceResult<Angle> {
     let val = value.v.float();
@@ -344,7 +344,8 @@ pub fn atan(
 
 /// Calculates the four-quadrant arctangent of a coordinate.
 ///
-/// The arguments are `(x, y)`, not `(y, x)`.
+/// Note that contrary to the usual convention, this function accepts $(x, y)$
+/// instead of $(y, x)$.
 ///
 /// ```example
 /// #calc.atan2(1, 1) \
@@ -352,9 +353,9 @@ pub fn atan(
 /// ```
 #[func(title = "Four-quadrant Arctangent")]
 pub fn atan2(
-    /// The X coordinate.
+    /// The $x$ coordinate.
     x: Num,
-    /// The Y coordinate.
+    /// The $y$ coordinate.
     y: Num,
 ) -> Angle {
     Angle::atan2(y.float(), x.float())
@@ -425,7 +426,7 @@ pub fn asinh(
 #[func(title = "Inverse Hyperbolic Cosine")]
 pub fn acosh(
     /// The number whose inverse hyperbolic cosine to calculate. Must be greater
-    /// than or equal to 1.
+    /// than or equal to $1$.
     value: Spanned<f64>,
 ) -> SourceResult<f64> {
     let val = value.v;
@@ -444,7 +445,7 @@ pub fn acosh(
 #[func(title = "Inverse Hyperbolic Tangent")]
 pub fn atanh(
     /// The number whose inverse hyperbolic tangent to calculate. Must be
-    /// between -1 and 1 (exclusive).
+    /// between $-1$ and $1$ (exclusive).
     value: Spanned<f64>,
 ) -> SourceResult<f64> {
     let val = value.v;
@@ -1132,7 +1133,7 @@ pub fn quo(
     floor(divided).at(span)
 }
 
-/// Calculates the p-norm of a sequence of values.
+/// Calculates the $p$-norm of a sequence of values.
 ///
 /// ```example
 /// #calc.norm(1, 2, -3, 0.5) \
@@ -1140,11 +1141,11 @@ pub fn quo(
 /// ```
 #[func(title = "𝑝-Norm")]
 pub fn norm(
-    /// The p value to calculate the p-norm of.
+    /// The value of $p$. Must be greater than zero.
     #[named]
     #[default(Spanned::detached(2.0))]
     p: Spanned<f64>,
-    /// The sequence of values from which to calculate the p-norm. Returns `0.0`
+    /// The sequence of values to calculate the $p$-norm of. Returns `{0.0}`
     /// if empty.
     #[variadic]
     values: Vec<f64>,

--- a/crates/typst-library/src/foundations/calc.rs
+++ b/crates/typst-library/src/foundations/calc.rs
@@ -490,7 +490,7 @@ pub fn atanh(
 
 /// Calculates the logarithm of a number.
 ///
-/// If the base is not specified, the logarithm is calculated in base 10.
+/// If the base is not specified, the logarithm is calculated in base ten.
 ///
 /// ```example
 /// #calc.log(100)

--- a/crates/typst-library/src/foundations/calc.rs
+++ b/crates/typst-library/src/foundations/calc.rs
@@ -344,6 +344,9 @@ pub fn atan(
 
 /// Calculates the four-quadrant arctangent of a coordinate.
 ///
+/// The four-quadrant arctangent of $(x, y)$ is defined as the argument of the
+/// complex number $x + i y$.
+///
 /// Note that contrary to the usual convention, this function accepts $(x, y)$
 /// instead of $(y, x)$.
 ///
@@ -363,6 +366,11 @@ pub fn atan2(
 
 /// Calculates the hyperbolic sine of a hyperbolic angle.
 ///
+/// The hyperbolic sine of $x$ is defined as follows:
+/// $
+///   (e^x - e^(-x)) / 2
+/// $
+///
 /// ```example
 /// #calc.sinh(0) \
 /// #calc.sinh(1.5)
@@ -376,6 +384,11 @@ pub fn sinh(
 }
 
 /// Calculates the hyperbolic cosine of a hyperbolic angle.
+///
+/// The hyperbolic cosine of $x$ is defined as follows:
+/// $
+///   (e^x + e^(-x)) / 2
+/// $
 ///
 /// ```example
 /// #calc.cosh(0) \
@@ -391,6 +404,11 @@ pub fn cosh(
 
 /// Calculates the hyperbolic tangent of a hyperbolic angle.
 ///
+/// The hyperbolic tangent of $x$ is defined as follows:
+/// $
+///   (e^x - e^(-x)) / (e^x + e^(-x))
+/// $
+///
 /// ```example
 /// #calc.tanh(0) \
 /// #calc.tanh(1.5)
@@ -405,6 +423,11 @@ pub fn tanh(
 
 /// Calculates the inverse hyperbolic sine of a number.
 ///
+/// The inverse hyperbolic sine of $x$ is defined as follows:
+/// $
+///   ln(x + sqrt(x^2 + 1))
+/// $
+///
 /// ```example
 /// #calc.asinh(0) \
 /// #calc.asinh(1)
@@ -418,6 +441,11 @@ pub fn asinh(
 }
 
 /// Calculates the inverse hyperbolic cosine of a number.
+///
+/// The inverse hyperbolic cosine of $x$ is defined as follows:
+/// $
+///   ln(x + sqrt(x^2 - 1))
+/// $
 ///
 /// ```example
 /// #calc.acosh(1) \
@@ -437,6 +465,11 @@ pub fn acosh(
 }
 
 /// Calculates the inverse hyperbolic tangent of a number.
+///
+/// The inverse hyperbolic tangent of $x$ is defined as follows:
+/// $
+///   1/2 ln((1 + x) / (1 - x))
+/// $
 ///
 /// ```example
 /// #calc.atanh(0) \
@@ -524,12 +557,17 @@ pub fn ln(
 
 /// Applies the error function to a number.
 ///
+/// The value of the error function at $x$ is defined as follows:
+/// $
+///   2 / sqrt(pi) integral_0^x e^(-t^2) dif t
+/// $
+///
 /// ```example
 /// #calc.erf(0.2)
 /// ```
 #[func(title = "Error function")]
 pub fn erf(
-    /// The number whose error function to calculate.
+    /// The number at which to calculate the error function.
     value: f64,
 ) -> f64 {
     libm::erf(value)
@@ -550,18 +588,23 @@ pub fn fact(
 
 /// Calculates a permutation.
 ///
-/// Returns the `k`-permutation of `n`, or the number of ways to choose `k`
-/// items from a set of `n` with regard to order.
+/// Returns the $k$-permutation of $n$, or the number of ways to choose $k$
+/// items from a set of $n$ with regard to order, defined as follows:
+/// $
+///   cases(
+///     0 quad &"if" k > n,
+///     (n!) / ((n - k)!) quad &"if" k <= n,
+///   )
+/// $
 ///
 /// ```example
-/// $ "perm"(n, k) &= n!/((n - k)!) \
-///   "perm"(5, 3) &= #calc.perm(5, 3) $
+/// #calc.perm(5, 3)
 /// ```
 #[func(title = "Permutation")]
 pub fn perm(
-    /// The base number. Must be non-negative.
+    /// The value of $n$. Must be non-negative.
     base: u64,
-    /// The number of permutations. Must be non-negative.
+    /// The value of $k$. Must be non-negative.
     numbers: u64,
 ) -> StrResult<i64> {
     // By convention.
@@ -591,17 +634,23 @@ fn fact_impl(start: u64, end: u64) -> Option<i64> {
 
 /// Calculates a binomial coefficient.
 ///
-/// Returns the `k`-combination of `n`, or the number of ways to choose `k`
-/// items from a set of `n` without regard to order.
+/// Returns the $k$-combination of $n$, or the number of ways to choose $k$
+/// items from a set of $n$ without regard to order, defined as follows:
+/// $
+///   cases(
+///     (n!) / (k! (n - k)!) quad &"if" 0 <= k <= n,
+///     0 quad &"otherwise",
+///   )
+/// $
 ///
 /// ```example
 /// #calc.binom(10, 5)
 /// ```
 #[func(title = "Binomial")]
 pub fn binom(
-    /// The upper coefficient. Must be non-negative.
+    /// The value of $n$. Must be non-negative.
     n: u64,
-    /// The lower coefficient. Must be non-negative.
+    /// The value of $k$. Must be non-negative.
     k: u64,
 ) -> StrResult<i64> {
     Ok(binom_impl(n, k).ok_or_else(too_large)?)
@@ -1135,6 +1184,15 @@ pub fn quo(
 
 /// Calculates the $p$-norm of a sequence of values.
 ///
+/// The $p$-norm of $x_1, ..., x_n$ is defined as follows:
+/// $
+///   cases(
+///     (sum_(i=1)^n abs(x_i)^p)^frac(style: "horizontal", 1, p)
+///       quad &"if" 0 < p < +oo,
+///     max_(i=1)^n abs(x_i) quad &"if" p = +oo,
+///   )
+/// $
+///
 /// ```example
 /// #calc.norm(1, 2, -3, 0.5) \
 /// #calc.norm(p: 3, 1, 2)
@@ -1142,6 +1200,11 @@ pub fn quo(
 #[func(title = "𝑝-Norm")]
 pub fn norm(
     /// The value of $p$. Must be greater than zero.
+    ///
+    /// The default value of `{2.0}` corresponds to the Euclidean norm:
+    /// $
+    ///   sqrt(sum_(i=1)^n x_i^2)
+    /// $
     #[named]
     #[default(Spanned::detached(2.0))]
     p: Spanned<f64>,

--- a/crates/typst-library/src/foundations/calc.rs
+++ b/crates/typst-library/src/foundations/calc.rs
@@ -565,7 +565,7 @@ pub fn ln(
 /// ```example
 /// #calc.erf(0.2)
 /// ```
-#[func(title = "Error function")]
+#[func(title = "Error Function")]
 pub fn erf(
     /// The number at which to calculate the error function.
     value: f64,

--- a/crates/typst-library/src/foundations/calc.rs
+++ b/crates/typst-library/src/foundations/calc.rs
@@ -349,8 +349,7 @@ pub fn atan(
 ///
 /// Returns an @angle between `{-180deg}` and `{180deg}`.
 ///
-/// Note that contrary to the usual convention, this function accepts $(x, y)$
-/// instead of $(y, x)$.
+/// Note that this function accepts $(x, y)$, not $(y, x)$.
 ///
 /// ```example
 /// #calc.atan2(1, 1) \

--- a/crates/typst-library/src/foundations/calc.rs
+++ b/crates/typst-library/src/foundations/calc.rs
@@ -603,9 +603,10 @@ pub fn fact(
 /// ```
 #[func(title = "Permutation")]
 pub fn perm(
-    /// The value of $n$. Must be non-negative.
+    /// The value of $n$: The number of items to choose from. Must be
+    /// non-negative.
     base: u64,
-    /// The value of $k$. Must be non-negative.
+    /// The value of $k$: The number of items to choose. Must be non-negative.
     numbers: u64,
 ) -> StrResult<i64> {
     // By convention.
@@ -649,9 +650,10 @@ fn fact_impl(start: u64, end: u64) -> Option<i64> {
 /// ```
 #[func(title = "Binomial")]
 pub fn binom(
-    /// The value of $n$. Must be non-negative.
+    /// The value of $n$: The numbers of items to choose from. Must be
+    /// non-negative.
     n: u64,
-    /// The value of $k$. Must be non-negative.
+    /// The value of $k$: The number of items to choose. Must be non-negative.
     k: u64,
 ) -> StrResult<i64> {
     Ok(binom_impl(n, k).ok_or_else(too_large)?)

--- a/crates/typst-library/src/foundations/calc.rs
+++ b/crates/typst-library/src/foundations/calc.rs
@@ -368,9 +368,7 @@ pub fn atan2(
 /// Calculates the hyperbolic sine of a hyperbolic angle.
 ///
 /// The hyperbolic sine of $x$ is defined as follows:
-/// $
-///   (e^x - e^(-x)) / 2
-/// $
+/// $ (e^x - e^(-x)) / 2 $
 ///
 /// ```example
 /// #calc.sinh(0) \
@@ -387,9 +385,7 @@ pub fn sinh(
 /// Calculates the hyperbolic cosine of a hyperbolic angle.
 ///
 /// The hyperbolic cosine of $x$ is defined as follows:
-/// $
-///   (e^x + e^(-x)) / 2
-/// $
+/// $ (e^x + e^(-x)) / 2 $
 ///
 /// ```example
 /// #calc.cosh(0) \
@@ -406,9 +402,7 @@ pub fn cosh(
 /// Calculates the hyperbolic tangent of a hyperbolic angle.
 ///
 /// The hyperbolic tangent of $x$ is defined as follows:
-/// $
-///   (e^x - e^(-x)) / (e^x + e^(-x))
-/// $
+/// $ (e^x - e^(-x)) / (e^x + e^(-x)) $
 ///
 /// ```example
 /// #calc.tanh(0) \
@@ -425,9 +419,7 @@ pub fn tanh(
 /// Calculates the inverse hyperbolic sine of a number.
 ///
 /// The inverse hyperbolic sine of $x$ is defined as follows:
-/// $
-///   ln(x + sqrt(x^2 + 1))
-/// $
+/// $ ln(x + sqrt(x^2 + 1)) $
 ///
 /// ```example
 /// #calc.asinh(0) \
@@ -444,9 +436,7 @@ pub fn asinh(
 /// Calculates the inverse hyperbolic cosine of a number.
 ///
 /// The inverse hyperbolic cosine of $x$ is defined as follows:
-/// $
-///   ln(x + sqrt(x^2 - 1))
-/// $
+/// $ ln(x + sqrt(x^2 - 1)) $
 ///
 /// ```example
 /// #calc.acosh(1) \
@@ -468,9 +458,7 @@ pub fn acosh(
 /// Calculates the inverse hyperbolic tangent of a number.
 ///
 /// The inverse hyperbolic tangent of $x$ is defined as follows:
-/// $
-///   1/2 ln((1 + x) / (1 - x))
-/// $
+/// $ 1/2 ln((1 + x) / (1 - x)) $
 ///
 /// ```example
 /// #calc.atanh(0) \
@@ -559,9 +547,7 @@ pub fn ln(
 /// Applies the error function to a number.
 ///
 /// The value of the error function at $x$ is defined as follows:
-/// $
-///   2 / sqrt(pi) integral_0^x e^(-t^2) dif t
-/// $
+/// $ 2 / sqrt(pi) integral_0^x e^(-t^2) dif t $
 ///
 /// ```example
 /// #calc.erf(0.2)
@@ -1205,9 +1191,7 @@ pub fn norm(
     /// The value of $p$. Must be greater than zero.
     ///
     /// The default value of `{2.0}` corresponds to the Euclidean norm:
-    /// $
-    ///   sqrt(sum_(i=1)^n x_i^2)
-    /// $
+    /// $ sqrt(sum_(i=1)^n x_i^2) $
     #[named]
     #[default(Spanned::detached(2.0))]
     p: Spanned<f64>,

--- a/crates/typst-library/src/foundations/calc.rs
+++ b/crates/typst-library/src/foundations/calc.rs
@@ -347,6 +347,8 @@ pub fn atan(
 /// The four-quadrant arctangent of $(x, y)$ is defined as the argument of the
 /// complex number $x + i y$.
 ///
+/// Returns an @angle between `{-180deg}` and `{180deg}`.
+///
 /// Note that contrary to the usual convention, this function accepts $(x, y)$
 /// instead of $(y, x)$.
 ///

--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -169,6 +169,11 @@ dd {
   margin-inline: 0px;
 }
 
+math {
+  font-family: "NewComputerModernMath", math;
+  font-size: 1.1em;
+}
+
 main table {
   border-collapse: collapse;
   margin-block: 16px;

--- a/docs/components/styling.typ
+++ b/docs/components/styling.typ
@@ -55,7 +55,8 @@
   // Here, we cancel the compiler default.
   show raw: set text(size: 1em / 0.8, font: (fonts.mono, ..fonts.fallback))
 
-  show math.equation: set text(font: "New Computer Modern Math", size: 1.1em)
+  // A bit larger font size make this a better pairing with HK Grotesk.
+  show math.equation: set text(font: fonts.math, size: sizes.math)
 
   // Outline entries pick the short versions of content which makes use of
   // the `short-or-long` component.

--- a/docs/components/styling.typ
+++ b/docs/components/styling.typ
@@ -55,6 +55,8 @@
   // Here, we cancel the compiler default.
   show raw: set text(size: 1em / 0.8, font: (fonts.mono, ..fonts.fallback))
 
+  show math.equation: set text(font: "New Computer Modern Math", size: 1.1em)
+
   // Outline entries pick the short versions of content which makes use of
   // the `short-or-long` component.
   show outline: with-short-versions

--- a/docs/components/system.typ
+++ b/docs/components/system.typ
@@ -51,6 +51,7 @@
 #let fonts = (
   body: "HK Grotesk",
   mono: "Cascadia Mono",
+  math: "New Computer Modern Math",
   fallback: ("Noto Serif CJK SC",),
 )
 
@@ -58,6 +59,7 @@
 #let sizes = (
   body: 9pt,
   mono: 0.9em,
+  math: 1.1em,
   small: 0.85em,
 )
 


### PR DESCRIPTION
With https://github.com/typst/typst/pull/7436 now merged, we can use math equations in the documentation.

I took the opportunity to properly define the less common mathematical functions from `calc`.

As suggested by Laurenz on Discord,[^1] I used New Computer Modern Math for the math font. Notably, this is a serif font, while the text font is a sans serif font. Noto Sans Math is a good candidate for a font that looks like the text font.

Example of a result (here in the PDF documentation):
<img width="1308" height="989" alt="The doc for `calc.norm`, containing a block mathematical equation defining the p-norm and the special case of the Euclidean norm when p = 2." src="https://github.com/user-attachments/assets/1f41d2af-101f-4515-aeac-3f0abb2f8bbd" />


[^1]: https://discord.com/channels/1054443721975922748/1088371867913572452/1496184132445929613