### PR TITLE
Fix URI inside documentation for creation-timestamp

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -412,7 +412,7 @@ pub struct WorldArgs {
 
     /// The document's creation date formatted as a UNIX timestamp.
     ///
-    /// For more information, see <https://reproducible-builds.org/specs/source-date-epoch/>.
+    /// For more information, see <https://reproducible-builds.org/docs/source-date-epoch/>.
     #[clap(
         long = "creation-timestamp",
         env = "SOURCE_DATE_EPOCH",

--- a/crates/typst-library/src/foundations/datetime.rs
+++ b/crates/typst-library/src/foundations/datetime.rs
@@ -358,7 +358,7 @@ impl Datetime {
     ///
     /// In the CLI, this can be overridden with the `--creation-timestamp`
     /// argument or by setting the
-    /// #link("https://reproducible-builds.org/specs/source-date-epoch/")[`SOURCE_DATE_EPOCH`]
+    /// #link("https://reproducible-builds.org/docs/source-date-epoch/")[`SOURCE_DATE_EPOCH`]
     /// environment variable. In both cases, the value should be given as a UNIX
     /// timestamp.
     ///


### PR DESCRIPTION
<!--
Thanks for your interest in landing a change in Typst! Before opening the PR, please review our contribution guidelines: https://github.com/typst/typst/blob/main/CONTRIBUTING.md

In particular, please keep in mind that we do not accept contributions implemented by an AI model. We would also ask you to refrain from using AI to write your pull request description. Summarizing your work helps organizing your thoughts as much as it helps us with seeing the human thought process behind a particular change.
-->
URI `https://reproducible-builds.org/specs/...` changed to use `docs` instead of `specs`.

Related:
- PR (https://github.com/typst/typst/pull/7311)
- Commit 7ed54a5