### PR TITLE
Add copy button to code examples in documentation

### DIFF
--- a/docs/assets/base.css
+++ b/docs/assets/base.css
@@ -153,6 +153,7 @@ The `url()` routes are replaced to include the docs base paths.
   --action-secondary-hover: rgba(228, 229, 234, 1);
   --brand: #239dad;
   --text-primary: rgba(25, 24, 31, 1);
+  --text-disabled: rgba(25, 24, 31, 0.5);
   --text-c-comment: #74747c;
   --text-c-monospace: #6b6b6f;
   --text-c-math-delim: #198810;

--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -301,15 +301,45 @@ sup[role="doc-noteref"] {
 
 /* Code example components */
 
-pre > button.copy {
-  top: -8px;
-  right: -8px;
-  padding: 2px;
-  background: none;
-  border: 0px;
+pre {
   position: relative;
+}
+
+pre > button.copy {
+  top: 8px;
+  right: 8px;
+  padding: 8px;
+  background: #fdfdfd;
+  border: 1px solid var(--border-secondary);
+  color: #565565; /* Should be var(--text-secondary) */
+  position: absolute;
   float: right;
   cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+pre:hover > button.copy,
+pre > button.copy:active,
+pre > button.copy:focus-visible {
+  opacity: 1;
+}
+
+pre > button.copy:hover {
+  background: var(--action-secondary-hover);
+}
+
+pre > button.copy:focus-visible {
+  background: #fdfdfd;
+  transition: opacity 0s;
+}
+
+pre > button.copy:disabled {
+  color: rgba(25, 24, 31, 0.5) /* Should be var(--text-disabled) */
+}
+
+pre > button.copy > svg {
+  display: block;
 }
 
 .code-definition + h4,

--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -311,7 +311,7 @@ pre > button.copy {
   padding: 8px;
   background: #fdfdfd;
   border: 1px solid var(--border-secondary);
-  color: #565565; /* Should be var(--text-secondary) */
+  color: var(--text-primary);
   position: absolute;
   float: right;
   cursor: pointer;

--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -319,7 +319,6 @@ pre > button.copy {
   transition: opacity 0.2s;
 }
 
-pre:hover > button.copy,
 pre > button.copy:active,
 pre > button.copy:focus-visible {
   opacity: 1;
@@ -336,6 +335,18 @@ pre > button.copy:focus-visible {
 
 pre > button.copy:disabled {
   color: rgba(25, 24, 31, 0.5) /* Should be var(--text-disabled) */
+}
+
+@media (hover: hover) {
+  pre:hover > button.copy {
+    opacity: 1;
+  }
+}
+
+@media (hover: none) {
+  pre.tapped > button.copy {
+    opacity: 1;
+  }
 }
 
 pre > button.copy > svg {

--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -316,11 +316,11 @@ pre > button.copy {
   float: right;
   cursor: pointer;
   opacity: 0;
-  transition: opacity 0.2s;
+  transition: opacity 0.2s ease-in-out;
 }
 
 pre > button.copy:active,
-pre > button.copy:focus-visible {
+pre > button.copy:focus {
   opacity: 1;
 }
 

--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -334,7 +334,7 @@ pre > button.copy:focus-visible {
 }
 
 pre > button.copy:disabled {
-  color: rgba(25, 24, 31, 0.5) /* Should be var(--text-disabled) */
+  color: var(--text-disabled);
 }
 
 @media (hover: hover) {

--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -301,6 +301,17 @@ sup[role="doc-noteref"] {
 
 /* Code example components */
 
+pre > button.copy {
+  top: -8px;
+  right: -8px;
+  padding: 2px;
+  background: none;
+  border: 0px;
+  position: relative;
+  float: right;
+  cursor: pointer;
+}
+
 .code-definition + h4,
 .previewed-code + h4 {
   margin-block-start: 28px;

--- a/docs/assets/docs.js
+++ b/docs/assets/docs.js
@@ -428,18 +428,13 @@ function setUpPreviewSplits() {
  * Sets up the Copy button on example codes.
  */
 function setUpPreviewCopy() {
-  for (const pre of document.querySelectorAll(".previewed-code > pre")) {
+  for (const button of document.querySelectorAll("pre > button.copy")) {
+    const pre = button.parentElement;
     const code = pre.innerText;
-    const button = document.createElement("button");
-    button.classList.add("copy");
-    const img = document.createElement("img");
-    img.src = copyIconSrc;
-    img.alt = "Copy";
-    button.appendChild(img);
     button.addEventListener("click", () => {
       copyText(code);
     });
-    pre.prepend(button);
+    button.disabled = false;
   }
 }
 

--- a/docs/assets/docs.js
+++ b/docs/assets/docs.js
@@ -431,6 +431,14 @@ function setUpPreviewCopy() {
   for (const button of document.querySelectorAll("pre > button.copy")) {
     const pre = button.parentElement;
     const code = pre.innerText;
+    // Display the Copy button for 30s when the `<pre>` is tapped on touch
+    // screens.
+    let timeoutId;
+    pre.addEventListener("click", () => {
+      pre.classList.add("tapped");
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => pre.classList.remove("tapped"), 30_000);
+    });
     button.addEventListener("click", () => {
       copyText(code);
     });

--- a/docs/assets/docs.js
+++ b/docs/assets/docs.js
@@ -430,7 +430,6 @@ function setUpPreviewSplits() {
 function setUpPreviewCopy() {
   for (const button of document.querySelectorAll("pre > button.copy")) {
     const pre = button.parentElement;
-    const code = pre.innerText;
     // Display the Copy button for 30s when the `<pre>` is tapped on touch
     // screens.
     let timeoutId;
@@ -440,7 +439,7 @@ function setUpPreviewCopy() {
       timeoutId = setTimeout(() => pre.classList.remove("tapped"), 30_000);
     });
     button.addEventListener("click", () => {
-      copyText(code);
+      copyText(pre.innerText);
     });
     button.disabled = false;
   }

--- a/docs/assets/docs.js
+++ b/docs/assets/docs.js
@@ -4,6 +4,7 @@
 const assetBase = "/assets/";
 const closeIconSrc = assetBase + "icons/16-close.svg";
 const checkIconSrc = assetBase + "icons/16-check.svg";
+const copyIconSrc = assetBase + "icons/16-copy.svg";
 const searchIndexSrc = assetBase + "search.json";
 
 const hasTransitionEnd = "ontransitionend" in window;
@@ -29,6 +30,7 @@ function main() {
     setUpOnThisPage();
     setUpTooltips();
     setUpPreviewSplits();
+    setUpPreviewCopy();
     setUpSymbolFlyouts();
     setUpGlobalSearch();
     setUpSymbolSearch();
@@ -419,6 +421,25 @@ function setUpPreviewSplits() {
     if (example.clientWidth < example.scrollWidth) {
       example.classList.add("big");
     }
+  }
+}
+
+/**
+ * Sets up the Copy button on example codes.
+ */
+function setUpPreviewCopy() {
+  for (const pre of document.querySelectorAll(".previewed-code > pre")) {
+    const code = pre.innerText;
+    const button = document.createElement("button");
+    button.classList.add("copy");
+    const img = document.createElement("img");
+    img.src = copyIconSrc;
+    img.alt = "Copy";
+    button.appendChild(img);
+    button.addEventListener("click", () => {
+      copyText(code);
+    });
+    pre.prepend(button);
   }
 }
 

--- a/docs/components/example.typ
+++ b/docs/components/example.typ
@@ -6,7 +6,7 @@
 // Cooperates with `docs/src/example.rs`.
 
 #import "system.typ": colors, sizes
-#import "base.typ": folding-details, labelled, small
+#import "base.typ": folding-details, labelled, small, use-icon
 
 // Shared styling properties for all elements with a "boxy" look.
 #let radius = 2pt
@@ -159,6 +159,22 @@
       )
     })
   } else {
+    show html.elem.where(tag: "pre"): pre => {
+      if pre.at("label", default: none) == <_stop> {
+        return pre
+      }
+      let copy-button = html.button(
+        class: "copy",
+        disabled: true,
+        use-icon(16, "copy", "Copy"),
+      )
+      let reconstructed = html.elem(
+        "pre",
+        attrs: pre.attrs,
+        copy-button + pre.body
+      )
+      labelled(reconstructed, <_stop>)
+    }
     html.div(class: "previewed-code", {
       with-hidden-lines(it)
       html.div(class: "preview", pages.join())

--- a/docs/components/example.typ
+++ b/docs/components/example.typ
@@ -171,7 +171,7 @@
       let reconstructed = html.elem(
         "pre",
         attrs: pre.attrs,
-        copy-button + pre.body
+        copy-button + pre.body,
       )
       labelled(reconstructed, <_stop>)
     }


### PR DESCRIPTION
This closes https://github.com/typst/typst/issues/8264 by adding a Copy button to all code examples (only those that have a preview).

The Copy button is added within the JavaScript script. Alternatively, it could be added in the Typst template directly, but this seemed less easy, and also the current solution has the advantage of not showing a Copy button to users that have JavaScript disabled, or when the page has not fully loaded yet.

Current result:

<img width="980" height="242" alt="A side-by-side example with code and preview has a small copy button at the top right of the code." src="https://github.com/user-attachments/assets/17dca6e1-7d69-4666-9a60-e141f7d82460" />

Feel free to suggest changes to the styling.