### PR TITLE
Replace `ArcExt::take` with `Arc::unwrap_or_clone` from Rust 1.76

### DIFF
--- a/crates/typst-library/src/foundations/dict.rs
+++ b/crates/typst-library/src/foundations/dict.rs
@@ -9,7 +9,6 @@ use indexmap::IndexMap;
 use rustc_hash::FxBuildHasher;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use typst_syntax::is_ident;
-use typst_utils::ArcExt;
 
 use crate::diag::{At, Hint, HintedStrResult, SourceResult, StrResult};
 use crate::engine::Engine;
@@ -444,7 +443,7 @@ impl IntoIterator for Dict {
     type IntoIter = indexmap::map::IntoIter<Str, Value>;
 
     fn into_iter(self) -> Self::IntoIter {
-        Arc::take(self.0).into_iter()
+        Arc::unwrap_or_clone(self.0).into_iter()
     }
 }
 

--- a/crates/typst-library/src/foundations/value.rs
+++ b/crates/typst-library/src/foundations/value.rs
@@ -9,7 +9,6 @@ use serde::de::value::{MapAccessDeserializer, SeqAccessDeserializer};
 use serde::de::{Error, MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use typst_syntax::{Span, ast};
-use typst_utils::ArcExt;
 
 use crate::diag::{HintedStrResult, HintedString, StrResult, WarningSink};
 use crate::foundations::{
@@ -682,7 +681,7 @@ impl<T: Reflect> Reflect for Arc<T> {
 
 impl<T: Clone + IntoValue> IntoValue for Arc<T> {
     fn into_value(self) -> Value {
-        Arc::take(self).into_value()
+        Arc::unwrap_or_clone(self).into_value()
     }
 }
 
@@ -699,13 +698,13 @@ impl<T: Clone + Resolve> Resolve for Arc<T> {
     type Output = Arc<T::Output>;
 
     fn resolve(self, styles: super::StyleChain) -> Self::Output {
-        Arc::new(Arc::take(self).resolve(styles))
+        Arc::new(Arc::unwrap_or_clone(self).resolve(styles))
     }
 }
 
 impl<T: Clone + Fold> Fold for Arc<T> {
     fn fold(self, outer: Self) -> Self {
-        Arc::new(Arc::take(self).fold(Arc::take(outer)))
+        Arc::new(Arc::unwrap_or_clone(self).fold(Arc::unwrap_or_clone(outer)))
     }
 }
 

--- a/crates/typst-utils/src/lib.rs
+++ b/crates/typst-utils/src/lib.rs
@@ -35,7 +35,6 @@ use std::hash::Hash;
 use std::iter::{Chain, Flatten, Rev};
 use std::num::{NonZeroU32, NonZeroUsize};
 use std::ops::{Add, Deref, DerefMut, Div, Mul, Neg, Sub};
-use std::sync::Arc;
 
 use unicode_math_class::MathClass;
 
@@ -89,22 +88,6 @@ impl NonZeroExt for NonZeroUsize {
 
 impl NonZeroExt for NonZeroU32 {
     const ONE: Self = Self::new(1).unwrap();
-}
-
-/// Extra methods for [`Arc`].
-pub trait ArcExt<T> {
-    /// Takes the inner value if there is exactly one strong reference and
-    /// clones it otherwise.
-    fn take(self) -> T;
-}
-
-impl<T: Clone> ArcExt<T> for Arc<T> {
-    fn take(self) -> T {
-        match Arc::try_unwrap(self) {
-            Ok(v) => v,
-            Err(rc) => (*rc).clone(),
-        }
-    }
 }
 
 /// Extra methods for [`Option`].


### PR DESCRIPTION
This replaces a 4-year-old trait extenstion that was originally added in https://github.com/typst/typst/commit/5becb32ba463d6b0ace914ab06bb237483a94fbc with the equivalent standard library method. `Arc::unwrap_or_clone` was stabilized in Rust 1.76, although I do admit to disliking the new name.