### PR TITLE
Fix non-ASCII paths for live reload server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1901,9 +1901,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
@@ -3168,6 +3168,7 @@ dependencies = [
  "once_cell",
  "openssl",
  "parking_lot",
+ "percent-encoding",
  "rustc-hash",
  "same-file",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ oxipng = { version = "10", default-features = false, features = ["filetime", "pa
 palette = { version = "0.7.3", default-features = false, features = ["approx", "libm"] }
 parking_lot = "0.12.1"
 pathdiff = "0.2"
+percent-encoding = "2.3.2"
 phf = { version = "0.13", features = ["macros"] }
 pixglyph = "0.6"
 png = "0.17"

--- a/crates/typst-kit/Cargo.toml
+++ b/crates/typst-kit/Cargo.toml
@@ -30,6 +30,7 @@ native-tls = { workspace = true, optional = true }
 notify = { workspace = true, optional = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
+percent-encoding = { workspace = true, optional = true }
 rustc-hash = { workspace = true }
 same-file = { workspace = true, optional = true }
 serde = { workspace = true }
@@ -84,7 +85,7 @@ watcher = ["dep:notify", "dep:same-file"]
 timer = []
 
 # Enables live-reloading HTTP serving via `server::HttpServer`.
-http-server = ["dep:tiny_http", "dep:infer"]
+http-server = ["dep:tiny_http", "dep:infer", "dep:percent-encoding"]
 
 # Whether to vendor OpenSSL for the `system-downloader`. Not applicable to
 # Windows and macOS build.

--- a/crates/typst-kit/src/server.rs
+++ b/crates/typst-kit/src/server.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use ecow::eco_format;
 use parking_lot::{Condvar, Mutex, MutexGuard};
+use percent_encoding::percent_decode_str;
 use tiny_http::{Header, Request, Response, StatusCode};
 use typst_library::diag::{StrResult, bail};
 use typst_library::foundations::Bytes;
@@ -147,12 +148,16 @@ fn handle(req: Request, reload: bool, bucket: &Arc<RouterBucket>) -> io::Result<
     };
 
     let path = url.path();
+    let Ok(path) = percent_decode_str(path).decode_utf8() else {
+        return req.respond(Response::empty(StatusCode(400)));
+    };
+
     if path == "/__events" {
         return handle_events(req, bucket.clone());
     }
 
     let fs = bucket.get();
-    let Some(body) = fs(path) else {
+    let Some(body) = fs(path.as_ref()) else {
         return req.respond(Response::empty(StatusCode(404)));
     };
 


### PR DESCRIPTION
Fix #8084 by percent-decoding the paths before routing.

No new dependency is added since `percent-encoding` is already in use by `url`.

Tested locally using the example in the issue.