### PR TITLE
Fix various doc comment warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
       - run: cargo clippy --workspace --all-targets --all-features
       - run: cargo clippy --workspace --all-targets --no-default-features
       - run: cargo fmt --check --all
-      - run: cargo doc --workspace --no-deps
+      - run: cargo doc --workspace --no-deps --document-private-items
       - run: git diff --exit-code
 
   docs:

--- a/crates/typst-html/src/convert.rs
+++ b/crates/typst-html/src/convert.rs
@@ -47,7 +47,7 @@ pub enum Whitespace {
     ///   lookahead and lookbehind across different levels of the element
     ///   hierarchy.
     ///
-    /// [^1]: https://www.w3.org/TR/css-text-3/#white-space-rules
+    /// [^1]: <https://www.w3.org/TR/css-text-3/#white-space-rules>
     Normal,
     /// The whitespace is emitted as-is. This happens in
     /// - `<pre>` elements as they already have `white-space: pre`,

--- a/crates/typst-html/src/document.rs
+++ b/crates/typst-html/src/document.rs
@@ -227,7 +227,7 @@ impl HtmlOutput {
     }
 }
 
-/// Wrap the user generated HTML in <html>, <body> or both if needed.
+/// Wrap the user generated HTML in `<html>`, `<body>` or both if needed.
 ///
 /// Returns a vector containing outer introspection tags and the HTML root element.
 /// A direct reference to the root element is also returned.

--- a/crates/typst-html/src/fragment.rs
+++ b/crates/typst-html/src/fragment.rs
@@ -36,7 +36,7 @@ pub fn html_block_fragment(
     )
 }
 
-/// The cached, internal implementation of [`html_fragment`].
+/// The cached, internal implementation of [`html_block_fragment`].
 #[comemo::memoize]
 #[allow(clippy::too_many_arguments)]
 fn html_block_fragment_impl(

--- a/crates/typst-html/src/typed.rs
+++ b/crates/typst-html/src/typed.rs
@@ -1,7 +1,7 @@
 //! The typed HTML element API (e.g. `html.div`).
 //!
 //! The typed API is backed by generated data derived from the HTML
-//! specification. See `typst_assets_codegen::html::codegen` and `typst_assets::html`.
+//! specification.
 
 use std::fmt::Write;
 use std::num::{NonZeroI64, NonZeroU64};

--- a/crates/typst-html/src/typed.rs
+++ b/crates/typst-html/src/typed.rs
@@ -1,7 +1,7 @@
 //! The typed HTML element API (e.g. `html.div`).
 //!
 //! The typed API is backed by generated data derived from the HTML
-//! specification. See [generated] and `tools/codegen`.
+//! specification. See `typst_assets_codegen::html::codegen` and `typst_assets::html`.
 
 use std::fmt::Write;
 use std::num::{NonZeroI64, NonZeroU64};

--- a/crates/typst-layout/src/flow/compose.rs
+++ b/crates/typst-layout/src/flow/compose.rs
@@ -30,7 +30,7 @@ use super::{
 /// the distributor).
 ///
 /// To lay out the in-flow contents of individual subregions, the composer
-/// invokes [distribution](distribute).
+/// invokes [distribution](distribute()).
 pub fn compose(
     engine: &mut Engine,
     work: &mut Work,
@@ -247,7 +247,7 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
 
     /// Lays out an item with floating placement.
     ///
-    /// This is called from within [`distribute`]. When the float fits, this
+    /// This is called from within [`distribute()`]. When the float fits, this
     /// returns an `Err(Stop::Relayout(..))`, which bubbles all the way through
     /// distribution and is handled in [`Self::page`] or [`Self::column`]
     /// (depending on `placed.scope`).

--- a/crates/typst-layout/src/pages/mod.rs
+++ b/crates/typst-layout/src/pages/mod.rs
@@ -1,4 +1,4 @@
-//! Layout of content into a [`Document`].
+//! Layout of content into a [`PagedDocument`].
 
 mod collect;
 mod finalize;

--- a/crates/typst-library/src/diag.rs
+++ b/crates/typst-library/src/diag.rs
@@ -1032,8 +1032,8 @@ impl<T> ExpectInternal<T> for Option<T> {
     }
 }
 
-/// The shared internal implementation of [`assert_internal`] and
-/// [`expect_internal`].
+/// The shared internal implementation of [`assert_internal`], [`panic_internal`] and
+/// [`ExpectInternal::expect_internal`].
 #[track_caller]
 fn internal_error(msg: &str) -> HintedString {
     let loc = std::panic::Location::caller();

--- a/crates/typst-library/src/diag.rs
+++ b/crates/typst-library/src/diag.rs
@@ -1032,8 +1032,8 @@ impl<T> ExpectInternal<T> for Option<T> {
     }
 }
 
-/// The shared internal implementation of [`assert_internal`], [`panic_internal`] and
-/// [`ExpectInternal::expect_internal`].
+/// The shared internal implementation of [`assert_internal`],
+/// [`panic_internal`] and [`ExpectInternal::expect_internal`].
 #[track_caller]
 fn internal_error(msg: &str) -> HintedString {
     let loc = std::panic::Location::caller();

--- a/crates/typst-library/src/foundations/content/raw.rs
+++ b/crates/typst-library/src/foundations/content/raw.rs
@@ -171,8 +171,8 @@ impl RawContent {
     /// of the correct type.**
     ///
     /// # Safety
-    /// This must be preceded by a check to [`is`]. The safe API for this is
-    /// [`Content::to_packed`] and the [`Packed`] struct.
+    /// This must be preceded by a check to [`Self::is`]. The safe API for this is
+    /// [`super::Content::to_packed`] and the [`Packed`] struct.
     pub(super) unsafe fn data<E: NativeElement>(&self) -> &E {
         debug_assert!(self.is::<E>());
 
@@ -189,8 +189,8 @@ impl RawContent {
     /// Ensures that the element's allocation is unique.
     ///
     /// # Safety
-    /// This must be preceded by a check to [`is`]. The safe API for this is
-    /// [`Content::to_packed_mut`] and the [`Packed`] struct.
+    /// This must be preceded by a check to [`Self::is`]. The safe API for this is
+    /// [`super::Content::to_packed_mut`] and the [`Packed`] struct.
     pub(super) unsafe fn data_mut<E: NativeElement>(&mut self) -> &mut E {
         debug_assert!(self.is::<E>());
 

--- a/crates/typst-library/src/foundations/content/raw.rs
+++ b/crates/typst-library/src/foundations/content/raw.rs
@@ -171,8 +171,9 @@ impl RawContent {
     /// of the correct type.**
     ///
     /// # Safety
-    /// This must be preceded by a check to [`Self::is`]. The safe API for this is
-    /// [`super::Content::to_packed`] and the [`Packed`] struct.
+    /// This must be preceded by a check to [`is`](Self::is). The safe API for
+    /// this is [`Content::to_packed`](super::Content::to_packed) and the
+    /// [`Packed`] struct.
     pub(super) unsafe fn data<E: NativeElement>(&self) -> &E {
         debug_assert!(self.is::<E>());
 
@@ -189,8 +190,9 @@ impl RawContent {
     /// Ensures that the element's allocation is unique.
     ///
     /// # Safety
-    /// This must be preceded by a check to [`Self::is`]. The safe API for this is
-    /// [`super::Content::to_packed_mut`] and the [`Packed`] struct.
+    /// This must be preceded by a check to [`is`](Self::is). The safe API for
+    /// this is [`Content::to_packed_mut`](super::Content::to_packed_mut) and
+    /// the [`Packed`] struct.
     pub(super) unsafe fn data_mut<E: NativeElement>(&mut self) -> &mut E {
         debug_assert!(self.is::<E>());
 

--- a/crates/typst-library/src/introspection/query.rs
+++ b/crates/typst-library/src/introspection/query.rs
@@ -272,7 +272,8 @@ impl Introspect for QueryLabelIntrospection {
     }
 }
 
-/// The warning when an introspection on a [`super::Location`] did not converge.
+/// The warning when an introspection on a [`Location`](super::Location) did not
+/// converge.
 fn format_convergence_warning(
     span: Span,
     lengths: &History<usize>,

--- a/crates/typst-library/src/introspection/query.rs
+++ b/crates/typst-library/src/introspection/query.rs
@@ -272,7 +272,7 @@ impl Introspect for QueryLabelIntrospection {
     }
 }
 
-/// The warning when an introspection on a [`Location`] did not converge.
+/// The warning when an introspection on a [`super::Location`] did not converge.
 fn format_convergence_warning(
     span: Span,
     lengths: &History<usize>,

--- a/crates/typst-pdf/src/tags/tree/build.rs
+++ b/crates/typst-pdf/src/tags/tree/build.rs
@@ -260,8 +260,8 @@ fn visit_frame(tree: &mut TreeBuilder, frame: &Frame) -> SourceResult<()> {
 
 /// Handle children frames logically belonging to another element, because
 /// [typst_library::layout::GroupItem::parent] has been set. All elements that
-/// can have children set by this mechanism must be handled in [`handle_start`]
-/// and must produce a located [`Group`], so the children can be inserted there.
+/// can have children set by this mechanism must be handled in [`crate::tags::handle_start`]
+/// and must produce a located [`crate::tags::groups::Group`], so the children can be inserted there.
 ///
 /// Currently the frame parent is only set for:
 /// - place elements [`PlaceElem`]

--- a/crates/typst-pdf/src/tags/tree/build.rs
+++ b/crates/typst-pdf/src/tags/tree/build.rs
@@ -260,8 +260,9 @@ fn visit_frame(tree: &mut TreeBuilder, frame: &Frame) -> SourceResult<()> {
 
 /// Handle children frames logically belonging to another element, because
 /// [typst_library::layout::GroupItem::parent] has been set. All elements that
-/// can have children set by this mechanism must be handled in [`crate::tags::handle_start`]
-/// and must produce a located [`crate::tags::groups::Group`], so the children can be inserted there.
+/// can have children set by this mechanism must be handled in
+/// [`crate::tags::handle_start`] and must produce a located
+/// [`crate::tags::groups::Group`], so the children can be inserted there.
 ///
 /// Currently the frame parent is only set for:
 /// - place elements [`PlaceElem`]

--- a/crates/typst-svg/src/write.rs
+++ b/crates/typst-svg/src/write.rs
@@ -204,7 +204,7 @@ impl SvgDisplay for f64 {
 /// Displays as an SVG transform. The exact representation is chosen based on
 /// the specific transform. Either `matrix`, `scale`, or `translate` is used.
 ///
-/// See https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/transform
+/// See <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/transform>
 pub struct SvgTransform(pub Transform);
 
 impl SvgDisplay for SvgTransform {


### PR DESCRIPTION
Mostly broken links.

In most cases it's pretty clear what something is supposed to refer to.

I'm not so sure about crates/typst-html/src/typed.rs