### PR TITLE
Support `raw` serialization format for `typst eval`

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -209,7 +209,7 @@ pub struct EvalCommand {
 
     /// The format to serialize in.
     #[clap(long = "format", default_value_t)]
-    pub format: SerializationFormat,
+    pub format: EvalSerializationFormat,
 
     /// Whether to pretty-print the serialized output.
     ///
@@ -721,6 +721,19 @@ pub enum SerializationFormat {
 }
 
 display_possible_values!(SerializationFormat);
+
+/// Output file format for eval command
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, ValueEnum)]
+pub enum EvalSerializationFormat {
+    #[default]
+    Json,
+    Yaml,
+    /// Prints the eval result without any additional formatting or escaping (only available for
+    /// results of type `string` or `bytes`).
+    Raw,
+}
+
+display_possible_values!(EvalSerializationFormat);
 
 /// Implements parsing of page ranges (`1-3`, `4`, `5-`, `-2`), used by the
 /// `CompileCommand.pages` argument, through the `FromStr` trait instead of a

--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -728,8 +728,8 @@ pub enum EvalSerializationFormat {
     #[default]
     Json,
     Yaml,
-    /// Prints the eval result without any additional formatting or escaping (only available for
-    /// results of type `string` or `bytes`).
+    /// Prints the output without any additional formatting or escaping
+    /// (only supports strings and bytes).
     Raw,
 }
 

--- a/crates/typst-cli/src/eval.rs
+++ b/crates/typst-cli/src/eval.rs
@@ -1,9 +1,10 @@
+use std::io::{Write, stdout};
 use std::sync::LazyLock;
 
 use comemo::Track;
 use ecow::eco_format;
 use typst::Library;
-use typst::diag::{FileResult, HintedStrResult, SourceResult, Warned};
+use typst::diag::{FileResult, HintedStrResult, SourceResult, Warned, bail};
 use typst::foundations::{
     Bytes, Context, Datetime, Duration, Output, Scope, StyleChain, Value,
 };
@@ -20,7 +21,7 @@ use typst_kit::diagnostics::DiagnosticWorld;
 use typst_layout::PagedDocument;
 use typst_utils::LazyHash;
 
-use crate::args::{EvalCommand, Target};
+use crate::args::{EvalCommand, EvalSerializationFormat, SerializationFormat, Target};
 use crate::compile::print_diagnostics;
 use crate::set_failed;
 use crate::world::SystemWorld;
@@ -66,9 +67,7 @@ pub fn eval(command: &'static EvalCommand) -> HintedStrResult<()> {
                     errors.as_slice()
                 }
                 Ok(value) => {
-                    let serialized =
-                        crate::serialize(value, command.format, command.pretty)?;
-                    println!("{serialized}");
+                    print_eval_result(value, command.format, command.pretty)?;
                     &[]
                 }
             };
@@ -125,6 +124,42 @@ fn evaluate_expression(
         SyntaxMode::Code,
         Scope::default(),
     )
+}
+
+fn print_eval_result(
+    value: &Value,
+    format: EvalSerializationFormat,
+    pretty: bool,
+) -> HintedStrResult<()> {
+    match format {
+        EvalSerializationFormat::Json => {
+            println!("{}", crate::serialize(&value, SerializationFormat::Json, pretty)?);
+        }
+        EvalSerializationFormat::Yaml => {
+            println!("{}", crate::serialize(&value, SerializationFormat::Yaml, pretty)?);
+        }
+        EvalSerializationFormat::Raw => match value {
+            Value::Str(s) => {
+                print_raw(s.as_bytes());
+            }
+            Value::Bytes(bytes) => {
+                print_raw(bytes);
+            }
+            _ => bail!(
+                "cannot print raw bytes of {}", value.ty();
+                hint: "--format=raw allows only string and bytes as result types"
+            ),
+        },
+    }
+
+    Ok(())
+}
+
+fn print_raw(bytes: &[u8]) {
+    stdout()
+        .lock()
+        .write_all(bytes)
+        .expect("failed to write eval result to stdout");
 }
 
 /// Static [`FileId`] for an input expression. This allows giving accurate

--- a/crates/typst-cli/src/eval.rs
+++ b/crates/typst-cli/src/eval.rs
@@ -126,6 +126,7 @@ fn evaluate_expression(
     )
 }
 
+/// Prints the output value of `typst eval`.
 fn print_eval_result(
     value: &Value,
     format: EvalSerializationFormat,
@@ -138,28 +139,19 @@ fn print_eval_result(
         EvalSerializationFormat::Yaml => {
             println!("{}", crate::serialize(&value, SerializationFormat::Yaml, pretty)?);
         }
-        EvalSerializationFormat::Raw => match value {
-            Value::Str(s) => {
-                print_raw(s.as_bytes());
-            }
-            Value::Bytes(bytes) => {
-                print_raw(bytes);
-            }
-            _ => bail!(
-                "cannot print raw bytes of {}", value.ty();
-                hint: "--format=raw allows only string and bytes as result types"
-            ),
-        },
+        EvalSerializationFormat::Raw => {
+            let bytes = match value {
+                Value::Str(string) => string.as_bytes(),
+                Value::Bytes(bytes) => bytes,
+                _ => bail!(
+                    "cannot print {} in raw format", value.ty();
+                    hint: "`--format=raw` only supports strings and bytes"
+                ),
+            };
+            stdout().lock().write_all(bytes).expect("failed to write eval output");
+        }
     }
-
     Ok(())
-}
-
-fn print_raw(bytes: &[u8]) {
-    stdout()
-        .lock()
-        .write_all(bytes)
-        .expect("failed to write eval result to stdout");
 }
 
 /// Static [`FileId`] for an input expression. This allows giving accurate

--- a/crates/typst-cli/tests/smoke.rs
+++ b/crates/typst-cli/tests/smoke.rs
@@ -45,6 +45,21 @@ fn test_compile_pdf_version() {
 fn test_eval() {
     let output = exec().arg("eval").arg("1+2").must_succeed();
     output.stdout.must_match_lines(["3"]);
+
+    let output = exec()
+        .arg("eval")
+        .arg("--format=raw")
+        .arg("bytes((1,2,3,0xff))")
+        .must_succeed();
+    assert_eq!(output.stdout.0, b"\x01\x02\x03\xff");
+
+    // trailing newline
+    let output = exec().arg("eval").arg("str(42)").must_succeed();
+    assert_eq!(output.stdout.0, b"\"42\"\n");
+
+    // no trailing newline
+    let output = exec().arg("eval").arg("--format=raw").arg("str(42)").must_succeed();
+    assert_eq!(output.stdout.0, b"42");
 }
 
 #[test]

--- a/crates/typst-cli/tests/smoke.rs
+++ b/crates/typst-cli/tests/smoke.rs
@@ -53,13 +53,17 @@ fn test_eval() {
         .must_succeed();
     assert_eq!(output.stdout.0, b"\x01\x02\x03\xff");
 
-    // trailing newline
+    // Trailing newline.
     let output = exec().arg("eval").arg("str(42)").must_succeed();
     assert_eq!(output.stdout.0, b"\"42\"\n");
 
-    // no trailing newline
+    // No trailing newline.
     let output = exec().arg("eval").arg("--format=raw").arg("str(42)").must_succeed();
     assert_eq!(output.stdout.0, b"42");
+
+    // Unsupported type.
+    let output = exec().arg("eval").arg("--format=raw").arg("42").must_fail();
+    output.stderr.must_contain("cannot print integer in raw format");
 }
 
 #[test]


### PR DESCRIPTION
Fixes #7768.