### PR TITLE
Implement `std::error::Error` for some core Error types

### DIFF
--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -1,3 +1,4 @@
+use std::error;
 use std::fmt;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
@@ -318,6 +319,15 @@ impl fmt::Display for WorldCreationError {
                 write!(f, "creation timestamp out of range")
             }
             WorldCreationError::Io(err) => write!(f, "{err}"),
+        }
+    }
+}
+
+impl error::Error for WorldCreationError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            Self::Io(error) => Some(error),
+            _ => None,
         }
     }
 }

--- a/crates/typst-syntax/src/path.rs
+++ b/crates/typst-syntax/src/path.rs
@@ -1,5 +1,6 @@
 //! Virtual, cross-platform reproducible path handling.
 
+use std::error;
 use std::fmt::{self, Debug, Formatter};
 use std::num::NonZeroU16;
 use std::ops::Deref;
@@ -564,6 +565,17 @@ pub enum PathError {
     Backslash,
 }
 
+impl fmt::Display for PathError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Escapes => write!(f, "path escapes project root"),
+            Self::Backslash => write!(f, "path contains backslash"),
+        }
+    }
+}
+
+impl error::Error for PathError {}
+
 /// An error that can occur in [`VirtualPath::virtualize`].
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum VirtualizeError {
@@ -576,6 +588,25 @@ pub enum VirtualizeError {
     /// The file path contains non-UTF-8 encodable bytes.
     Utf8,
 }
+
+impl fmt::Display for VirtualizeError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "could not virtualize path, ")?;
+
+        match self {
+            Self::Path(inner) => fmt::Display::fmt(inner, f),
+            Self::Invalid(component) => {
+                write!(f, "path contains invalid component {component:?}")
+            }
+            Self::Utf8 => write!(f, "path contains non-UTF-8 bytes"),
+        }
+    }
+}
+
+// NOTE: Because we opt to inline the formatting of the PathError we cannot
+// also return it as the error source, else it will be displayed twice in error
+// backtraces.
+impl error::Error for VirtualizeError {}
 
 impl From<PathError> for VirtualizeError {
     fn from(err: PathError) -> Self {

--- a/crates/typst-syntax/src/path.rs
+++ b/crates/typst-syntax/src/path.rs
@@ -596,7 +596,7 @@ impl fmt::Display for VirtualizeError {
         match self {
             Self::Path(inner) => fmt::Display::fmt(inner, f),
             Self::Invalid(component) => {
-                write!(f, "path contains invalid component {component:?}")
+                write!(f, "path contains invalid component `{component:?}`")
             }
             Self::Utf8 => write!(f, "path contains non-UTF-8 bytes"),
         }


### PR DESCRIPTION
Because PathError is essentially treated as part of VirtualizationError while also being its own type, we inline the formatting for it and don't treat as an error source. This way, error backtraces don't contain the `Display::fmt` result twice, while also not making the PathError case in Display on its own useless outside backtrace contexts.

<!--
Thanks for your interest in landing a change in Typst! Before opening the PR, please review our contribution guidelines: https://github.com/typst/typst/blob/main/CONTRIBUTING.md

In particular, please keep in mind that we do not accept contributions implemented by an AI model. We would also ask you to refrain from using AI to write your pull request description. Summarizing your work helps organizing your thoughts as much as it helps us with seeing the human thought process behind a particular change.
-->
