### PR TITLE
Add links to sources in the documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3035,7 +3035,7 @@ dependencies = [
 [[package]]
 name = "typst-dev-assets"
 version = "0.14.2"
-source = "git+https://github.com/typst/typst-dev-assets?rev=3ec55c5#3ec55c5a14e519242a120e035d20725224e3e850"
+source = "git+https://github.com/typst/typst-dev-assets?rev=263883b#263883b3d0e070e82b17b2f7062df7579a7e76fb"
 
 [[package]]
 name = "typst-docs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ typst-syntax = { path = "crates/typst-syntax", version = "0.14.2" }
 typst-timing = { path = "crates/typst-timing", version = "0.14.2" }
 typst-utils = { path = "crates/typst-utils", version = "0.14.2" }
 typst-assets = { git = "https://github.com/typst/typst-assets", rev = "3284e80" }
-typst-dev-assets = { git = "https://github.com/typst/typst-dev-assets", rev = "3ec55c5" }
+typst-dev-assets = { git = "https://github.com/typst/typst-dev-assets", rev = "263883b" }
 arrayvec = "0.7.4"
 az = "1.2"
 base64 = "0.22"

--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -139,6 +139,15 @@ h3 small svg {
   }
 }
 
+a.sources-link {
+  margin-inline-start: auto;
+}
+
+a.sources-link > svg {
+  display: block;
+  color: var(--text-primary);
+}
+
 li p + ul,
 li p + ol {
   margin-block-start: -0.5rem;

--- a/docs/assets/index.typ
+++ b/docs/assets/index.typ
@@ -21,6 +21,7 @@
   "16-check.svg",
   "16-chevron-right.svg",
   "16-close.svg",
+  "16-code.svg",
   "16-copy.svg",
   "16-docs-dark.svg",
   "16-hamburger-dark.svg",

--- a/docs/components/category.typ
+++ b/docs/components/category.typ
@@ -6,7 +6,7 @@
 )
 #import "example.typ": example, example-like-block
 #import "linking.typ": def-dest, def-label, register-def
-#import "live.typ": live-docs
+#import "live.typ": live-docs, item-source-link
 #import "pill.typ": ty-pill
 #import "reflect.typ": cast-strings, flat-types, std-path-of
 #import "search.typ": register-index-item
@@ -238,16 +238,13 @@
 //
 // Requires context.
 #let sources-link(info) = {
-  if info.def-site != none {
-    let file = eval(repr(info.def-site.path).slice("path".len()))
-    let url = "https://github.com/typst/typst/blob/" + stdx.commit + file
-    if target() == "html" {
-      html.a(
-        href: url,
-        class: "sources-link",
-        use-icon(16, "code", "Source"),
-      )
-    }
+  if target() == "html" and info.def-site != none {
+    let url = item-source-link(info.def-site)
+    html.a(
+      href: url,
+      class: "sources-link",
+      use-icon(16, "code", "Source"),
+    )
   }
 }
 

--- a/docs/components/category.typ
+++ b/docs/components/category.typ
@@ -1,7 +1,8 @@
 #import "system.typ": colors
 #import "base.typ": (
   classnames, deprecation, folding-details, heading-offset, labelled, oneliner,
-  paged-heading-offset, short-or-long, small, title-case, to-func, with-tooltip,
+  paged-heading-offset, short-or-long, small, use-icon, title-case, to-func,
+  with-tooltip,
 )
 #import "example.typ": example, example-like-block
 #import "linking.typ": def-dest, def-label, register-def
@@ -233,6 +234,23 @@
   }
 }
 
+// Displays a link to the sources for an item.
+//
+// Requires context.
+#let sources-link(info) = {
+  if info.def-site != none {
+    let file = eval(repr(info.def-site.path).slice("path".len()))
+    let url = "https://github.com/typst/typst/blob/" + stdx.commit + file
+    if target() == "html" {
+      html.a(
+        href: url,
+        class: "sources-link",
+        use-icon(16, "code", "Source"),
+      )
+    }
+  }
+}
+
 // Displays additional details about a function.
 #let func-subtitle(info, deprecation-info) = context {
   let gap = if target() == "paged" { h(0.5em, weak: true) }
@@ -252,6 +270,13 @@
   }
   gap
   deprecation(deprecation-info)
+  sources-link(info)
+}
+
+// Displays additional details about a type.
+#let ty-subtitle(ty-info, deprecation-info) = context {
+  deprecation(deprecation-info)
+  sources-link(ty-info)
 }
 
 // Renders documentation for a function as part of a large documentation
@@ -448,7 +473,7 @@
     route: base-route + "/" + name,
     title: ty-info.title,
     title-fmt: ty-pill(ty, linked: false),
-    subtitle: deprecation(deprecation-info),
+    subtitle: ty-subtitle(ty-info, deprecation-info),
     has-summary: true,
     kind: "Type",
     keywords: ty-info.keywords,

--- a/docs/components/category.typ
+++ b/docs/components/category.typ
@@ -243,7 +243,7 @@
     html.a(
       href: url,
       class: "sources-link",
-      use-icon(16, "code", "Source"),
+      use-icon(16, "code", "Go to source"),
     )
   }
 }

--- a/docs/components/live.typ
+++ b/docs/components/live.typ
@@ -15,11 +15,11 @@
   short-or-long: short-or-long,
 )
 
-// Returns a dictionary with all live-loaded docs in the Rust file at the given
+// Returns a dictionary with all live-loaded data in the Rust file at the given
 // path.
 //
 // This is a separate function so that it's memoized per path.
-#let live-docs-at-path(path) = stdx.docs-in-source(read(path))
+#let live-item-data-at-path(path) = stdx.live-item-data(read(path))
 
 // Processes docs content for a doc comment in the Rust sources.
 //
@@ -40,12 +40,12 @@
     return eval(markup, scope: scope, mode: "markup")
   }
 
-  let live = live-docs-at-path(def-site.path)
+  let live = live-item-data-at-path(def-site.path)
   if def-site.key not in live {
     panic("def site was not found:", def-site)
   }
 
-  let (markup, ranges) = live.at(def-site.key)
+  let (_, markup, ranges) = live.at(def-site.key)
   stdx.eval-mapped(
     markup,
     def-site.path,
@@ -53,4 +53,17 @@
     mode: "markup",
     scope: scope,
   )
+}
+
+// Returns a GitHub permalink to the source of an item, including the commit and
+// line number.
+#let item-source-link(def-site) = {
+  let live = live-item-data-at-path(def-site.path)
+  if def-site.key not in live {
+    panic("def site was not found:", def-site)
+  }
+
+  let (line, _, _) = live.at(def-site.key)
+  let file = eval(repr(def-site.path).slice("path".len()))
+  "https://github.com/typst/typst/blob/" + stdx.commit + file + "#L" + str(line)
 }

--- a/docs/components/live.typ
+++ b/docs/components/live.typ
@@ -64,6 +64,6 @@
   }
 
   let (line, _, _) = live.at(def-site.key)
-  let file = eval(repr(def-site.path).slice("path".len()))
+  let file = stdx.str-from-path(def-site.path)
   "https://github.com/typst/typst/blob/" + stdx.commit + file + "#L" + str(line)
 }

--- a/docs/src/live.rs
+++ b/docs/src/live.rs
@@ -1,15 +1,19 @@
 //! Cooperates with `docs/components/live.typ`.
 
+use proc_macro2::Span;
 use std::ops::Range;
-
 use syn::spanned::Spanned as _;
 use typst::diag::bail;
 use typst::foundations::{Array, Dict, IntoValue, Str, array, cast, func};
 
 /// Takes a string of Rust source code and provides all doc comments in it that
-/// belong to native definitions, keyed by the definitions def site key.
+/// belong to native definitions, keyed by the definitions def site key. Also
+/// returns the position of each native definition.
 ///
-/// Returns a dictionary from items keys to pairs of (strings, ranges).
+/// Returns a dictionary from items keys to triplets of:
+/// - The line number where the item is defined within the file;
+/// - A single string containing the full documentation source;
+/// - The corresponding ranges in the source file.
 ///
 /// The item keys are per-file unique string that identify specific items. The
 /// key structure is agreed upon between this function and the `key` file of
@@ -20,8 +24,8 @@ use typst::foundations::{Array, Dict, IntoValue, Str, array, cast, func};
 /// The ranges are represented as arrays of (start, end) pairs. They plug right
 /// into `eval_mapped`'s `ranges` parameter.
 #[func]
-pub fn docs_in_source(source: Str) -> Dict {
-    let mut v = DocsVisitor { items: Dict::new() };
+pub fn live_item_data(source: Str) -> Dict {
+    let mut v = LiveVisitor { items: Dict::new() };
     let file = syn::parse_file(&source);
     if let Ok(file) = &file {
         for item in &file.items {
@@ -31,35 +35,37 @@ pub fn docs_in_source(source: Str) -> Dict {
     v.items
 }
 
-/// Processes a Rust file and collects doc comments for items. Internally this
-/// accumulates the collected documentation for all recognized items.
-struct DocsVisitor {
-    /// See `docs_in_source` for more information on the structure of this.
+/// Processes a Rust file and collects positions and doc comments of items.
+/// Internally, this accumulates the collected documentation for all recognized
+/// items.
+struct LiveVisitor {
+    /// See [`live_item_data`][live_item_data()] for more information on the
+    /// structure of this.
     items: Dict,
 }
 
-impl DocsVisitor {
+impl LiveVisitor {
     fn visit_item(&mut self, item: &syn::Item) {
         match item {
             syn::Item::Struct(s) if has_attr(&s.attrs, "ty") => {
                 let key = s.ident.to_string();
-                self.save_docs(key, &s.attrs);
+                self.save_docs(key, s.span(), &s.attrs);
             }
             syn::Item::Struct(s) if has_attr(&s.attrs, "elem") => {
                 let key = s.ident.to_string();
                 for field in &s.fields {
                     let Some(ident) = &field.ident else { continue };
                     let key = format!("{key}::{ident}");
-                    self.save_docs(key, &field.attrs);
+                    self.save_docs(key, field.span(), &field.attrs);
                 }
-                self.save_docs(key, &s.attrs);
+                self.save_docs(key, s.span(), &s.attrs);
             }
             syn::Item::Enum(e) if has_attr(&e.attrs, "ty") => {
                 let key = e.ident.to_string();
-                self.save_docs(key, &e.attrs);
+                self.save_docs(key, e.span(), &e.attrs);
             }
             syn::Item::Fn(f) if has_attr(&f.attrs, "func") => {
-                self.visit_func(&f.attrs, &f.sig, None);
+                self.visit_func(f.span(), &f.attrs, &f.sig, None);
             }
             syn::Item::Impl(i) => {
                 if let syn::Type::Path(path) = &*i.self_ty
@@ -69,7 +75,12 @@ impl DocsVisitor {
                         if let syn::ImplItem::Fn(item) = item
                             && has_attr(&item.attrs, "func")
                         {
-                            self.visit_func(&item.attrs, &item.sig, Some(parent));
+                            self.visit_func(
+                                item.span(),
+                                &item.attrs,
+                                &item.sig,
+                                Some(parent),
+                            );
                         }
                     }
                 }
@@ -79,7 +90,7 @@ impl DocsVisitor {
                     && has_attr(&t.attrs, "ty")
                 {
                     let key = t.ident.to_string();
-                    self.save_docs(key, &t.attrs);
+                    self.save_docs(key, s.span(), &t.attrs);
                 }
             }
             _ => {}
@@ -88,6 +99,7 @@ impl DocsVisitor {
 
     fn visit_func(
         &mut self,
+        span: Span,
         attrs: &[syn::Attribute],
         sig: &syn::Signature,
         parent: Option<&syn::Ident>,
@@ -103,14 +115,15 @@ impl DocsVisitor {
                 && let syn::Pat::Ident(pat) = &*pat_type.pat
             {
                 let key = format!("{key}::{}", pat.ident);
-                self.save_docs(key, &pat_type.attrs);
+                self.save_docs(key, pat_type.span(), &pat_type.attrs);
             }
         }
 
-        self.save_docs(key, attrs);
+        self.save_docs(key, span, attrs);
     }
 
-    fn save_docs(&mut self, key: String, attrs: &[syn::Attribute]) {
+    fn save_docs(&mut self, key: String, item_span: Span, attrs: &[syn::Attribute]) {
+        let line = item_span.start().line;
         let mut docs = String::new();
         let mut ranges = Vec::new();
 
@@ -132,7 +145,7 @@ impl DocsVisitor {
             }
         }
 
-        self.items.insert(key.into(), array![docs, ranges].into_value());
+        self.items.insert(key.into(), array![line, docs, ranges].into_value());
     }
 }
 

--- a/docs/src/world.rs
+++ b/docs/src/world.rs
@@ -224,6 +224,7 @@ fn stdx_module() -> Module {
     scope.define_func::<crate::reflect::unicode_name>();
     scope.define_func::<crate::reflect::latex_name>();
     scope.define_func::<crate::reflect::is_global_html_attr>();
+    scope.define("commit", typst_utils::version().commit());
     scope.define("shorthands", crate::reflect::shorthands());
     Module::new("stdx", scope)
 }

--- a/docs/src/world.rs
+++ b/docs/src/world.rs
@@ -212,6 +212,7 @@ fn library() -> Library {
 fn stdx_module() -> Module {
     let mut scope = Scope::new();
     scope.define_elem::<ConfigElem>();
+    scope.define_func::<str_from_path>();
     scope.define_func::<read_dev_asset>();
     scope.define_func::<read_font>();
     scope.define_func::<eval_mapped>();
@@ -237,6 +238,14 @@ fn stdx_module() -> Module {
 pub struct ConfigElem {
     pub content_base: EcoString,
     pub asset_base: EcoString,
+}
+
+/// Returns the virtual path part of a path as a string.
+///
+/// This does not include the package spec.
+#[func]
+fn str_from_path(path: RootedPath) -> EcoString {
+    path.vpath().get_with_slash().into()
 }
 
 /// Loads an asset from the `typst_dev_assets` crate by file name.

--- a/docs/src/world.rs
+++ b/docs/src/world.rs
@@ -215,7 +215,7 @@ fn stdx_module() -> Module {
     scope.define_func::<read_dev_asset>();
     scope.define_func::<read_font>();
     scope.define_func::<eval_mapped>();
-    scope.define_func::<crate::live::docs_in_source>();
+    scope.define_func::<crate::live::live_item_data>();
     scope.define_func::<crate::example::compile_example>();
     scope.define_func::<crate::reflect::describe>();
     scope.define_func::<crate::reflect::binding>();


### PR DESCRIPTION
Closes https://github.com/typst/typst/issues/981.

I had to add a `stdx.commit` constant to construct GitHub permalinks.

To get the path of the file, I used `info.def-site.path`. Right now, there is no way to convert a `path` to a string, so I used a bit of a hack to get the file path as a string. I could add support for `path`s to the `str` constructor in a separate PR if wanted, or alternatively implement a `stdx.str-from-path` function.