### PR TITLE
Fix multiple broken examples

### DIFF
--- a/crates/typst-library/src/text/mod.rs
+++ b/crates/typst-library/src/text/mod.rs
@@ -241,6 +241,9 @@ pub struct TextElem {
     /// property instead.
     ///
     /// ```example
+    /// // The default font does not have a
+    /// // condensed variant.
+    /// #set text(font: "IBM Plex Sans")
     /// #text(stretch: 75%)[Condensed] \
     /// #text(stretch: 100%)[Normal]
     /// ```

--- a/crates/typst-library/src/text/mod.rs
+++ b/crates/typst-library/src/text/mod.rs
@@ -241,8 +241,6 @@ pub struct TextElem {
     /// property instead.
     ///
     /// ```example
-    /// // The default font does not have a
-    /// // condensed variant.
     /// #set text(font: "IBM Plex Sans")
     /// #text(stretch: 75%)[Condensed] \
     /// #text(stretch: 100%)[Normal]

--- a/crates/typst-library/src/text/mod.rs
+++ b/crates/typst-library/src/text/mod.rs
@@ -471,7 +471,7 @@ pub struct TextElem {
     ///
     /// ```example
     /// #set text(
-    ///   font: "Libertinus Serif",
+    ///   font: "IBM Plex Sans",
     ///   size: 20pt,
     /// )
     ///


### PR DESCRIPTION
Fixes https://github.com/typst/typst/issues/1251 by using IBM Plex Sans, which has a condensed version:
<img width="480" height="105" alt="The word &quot;Condensed&quot; typeset in IBM Plex Sans Condensed above the word &quot;Normal&quot; typeset in IBM Plex Sans." src="https://github.com/user-attachments/assets/4538b9ff-2ad0-451d-9961-67b4d2ade5a2" />

Also fixes https://github.com/typst/typst/issues/6465 by using IBM Plex Sans:
<img width="480" height="240" alt="The same letter, Ş, appears differently: first with a cedilla, then with a subscript comma, then with a cedilla again." src="https://github.com/user-attachments/assets/4bb68137-180a-40d0-8d71-8b885d913397" />

