### PR TITLE
Prevent unnecessary Typst function call in `array.sorted`

### DIFF
--- a/crates/typst-library/src/foundations/array.rs
+++ b/crates/typst-library/src/foundations/array.rs
@@ -932,7 +932,9 @@ impl Array {
                     // Because we use booleans for the comparison function, in
                     // order to keep the sort stable, we need to compare in the
                     // right order.
-                    if i < j {
+                    if i == j {
+                        Ordering::Equal
+                    } else if i < j {
                         // If `x` and `y` appear in this order in the original
                         // array, then we should change their order (i.e.,
                         // return `Ordering::Greater`) iff `y` is strictly less


### PR DESCRIPTION
As I recently discovered, Glidesort sometimes compares two elements that come from the same place in the original array. This is evidenced by the fact that the following Typst code panics:

```typ
// An array of unique elements.
#let arr = range(8)
// We panic if two equal elements are compared.
#arr.sorted(by: (l, r) => {
  if l == r {
    panic("we compared two equal elements")
  } else {
    l <= r
  }
})
```

This is not an issue in and of itself, but there is a small optimization we can make: in case a `by` function is provided, we already keep track of where each element comes from. Therefore, if Glidesort tries to compare two elements that come from the same index in the original array, we can detect that we don't need to call `by`, because it should return `true` anyway.

After adding the `if i == j` special case, I hit this case about 3.5k times for an array of 10k random integers, and about 35k times for an array of 100k random integers. I can make more benchmarks if necessary, but I am reasonably confident that this change should not have a negative impact on performance which is why I did not go further.

Note that in addition to being a potential optimization, this change also fixes an error making our custom comparison function incorrect from Glidesort's POV that thankfully did not surface as a bug AFAIK: when two elements coming from the same place in the original arrays were being compared, we would not return `Ordering::Equal` but `Ordering::Greater`.