### PR TITLE
Explicitly document the paragraph creation behavior of `list` / `enum`

### DIFF
--- a/crates/typst-library/src/model/enum.rs
+++ b/crates/typst-library/src/model/enum.rs
@@ -81,6 +81,10 @@ pub struct EnumElem {
     /// line, this is set to `{false}`. The markup-defined tightness cannot be
     /// overridden with set rules.
     ///
+    /// Items of non-tight enumerations are considered paragraphs. See
+    /// @par:what-becomes-a-paragraph[the paragraph documentation] for more
+    /// details.
+    ///
     /// ```example
     /// + If an enum has a lot of text, and
     ///   maybe other inline content, it

--- a/crates/typst-library/src/model/list.rs
+++ b/crates/typst-library/src/model/list.rs
@@ -55,6 +55,10 @@ pub struct ListElem {
     /// line, this is set to `{false}`. The markup-defined tightness cannot be
     /// overridden with set rules.
     ///
+    /// Items of non-tight lists are considered paragraphs. See
+    /// @par:what-becomes-a-paragraph[the paragraph documentation] for more
+    /// details.
+    ///
     /// ```example
     /// - If a list has a lot of text, and
     ///   maybe other inline content, it


### PR DESCRIPTION
Should Close #7970

I do still feel this note is quite helpful, but since we had such trouble replicating the OP's issue, I opted to avoid giving too many details here (which I fear would only serve to confuse users).

Motivation for the wording:
- "non-tight" is concise and also used under `list/enum.spacing`, as well as the paragraph docs we link to
- "See the paragraph documentation for more details." is copied verbatim from the intro for `block`