### PR TITLE
Clean up the `par.spacing` documentation

### DIFF
--- a/crates/typst-library/src/model/par.rs
+++ b/crates/typst-library/src/model/par.rs
@@ -214,12 +214,13 @@ pub struct ParElem {
     ///
     /// Just like leading, this defines the spacing between the bottom edge of a
     /// paragraph's last line and the top edge of the next paragraph's first
-    /// line.
+    /// line. Spacing acts both above and below, collapsing to the greater of
+    /// the amounts defined by adjacent paragraphs.
     ///
-    /// When a paragraph is adjacent to a @block that is not a paragraph, that
-    /// block's @block.above[`above`] or @block.below[`below`] property takes
-    /// precedence over the paragraph spacing. Headings, for instance, reduce
-    /// the spacing below them by default for a better look.
+    /// When a paragraph is adjacent to a @block, that block's
+    /// @block.above[`above`] or @block.below[`below`] property takes precedence
+    /// over the paragraph spacing. Headings, for instance, reduce the spacing
+    /// below them by default for a better look.
     #[default(Em::new(1.2).into())]
     pub spacing: Length,
 


### PR DESCRIPTION
Closes #6995

I've also removed a reference to `block`s being `par`s, which I believe to be more confusing than helpful by now. Though this may be reverted if still deemed an intentional comparison. More thoughts [on Discord](https://discord.com/channels/1054443721975922748/1399326777540608041/1505611707979005963) (in the Documentation forge)