### PR TITLE
Support for multiple bibliographies

### DIFF
--- a/crates/typst-html/src/rules.rs
+++ b/crates/typst-html/src/rules.rs
@@ -501,9 +501,10 @@ const CITE_GROUP_RULE: ShowFn<CiteGroup> = |elem, engine, _| {
 // properly overridden. For those, we currently emit classes so that a user can
 // style them with CSS, but do not emit any styles ourselves.
 const BIBLIOGRAPHY_RULE: ShowFn<BibliographyElem> = |elem, engine, styles| {
+    let loc = elem.location().unwrap();
     let span = elem.span();
-    let works = Works::with_bibliography(engine, elem.clone())?;
-    let bibliography = works.bibliography()?;
+    let works = Works::generate(engine, elem.span())?;
+    let bibliography = works.bibliography(loc, span)?;
 
     let items = bibliography.entries.iter().map(|entry| {
         let mut realized = entry.body.clone();

--- a/crates/typst-layout/src/rules.rs
+++ b/crates/typst-layout/src/rules.rs
@@ -453,13 +453,14 @@ const BIBLIOGRAPHY_RULE: ShowFn<BibliographyElem> = |elem, engine, styles| {
     const COLUMN_GUTTER: Em = Em::new(0.65);
     const INDENT: Em = Em::new(1.5);
 
+    let loc = elem.location().unwrap();
     let span = elem.span();
 
     let mut seq = vec![];
     seq.extend(elem.realize_title(styles));
 
-    let works = Works::with_bibliography(engine, elem.clone())?;
-    let bibliography = works.bibliography()?;
+    let works = Works::generate(engine, elem.span())?;
+    let bibliography = works.bibliography(loc, span)?;
 
     if bibliography.entries.iter().any(|entry| entry.prefix.is_some()) {
         let row_gutter = styles.get(ParElem::spacing);

--- a/crates/typst-library/src/foundations/auto.rs
+++ b/crates/typst-library/src/foundations/auto.rs
@@ -1,4 +1,5 @@
 use std::fmt::{self, Debug, Formatter};
+use std::ops::Deref;
 
 use ecow::EcoString;
 
@@ -95,6 +96,17 @@ impl<T> Smart<T> {
 
     /// Returns a `Smart<&T>` borrowing the inner `T`.
     pub fn as_ref(&self) -> Smart<&T> {
+        match self {
+            Smart::Auto => Smart::Auto,
+            Smart::Custom(v) => Smart::Custom(v),
+        }
+    }
+
+    /// Returns a `Smart<&T::Target>`, derefercing the inner `T`.
+    pub fn as_deref(&self) -> Smart<&T::Target>
+    where
+        T: Deref,
+    {
         match self {
             Smart::Auto => Smart::Auto,
             Smart::Custom(v) => Smart::Custom(v),

--- a/crates/typst-library/src/model/bibliography.rs
+++ b/crates/typst-library/src/model/bibliography.rs
@@ -4,8 +4,8 @@ use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::{Arc, LazyLock};
 
-use comemo::{Track, Tracked};
-use ecow::{EcoString, EcoVec, eco_format};
+use comemo::{Track, Tracked, TrackedMut};
+use ecow::{EcoString, EcoVec, eco_format, eco_vec};
 use hayagriva::archive::ArchivedStyle;
 use hayagriva::io::BibLaTeXError;
 use hayagriva::{
@@ -14,19 +14,22 @@ use hayagriva::{
 };
 use indexmap::IndexMap;
 use rustc_hash::{FxBuildHasher, FxHashMap};
+use smallvec::SmallVec;
 use typst_syntax::{Span, Spanned, SyntaxMode};
-use typst_utils::{ManuallyHash, NonZeroExt, PicoStr, ResolvedPicoStr};
+use typst_utils::{
+    LazyHash, ManuallyHash, NonZeroExt, PicoStr, Protected, ResolvedPicoStr,
+};
 
 use crate::World;
 use crate::diag::{
     At, HintedStrResult, HintedString, LoadError, LoadResult, LoadedWithin,
     ReportTextPos, SourceDiagnostic, SourceResult, StrResult, bail, error, warning,
 };
-use crate::engine::{Engine, Sink};
+use crate::engine::{Engine, Route, Sink, Traced};
 use crate::foundations::{
     Bytes, CastInfo, Content, Context, Derived, FromValue, IntoValue, Label,
-    NativeElement, OneOrMultiple, Packed, Reflect, Repr, Scope, ShowSet, Smart,
-    StyleChain, Styles, Synthesize, Value, elem,
+    LocatableSelector, NativeElement, OneOrMultiple, Packed, Reflect, Repr, Scope,
+    Selector, ShowSet, Smart, StyleChain, Styles, Synthesize, Value, elem,
 };
 use crate::introspection::{
     EmptyIntrospector, History, Introspect, Introspector, Locatable, Location,
@@ -57,6 +60,17 @@ use crate::text::{Lang, LocalName, Region, SmallcapsElem, SubElem, SuperElem, Te
 /// @cite[citation] function (`[#cite(<key>)]`). The bibliography will only show
 /// entries for works that were referenced in the document.
 ///
+/// = Example <example>
+/// ```example
+/// This was already noted by
+/// pirates long ago. @arrgh
+///
+/// Multiple sources say ...
+/// @arrgh @netwok.
+///
+/// #bibliography("works.bib")
+/// ```
+///
 /// = Styles <styles>
 /// Typst offers a wide selection of built-in
 /// @bibliography.style[citation and bibliography styles]. Beyond those, you can
@@ -86,16 +100,14 @@ use crate::text::{Lang, LocalName, Region, SmallcapsElem, SubElem, SuperElem, Te
 ///   [`{"american-physics-society"}`],
 /// )
 ///
-/// = Example <example>
-/// ```example
-/// This was already noted by
-/// pirates long ago. @arrgh
-///
-/// Multiple sources say ...
-/// @arrgh @netwok.
-///
-/// #bibliography("works.bib")
-/// ```
+/// = Multiple bibliographies <multiple-bibliographies>
+/// When a Typst document contains multiple bibliographies, each citation is
+/// assigned to one of them. By default, Typst will automatically pick a
+/// suitable bibliography (typically, the closest following one that contains
+/// the referenced citation key). This covers common cases like by-chapter or
+/// thematic bibliographies. For more fine-grained control, citations can be
+/// explicitly targeted by a bibliography through a
+/// @bibliography.target[`target`] selector.
 #[elem(Locatable, Synthesize, ShowSet, LocalName)]
 pub struct BibliographyElem {
     /// One or multiple paths to or raw bytes for Hayagriva `.yaml` and/or
@@ -151,6 +163,115 @@ pub struct BibliographyElem {
     })]
     pub style: Derived<CslSource, CslStyle>,
 
+    /// Defines which citations to include in the bibliography.
+    ///
+    /// Typst will automatically assign each citation in the document to a
+    /// bibliography. Concretely, a citation will be assigned to (in order of
+    /// precedence)
+    /// + the first bibliography that includes it in its `target` selector; or
+    ///   if no such bibliography exists
+    /// + the closest _following_ bibliography with `{target: auto}` that
+    ///   contains its key; or if no such bibliography follows
+    /// + the closest _preceding_ bibliography with `{target: auto}` that
+    ///   contains its key.
+    ///
+    /// #example(
+    ///   title: [Local bibliography],
+    ///   ```
+    ///   #let info(body) = block(
+    ///     stroke: (left: 1.5pt + blue),
+    ///     fill: aqua.lighten(50%),
+    ///     inset: 1em,
+    ///     context {
+    ///       body
+    ///       show divider: set block(spacing: 1.2em)
+    ///       divider()
+    ///       bibliography(
+    ///         "works.bib",
+    ///         title: none,
+    ///         target: selector(cite).within(here()),
+    ///         style: "mla",
+    ///       )
+    ///     }
+    ///   )
+    ///
+    ///   = On the matter of dumplings
+    ///   In recent years, we can observe an uptick in
+    ///   dumpling consumption across the board. @netwok
+    ///
+    ///   #info[
+    ///     Dumplings are particularly enjoyed
+    ///     among pirates. @arrgh
+    ///   ]
+    ///
+    ///   #bibliography("works.bib")
+    ///   ```
+    /// )
+    pub target: Smart<LocatableSelector>,
+
+    /// Conceptually groups this bibliography with other bibliographies for
+    /// numbering purposes. Bibliographies in the same group will assign
+    /// consecutive citation numbers.
+    ///
+    /// This can be:
+    /// - `{none}`: The bibliography will be numbered in isolation.
+    /// - `{auto}`: The bibliography will be consecutively numbered with all
+    ///   other bibliographies in the `{auto}` group.
+    /// - A @str[string]: The bibliography will be consecutively numbered with
+    ///   all other bibliographies with the same `group` value.
+    ///
+    /// The `{auto}` group works just like any string group, but it is the
+    /// canonical default group.
+    ///
+    /// #example(
+    ///   title: [Consecutive citation numbers],
+    ///   ```
+    ///   #show bibliography: set heading(
+    ///     offset: 1,
+    ///   )
+    ///
+    ///   = First part
+    ///   Starts at one: @netwok @arrgh
+    ///   #bibliography(
+    ///     "works.bib",
+    ///     style: "ieee",
+    ///   )
+    ///
+    ///   = Second part
+    ///   Continues with three: @distress
+    ///   #bibliography(
+    ///     "works.bib",
+    ///     style: "nlm-citation-sequence",
+    ///   )
+    ///   ```
+    /// )
+    ///
+    /// #example(
+    ///   title: [Separate citation numbers],
+    ///   ```
+    ///   #show bibliography: set heading(
+    ///     offset: 1,
+    ///   )
+    ///   #set bibliography(group: none)
+    ///
+    ///   = First part
+    ///   Starts at one: @netwok @arrgh
+    ///   #bibliography(
+    ///     "works.bib",
+    ///     style: "ieee",
+    ///   )
+    ///
+    ///   = Second part
+    ///   Resets to one: @distress
+    ///   #bibliography(
+    ///     "works.bib",
+    ///     style: "nlm-citation-sequence",
+    ///   )
+    ///   ```
+    /// )
+    #[default(Some(Smart::Auto))]
+    pub group: Option<Smart<EcoString>>,
+
     /// The language setting where the bibliography is.
     #[internal]
     #[synthesized]
@@ -163,23 +284,7 @@ pub struct BibliographyElem {
 }
 
 impl BibliographyElem {
-    /// Find the document's bibliography.
-    pub fn find(engine: &mut Engine, span: Span) -> StrResult<Packed<Self>> {
-        let elems = engine.introspect(QueryIntrospection(Self::ELEM.select(), span));
-
-        let mut iter = elems.iter();
-        let Some(elem) = iter.next() else {
-            bail!("the document does not contain a bibliography");
-        };
-
-        if iter.next().is_some() {
-            bail!("multiple bibliographies are not yet supported");
-        }
-
-        Ok(elem.to_packed::<Self>().unwrap().clone())
-    }
-
-    /// Whether the bibliography contains the given key.
+    /// Whether any bibliography contains the given key.
     pub fn has(engine: &mut Engine, key: Label, span: Span) -> bool {
         engine
             .introspect(QueryIntrospection(Self::ELEM.select(), span))
@@ -568,9 +673,14 @@ fn replacement(style: &str) -> Option<&'static str> {
 /// memoization) for the whole document. This setup is necessary because
 /// citation formatting is inherently stateful and we need access to all
 /// citations to do it.
+/// Fully formatted citation groups and bibliographies, generated once (through
+/// memoization) for the whole document.
+///
+/// This setup is necessary because citation formatting is inherently stateful
+/// and we need access to all citations to do it.
 pub struct Works {
-    /// The document's rendered [`BibliographyElem`].
-    bibliography: SourceResult<RenderedBibliography>,
+    /// The document's rendered [`BibliographyElem`]s, keyed by their locations.
+    bibliographies: FxHashMap<Location, SourceResult<RenderedBibliography>>,
     /// The document's rendered [`CiteGroup`]s, keyed by their locations.
     groups: FxHashMap<Location, SourceResult<Content>>,
 }
@@ -596,65 +706,53 @@ pub struct RenderedEntry {
 }
 
 impl Works {
-    /// Generates and formats the bibliography and citations.
+    /// Generates and formats all bibliographies and citations.
     pub fn generate(engine: &mut Engine, span: Span) -> SourceResult<Arc<Works>> {
-        let bibliography = BibliographyElem::find(engine, span).at(span)?;
-        let groups = engine.introspect(CiteGroupIntrospection(span));
-        Self::generate_impl(engine.world, &bibliography, &groups).at(span)
-    }
-
-    /// Same as [`Works::generate`], but reuses an existing
-    /// bibliography (no need to query it).
-    pub fn with_bibliography(
-        engine: &mut Engine,
-        bibliography: Packed<BibliographyElem>,
-    ) -> SourceResult<Arc<Works>> {
-        let span = bibliography.span();
-        let groups = engine.introspect(CiteGroupIntrospection(span));
-        Self::generate_impl(engine.world, &bibliography, &groups).at(span)
+        let bibs_and_groups = engine.introspect(BibliographyIntrospection(span));
+        Self::generate_impl(
+            engine.world,
+            engine.library,
+            engine.introspector.into_raw(),
+            engine.traced,
+            TrackedMut::reborrow_mut(&mut engine.sink),
+            engine.route.track(),
+            &bibs_and_groups,
+        )
+        .at(span)
     }
 
     /// The internal implementation of [`Works::generate`].
     #[comemo::memoize]
     fn generate_impl(
         world: Tracked<dyn World + '_>,
-        bibliography: &Packed<BibliographyElem>,
-        groups: &[Content],
+        library: &LazyHash<crate::Library>,
+        introspector: Tracked<dyn Introspector + '_>,
+        traced: Tracked<Traced>,
+        sink: TrackedMut<Sink>,
+        route: Tracked<Route>,
+        bibs_and_groups: &[Content],
     ) -> StrResult<Arc<Works>> {
-        let mut shown_groups =
-            FxHashMap::with_capacity_and_hasher(groups.len(), FxBuildHasher);
-
-        // Render the bibliography and citations with hayagriva. Already inserts
-        // errors into `citations` for citation key that don't resolve.
-        let (rendered, successes) = render(bibliography, groups, &mut shown_groups);
-
-        // Show the citations.
-        let to_entries = match &rendered.bibliography {
-            Some(rendered) => links_to_entries(bibliography, rendered),
-            None => FxHashMap::default(),
+        let mut engine = Engine {
+            world,
+            library,
+            introspector: Protected::from_raw(introspector),
+            traced,
+            sink,
+            route: Route::extend(route),
         };
-        for (rendered, group) in rendered.citations.iter().zip(successes) {
-            let loc = group.location().unwrap();
-            let result =
-                show_cite_group(world, bibliography, group, rendered, &to_entries);
-            shown_groups.insert(loc, result);
-        }
 
-        // Show the bibliography.
-        let shown_bibliography = rendered
-            .bibliography
-            .as_ref()
-            .ok_or_else(|| {
-                style_unsuitable(
-                    &bibliography.style.get_ref(StyleChain::default()).source,
-                )
-            })
-            .and_then(|rendered| show_bibliography(world, bibliography, groups, rendered))
-            .at(bibliography.span());
+        // Prepare bibliographies and citation groups for rendering with
+        // hayagriva.
+        let p = prepare(&mut engine, bibs_and_groups);
+
+        // Render the bibliography and citations with hayagriva.
+        let mut offsets = FxHashMap::default();
+        let rendered =
+            p.bibs.iter().map(|bib| render(bib, &mut offsets)).collect::<Vec<_>>();
 
         Ok(Arc::new(Works {
-            groups: shown_groups,
-            bibliography: shown_bibliography,
+            bibliographies: show_bibliographies(world, &p, &rendered),
+            groups: show_cite_groups(world, p, &rendered),
         }))
     }
 
@@ -663,72 +761,319 @@ impl Works {
         self.groups
             .get(&loc)
             .cloned()
-            .ok_or_else(failed_to_format_citation)
+            .ok_or_else(citation_could_not_be_located)
             .at(span)?
     }
 
     /// Returns the shown content for a bibliography.
-    pub fn bibliography(&self) -> SourceResult<&RenderedBibliography> {
-        self.bibliography.as_ref().map_err(Clone::clone)
+    pub fn bibliography(
+        &self,
+        loc: Location,
+        span: Span,
+    ) -> SourceResult<&RenderedBibliography> {
+        self.bibliographies
+            .get(&loc)
+            .ok_or_else(bibliography_could_not_be_located)
+            .at(span)?
+            .as_ref()
+            .map_err(Clone::clone)
     }
+}
+
+/// Preprocessed information for all bibliographies and citation groups in the
+/// document, ready for rendering with hayagriva.
+struct Preparation<'a> {
+    /// Preprocessed information for all bibliographies in the document, in
+    /// document order.
+    bibs: Vec<PreparedBibliography<'a>>,
+    /// Preprocessed information for all [`CiteGroup`] elements in the document,
+    /// keyed by their [`Location`].
+    groups: FxHashMap<Location, SourceResult<PreparedCiteGroup<'a>>>,
+}
+
+/// Preprocessed information for a bibliography and the citations assigned to
+/// it, ready for processing by hayagriva.
+struct PreparedBibliography<'a> {
+    /// The underlying bibliography element.
+    elem: &'a Packed<BibliographyElem>,
+    /// Information about citation subgroups assigned to this bibliography, in
+    /// document order. Each subgroup turns into one citation sent to hayagriva,
+    /// A single [`CiteGroup`] can comprise multiple subgroups assigned to
+    /// different bibliographies.
+    subgroups: Vec<Subgroup<'a>>,
+}
+
+/// Holds consecutive citations from a `CiteGroup` that were assigned to the
+/// same bibliography.
+///
+/// See [`CiteGroup`] for more details on citation grouping.
+struct Subgroup<'a> {
+    /// The underlying citation group.
+    elem: &'a Packed<CiteGroup>,
+    /// The citations in this subgroup.
+    citations: SmallVec<[&'a Packed<CiteElem>; 1]>,
+    /// The style picked for this subgroup. Citations are not segmented by style
+    /// (at least currently); we simply pick the style of the first citation.
+    style: &'a CslStyle,
+}
+
+/// Preprocessed information for a [`CiteGroup`]. Can be used to show the group
+/// as [`Content`] after bibliographies are processed with hayagriva.
+struct PreparedCiteGroup<'a>(SmallVec<[GroupPart<'a>; 1]>);
+
+/// A segment in a preprocessed [`CiteGroup`].
+enum GroupPart<'a> {
+    /// This content should be displayed verbatim. In practice, this is only
+    /// ever a [`SpaceElem`](crate::text::SpaceElem) between subgroups.
+    Content(&'a Content),
+    /// Points to a subgroup in one of the bibliographies in the document and
+    /// should be substituted by the content produced for the citation.
+    Subgroup(BibIndex, SubgroupIndex),
+}
+
+/// The index of a bibliography among all bibliographies in `p.bibs` where
+/// `p: Preparation`.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+struct BibIndex(usize);
+
+/// The index of a subgroup in `bib.subgroups` where `bib: PreparedBibliography`
+/// among those assigned to the same bibliography.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+struct SubgroupIndex(usize);
+
+/// Prepares the document's bibliographies and citation groups for rendering
+/// with hayagriva.
+///
+/// Primarily, this involves
+/// - assigning citations to bibliographies (and while doing so splitting
+///   [`CiteGroup`]s into subgroups assigned to the same bibliography).
+/// - retaining data structures that can be used to show the hayagriva output as
+///   [`Content`] for bibliography and citation group elements.
+fn prepare<'a>(engine: &mut Engine, bibs_and_groups: &'a [Content]) -> Preparation<'a> {
+    // Maps from citations to bibliography indices for citations that were
+    // explicitly selected via a bibliography with a `target`.
+    let mut selected = FxHashMap::<Location, BibIndex>::default();
+
+    // First, we process bibliographies. This involves:
+    // - Creating a slot in `bibs` for each
+    // - Creating a mapping from citations to bibliography index for all
+    //   citations specifically targetted by a bibliography.
+    let mut bibs = Vec::<PreparedBibliography>::new();
+    for elem in bibs_and_groups {
+        let Some(bib) = elem.to_packed::<BibliographyElem>() else { continue };
+        let idx = BibIndex(bibs.len());
+        bibs.push(PreparedBibliography { elem: bib, subgroups: vec![] });
+
+        if let Smart::Custom(LocatableSelector(selector)) =
+            bib.target.get_cloned(StyleChain::default())
+        {
+            for citation in engine.introspect(QueryIntrospection(selector, bib.span())) {
+                selected.entry(citation.location().unwrap()).or_insert(idx);
+            }
+        }
+    }
+
+    // Then, we process citations groups. See the doc comment of
+    // `prepare_cite_group` for more information on which steps this involves.
+    let mut groups = FxHashMap::default();
+    let mut bib_cursor = 0;
+    for elem in bibs_and_groups {
+        let Some(group) = elem.to_packed::<CiteGroup>() else {
+            debug_assert!(elem.is::<BibliographyElem>());
+            bib_cursor += 1;
+            continue;
+        };
+
+        let loc = group.location().unwrap();
+        let result = prepare_cite_group(&mut bibs, bib_cursor, group, &selected);
+        groups.insert(loc, result);
+    }
+
+    Preparation { bibs, groups }
+}
+
+/// Prepares a [`CiteGroup`] by
+/// - splitting it into subgroups assigned to the same bibliography
+/// - storing a [`Subgroup`] for each of these in the approprate slot in `bibs`
+/// - creating a [`PreparedCiteGroup`] which can be used to stitch the shown
+///   content for the subgroups together after it was rendered with hayagriva.
+fn prepare_cite_group<'a>(
+    bibs: &mut [PreparedBibliography<'a>],
+    bib_cursor: usize,
+    group: &'a Packed<CiteGroup>,
+    selected: &FxHashMap<Location, BibIndex>,
+) -> SourceResult<PreparedCiteGroup<'a>> {
+    // Holds the collected segments of the citation group.
+    let mut parts = SmallVec::new();
+    // Citations that make up the current subgroup.
+    let mut subgroup = SmallVec::new();
+    // The bibliography index for the current subgroup. If `Some(_)`, then
+    // `subgroup` is not empty.
+    let mut subgroup_bib = None;
+    // The elements in `group.children[tail..i]` are interior spaces.
+    let mut tail = 0;
+    // Holds errors for any uncovered citation. We collect them instead of
+    // bailing early so that we can give multiple errors at once.
+    let mut errors = EcoVec::new();
+
+    for (i, child) in group.children.iter().enumerate() {
+        // The children are either citations or spaces. We skip interior spaces
+        // without updating `tail`, so that at any point we can produce a slice
+        // with the trailing spaces.
+        //
+        // Note that exterior spaces are not supported, but they also will never
+        // appear in groups in practice.
+        let Some(citation) = child.to_packed::<CiteElem>() else { continue };
+        let spaces = &group.children[tail..i];
+        tail = i + 1;
+
+        // Determine the pre-selected bibliography or assign an auto
+        // bibliography.
+        let bib_idx = if let Some(&idx) = selected.get(&citation.location().unwrap()) {
+            // Ensure that the bibliography contains the key.
+            let bib = &bibs[idx.0];
+            if !bib.elem.sources.derived.has(citation.key) {
+                errors.push(key_does_not_exist(citation, bib));
+                continue;
+            }
+            idx
+        } else if let Some(idx) = select_auto_bib(citation, bibs, bib_cursor) {
+            idx
+        } else {
+            errors.push(uncovered_citation(citation, bibs));
+            continue;
+        };
+
+        // If the assigned bibliography changes, flush the previous subgroup and
+        // the spaces between it and the current `child`.
+        if let Some(subgroup_bib) = subgroup_bib
+            && subgroup_bib != bib_idx
+        {
+            parts.push(save_subgroup(
+                bibs,
+                subgroup_bib,
+                group,
+                std::mem::take(&mut subgroup),
+            ));
+            parts.extend(spaces.iter().map(GroupPart::Content));
+        }
+
+        subgroup_bib = Some(bib_idx);
+        subgroup.push(citation);
+    }
+
+    // Flush the final subgroup if any.
+    if let Some(subgroup_bib) = subgroup_bib {
+        parts.push(save_subgroup(bibs, subgroup_bib, group, subgroup));
+    }
+
+    if !errors.is_empty() {
+        return Err(errors);
+    }
+
+    Ok(PreparedCiteGroup(parts))
+}
+
+/// Builds a [`Subgroup`] and stores it in the selected bibliography. Returns a
+/// [`GroupPart`] to remember that this subgroup belongs to the [`CiteGroup`]
+/// that's currently being prepared.
+fn save_subgroup<'a>(
+    bibs: &mut [PreparedBibliography<'a>],
+    bib_idx: BibIndex,
+    elem: &'a Packed<CiteGroup>,
+    citations: SmallVec<[&'a Packed<CiteElem>; 1]>,
+) -> GroupPart<'a> {
+    let bib = &mut bibs[bib_idx.0];
+    let style = if let Some(first) = citations.first()
+        && let Smart::Custom(style) = first.style.get_ref(StyleChain::default())
+    {
+        &style.derived
+    } else {
+        &bib.elem.style.get_ref(StyleChain::default()).derived
+    };
+
+    let sub_idx = SubgroupIndex(bib.subgroups.len());
+    bib.subgroups.push(Subgroup { elem, citations, style });
+
+    GroupPart::Subgroup(bib_idx, sub_idx)
+}
+
+/// Selects the appropriate bibliography for a citation that was not explicitly
+/// targeted by a bibliography.
+///
+/// The priority is:
+/// 1. First following auto bibliography containing the citation key
+/// 2. First preceding auto bibliography containing the citation key
+///
+/// Returns `None` if no auto bibliography contains the key.
+fn select_auto_bib(
+    citation: &Packed<CiteElem>,
+    bibs: &[PreparedBibliography],
+    bib_cursor: usize,
+) -> Option<BibIndex> {
+    let bibs = bibs.iter().enumerate();
+    let before = bibs.clone().take(bib_cursor);
+    let after = bibs.skip(bib_cursor);
+    after
+        .chain(before.rev())
+        .find(|(_, bib)| {
+            bib.elem.target.get_ref(StyleChain::default()).is_auto()
+                && bib.elem.sources.derived.has(citation.key)
+        })
+        .map(|(idx, _)| BibIndex(idx))
 }
 
 /// Renders the bibliography and citation groups with hayagriva.
 fn render<'a>(
-    bibliography: &Packed<BibliographyElem>,
-    groups: &'a [Content],
-    failures: &mut FxHashMap<Location, SourceResult<Content>>,
-) -> (hayagriva::Rendered, Vec<&'a Packed<CiteGroup>>) {
+    bib: &PreparedBibliography<'a>,
+    offsets: &mut FxHashMap<Smart<&'a str>, usize>,
+) -> hayagriva::Rendered {
     static LOCALES: LazyLock<Vec<citationberg::Locale>> =
         LazyLock::new(hayagriva::archive::locales);
 
-    let database = &bibliography.sources.derived;
+    let database = &bib.elem.sources.derived;
 
-    // Process all citation groups.
     let mut driver = BibliographyDriver::new();
-    let mut successes = Vec::new();
+    let mut offset = bib
+        .elem
+        .group
+        .get_ref(StyleChain::default())
+        .as_ref()
+        .map(|group| offsets.entry(group.as_deref()).or_insert(0));
 
-    for elem in groups {
-        let group = elem.to_packed::<CiteGroup>().unwrap();
-        let location = elem.location().unwrap();
-
-        // Groups should never be empty.
-        let Some(first) = group.children.first() else { continue };
-
-        let mut items = Vec::with_capacity(group.children.len());
-        let mut errors = EcoVec::new();
-
-        // Create infos and items for each child in the group.
-        for child in &group.children {
-            match database.get(child.key) {
-                Some(entry) => items.push(citation_item(entry, child)),
-                _ => errors.push(error!(
-                    child.span(),
-                    "key `{}` does not exist in the bibliography",
-                    child.key.resolve(),
-                )),
-            }
-        }
-
-        if !errors.is_empty() {
-            failures.insert(location, Err(errors));
-            continue;
-        }
-
-        let style = resolve_style(group, bibliography).get();
-        let locale = locale(first.lang.unwrap_or(Lang::ENGLISH), first.region.flatten());
-
-        driver.citation(CitationRequest::new(items, style, Some(locale), &LOCALES, None));
-        successes.push(group);
+    if let Some(offset) = &mut offset {
+        driver = driver.with_citation_number_offset(**offset);
     }
 
-    let bib_style = &bibliography.style.get_ref(StyleChain::default()).derived;
+    for group in &bib.subgroups {
+        let items = group
+            .citations
+            .iter()
+            .map(|child| {
+                let entry = database.get(child.key).expect("entry to be present");
+                citation_item(entry, child)
+            })
+            .collect::<Vec<_>>();
+
+        let first = &group.citations[0];
+        let locale = locale(first.lang.unwrap_or(Lang::ENGLISH), first.region.flatten());
+
+        driver.citation(CitationRequest::new(
+            items,
+            group.style.get(),
+            Some(locale),
+            &LOCALES,
+            None,
+        ));
+    }
+
+    let bib_style = &bib.elem.style.get_ref(StyleChain::default()).derived;
     let locale =
-        locale(bibliography.lang.unwrap_or(Lang::ENGLISH), bibliography.region.flatten());
+        locale(bib.elem.lang.unwrap_or(Lang::ENGLISH), bib.elem.region.flatten());
 
     // Add hidden items for everything if we should print the whole
     // bibliography.
-    if bibliography.full.get(StyleChain::default()) {
+    if bib.elem.full.get(StyleChain::default()) {
         for (_, entry) in database.iter() {
             driver.citation(CitationRequest::new(
                 vec![CitationItem::new(entry, None, None, true, None)],
@@ -746,7 +1091,20 @@ fn render<'a>(
         locale_files: &LOCALES,
     });
 
-    (rendered, successes)
+    if let Some(offset) = offset
+        && let Some(bib) = &rendered.bibliography
+        // Check whether the style uses numbering.
+        && rendered.citations.iter().any(|rendered| {
+            rendered
+                .citation
+                .find_meta(&hayagriva::ElemMeta::CitationNumber)
+                .is_some()
+        })
+    {
+        *offset += bib.items.len();
+    }
+
+    rendered
 }
 
 /// Creates a hayagriva citation item for a citation element.
@@ -778,21 +1136,48 @@ fn citation_item<'a>(
     CitationItem::new(entry, locator, None, hidden, special_form)
 }
 
+/// Produces the structured content for all [`BibliographyElem`]s in the
+/// document. The output of this is directly stored in the [`Works`] and
+/// consumed by the target-specific bibliography show rules.
+fn show_bibliographies(
+    world: Tracked<dyn World + '_>,
+    p: &Preparation,
+    rendered: &[hayagriva::Rendered],
+) -> FxHashMap<Location, SourceResult<RenderedBibliography>> {
+    p.bibs
+        .iter()
+        .zip(rendered)
+        .map(|(bib, rendered)| {
+            let loc = bib.elem.location().unwrap();
+            let result = rendered
+                .bibliography
+                .as_ref()
+                .ok_or_else(|| {
+                    style_unsuitable(
+                        &bib.elem.style.get_ref(StyleChain::default()).source,
+                    )
+                })
+                .and_then(|rendered| show_bibliography(world, bib, rendered))
+                .at(bib.elem.span());
+            (loc, result)
+        })
+        .collect()
+}
+
 /// Turns a bibliography rendered with hayagriva into a final
 /// [`RenderedBibliography`].
 fn show_bibliography(
     world: Tracked<dyn World + '_>,
-    bibliography: &Packed<BibliographyElem>,
-    groups: &[Content],
+    bib: &PreparedBibliography,
     rendered: &hayagriva::RenderedBibliography,
 ) -> StrResult<RenderedBibliography> {
-    let to_citations = links_to_citations(groups);
+    let to_citations = links_to_citations(&bib.subgroups);
 
-    let mut entries = vec![];
+    let mut entries = Vec::with_capacity(rendered.items.len());
     for (k, item) in rendered.items.iter().enumerate() {
         let ctx = ShowCtx {
             world,
-            span: bibliography.span(),
+            span: bib.elem.span(),
             supplement: &|_| None,
             link: &|_| None,
         };
@@ -818,50 +1203,84 @@ fn show_bibliography(
             }
         });
 
-        entries.push(RenderedEntry {
-            prefix,
-            body,
-            backlink: entry_location(bibliography, k),
-        });
+        entries.push(RenderedEntry { prefix, body, backlink: entry_location(bib, k) });
     }
 
     Ok(RenderedBibliography { entries, hanging_indent: rendered.hanging_indent })
 }
 
-/// Produces the content for a [`CiteGroup`].
+/// Produces the content for all [`CiteGroup`]s in the document. The output of
+/// this is directly stored in the [`Works`] and consumed by [`CiteGroup`] show
+/// rule.
+fn show_cite_groups(
+    world: Tracked<dyn World + '_>,
+    p: Preparation,
+    rendered: &[hayagriva::Rendered],
+) -> FxHashMap<Location, SourceResult<Content>> {
+    let to_entries = links_to_entries(&p, rendered);
+    p.groups
+        .into_iter()
+        .map(|(loc, group)| {
+            let result = group.and_then(|group| {
+                show_cite_group(world, &group, &p.bibs, rendered, |idx, key| {
+                    to_entries.get(&(idx, key)).copied()
+                })
+            });
+            (loc, result)
+        })
+        .collect()
+}
+
+/// Produces the content for a [`CiteGroup`] by stitching together the hayagriva
+/// output for each subgroup and interspersing potential space elements that
+/// were retained between subgroups.
 fn show_cite_group(
     world: Tracked<dyn World + '_>,
-    bibliography: &Packed<BibliographyElem>,
-    group: &Packed<CiteGroup>,
+    group: &PreparedCiteGroup,
+    prepared: &[PreparedBibliography],
+    rendered: &[hayagriva::Rendered],
+    to_entry: impl Fn(BibIndex, &str) -> Option<Location>,
+) -> SourceResult<Content> {
+    let mut seq = vec![];
+    for part in &group.0 {
+        seq.push(match part {
+            GroupPart::Content(c) => (**c).clone(),
+            GroupPart::Subgroup(bib_idx, sub_idx) => {
+                let subgroup = &prepared[bib_idx.0].subgroups[sub_idx.0];
+                let item = &rendered[bib_idx.0].citations[sub_idx.0];
+                show_subgroup(world, subgroup, item, |key| to_entry(*bib_idx, key))?
+            }
+        });
+    }
+    Ok(Content::sequence(seq))
+}
+
+/// Displays a single citation subgroup.
+fn show_subgroup(
+    world: Tracked<dyn World + '_>,
+    group: &Subgroup,
     citation: &hayagriva::RenderedCitation,
-    to_entries: &FxHashMap<&str, Location>,
+    to_entry: impl Fn(&str) -> Option<Location>,
 ) -> SourceResult<Content> {
     if group
-        .children
+        .citations
         .iter()
         .all(|sub| sub.form.get(StyleChain::default()).is_none())
     {
         return Ok(Content::empty());
     }
 
+    let span = Span::find(group.citations.iter().map(|elem| elem.span()));
     let supplement =
-        |i: usize| group.children.get(i)?.supplement.get_cloned(StyleChain::default());
-    let link =
-        |i: usize| to_entries.get(group.children.get(i)?.key.resolve().as_str()).copied();
-
-    let ctx = ShowCtx {
-        world,
-        span: group.span(),
-        supplement: &supplement,
-        link: &link,
-    };
+        |i: usize| group.citations.get(i)?.supplement.get_cloned(StyleChain::default());
+    let link = |i: usize| to_entry(group.citations.get(i)?.key.resolve().as_str());
+    let ctx = ShowCtx { world, span, supplement: &supplement, link: &link };
 
     let mut realized =
-        show_elem_children(&ctx, &citation.citation, None, true).at(group.span())?;
+        show_elem_children(&ctx, &citation.citation, None, true).at(span)?;
 
-    if resolve_style(group, bibliography).get().settings.class
-        == citationberg::StyleClass::Note
-        && group.children.iter().all(|sub| {
+    if group.style.get().settings.class == citationberg::StyleClass::Note
+        && group.citations.iter().all(|sub| {
             matches!(
                 sub.form.get(StyleChain::default()),
                 None | Some(CitationForm::Normal)
@@ -874,47 +1293,37 @@ fn show_cite_group(
     Ok(realized)
 }
 
-/// Determines the CSL style to use for a citation group.
-fn resolve_style<'a>(
-    group: &'a Packed<CiteGroup>,
-    bibliography: &'a Packed<BibliographyElem>,
-) -> &'a CslStyle {
-    if let Some(first) = group.children.first()
-        && let Smart::Custom(style) = first.style.get_ref(StyleChain::default())
-    {
-        &style.derived
-    } else {
-        &bibliography.style.get_ref(StyleChain::default()).derived
-    }
-}
-
-/// Creates a map that links from citation keys to the first citation group
-/// that contains the key.
+/// Creates a map from citation keys to the citation group containing the first
+/// citation assigned to a particular bibliography that references the key.
 ///
 /// This is used by bibliography entries to link back to the first citation that
 /// references them.
-fn links_to_citations(groups: &[Content]) -> FxHashMap<ResolvedPicoStr, Location> {
+fn links_to_citations(groups: &[Subgroup]) -> FxHashMap<ResolvedPicoStr, Location> {
     let mut map = FxHashMap::default();
     for group in groups {
-        let group = group.to_packed::<CiteGroup>().unwrap();
-        let loc = group.location().unwrap();
-        for child in &group.children {
+        for child in &group.citations {
             let key = child.key.resolve();
-            map.entry(key).or_insert(loc);
+            map.entry(key).or_insert(group.elem.location().unwrap());
         }
     }
     map
 }
 
-/// Creates a map that links from citation keys to the corresponding entry in
-/// the bibliography.
+/// Creates a map from a bibliography index + citation key to the corresponding
+/// entry in the bibliography.
+///
+/// This is used by citations to link forward to the bibliography entry they
+/// reference.
 fn links_to_entries<'a>(
-    bibliography: &Packed<BibliographyElem>,
-    rendered: &'a hayagriva::RenderedBibliography,
-) -> FxHashMap<&'a str, Location> {
+    p: &Preparation,
+    rendered: &'a [hayagriva::Rendered],
+) -> FxHashMap<(BibIndex, &'a str), Location> {
     let mut links = FxHashMap::default();
-    for (k, item) in rendered.items.iter().enumerate() {
-        links.insert(item.key.as_str(), entry_location(bibliography, k));
+    for (i, (bib, rendered)) in p.bibs.iter().zip(rendered).enumerate() {
+        let Some(rendered) = &rendered.bibliography else { continue };
+        for (k, item) in rendered.items.iter().enumerate() {
+            links.insert((BibIndex(i), item.key.as_str()), entry_location(bib, k));
+        }
     }
     links
 }
@@ -923,8 +1332,8 @@ fn links_to_entries<'a>(
 /// derived from the bibliography's location. This way, citations can link to
 /// them without having to query for them (which would incur an extra layout
 /// iteration).
-fn entry_location(bibliography: &Packed<BibliographyElem>, k: usize) -> Location {
-    bibliography.location().unwrap().variant(k + 1)
+fn entry_location(bib: &PreparedBibliography, k: usize) -> Location {
+    bib.elem.location().unwrap().variant(k + 1)
 }
 
 /// Additional data needed to show hayagriva elements as content.
@@ -1174,15 +1583,15 @@ pub struct CslIndentElem {
     pub body: Content,
 }
 
-/// Retrieves all citation groups in the document.
+/// Retrieves all bibliographies and citation groups in the document.
 ///
 /// This is separate from `QueryIntrospection` so that we can customize the
 /// diagnostic as the `CiteGroup` is internal. The default query message is also
 /// not that helpful in this case.
 #[derive(Debug, Clone, PartialEq, Hash)]
-struct CiteGroupIntrospection(Span);
+struct BibliographyIntrospection(Span);
 
-impl Introspect for CiteGroupIntrospection {
+impl Introspect for BibliographyIntrospection {
     type Output = EcoVec<Content>;
 
     fn introspect(
@@ -1190,24 +1599,74 @@ impl Introspect for CiteGroupIntrospection {
         _: &mut Engine,
         introspector: Tracked<dyn Introspector + '_>,
     ) -> Self::Output {
-        introspector.query(&CiteGroup::ELEM.select())
+        introspector.query(&Selector::Or(eco_vec![
+            BibliographyElem::ELEM.select(),
+            CiteGroup::ELEM.select(),
+        ]))
     }
 
     fn diagnose(&self, _: &History<Self::Output>) -> SourceDiagnostic {
-        warning!(
-            self.0, "citation grouping did not stabilize";
-            hint: "this can happen if the citations and bibliographies in the \
-                   document did not stabilize by the end of the third layout iteration";
-        )
+        warning!(self.0, "citations and bibliographies did not stabilize")
     }
 }
 
 /// The diagnostic when a citation wasn't found in the pre-formatted list.
-fn failed_to_format_citation() -> HintedString {
+fn citation_could_not_be_located() -> HintedString {
     error!(
-        "cannot format citation in isolation";
-        hint: "check whether this citation is measured \
-               without being inserted into the document";
+        "citation could not be located";
+        hint: "this citation is not stably present in the document";
+        hint: "this can be caused by measurement or introspection";
+    )
+}
+
+/// The diagnostic when a bibliography wasn't found in the pre-formatted list.
+fn bibliography_could_not_be_located() -> HintedString {
+    error!(
+        "bibliography could not be located";
+        hint: "this bibliography is not stably present in the document";
+        hint: "this can be caused by measurement or introspection";
+    )
+}
+
+/// The diagnostic when a citation is not picked up by any bibliography.
+fn uncovered_citation(
+    citation: &Packed<CiteElem>,
+    bibs: &[PreparedBibliography],
+) -> SourceDiagnostic {
+    let span = citation.span();
+    let key = citation.key.resolve();
+    if bibs.is_empty() {
+        error!(span, "the document does not contain a bibliography")
+    } else if let Some(bib) =
+        bibs.iter().find(|bib| bib.elem.sources.derived.has(citation.key))
+    {
+        error!(
+            span,
+            "citation is not covered by any bibliography";
+            hint[bib.elem.span()]:
+            "a bibliography containing the key `{key}` exists, \
+             but its `target` excludes this citation";
+        )
+    } else {
+        error!(
+            span,
+            "citation key `{key}` is not present in {} bibliography",
+            if bibs.len() == 1 { "the" } else { "any" },
+        )
+    }
+}
+
+/// The diagnostic when a citation is explicitly targeted by a bibliography,
+/// but its key does not exist in said bibliography.
+fn key_does_not_exist(
+    citation: &Packed<CiteElem>,
+    bib: &PreparedBibliography,
+) -> SourceDiagnostic {
+    error!(
+        citation.span(),
+        "key `{}` does not exist in the bibliography",
+        citation.key.resolve();
+        hint[bib.elem.span()]: "the citation was assigned to this bibliography";
     )
 }
 

--- a/crates/typst-library/src/model/cite.rs
+++ b/crates/typst-library/src/model/cite.rs
@@ -148,15 +148,33 @@ pub enum CitationForm {
     Year,
 }
 
-/// A group of citations.
+/// A group of consecutive citations.
 ///
-/// This is automatically created from adjacent citations during show rule
-/// application.
+/// This element is automatically created from adjacent citations during
+/// realization. Citations are grouped without regard to which bibliography they
+/// end up being assigned to. They are only split into subgroups during
+/// bibliography assignment within the call tree of [`Works::generate`].
+///
+/// Each subgroup created there may consist of one or multiple citations that
+/// are processed as a union by hayagriva. If hayagriva were to support a single
+/// citation group for multiple bibliographies, the subgroup concept could be
+/// removed, but it's unclear whether that can be reasonably supported.
+///
+/// Another alternative would have been to already segment by assigned
+/// bibliography when grouping consecutive citations into [`CiteGroup`]s during
+/// realization. This would be quite clean, but unfortunately it would incur one
+/// additional document iteration, which is too high a price to pay for the
+/// conceptual cleanliness.
+///
+/// The citation group element is purposefully kept internal to retain
+/// flexibility in how it is collected.
 #[elem(Locatable)]
 pub struct CiteGroup {
-    /// The citations.
+    /// Holds citations and potentially spaces in between them. The spaces are
+    /// retained so that they can be correctly rendered between subgroups
+    /// assigned to different bibliographies.
     #[required]
-    pub children: Vec<Packed<CiteElem>>,
+    pub children: Vec<Content>,
 }
 
 impl Packed<CiteGroup> {

--- a/crates/typst-library/src/model/reference.rs
+++ b/crates/typst-library/src/model/reference.rs
@@ -264,7 +264,7 @@ impl Packed<RefElem> {
             if let Ok(elem) = elem {
                 bail!(
                     span,
-                    "label `{}` occurs both in the document and its bibliography",
+                    "label `{}` occurs both in the document and a bibliography",
                     self.target.repr();
                     hint: "change either the {}'s label or the \
                            bibliography key to resolve the ambiguity",

--- a/crates/typst-realize/src/lib.rs
+++ b/crates/typst-realize/src/lib.rs
@@ -1210,11 +1210,7 @@ fn finish_cites(grouped: Grouped) -> SourceResult<()> {
     let elems = grouped.get();
     let span = select_span(elems);
     let trunk = elems[0].1;
-    let children = elems
-        .iter()
-        .filter_map(|(c, _)| c.to_packed::<CiteElem>())
-        .cloned()
-        .collect();
+    let children = elems.iter().map(|(c, _)| (**c).clone()).collect();
 
     // Create and visit the citation group.
     let s = grouped.end();

--- a/tests/ref/html/hashes.txt
+++ b/tests/ref/html/hashes.txt
@@ -3,6 +3,10 @@ a845db3f6f6d466d683136b703f44cf6 basic-table
 7c963ec939cdb49eb712fb761554ecbd bibliography-basic
 3f625e61698549ccccf65b72a66b72e7 bibliography-csl-display
 74b33b507da27e15d265f3217c858ac6 bibliography-custom-title
+b7db257520089ca4fabc7de0ce145d4f bibliography-group-auto
+0b7c6366e0660d06550c9081512d5bb9 bibliography-group-none
+5fab6af8d6370f60818ea4e1eec8095a bibliography-group-out-of-order
+17da3cafc27f03d422dd8863d4bf9707 bibliography-group-str
 376934db510f9e65eee13bd8a679ddc3 bibliography-multiple-files
 1e0f40cc69e2d5efa0590d9c17fec0a6 bibliography-no-title
 805860e9a2d6bc7f9e466517c058eeec block-block-html
@@ -21,6 +25,10 @@ ffa25d90e2baac1e02b03a60cae89720 block-html-block
 9c97626487e554505316c09c201e2672 box-html-text
 70108e658925ad830eb52315ae468ef2 box-invalid-html
 2aed0e9d684405e21767d60dd095416d cases-content-html
+98dedb048606424f38be96c08c885d5b cite-assignment-auto
+7ff41d13a261fd9d9880af433772692b cite-assignment-by-chapter
+6f9bcc678f7d826be4de22b3137fee1b cite-assignment-mixed-group
+7ae64640fd751161f5897e1506c73bc3 cite-assignment-target
 661ff95a98d1254954d821d2146617ce cite-form
 252cb984e3a921ac9d717570371f4fa6 cite-group
 e87734ba4dba7fed32967be69484478c col-gutter-table

--- a/tests/suite/introspection/convergence.typ
+++ b/tests/suite/introspection/convergence.typ
@@ -183,9 +183,13 @@
 
 --- converge-bibliography-1 paged ---
 // Warning: document did not converge within five attempts
-// Hint: see 1 additional warning for more details
+// Hint: see 2 additional warnings for more details
 // Hint: see https://typst.app/help/convergence for help
 #import "switch.typ": switch
+// Warning: 26-63 citations and bibliographies did not stabilize
+// Error: 26-63 bibliography could not be located
+// Hint: 26-63 this bibliography is not stably present in the document
+// Hint: 26-63 this can be caused by measurement or introspection
 #switch(n => if n >= 5 { bibliography("/assets/bib/works.bib") })
 
 // Error: 1-8 label `<netwok>` does not exist in the document
@@ -199,14 +203,13 @@
 // Hint: see https://typst.app/help/convergence for help
 #import "switch.typ": switch
 
-// Warning: 26-63 citation grouping did not stabilize
-// Hint: 26-63 this can happen if the citations and bibliographies in the document did not stabilize by the end of the third layout iteration
+// Warning: 26-63 citations and bibliographies did not stabilize
 #switch(n => if n >= 4 { bibliography("/assets/bib/works.bib") })
 
-// Error: 1-8 cannot format citation in isolation
-// Hint: 1-8 check whether this citation is measured without being inserted into the document
-// Warning: 1-8 citation grouping did not stabilize
-// Hint: 1-8 this can happen if the citations and bibliographies in the document did not stabilize by the end of the third layout iteration
+// Error: 1-8 citation could not be located
+// Hint: 1-8 this citation is not stably present in the document
+// Warning: 1-8 citations and bibliographies did not stabilize
+// Hint: 1-8 this can be caused by measurement or introspection
 @netwok
 
 --- convergence-measure paged empty ---

--- a/tests/suite/layout/measure.typ
+++ b/tests/suite/layout/measure.typ
@@ -58,8 +58,9 @@
 --- measure-citation-in-flow-different-span paged ---
 // When the citation has a different span, it stops working.
 #context {
-  // Error: 22-29 cannot format citation in isolation
-  // Hint: 22-29 check whether this citation is measured without being inserted into the document
+  // Error: 22-29 citation could not be located
+  // Hint: 22-29 this citation is not stably present in the document
+  // Hint: 22-29 this can be caused by measurement or introspection
   let size = measure[@netwok]
   place(line(length: size.width))
   v(1mm)

--- a/tests/suite/model/bibliography.typ
+++ b/tests/suite/model/bibliography.typ
@@ -180,3 +180,31 @@ hi:
   title: none,
   full: true,
 )
+
+--- bibliography-group-none html ---
+#set bibliography(group: none)
+
+@keshav2007read @netwok @arrgh
+#bibliography("/assets/bib/works.bib")
+#bibliography("/assets/bib/works_too.bib", style: "nlm-citation-sequence")
+
+--- bibliography-group-auto html ---
+@netwok @arrgh @keshav2007read
+#bibliography("/assets/bib/works.bib")
+#bibliography("/assets/bib/works_too.bib")
+
+--- bibliography-group-str html ---
+@netwok @arrgh @keshav2007read
+#bibliography("/assets/bib/works.bib", group: "a")
+#bibliography("/assets/bib/works_too.bib", group: "b", style: "nlm-citation-sequence")
+
+@quark @distress @keshav2007read
+#bibliography("/assets/bib/works.bib", group: "a")
+#bibliography("/assets/bib/works_too.bib", group: "b", style: "nlm-citation-sequence")
+
+--- bibliography-group-out-of-order html ---
+// The numbers are ordered in the order of the bibliographies, so in the prose
+// they can be out of order if using shared numbering.
+@keshav2007read @netwok @arrgh
+#bibliography("/assets/bib/works.bib")
+#bibliography("/assets/bib/works_too.bib")

--- a/tests/suite/model/cite.typ
+++ b/tests/suite/model/cite.typ
@@ -246,3 +246,101 @@ Par 6 @arrgh[*p. 9-10*]
 )
 
 #bibliography("/assets/bib/works.bib", style: style)
+
+--- cite-no-bib paged ---
+// Error: 2-19 the document does not contain a bibliography
+#cite(<something>)
+
+--- cite-unknown paged ---
+// Error: 2-19 citation key `something` is not present in the bibliography
+#cite(<something>)
+#bibliography("/assets/bib/works.bib")
+
+--- cite-unknown-multi-bib paged ---
+// Error: 2-19 citation key `something` is not present in any bibliography
+#cite(<something>)
+#bibliography("/assets/bib/works.bib")
+#bibliography("/assets/bib/works_too.bib")
+
+--- cite-uncovered paged ---
+// Error: 1-8 citation is not covered by any bibliography
+@netwok
+// Hint: 1:10-4:2 a bibliography containing the key `netwok` exists, but its `target` excludes this citation
+#context bibliography(
+  "/assets/bib/works.bib",
+  target: selector(cite).after(here()),
+)
+
+--- cite-nonexistent paged ---
+// Error: 2-14 key `baum` does not exist in the bibliography
+#cite(<baum>)
+// Hint: 2-72 the citation was assigned to this bibliography
+#bibliography("/assets/bib/works.bib", target: cite.where(key: <baum>))
+
+--- cite-assignment-by-chapter html ---
+#show bibliography: set heading(offset: 1)
+
+= Pirates
+@netwok @arrgh
+#bibliography("/assets/bib/works.bib")
+
+= Glaciers
+@glacier-melt
+#bibliography("/assets/bib/works.bib")
+
+--- cite-assignment-auto html ---
+#show bibliography: set heading(numbering: "(A)")
+@netwok // bib (C)
+#bibliography("/assets/bib/works_too.bib")
+#bibliography("/assets/bib/works.bib", target: cite.where(key: <never>))
+#bibliography("/assets/bib/works.bib")
+@keshav2007read // bib (A)
+@arrgh // bib (D)
+#bibliography("/assets/bib/works.bib")
+
+--- cite-assignment-target html ---
+#bibliography(
+  "/assets/bib/works.bib",
+  title: [The middle],
+  target: selector(cite).after(<b>).before(<c>),
+  style: "mla",
+)
+
+= A <a>
+@netwok @arrgh
+
+= B <b>
+@netwok
+@arrgh
+
+= C <c>
+@distress
+
+#bibliography(
+  "/assets/bib/works.bib",
+  title: [The rest],
+)
+
+--- cite-assignment-mixed-group html ---
+// There's a space between [2] and (Keshav), but none between (Keshav) and [3].
+// Should be the same in the output.
+See @netwok @arrgh @keshav2007read#cite(<quark>) @distress @tolkien54 @sharing
+
+#show bibliography: set heading(offset: 1)
+= Bibliographies
+#bibliography(
+  "/assets/bib/works.bib",
+  title: [IEEE],
+  style: "ieee",
+)
+#bibliography(
+  "/assets/bib/works_too.bib",
+  title: [MLA],
+  style: "mla",
+)
+#bibliography(
+  "/assets/bib/works.bib",
+  title: [Chicago],
+  style: "chicago-author-date",
+  target: selector.or(cite.where(key: <tolkien54>), cite.where(key: <sharing>)),
+)

--- a/tests/suite/model/ref.typ
+++ b/tests/suite/model/ref.typ
@@ -51,7 +51,7 @@ $ A = 1 $ <eq2>
 // Test ambiguous reference.
 = Introduction <arrgh>
 
-// Error: 1-7 label `<arrgh>` occurs both in the document and its bibliography
+// Error: 1-7 label `<arrgh>` occurs both in the document and a bibliography
 // Hint: 1-7 change either the heading's label or the bibliography key to resolve the ambiguity
 @arrgh
 #bibliography("/assets/bib/works.bib")


### PR DESCRIPTION
This PR adds support for including multiple bibliographies in a single Typst document. When a Typst document contains multiple bibliographies, each citation is assigned to one of them. By default, Typst will automatically pick a suitable bibliography (typically, the closest following one that contains the referenced citation key). This covers common cases like by-chapter or thematic bibliographies. For more fine-grained control, citations can be explicitly targeted by a bibliography through a `target` selector.

Closes #1097.

### Design
The PR supersedes https://github.com/typst/typst/pull/7277, but follows largely the same design:

- There is still the `bibliography.target` field for fine-grained control over which bibliography picks up which citation. Thanks to @thuiop for this idea, it's a really nice general mechanism.

- The `kind` field from said PR was adjusted to match my original design intent and renamed to `group` because `kind` felt a bit too generic after all. The purpose of the `group` field is to define groups of bibliographies that have shared citation numbering (you can view the updated docs for more info). I'm still not _super_ happy with the design, but exposing some control over this seems important and it's not too bad.

### Implementation
Code-wise, the PR is fairly far removed from #7277, but conceptually there is really mostly just one core difference. When there are consecutive citations that will be picked up by different bibliographies, #7277 would already separate them during citation grouping in realization. While this is conceptually quite nice and clean, it would unfortunately incur an additional document iteration. This is too high a price to pay, so I've moved this logic into the bibliography generation (which is a bit annoying).

Beyond this, I've done some preparatory refactoring of the bibliography generation at large in #8283 to make all of this fit in more nicely, added various diagnostics, tests, docs, etc.

Before this is ready for merge, I still gotta land https://github.com/typst/hayagriva/pull/409 and I have one TODO left there because the interaction of the offsetting with bibliography styles that are unnumbered does not seem ideal yet.

### Example
As mentioned, for basic use cases like by-chapter or thematic bibliographies, no `target` selector is necessary, but here's an example of how the `target` selector could be used in combination with the `within` selector to have a bibliography local to an info box.

<table>

<thead>
<th>Code</th>
<th>Output</th>
</thead>

<tbody>
<tr>
<td>

```typ
#let info(body) = block(
  stroke: (left: 1.5pt + blue),
  fill: aqua.lighten(50%),
  inset: 1em,
  context {
    body
    show divider: set block(spacing: 1.2em)
    divider()
    bibliography(
      "works.bib",
      title: none,
      target: selector(cite).within(here()),
      style: "mla",
    )
  }
)

= On the matter of dumplings
In recent years, we can observe an uptick in
dumpling consumption across the board. @netwok

#info[
  Dumplings are particularly enjoyed
  among pirates. @arrgh
]

#bibliography("works.bib")
```

</td>
<td>

<img width="480" height="526" alt="Document with main text and main bibliography and an info box that contains a local bibliography" src="https://github.com/user-attachments/assets/9d78c608-1bd1-4b75-a283-b1680f07ac52" />

</td>

</tr>
</tbody>

</table>
