### PR TITLE
Use stable scrollbar gutter in docs

### DIFF
--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -3,6 +3,10 @@
 /** General note: The docs class is used in some places to increase the
  * specificity. */
 
+:root {
+  scrollbar-gutter: stable;
+}
+
 body.docs {
   font-size: 16px;
 }


### PR DESCRIPTION
Currently, when on the Overview page, which on my 1920×1808 screen does not have a scrollbar by default, and developing the Reference category in the outline on the left, this makes a scrollbar appear, which causes a slight jump of the page's content to the left. With this change, there is no jump anymore.