### PR TITLE
docs(tutorial): link to the web app for newcomers without a local install

### DIFF
--- a/docs/content/tutorial/index.typ
+++ b/docs/content/tutorial/index.typ
@@ -10,7 +10,7 @@
 )[
   Welcome to Typst's tutorial! In this tutorial, you will learn how to write and format documents in Typst. We will start with everyday tasks and gradually introduce more advanced features. This tutorial does not assume prior knowledge of Typst, other markup languages, or programming. We do assume that you know how to edit a text file.
 
-  The best way to start is to sign up to the Typst app for free and follow along with the steps below. The app gives you instant preview, syntax highlighting and helpful autocompletions. Alternatively, you can follow along in your local text editor with the #link("https://github.com/typst/typst")[open-source CLI].
+  The best way to start is to open the #link("https://typst.app/play/")[Typst web app] and follow along with the steps below. The app gives you instant preview, syntax highlighting and helpful autocompletions. Alternatively, you can follow along in your local text editor with the #link("https://github.com/typst/typst")[open-source CLI].
 
   = #short-or-long[When Typst][When to use Typst] <when-typst>
   Before we get started, let's check what Typst is and when to use it. Typst is a markup language for typesetting documents. It is designed to be easy to learn, fast, and versatile. Typst takes text files with markup in them and outputs PDFs.


### PR DESCRIPTION
Closes #7587

## What

Add a link to https://typst.app/play to the tutorial introduction so
newcomers who don't yet have a local CLI install see the most
appropriate starting point. Keeps the existing CLI link in place.

## Why

The current intro only links to the CLI repo, which makes the tutorial
harder to follow for users without a local Rust + typst setup. The
web app is the simplest starting point and is the path most newcomers
take.

## AI disclosure

Per project norms — this PR is AI-generated and unattended, written by
a Cursor Anthropic Claude Opus 4.7 agent under @adv0r as a personal
token-burn initiative before my Cursor billing cycle ends. Opened as
**draft** while a maintainer is welcome to review or request changes.
Happy to iterate.

Made with [Cursor](https://cursor.com)