### PR TITLE
Reorganize and improve tiling docs

### DIFF
--- a/crates/typst-library/src/visualize/gradient.rs
+++ b/crates/typst-library/src/visualize/gradient.rs
@@ -223,9 +223,8 @@ impl Gradient {
         space: ColorSpace,
         /// The @gradient:relativeness[relative placement] of the gradient.
         ///
-        /// For an element placed at the root/top level of the document, the
-        /// parent is the page itself. For other elements, the parent is the
-        /// innermost @block or @box that contains the element.
+        /// The parent of an element is the innermost @box or @block that
+        /// contains the element, or, if there is none, the page itself.
         #[named]
         #[default(Smart::Auto)]
         relative: Smart<RelativeTo>,
@@ -311,9 +310,8 @@ impl Gradient {
         space: ColorSpace,
         /// The @gradient:relativeness[relative placement] of the gradient.
         ///
-        /// For an element placed at the root/top level of the document, the
-        /// parent is the page itself. For other elements, the parent is the
-        /// innermost @block or @box that contains the element.
+        /// The parent of an element is the innermost @box or @block that
+        /// contains the element, or, if there is none, the page itself.
         #[named]
         #[default(Smart::Auto)]
         relative: Smart<RelativeTo>,
@@ -431,9 +429,8 @@ impl Gradient {
         space: ColorSpace,
         /// The @gradient:relativeness[relative placement] of the gradient.
         ///
-        /// For an element placed at the root/top level of the document, the
-        /// parent is the page itself. For other elements, the parent is the
-        /// innermost @block or @box that contains the element.
+        /// The parent of an element is the innermost @box or @block that
+        /// contains the element, or, if there is none, the page itself.
         #[named]
         #[default(Smart::Auto)]
         relative: Smart<RelativeTo>,

--- a/crates/typst-library/src/visualize/tiling.rs
+++ b/crates/typst-library/src/visualize/tiling.rs
@@ -16,23 +16,25 @@ use crate::visualize::RelativeTo;
 ///
 /// Typst supports the most common type of tilings, where a pattern is repeated
 /// in a grid-like fashion, covering the entire area of an element that is
-/// filled or stroked. The pattern is defined by a tile size and a body defining
-/// the content of each cell. You can also add horizontal or vertical spacing
-/// between the cells of the tiling, as well as offset the starting position of
-/// the tiling using the @tiling.constructor.offset[offset] parameter.
+/// filled or stroked. The pattern is defined by a tile
+/// @tiling.constructor.size[`size`] and a body defining the content of each
+/// cell. You can also add horizontal or vertical
+/// @tiling.constructor.spacing[`spacing`] between the cells of the tiling and
+/// @tiling.constructor.offset[`offset`] the starting position of the tiling.
 ///
-/// = Examples <examples>
+/// = Example <example>
 /// ```example
-/// #let pat = tiling(size: (30pt, 30pt))[
-///   #place(line(start: (0%, 0%), end: (100%, 100%)))
-///   #place(line(start: (0%, 100%), end: (100%, 0%)))
-/// ]
+/// #let pat = tiling(size: (30pt, 30pt), {
+///   place(line(start: (0%, 0%), end: (100%, 100%)))
+///   place(line(start: (0%, 100%), end: (100%, 0%)))
+/// })
 ///
 /// #rect(fill: pat, width: 100%, height: 60pt, stroke: 1pt)
 /// ```
 ///
-/// Tilings are also supported on text, but only when setting the
-/// @tiling.constructor.relative[relativeness] to either `{auto}` (the default
+/// = Tilings on text <tilings-on-text>
+/// Tilings are also supported on text, but only when setting
+/// @tiling.constructor.relative[`relative`] to either `{auto}` (the default
 /// value) or `{"parent"}`. To create word-by-word or glyph-by-glyph tilings,
 /// you can wrap the words or characters of your text in @box[boxes] manually or
 /// through a @reference:styling:show-rules[show rule].
@@ -51,81 +53,6 @@ use crate::visualize::RelativeTo;
 /// #set text(fill: pat)
 /// #lorem(10)
 /// ```
-///
-/// You can also space the elements further or closer apart using the
-/// @tiling.constructor.spacing[`spacing`] feature of the tiling. If the spacing
-/// is lower than the size of the tiling, the tiling will overlap. If it is
-/// higher, the tiling will have gaps of the same color as the background of the
-/// tiling.
-///
-/// ```example
-/// #let pat = tiling(
-///   size: (30pt, 30pt),
-///   spacing: (10pt, 10pt),
-///   relative: "parent",
-///   square(
-///     size: 30pt,
-///     fill: gradient
-///      .conic(..color.map.rainbow),
-///   ),
-/// )
-///
-/// #rect(
-///   width: 100%,
-///   height: 60pt,
-///   fill: pat,
-/// )
-/// ```
-///
-/// = Offset <offset>
-/// The `offset` parameter allows you to offset the starting
-/// position of the tiling. This shifts the entire tile grid without affecting
-/// the tile size or spacing. Positive x values move the pattern to the right,
-/// and positive y values move it down. Relative values are resolved against
-/// the tile size plus spacing.
-///
-/// Note that the displacement caused by the offset affects the tiles themselves,
-/// while displacement of the inner contents (e.g. by using `place(dx: ...,
-/// dy: ...)`) can cause clipping when the content moves outside the tile's
-/// bounding box.
-///
-/// ```example
-/// #let pat = tiling(size: (20pt, 20pt))[
-///   #place(circle(radius: 10pt, fill: blue))
-/// ]
-/// #let pat-offset = tiling(
-///   size: (20pt, 20pt),
-///   offset: (50%, 50%),
-/// )[
-///   #place(circle(radius: 10pt, fill: blue))
-/// ]
-///
-/// #grid(
-///   columns: 2,
-///   column-gutter: 10pt,
-///   rect(fill: pat, width: 100pt, height: 80pt, stroke: 1pt),
-///   rect(fill: pat-offset, width: 100pt, height: 80pt, stroke: 1pt),
-/// )
-/// ```
-///
-/// = Relativeness <relativeness>
-/// The location of the starting point of the tiling is dependent on the
-/// dimensions of a container. This container can either be the shape that it is
-/// being painted on, or the closest surrounding container. This is controlled
-/// by the `relative` argument of a tiling constructor. By default, tilings are
-/// relative to the shape they are being painted on, unless the tiling is
-/// applied on text, in which case they are relative to the closest ancestor
-/// container.
-///
-/// Typst determines the ancestor container as follows:
-/// - For shapes that are placed at the root/top level of the document, the
-///   closest ancestor is the page itself.
-/// - For other shapes, the ancestor is the innermost @block or @box that
-///   contains the shape.
-///
-/// = Compatibility <compatibility>
-/// This type used to be called `pattern`. The name remains as an alias, but is
-/// deprecated since Typst 0.13.
 #[ty(scope, cast, keywords = ["pattern"])]
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Tiling(Arc<TilingInner>);
@@ -169,23 +96,115 @@ impl Tiling {
     pub fn construct(
         engine: &mut Engine,
         span: Span,
-        /// The bounding box of each cell of the tiling.
+        /// The bounding box of each cell of the tiling, specified as a `(x, y)`
+        /// pair.
+        ///
+        /// If set to `{auto}`, the tiling takes on the size of the laid-out
+        /// content.
         #[named]
         #[default(Spanned::detached(Smart::Auto))]
         size: Spanned<Smart<Axes<Length>>>,
-        /// The spacing between cells of the tiling.
+        /// The spacing between cells of the tiling, specified as a `(x, y)`
+        /// pair.
+        ///
+        /// If the spacing is lower than the size of the tiling, the tiling will
+        /// overlap with itself. If it is higher, the tiling will have gaps.
+        ///
+        /// ```example
+        /// >>> #set page(width: 5 * 30pt + 4 * 10pt + 2 * 15pt)
+        /// #let pat = tiling(
+        ///   size: (30pt, 30pt),
+        ///   spacing: (10pt, 20pt),
+        ///   square(size: 30pt, fill: gradient.conic(..color.map.rainbow)),
+        /// )
+        ///
+        /// #rect(
+        ///   width: 100%,
+        ///   height: 80pt,
+        ///   fill: pat,
+        ///   stroke: (thickness: 1pt, dash: "dotted"),
+        /// )
+        /// ```
         #[named]
         #[default(Spanned::detached(Axes::splat(Length::zero())))]
         spacing: Spanned<Axes<Length>>,
-        /// The @tiling:offset[offset] of the tiling.
+        /// Shifts the entire tile grid without affecting the tile size or
+        /// spacing.
+        ///
+        /// The offset is specified as a `(x, y)` pair. Positive `x` values move
+        /// the pattern to the right and positive `y` values move it down.
+        /// Relative values are resolved against the tile size plus spacing.
+        ///
+        /// Note that the displacement caused by the offset affects the tiles
+        /// themselves while displacement of the inner contents (e.g. via
+        /// `{place(dx: .., dy: ..)}`) can cause clipping when the content
+        /// moves outside of the tile's bounding box.
+        ///
+        /// ```example
+        /// #set rect(width: 100%, height: 80pt, stroke: 1pt)
+        ///
+        /// #let pat = tiling(
+        ///   size: (20pt, 20pt),
+        ///   circle(radius: 10pt, fill: blue),
+        /// )
+        ///
+        /// #let pat-with-offset = tiling(
+        ///   size: (20pt, 20pt),
+        ///   offset: (50%, 50%),
+        ///   circle(radius: 10pt, fill: blue),
+        /// )
+        ///
+        /// #grid(
+        ///   columns: 2,
+        ///   column-gutter: 10pt,
+        ///   rect(fill: pat),
+        ///   rect(fill: pat-with-offset),
+        /// )
+        /// ```
         #[named]
         #[default(Spanned::new(Axes::splat(Rel::zero()), Span::detached()))]
         offset: Spanned<Axes<Rel<Length>>>,
-        /// The @tiling:relativeness[relative placement] of the tiling.
+        /// Determines relative to which element's bounding box the tiling is
+        /// drawn.
         ///
-        /// For an element placed at the root/top level of the document, the
-        /// parent is the page itself. For other elements, the parent is the
-        /// innermost @block or @box that contains the element.
+        /// By default, tilings are drawn relative to the shape they are being
+        /// painted on (`{"self"}`), unless the tiling is applied on text, in
+        /// which case they are relative to the closest ancestor container
+        /// (`{"parent"}`).
+        ///
+        /// The parent of an element is the innermost @box or @block that
+        /// contains the element, or, if there is none, the page itself.
+        ///
+        /// ```example
+        /// #let pat = tiling(
+        ///   size: (20pt, 20pt),
+        ///   spacing: (5pt, 5pt),
+        ///   relative: "self",
+        ///   circle(radius: 10pt, fill: teal),
+        /// )
+        ///
+        /// #let pat-with-parent = tiling(
+        ///   size: (20pt, 20pt),
+        ///   spacing: (5pt, 5pt),
+        ///   relative: "parent",
+        ///   circle(radius: 10pt, fill: teal),
+        /// )
+        ///
+        /// #set raw(lang: "typc")
+        /// #table(
+        ///   columns: (1fr, 1fr, 1fr),
+        ///   rows: (auto, 80pt),
+        ///   table.header(`"self"`, `"parent"`, `"parent"`),
+        ///
+        ///   // This one is local to the cell itself.
+        ///   table.cell(fill: pat, none),
+        ///
+        ///   // These two are both page-relative, so the
+        ///   // pattern is continous.
+        ///   table.cell(fill: pat-with-parent, none),
+        ///   table.cell(fill: pat-with-parent, none),
+        /// )
+        /// ```
         #[named]
         #[default(Smart::Auto)]
         relative: Smart<RelativeTo>,


### PR DESCRIPTION
The tiling docs effectively had the parameter documentation at the top level and then no parameter documentation, which is a bit roundabout. I've fixed that and also cleaned things up a bit and added an additional example.

The gradient docs have the same issue, but there it makes a bit more sense because the concepts are all shared across the different gradient constructors. There's probably still a better way to organize these, but I've (mostly) left them as is for now (except for minor adjustment for consistency with tilings).