### PR TITLE
Move PackageSpec namespace/name validation from parser to SystemPackages resolver

### DIFF
--- a/crates/typst-kit/src/packages.rs
+++ b/crates/typst-kit/src/packages.rs
@@ -93,6 +93,20 @@ impl SystemPackages {
     /// [`FileStore`](crate::files::FileStore), this is already the case since
     /// it acquires a lock during file loading.
     pub fn obtain(&self, spec: &PackageSpec) -> PackageResult<FsRoot> {
+        if spec.namespace.contains('.') {
+            return Err(PackageError::Other(Some(eco_format!(
+                "`{}` is not a valid package namespace",
+                spec.namespace,
+            ))));
+        }
+
+        if spec.name.contains('/') {
+            return Err(PackageError::Other(Some(eco_format!(
+                "`{}` is not a valid package name",
+                spec.name,
+            ))));
+        }
+
         if let Some(packages) = &self.data
             && let Some(root) = packages.obtain(spec)
         {

--- a/crates/typst-syntax/src/package.rs
+++ b/crates/typst-syntax/src/package.rs
@@ -319,7 +319,7 @@ fn parse_namespace<'s>(s: &mut Scanner<'s>) -> Result<&'s str, EcoString> {
     let namespace = s.eat_until('/');
     if namespace.is_empty() {
         Err("package specification is missing namespace")?;
-    } else if !is_ident(namespace) {
+    } else if !namespace.split('.').all(|part| !part.is_empty() && is_ident(part)) {
         Err(eco_format!("`{namespace}` is not a valid package namespace"))?;
     }
 
@@ -332,7 +332,7 @@ fn parse_name<'s>(s: &mut Scanner<'s>) -> Result<&'s str, EcoString> {
     let name = s.eat_until(':');
     if name.is_empty() {
         Err("package specification is missing name")?;
-    } else if !is_ident(name) {
+    } else if !name.split('/').all(|part| !part.is_empty() && is_ident(part)) {
         Err(eco_format!("`{name}` is not a valid package name"))?;
     }
 
@@ -654,5 +654,26 @@ mod tests {
         .unwrap();
 
         assert!(manifest.unknown_fields.contains_key("unknown"));
+    }
+
+    #[test]
+    fn valid_namespace() {
+        assert!("@preview/polylux:0.3.1".parse::<PackageSpec>().is_ok());
+        assert!("@example.com/foo/bar:1.2.3".parse::<PackageSpec>().is_ok());
+        assert!("@registry.example.org/foo/bar:0.1.0".parse::<PackageSpec>().is_ok());
+
+        assert!("@example./foo/bar:1.2.3".parse::<PackageSpec>().is_err());
+        assert!("@.example.com/foo/bar:1.2.3".parse::<PackageSpec>().is_err());
+        assert!("@/foo/bar:1.2.3".parse::<PackageSpec>().is_err());
+    }
+
+    #[test]
+    fn valid_name() {
+        assert!("@preview/polylux:0.3.1".parse::<PackageSpec>().is_ok());
+        assert!("@example.com/foo/bar:1.2.3".parse::<PackageSpec>().is_ok());
+        assert!("@example.com/foo/bar/baz:1.2.3".parse::<PackageSpec>().is_ok());
+
+        assert!("@example.com//bar:1.2.3".parse::<PackageSpec>().is_err());
+        assert!("@example.com/:1.2.3".parse::<PackageSpec>().is_err());
     }
 }


### PR DESCRIPTION
This PR makes two small changes to `PackageSpec` parsing in `typst-syntax` and two corresponding defensive changes to `SystemPackages` in `typst-kit`:

1. `PackageSpec`: allow dot-separated namespaces (e.g. `foo.bar`) by changing `parse_namespace` to validate each dot-separated segment as an ident rather than requiring the whole string to be one
2. `PackageSpec`: allow slash-separated names (e.g. `category/name`) by changing parse_name to validate each slash-separated segment as an ident rather than requiring the whole string to be one
3. `SystemPackages`: explicitly reject dotted namespaces with a clear error message so the default implementation continues to function as it does today
4. `SystemPackages`: explicitly reject slashed names with a clear error message so the default implementation continues to function as it does today

All existing valid package specifications continue to parse and resolve identically.

## Motivation

The `World` trait exists so that tools embedding Typst can handle package resolution however they like. However, the parser currently undermines this by enforcing constraints that only make sense for one specific resolver: Typst Universe. Because of the ident check on namespaces and names, any `PackageSpec` that reaches the `World` can only ever look like a Universe spec. An embedder who wants to handle a different class of spec is out of luck, because the parser rejects it before `World` is ever consulted.

That's a layering violation. The parser should determine whether a spec is structurally well-formed, not whether it's meaningful to a particular resolver. That's the resolver's job. At the moment, these two responsibilities are conflated.

The fix is to broaden what the parser accepts structurally, and let `SystemPackages` explicitly reject what it doesn't support. The parser becomes permissive, while the resolver stays conservative. Each layer does its own job.

To be clear about scope, this doesn't add support for any new package source or resolution backend, doesn't add any dependencies, and doesn't change the behaviour of the CLI or anything built on `SystemPackages` for any currently valid document.