### PR TITLE
Add and fix lints from `#[clippy::format_args]` and explain `diag.rs` macro organization

### DIFF
--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -664,7 +664,7 @@ fn open_output(config: &mut CompileConfig) -> StrResult<()> {
 fn open_path(path: &OsStr, viewer: Option<&str>) -> StrResult<()> {
     if let Some(viewer) = viewer {
         open::with_detached(path, viewer)
-            .map_err(|err| eco_format!("failed to open file with {} ({})", viewer, err))
+            .map_err(|err| eco_format!("failed to open file with {viewer} ({err})"))
     } else {
         open::that_detached(path).map_err(|err| {
             let openers = open::commands(path)
@@ -673,9 +673,8 @@ fn open_path(path: &OsStr, viewer: Option<&str>) -> StrResult<()> {
                 .collect::<Vec<_>>()
                 .join(", ");
             eco_format!(
-                "failed to open file with any of these resource openers: {} ({})",
-                openers,
-                err,
+                "failed to open file with any of these resource openers: {openers} \
+                 ({err})",
             )
         })
     }

--- a/crates/typst-cli/src/update.rs
+++ b/crates/typst-cli/src/update.rs
@@ -165,8 +165,7 @@ impl Release {
     ) -> StrResult<Vec<u8>> {
         let asset = self.assets.iter().find(|a| a.name.starts_with(asset_name)).ok_or(
             eco_format!(
-                "could not find prebuilt binary `{}` for your platform",
-                asset_name
+                "could not find prebuilt binary `{asset_name}` for your platform"
             ),
         )?;
 

--- a/crates/typst-eval/src/code.rs
+++ b/crates/typst-eval/src/code.rs
@@ -77,7 +77,7 @@ impl Eval for ast::Expr<'_> {
     fn eval(self, vm: &mut Vm) -> SourceResult<Self::Output> {
         let span = self.span();
         let forbidden = |name| {
-            error!(span, "{} is only allowed directly in code and content blocks", name)
+            error!(span, "{name} is only allowed directly in code and content blocks")
         };
 
         let value = match self {

--- a/crates/typst-eval/src/flow.rs
+++ b/crates/typst-eval/src/flow.rs
@@ -169,10 +169,10 @@ impl Eval for ast::ForLoop<'_> {
                 iter!(for pattern in bytes.as_slice());
             }
             (Pattern::Destructuring(_), Value::Str(_) | Value::Bytes(_)) => {
-                bail!(pattern.span(), "cannot destructure values of {}", iterable_type);
+                bail!(pattern.span(), "cannot destructure values of {iterable_type}");
             }
             _ => {
-                bail!(self.iterable().span(), "cannot loop over {}", iterable_type);
+                bail!(self.iterable().span(), "cannot loop over {iterable_type}");
             }
         }
 

--- a/crates/typst-html/src/mathml.rs
+++ b/crates/typst-html/src/mathml.rs
@@ -1136,17 +1136,16 @@ fn make_mo(
 
     let lspace = lspace.unwrap_or(Em::zero()).get();
     let lspace =
-        (force_space || lspace != info.lspace).then(|| eco_format!("{}em", lspace));
+        (force_space || lspace != info.lspace).then(|| eco_format!("{lspace}em"));
     let rspace = rspace.unwrap_or(Em::zero()).get();
     let rspace =
-        (force_space || rspace != info.rspace).then(|| eco_format!("{}em", rspace));
+        (force_space || rspace != info.rspace).then(|| eco_format!("{rspace}em"));
 
-    let fence = (fence != is_fence(text)).then(|| eco_format!("{}", fence));
-    let separator =
-        (separator != is_separator(text)).then(|| eco_format!("{}", separator));
+    let fence = (fence != is_fence(text)).then(|| eco_format!("{fence}"));
+    let separator = (separator != is_separator(text)).then(|| eco_format!("{separator}"));
 
     let largeop = (largeop != info.properties.contains(Properties::LARGEOP))
-        .then(|| eco_format!("{}", largeop));
+        .then(|| eco_format!("{largeop}"));
 
     // In compact styles the browser will move top/bottom attachments to the tl
     // and br positions, so we need to explicitly disable this.
@@ -1166,7 +1165,7 @@ fn make_mo(
     };
     let explicit = stretch.is_some_and(|stretch| stretch.is_explicit(stretch_axis));
     let stretchy = (explicit != info.properties.contains(Properties::STRETCHY))
-        .then(|| eco_format!("{}", explicit));
+        .then(|| eco_format!("{explicit}"));
 
     // We don't need to set `maxsize` as it is infinity by default.
     let (symmetric, minsize) = if explicit {
@@ -1342,6 +1341,6 @@ fn ignored_math_item(
 ) -> SourceResult<Content> {
     ctx.engine
         .sink
-        .warn(warning!(span, "{} was ignored during MathML export", name));
+        .warn(warning!(span, "{name} was ignored during MathML export"));
     ctx.handle_into_node(body)
 }

--- a/crates/typst-library/src/diag.rs
+++ b/crates/typst-library/src/diag.rs
@@ -40,6 +40,7 @@ use crate::{World, WorldExt};
 /// ```
 #[macro_export]
 #[doc(hidden)]
+#[clippy::format_args]
 macro_rules! __bail {
     // If we don't have a span, forward to `error!` to create a `StrResult` or
     // `HintedStrResult`.
@@ -85,6 +86,7 @@ macro_rules! __bail {
 /// ```
 #[macro_export]
 #[doc(hidden)]
+#[clippy::format_args]
 macro_rules! __error {
     // For `error!("just a {}", "string")`.
     ($fmt:literal $(, $arg:expr)* $(,)?) => {
@@ -150,6 +152,7 @@ macro_rules! __error {
 /// ```
 #[macro_export]
 #[doc(hidden)]
+#[clippy::format_args]
 macro_rules! __warning {
     (
         $span:expr, $fmt:literal $(, $arg:expr)* $(,)?
@@ -170,9 +173,9 @@ macro_rules! __warning {
 #[rustfmt::skip]
 #[doc(inline)]
 pub use {
-    crate::__bail as bail,
-    crate::__error as error,
-    crate::__warning as warning,
+    __bail as bail,
+    __error as error,
+    __warning as warning,
     ecow::{eco_format, EcoString},
 };
 
@@ -1061,7 +1064,7 @@ fn internal_error(msg: &str) -> HintedString {
     let loc = std::panic::Location::caller();
     let mut error = error!(
         "internal error: {msg} (occurred at {loc})";
-        hint: "please report this as a bug"
+        hint: "please report this as a bug";
     );
 
     if cfg!(debug_assertions) {

--- a/crates/typst-library/src/diag.rs
+++ b/crates/typst-library/src/diag.rs
@@ -1,5 +1,12 @@
 //! Diagnostics.
 
+// We re-export these types from `ecow` so that the macros below can write
+// `$crate::diag::eco_format` instead of `::ecow::eco_format`. This allows
+// downstream crates to use the macros without needing to include `ecow` as a
+// direct dependency of the crate.
+#[doc(hidden)]
+pub use ecow::{EcoString, EcoVec, eco_format, eco_vec};
+
 use std::backtrace::{Backtrace, BacktraceStatus};
 use std::fmt::{self, Display, Formatter, Write as _};
 use std::io;
@@ -9,7 +16,6 @@ use std::string::FromUtf8Error;
 
 use az::SaturatingAs;
 use comemo::Tracked;
-use ecow::{EcoVec, eco_vec};
 use typst_syntax::package::{PackageSpec, PackageVersion};
 use typst_syntax::{Lines, Span, Spanned, SyntaxError, VirtualRoot};
 use utf8_iter::ErrorReportingUtf8Chars;
@@ -41,6 +47,7 @@ use crate::{World, WorldExt};
 #[macro_export]
 #[doc(hidden)]
 #[clippy::format_args]
+// See the comment below for why this is `__bail` and not `bail`.
 macro_rules! __bail {
     // If we don't have a span, forward to `error!` to create a `StrResult` or
     // `HintedStrResult`.
@@ -57,12 +64,12 @@ macro_rules! __bail {
 
     // Just early return for a `SourceResult`: `bail!(some_error)`.
     ($error:expr) => {
-        return Err(::ecow::eco_vec![$error])
+        return Err($crate::diag::eco_vec![$error])
     };
 
     // For `bail(span, ...)`, we reuse `error!` and produce a `SourceResult`.
     ($($tts:tt)*) => {
-        return Err(::ecow::eco_vec![$crate::diag::error!($($tts)*)])
+        return Err($crate::diag::eco_vec![$crate::diag::error!($($tts)*)])
     };
 }
 
@@ -87,6 +94,7 @@ macro_rules! __bail {
 #[macro_export]
 #[doc(hidden)]
 #[clippy::format_args]
+// See the comment below for why this is `__error` and not `error`.
 macro_rules! __error {
     // For `error!("just a {}", "string")`.
     ($fmt:literal $(, $arg:expr)* $(,)?) => {
@@ -153,6 +161,7 @@ macro_rules! __error {
 #[macro_export]
 #[doc(hidden)]
 #[clippy::format_args]
+// See the comment below for why this is `__warning` and not `warning`.
 macro_rules! __warning {
     (
         $span:expr, $fmt:literal $(, $arg:expr)* $(,)?
@@ -170,13 +179,28 @@ macro_rules! __warning {
     }};
 }
 
+// We want the `bail`, `error`, and `warning` macros and their documentation to
+// be scoped locally to this module and imported like normal items, including by
+// modules within this crate. However Rust only allows public macro_rules macros
+// to be exported at the root of the crate, and gives us no tools to avoid that.
+// See the "Import and Export" chapter of "The Little Book of Rust Macros" for
+// more: <https://lukaswirth.dev/tlborm/decl-macros/minutiae/import-export.html>
+//
+// Our solution is simple: the actual macros are named with two underscores, and
+// while they are available at the root of the crate, we add `doc(hidden)` to
+// hide their docs at the crate root. We then we re-export them here with new
+// names and `doc(inline)` so the preferred names and their documentation are
+// scoped to this module.
+//
+// Unfortunately, `__bail` is still available at the crate root here and in all
+// importers, but its name should suggest that we prefer to use `bail` instead.
+// Note that the `disallowed_macros` lint does not handle re-exports like this.
 #[rustfmt::skip]
 #[doc(inline)]
 pub use {
     __bail as bail,
     __error as error,
     __warning as warning,
-    ecow::{eco_format, EcoString},
 };
 
 /// A result that can carry multiple source errors. The recommended way to

--- a/crates/typst-library/src/foundations/args.rs
+++ b/crates/typst-library/src/foundations/args.rs
@@ -158,7 +158,7 @@ impl Args {
                 return error!(
                     item.span,
                     "the argument `{what}` is positional";
-                    hint: "try removing `{}:`", name;
+                    hint: "try removing `{name}:`";
                 );
             }
         }

--- a/crates/typst-library/src/foundations/array.rs
+++ b/crates/typst-library/src/foundations/array.rs
@@ -1092,7 +1092,7 @@ impl Array {
             .map(|value| {
                 let value_ty = value.ty();
                 let pair = value.cast::<Array>().map_err(|_| {
-                    eco_format!("expected (str, any) pairs, found {}", value_ty)
+                    eco_format!("expected (str, any) pairs, found {value_ty}")
                 })?;
                 if let [key, value] = pair.as_slice() {
                     let key = key.clone().cast::<Str>().map_err(|_| {

--- a/crates/typst-library/src/foundations/content/mod.rs
+++ b/crates/typst-library/src/foundations/content/mod.rs
@@ -735,7 +735,7 @@ impl Repr for SequenceElem {
                 &self.children.iter().map(|c| c.repr()).collect::<Vec<_>>(),
                 false,
             );
-            eco_format!("sequence{}", elements)
+            eco_format!("sequence{elements}")
         }
     }
 }

--- a/crates/typst-library/src/foundations/datetime.rs
+++ b/crates/typst-library/src/foundations/datetime.rs
@@ -598,7 +598,7 @@ cast! {
 /// Format the `Format` error of the time crate in an appropriate way.
 fn format_time_format_error(error: Format) -> EcoString {
     match error {
-        Format::InvalidComponent(name) => eco_format!("invalid component '{}'", name),
+        Format::InvalidComponent(name) => eco_format!("invalid component '{name}'"),
         Format::InsufficientTypeInformation { .. } => {
             "failed to format datetime (insufficient information)".into()
         }
@@ -613,29 +613,25 @@ fn format_time_invalid_format_description_error(
 ) -> EcoString {
     match error {
         InvalidFormatDescription::UnclosedOpeningBracket { index, .. } => {
-            eco_format!("missing closing bracket for bracket at index {}", index)
+            eco_format!("missing closing bracket for bracket at index {index}")
         }
         InvalidFormatDescription::InvalidComponentName { name, index, .. } => {
-            eco_format!("invalid component name '{}' at index {}", name, index)
+            eco_format!("invalid component name '{name}' at index {index}")
         }
         InvalidFormatDescription::InvalidModifier { value, index, .. } => {
-            eco_format!("invalid modifier '{}' at index {}", value, index)
+            eco_format!("invalid modifier '{value}' at index {index}")
         }
         InvalidFormatDescription::Expected { what, index, .. } => {
-            eco_format!("expected {} at index {}", what, index)
+            eco_format!("expected {what} at index {index}")
         }
         InvalidFormatDescription::MissingComponentName { index, .. } => {
-            eco_format!("expected component name at index {}", index)
+            eco_format!("expected component name at index {index}")
         }
         InvalidFormatDescription::MissingRequiredModifier { name, index, .. } => {
-            eco_format!(
-                "missing required modifier {} for component at index {}",
-                name,
-                index
-            )
+            eco_format!("missing required modifier {name} for component at index {index}")
         }
         InvalidFormatDescription::NotSupported { context, what, index, .. } => {
-            eco_format!("{} is not supported in {} at index {}", what, context, index)
+            eco_format!("{what} is not supported in {context} at index {index}")
         }
         err => eco_format!("failed to parse datetime format ({err})"),
     }

--- a/crates/typst-library/src/foundations/float.rs
+++ b/crates/typst-library/src/foundations/float.rs
@@ -200,11 +200,11 @@ cast! {
     v: f64 => Self(v),
     v: bool => Self(v as i64 as f64),
     v: i64 => Self(v as f64),
-    v: Decimal => Self(f64::try_from(v).map_err(|_| eco_format!("invalid float: {}", v))?),
+    v: Decimal => Self(f64::try_from(v).map_err(|_| eco_format!("invalid float: {v}"))?),
     v: Ratio => Self(v.get()),
     v: Str => Self(
         parse_float(v.clone().into())
-            .map_err(|_| eco_format!("invalid float: {}", v))?
+            .map_err(|_| eco_format!("invalid float: {v}"))?
     ),
 }
 

--- a/crates/typst-library/src/foundations/int.rs
+++ b/crates/typst-library/src/foundations/int.rs
@@ -393,7 +393,7 @@ impl i64 {
 
 impl Repr for i64 {
     fn repr(&self) -> EcoString {
-        eco_format!("{:?}", self)
+        eco_format!("{self:?}")
     }
 }
 

--- a/crates/typst-library/src/foundations/scope.rs
+++ b/crates/typst-library/src/foundations/scope.rs
@@ -407,7 +407,7 @@ impl From<Deprecation> for HintedString {
         HintedString::new(deprecation.message.into()).with_hints(
             deprecation
                 .until
-                .map(|v| eco_format!("it will be removed in Typst {}", v)),
+                .map(|v| eco_format!("it will be removed in Typst {v}")),
         )
     }
 }
@@ -416,13 +416,13 @@ impl From<Deprecation> for HintedString {
 /// library.
 #[cold]
 fn cannot_mutate_constant(var: &str) -> HintedString {
-    eco_format!("cannot mutate a constant: {}", var).into()
+    eco_format!("cannot mutate a constant: {var}").into()
 }
 
 /// The error message when a variable wasn't found.
 #[cold]
 fn unknown_variable(var: &str) -> HintedString {
-    let mut res = HintedString::new(eco_format!("unknown variable: {}", var));
+    let mut res = HintedString::new(eco_format!("unknown variable: {var}"));
 
     if var.contains('-') {
         res.hint(eco_format!(
@@ -439,7 +439,7 @@ fn unknown_variable(var: &str) -> HintedString {
 /// The error message when a variable wasn't found it math.
 #[cold]
 fn unknown_variable_math(var: &str, in_global: bool) -> HintedString {
-    let mut res = HintedString::new(eco_format!("unknown variable: {}", var));
+    let mut res = HintedString::new(eco_format!("unknown variable: {var}"));
 
     if matches!(var, "none" | "auto" | "false" | "true") {
         res.hint(eco_format!(

--- a/crates/typst-library/src/foundations/str.rs
+++ b/crates/typst-library/src/foundations/str.rs
@@ -936,23 +936,22 @@ fn captures_to_dict(cap: regex::Captures) -> Dict {
 /// The out of bounds access error message.
 #[cold]
 fn out_of_bounds(index: i64, len: usize) -> EcoString {
-    eco_format!("string index out of bounds (index: {}, len: {})", index, len)
+    eco_format!("string index out of bounds (index: {index}, len: {len})")
 }
 
 /// The out of bounds access error message when no default value was given.
 #[cold]
 fn no_default_and_out_of_bounds(index: i64, len: usize) -> EcoString {
     eco_format!(
-        "no default value was specified and string index out of bounds (index: {}, len: {})",
-        index,
-        len
+        "no default value was specified and string index out of bounds \
+         (index: {index}, len: {len})"
     )
 }
 
 /// The char boundary access error message.
 #[cold]
 fn not_a_char_boundary(index: i64) -> EcoString {
-    eco_format!("string index {} is not a character boundary", index)
+    eco_format!("string index {index} is not a character boundary")
 }
 
 /// The error message when the string is empty.

--- a/crates/typst-library/src/math/ir/resolve.rs
+++ b/crates/typst-library/src/math/ir/resolve.rs
@@ -1137,7 +1137,7 @@ fn resolve_cells<'a, 'v, 'e>(
             if processed.had_linebreaks {
                 ctx.engine.sink.warn(warning!(
                    cell.span(),
-                   "linebreaks are ignored in {}", children;
+                   "linebreaks are ignored in {children}";
                    hint: "use commas instead to separate each line";
                 ));
             }

--- a/crates/typst-library/src/math/matrix.rs
+++ b/crates/typst-library/src/math/matrix.rs
@@ -299,7 +299,7 @@ impl Delimiter {
             default_math_class(c),
             Some(MathClass::Opening | MathClass::Closing | MathClass::Fence),
         ) {
-            bail!("invalid delimiter: \"{}\"", c)
+            bail!("invalid delimiter: \"{c}\"")
         }
         Ok(Self(Some(c)))
     }

--- a/crates/typst-library/src/model/bibliography.rs
+++ b/crates/typst-library/src/model/bibliography.rs
@@ -530,7 +530,7 @@ impl FromValue for CslSource {
                 }
 
                 let style = ArchivedStyle::by_name(&string)
-                    .ok_or_else(|| eco_format!("unknown style: {}", string))?;
+                    .ok_or_else(|| eco_format!("unknown style: {string}"))?;
                 return Ok(CslSource::Named(style, warning));
             }
         }

--- a/crates/typst-library/src/text/lang.rs
+++ b/crates/typst-library/src/text/lang.rs
@@ -522,13 +522,14 @@ cast! {
         let result = Self::from_str(&string);
         if result.is_err()
             && let Some((lang, region)) = string.split_once('-')
-                && Lang::from_str(lang).is_ok() && Region::from_str(region).is_ok() {
-                    return result
-                        .hint(eco_format!(
-                            "you should leave only \"{}\" in the `lang` parameter and specify \"{}\" in the `region` parameter",
-                            lang, region,
-                        ));
-                }
+            && Lang::from_str(lang).is_ok()
+            && Region::from_str(region).is_ok()
+        {
+            return result.hint(eco_format!(
+                "you should leave only \"{lang}\" in the `lang` parameter and \
+                 specify \"{region}\" in the `region` parameter",
+            ));
+        }
 
         result?
     }

--- a/crates/typst-library/src/visualize/color.rs
+++ b/crates/typst-library/src/visualize/color.rs
@@ -958,9 +958,9 @@ impl Color {
     pub fn to_hex(self) -> EcoString {
         let (r, g, b, a) = self.to_rgb().into_format::<u8, u8>().into_components();
         if a != 255 {
-            eco_format!("#{:02x}{:02x}{:02x}{:02x}", r, g, b, a)
+            eco_format!("#{r:02x}{g:02x}{b:02x}{a:02x}")
         } else {
-            eco_format!("#{:02x}{:02x}{:02x}", r, g, b)
+            eco_format!("#{r:02x}{g:02x}{b:02x}")
         }
     }
 

--- a/crates/typst-library/src/visualize/image/svg.rs
+++ b/crates/typst-library/src/visualize/image/svg.rs
@@ -349,7 +349,7 @@ impl<'a> ImageResolver<'a> {
             Err(err) => {
                 self.error = Some(LoadError::text(
                     ReportTextPos::None,
-                    eco_format!("failed to load linked image {} in SVG", href),
+                    eco_format!("failed to load linked image {href} in SVG"),
                     err,
                 ));
                 None
@@ -431,7 +431,7 @@ impl<'a> ImageResolver<'a> {
                 FileError::IsDirectory => "is a directory".into(),
                 FileError::Other(Some(msg)) => msg,
                 FileError::Other(None) => "unspecified error".into(),
-                _ => eco_format!("unexpected error: {}", err),
+                _ => eco_format!("unexpected error: {err}"),
             }),
         }
     }

--- a/crates/typst-syntax/src/lexer.rs
+++ b/crates/typst-syntax/src/lexer.rs
@@ -232,7 +232,7 @@ impl Lexer<'_> {
                 .and_then(std::char::from_u32)
                 .is_none()
             {
-                return self.error(eco_format!("invalid Unicode codepoint: {}", hex));
+                return self.error(eco_format!("invalid Unicode codepoint: {hex}"));
             }
 
             return SyntaxKind::Escape;


### PR DESCRIPTION
The first commit adds the [`#[clippy::format_args]`](https://doc.rust-lang.org/clippy/attribs.html#clippyformat_args) attribute to `bail!` and friends, which allows us to warn for clippy lints that apply to `format!`, which I also fix in the commit. Although it only works for the initial format string, not for hints. The fixes are almost entirely just changes like `error!("message: {}", var)` to `error!("message: {var}")`.

I also added a PR at https://github.com/typst/ecow/pull/62 to apply the attribute on `eco_format!`, and I've fixed the warnings doing so would cause.

Note that changing `crate::__bail` to `__bail` in the commit was required due to triggering the `macro_expanded_macro_exports_accessed_by_absolute_paths` warning, since `clippy::format_args` is a macro expansion around `__bail`, meaning `crate::__bail` is an access of the absolute path of a macro expanded macro export (I'm so sorry). More details for the warning are tracked at https://github.com/rust-lang/rust/issues/144408.

The second commit separates the `ecow` re-exports in `diag.rs` from the macro re-exports to change their documentation to `#[doc(hidden)]`, but more importantly it adds comments explaining why we re-export them publicly at all, and why we re-export the macros like `__bail` as `bail` since this is a very odd pattern in Rust.
