### PR TITLE
Remove unneeded `.as_ref()`

### DIFF
--- a/docs/src/world.rs
+++ b/docs/src/world.rs
@@ -365,7 +365,7 @@ const PATCHED_IMAGE_RULE: ShowFn<ImageElem> = |elem, engine, styles| {
     let web_image = typst_svg::WebImage::new(&image);
     let hash = typst_utils::hash128(&web_image.data);
 
-    let base = styles.get_ref(ConfigElem::asset_base).as_ref();
+    let base = styles.get_ref(ConfigElem::asset_base);
     let path = eco_format!(
         "{base}images/{}.{}",
         encode_hash(hash),


### PR DESCRIPTION
I noticed this because I was using `ecow` from its current git main, which produces a compile error here since `ecow` added new `AsRef` impls for `EcoString`, which leaves the compiler unable to decide between `AsRef<str>`, `AsRef<[u8]>`, `AsRef<OsStr>`, or `AsRef<Path>`. Luckily just dropping `.as_ref()` works fine.