### PR TITLE
Add unreleased warning to documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
         uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
 
       - name: Compile documentation
-        run: cargo docit compile --format pdf
+        run: cargo docit compile --format pdf --release
 
       - name: Rename documentation file
         run: mv docs/dist/docs.pdf typst-documentation.pdf

--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -745,6 +745,21 @@ a.pill {
   );
 }
 
+.dev-version-warning {
+  position: absolute;
+  right: 16px;
+  top: 8px;
+  padding-block: 4px;
+  padding-inline: 8px;
+  border-radius: 8px;
+  width: unset;
+  background: #ea3e47;
+  color: #fdfdfd;
+  font-size: 12px;
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
 /* Navigation breadcrumbs */
 
 .breadcrumbs {

--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -747,13 +747,13 @@ a.pill {
 
 .dev-version-warning {
   position: absolute;
-  right: 16px;
+  right: 8px;
   top: 8px;
   padding-block: 4px;
   padding-inline: 8px;
   border-radius: 8px;
   width: unset;
-  background: #ea3e47;
+  background: #565565;
   color: #fdfdfd;
   font-size: 12px;
   font-weight: bold;

--- a/docs/components/base.typ
+++ b/docs/components/base.typ
@@ -324,3 +324,24 @@
 #let insertion(name, fallback: none) = context {
   stdx.config.insertions.at(name, default: fallback)
 }
+
+#let dev-version-warning() = {
+  if stdx.is-dev-version {
+    let body = [Dev build #stdx.commit]
+    context if target() == "html" {
+      html.div(class: "dev-version-warning", body)
+    } else {
+      set text(
+        size: 0.75em,
+        weight: "bold",
+        fill: colors.genuine.white,
+      )
+      show: box.with(
+        fill: colors.red.shade-50,
+        inset: 0.67em,
+        radius: 0.67em,
+      )
+      upper(body)
+    }
+  }
+}

--- a/docs/components/base.typ
+++ b/docs/components/base.typ
@@ -332,8 +332,8 @@
       html.div(class: "dev-version-warning", body)
     } else {
       set text(
-        size: sizes.small,
-        weight: "bold",
+        size: sizes.small * 0.9,
+        weight: "medium",
         fill: colors.genuine.white,
       )
       // Same metrics as `ty-pill`.

--- a/docs/components/base.typ
+++ b/docs/components/base.typ
@@ -332,14 +332,16 @@
       html.div(class: "dev-version-warning", body)
     } else {
       set text(
-        size: 0.75em,
+        size: sizes.small,
         weight: "bold",
         fill: colors.genuine.white,
       )
+      // Same metrics as `ty-pill`.
       show: box.with(
         fill: colors.red.shade-50,
-        inset: 0.67em,
-        radius: 0.67em,
+        inset: (x: 0.3em),
+        outset: (y: 0.3em),
+        radius: 0.3em,
       )
       upper(body)
     }

--- a/docs/components/base.typ
+++ b/docs/components/base.typ
@@ -325,7 +325,7 @@
   stdx.config.insertions.at(name, default: fallback)
 }
 
-// Displays a pill indicating a development build.
+// Displays an indicator for a development build.
 #let dev-version-warning() = {
   let body = [Development build #stdx.commit]
   context if target() == "html" {

--- a/docs/components/base.typ
+++ b/docs/components/base.typ
@@ -325,25 +325,12 @@
   stdx.config.insertions.at(name, default: fallback)
 }
 
+// Displays a pill indicating a development build.
 #let dev-version-warning() = {
-  if stdx.is-dev-version {
-    let body = [Dev build #stdx.commit]
-    context if target() == "html" {
-      html.div(class: "dev-version-warning", body)
-    } else {
-      set text(
-        size: sizes.small * 0.9,
-        weight: "medium",
-        fill: colors.genuine.white,
-      )
-      // Same metrics as `ty-pill`.
-      show: box.with(
-        fill: colors.red.shade-50,
-        inset: (x: 0.3em),
-        outset: (y: 0.3em),
-        radius: 0.3em,
-      )
-      upper(body)
-    }
+  let body = [Development build #stdx.commit]
+  context if target() == "html" {
+    html.div(class: "dev-version-warning", body)
+  } else {
+    small(body)
   }
 }

--- a/docs/components/section.typ
+++ b/docs/components/section.typ
@@ -1,6 +1,6 @@
 #import "base.typ": (
-  classnames, heading-offset, icon, labelled, short-or-long, title-state,
-  tooltip-counter, dev-version-warning,
+  classnames, dev-version-warning, heading-offset, icon, labelled,
+  short-or-long, title-state, tooltip-counter,
 )
 #import "linking.typ": register-def
 #import "nav.typ": nav-breadcrumbs, nav-folding, nav-on-this-page, nav-prev-next

--- a/docs/components/section.typ
+++ b/docs/components/section.typ
@@ -123,7 +123,9 @@
     })
 
     html.body(class: classnames("docs", class), {
-      dev-version-warning()
+      if stdx.is-dev-version {
+        dev-version-warning()
+      }
       html.header(class: "w695", {
         html.button(
           class: "hamburger",

--- a/docs/components/section.typ
+++ b/docs/components/section.typ
@@ -1,6 +1,6 @@
 #import "base.typ": (
   classnames, heading-offset, icon, labelled, short-or-long, title-state,
-  tooltip-counter,
+  tooltip-counter, dev-version-warning,
 )
 #import "linking.typ": register-def
 #import "nav.typ": nav-breadcrumbs, nav-folding, nav-on-this-page, nav-prev-next
@@ -123,6 +123,7 @@
     })
 
     html.body(class: classnames("docs", class), {
+      dev-version-warning()
       html.header(class: "w695", {
         html.button(
           class: "hamburger",

--- a/docs/components/styling.typ
+++ b/docs/components/styling.typ
@@ -4,7 +4,9 @@
 //   element docs (as opposed to componentized non-prose content).
 
 #import "system.typ": colors, fonts, sizes
-#import "base.typ": labelled, small, title-state, with-short-versions
+#import "base.typ": (
+  labelled, small, title-state, with-short-versions, dev-version-warning,
+)
 #import "example.typ": example, preview, source
 #import "footnote.typ": footnote-rule, with-footnotes
 #import "linking.typ": def-label, def-metadata, register-def
@@ -12,18 +14,6 @@
 // The part of the global styling that applies to the paged version.
 #let paged-styling(body) = {
   set page(margin: (x: 3cm, y: 2.5cm))
-  set page(background: {
-    show: place.with(top + left)
-    show: block.with(width: 2cm, height: 100%)
-    set align(center + horizon)
-    show: rotate.with(-90deg, reflow: true)
-    set text(
-      size: 32pt,
-      weight: "bold",
-      fill: colors.light-gray.shade-30,
-    )
-    upper[Development version]
-  }) if stdx.is-dev-version
   set text(font: (fonts.body, ..fonts.fallback), size: sizes.body)
   set list(marker: [--])
   set underline(offset: 0.2em)
@@ -80,11 +70,14 @@
   set page(
     numbering: "1",
     header: {
+      set align(right)
       counter(footnote).update(())
+      dev-version-warning()
+      h(1fr)
       context {
         let title = title-state.get()
         if title != none {
-          align(right, small(title))
+          small(title)
         }
       }
     },

--- a/docs/components/styling.typ
+++ b/docs/components/styling.typ
@@ -5,7 +5,7 @@
 
 #import "system.typ": colors, fonts, sizes
 #import "base.typ": (
-  labelled, small, title-state, with-short-versions, dev-version-warning,
+  dev-version-warning, labelled, small, title-state, with-short-versions,
 )
 #import "example.typ": example, preview, source
 #import "footnote.typ": footnote-rule, with-footnotes

--- a/docs/components/styling.typ
+++ b/docs/components/styling.typ
@@ -72,7 +72,9 @@
     header: {
       set align(right)
       counter(footnote).update(())
-      dev-version-warning()
+      if stdx.is-dev-version {
+        dev-version-warning()
+      }
       h(1fr)
       context {
         let title = title-state.get()

--- a/docs/components/styling.typ
+++ b/docs/components/styling.typ
@@ -12,6 +12,18 @@
 // The part of the global styling that applies to the paged version.
 #let paged-styling(body) = {
   set page(margin: (x: 3cm, y: 2.5cm))
+  set page(background: {
+    show: place.with(top + left)
+    show: block.with(width: 2cm, height: 100%)
+    set align(center + horizon)
+    show: rotate.with(-90deg, reflow: true)
+    set text(
+      size: 32pt,
+      weight: "bold",
+      fill: colors.light-gray.shade-30,
+    )
+    upper[Development version]
+  }) if stdx.is-dev-version
   set text(font: (fonts.body, ..fonts.fallback), size: sizes.body)
   set list(marker: [--])
   set underline(offset: 0.2em)

--- a/docs/components/system.typ
+++ b/docs/components/system.typ
@@ -17,6 +17,7 @@
   ),
   red: (
     shade-10: rgb("ffcbc4"),
+    shade-50: rgb("ea3e47"),
   ),
   green: (
     shade-10: rgb("d1ffe2"),

--- a/docs/src/args.rs
+++ b/docs/src/args.rs
@@ -74,6 +74,9 @@ pub struct CompileArgs {
     /// The output format.
     #[arg(long = "format", short = 'f', default_value_t)]
     pub format: OutputFormat,
+    /// Do not add the "development version" warning to the generated PDF.
+    #[arg(long)]
+    pub release: bool,
     /// Produces performance timings of the compilation process.
     #[arg(long = "timings", value_name = "OUTPUT_JSON")]
     pub timings: Option<PathBuf>,

--- a/docs/src/main.rs
+++ b/docs/src/main.rs
@@ -114,6 +114,8 @@ struct Config {
     output: Option<PathBuf>,
     /// The kind of output to produce.
     output_format: OutputFormat,
+    /// Whether to include a "development version" warning in the documentation.
+    is_dev_version: bool,
     /// A live reload server for the `watch` subcommand.
     server: Option<HttpServer>,
     /// Whether to open the output after compilation.
@@ -131,6 +133,7 @@ impl Config {
                 OutputFormat::Website => Some(SITE_PATH.into()),
             }),
             output_format: args.format,
+            is_dev_version: !args.release,
             server: (serve && args.format == OutputFormat::Website)
                 .then(|| HttpServer::new("docs", None, true).unwrap()),
             open: args.open,

--- a/docs/src/world.rs
+++ b/docs/src/world.rs
@@ -67,7 +67,7 @@ impl DocWorld {
     /// and entrypoint file.
     pub fn new(config: &Config) -> Self {
         Self {
-            library: LazyHash::new(library()),
+            library: LazyHash::new(library(config.is_dev_version)),
             files: FileStore::new(DocsFiles::new(config.input.as_deref())),
             now: Time::system(),
         }
@@ -198,10 +198,10 @@ pub static FONTS: LazyLock<(LazyHash<FontBook>, Vec<Font>)> = LazyLock::new(|| {
 /// A standard library that is extended for docs compilation. Includes
 /// - an `stdx` module with various utilities
 /// - a few patched show rules
-fn library() -> Library {
+fn library(is_dev_version: bool) -> Library {
     let mut lib = Library::builder().with_features(Features::all()).build();
     let scope = lib.global.scope_mut();
-    scope.define("stdx", stdx_module());
+    scope.define("stdx", stdx_module(is_dev_version));
     lib.rules.replace(Target::Html, PATCHED_LINK_RULE);
     lib.rules.replace(Target::Html, PATCHED_IMAGE_RULE);
     lib.rules.register(Target::Paged, FRAME_RULE);
@@ -209,7 +209,7 @@ fn library() -> Library {
 }
 
 /// A module with various utilities for the docs.
-fn stdx_module() -> Module {
+fn stdx_module(is_dev_version: bool) -> Module {
     let mut scope = Scope::new();
     scope.define_elem::<ConfigElem>();
     scope.define_func::<str_from_path>();
@@ -227,6 +227,7 @@ fn stdx_module() -> Module {
     scope.define_func::<crate::reflect::is_global_html_attr>();
     scope.define("commit", typst_utils::version().commit());
     scope.define("shorthands", crate::reflect::shorthands());
+    scope.define("is-dev-version", is_dev_version);
     Module::new("stdx", scope)
 }
 

--- a/docs/src/world.rs
+++ b/docs/src/world.rs
@@ -25,7 +25,7 @@ use typst_html::{HtmlAttrs, HtmlElem, attr, tag};
 use typst_kit::datetime::Time;
 use typst_kit::diagnostics::DiagnosticWorld;
 use typst_kit::files::{FileLoader, FileStore, FsRoot};
-use typst_utils::{LazyHash, PicoStr};
+use typst_utils::{LazyHash, PicoStr, display_commit};
 
 use crate::Config;
 use crate::example::FRAME_RULE;
@@ -227,6 +227,7 @@ fn stdx_module(is_dev_version: bool) -> Module {
     scope.define_func::<crate::reflect::is_global_html_attr>();
     scope.define("commit", typst_utils::version().commit());
     scope.define("shorthands", crate::reflect::shorthands());
+    scope.define("commit", display_commit(typst_utils::version().commit()));
     scope.define("is-dev-version", is_dev_version);
     Module::new("stdx", scope)
 }


### PR DESCRIPTION
This PR closes https://github.com/typst/typst/issues/8310 by adding a "DEVELOPMENT VERSION" warning on the left hand side of each page in the generated PDF. Notably, the warning is not emitted for web export because the main use case that was presented in the issue was distributing the PDF for an unreleased version, and I suspect this would be more common than distributing the website for an unreleased version. The message "DEVELOPMENT VERSION" is not the most self-explanatory, but it is short and makes it obvious that if something documented in the PDF does not work, it's probably due to this giant text and not a Typst bug.

The warning can be disabled using the `--release` command line argument (e.g., `cargo docit -f pdf --release`).

Feel free to suggest stylistic changes. Also, in case we should emit a warning for the web version as well, I don't really know what that would look like so any idea would be welcome.

Arbitrary page from the PDF:
<img width="730" height="1029" alt="A page with gray bold capital text on the left hand side reading DEVELOPMENT VERSION in a big font." src="https://github.com/user-attachments/assets/fd1a1f20-dffa-46de-b457-648d1ca70123" />

