### PR TITLE
Add `inclusive` parameter to `range`

### DIFF
--- a/crates/typst-library/src/foundations/array.rs
+++ b/crates/typst-library/src/foundations/array.rs
@@ -378,9 +378,7 @@ impl Array {
     /// #range(2, 5) \
     /// #range(20, step: 4) \
     /// #range(21, step: 4) \
-    /// #range(5, 2, step: -1) \
-    /// #range(3, inclusive: true) \
-    /// #range(-2, step: -1, inclusive: true)
+    /// #range(5, 2, step: -1)
     /// ```
     #[func]
     pub fn range(
@@ -393,6 +391,13 @@ impl Array {
         #[external]
         end: i64,
         /// Whether `end` is inclusive.
+        ///
+        /// ```example
+        /// #range(0, inclusive: true) \
+        /// #range(7, 10, inclusive: true) \
+        /// #range(-8, -4, inclusive: true) \
+        /// #range(-6, step: -2, inclusive: true)
+        /// ```
         #[named]
         #[default(false)]
         inclusive: bool,

--- a/crates/typst-library/src/foundations/array.rs
+++ b/crates/typst-library/src/foundations/array.rs
@@ -413,32 +413,29 @@ impl Array {
         };
 
         let step = step.get();
-        let try_step = |v: i64| match v.checked_add(step) {
-            Some(v) => Ok(v),
-            None => bail!(args.span, "result became too large"),
-        };
+        let step_dir = 0.cmp(&step);
 
         let mut x = start;
         let mut array = Self::new();
 
-        if inclusive {
-            // Push while `x` has not stepped past `end` in the `step` direction
-            while x.cmp(&end) != 0.cmp(&step).reverse() {
-                array.push(x.into_value());
-                match try_step(x) {
-                    Ok(v) => x = v,
-                    Err(_) if x == end => {
-                        // don't error if we've reached `end` exactly
-                        break;
-                    }
-                    Err(e) => Err(e)?,
-                }
+        let in_bounds = |x: i64| {
+            if inclusive {
+                // `x` must not exceed `end`.
+                x.cmp(&end) != step_dir.reverse()
+            } else {
+                // `x` must stay strictly before `end`.
+                x.cmp(&end) == step_dir
             }
-        } else {
-            // Push while `x` is strictly before `end` in the `step` direction
-            while x.cmp(&end) == 0.cmp(&step) {
-                array.push(x.into_value());
-                x = try_step(x)?;
+        };
+
+        while in_bounds(x) {
+            array.push(x.into_value());
+
+            if let Some(next) = x.checked_add(step) {
+                x = next;
+            } else {
+                // `end` must have been exceeded this iteration, so we yield.
+                break;
             }
         }
 

--- a/crates/typst-library/src/foundations/array.rs
+++ b/crates/typst-library/src/foundations/array.rs
@@ -378,7 +378,9 @@ impl Array {
     /// #range(2, 5) \
     /// #range(20, step: 4) \
     /// #range(21, step: 4) \
-    /// #range(5, 2, step: -1)
+    /// #range(5, 2, step: -1) \
+    /// #range(3, inclusive: true) \
+    /// #range(-2, step: -1, inclusive: true)
     /// ```
     #[func]
     pub fn range(
@@ -387,9 +389,13 @@ impl Array {
         #[external]
         #[default]
         start: i64,
-        /// The end of the range (exclusive).
+        /// The end of the range.
         #[external]
         end: i64,
+        /// Whether `end` is inclusive.
+        #[named]
+        #[default(false)]
+        inclusive: bool,
         /// The distance between the generated numbers.
         #[named]
         #[default(NonZeroI64::new(1).unwrap())]
@@ -402,11 +408,12 @@ impl Array {
         };
 
         let step = step.get();
+        let inclusive_end = end + if inclusive { step.signum() } else { 0 };
 
         let mut x = start;
         let mut array = Self::new();
 
-        while x.cmp(&end) == 0.cmp(&step) {
+        while x.cmp(&inclusive_end) == 0.cmp(&step) {
             array.push(x.into_value());
             x += step;
         }

--- a/crates/typst-library/src/foundations/array.rs
+++ b/crates/typst-library/src/foundations/array.rs
@@ -413,14 +413,26 @@ impl Array {
         };
 
         let step = step.get();
-        let inclusive_end = end + if inclusive { step.signum() } else { 0 };
+        let try_step = |v: i64| match v.checked_add(step) {
+            Some(v) => Ok(v),
+            None => bail!(args.span, "result became too large"),
+        };
 
         let mut x = start;
         let mut array = Self::new();
 
-        while x.cmp(&inclusive_end) == 0.cmp(&step) {
-            array.push(x.into_value());
-            x += step;
+        if inclusive {
+            // Push while `x` has not stepped past `end` in the `step` direction
+            while x.cmp(&end) != 0.cmp(&step).reverse() {
+                array.push(x.into_value());
+                x = try_step(x)?;
+            }
+        } else {
+            // Push while `x` is strictly before `end` in the `step` direction
+            while x.cmp(&end) == 0.cmp(&step) {
+                array.push(x.into_value());
+                x = try_step(x)?;
+            }
         }
 
         Ok(array)

--- a/crates/typst-library/src/foundations/array.rs
+++ b/crates/typst-library/src/foundations/array.rs
@@ -425,7 +425,14 @@ impl Array {
             // Push while `x` has not stepped past `end` in the `step` direction
             while x.cmp(&end) != 0.cmp(&step).reverse() {
                 array.push(x.into_value());
-                x = try_step(x)?;
+                match try_step(x) {
+                    Ok(v) => x = v,
+                    Err(_) if x == end => {
+                        // don't error if we've reached `end` exactly
+                        break;
+                    }
+                    Err(e) => Err(e)?,
+                }
             }
         } else {
             // Push while `x` is strictly before `end` in the `step` direction

--- a/tests/suite/foundations/array.typ
+++ b/tests/suite/foundations/array.typ
@@ -140,17 +140,16 @@
 #test(range(inclusive: true, 5, 2, step: -1), (5, 4, 3, 2))
 #test(range(inclusive: true, 0, -2, step: -1), (0, -1, -2))
 
-
 #let i64-max = 9223372036854775807
 #let i64-min = int("-9223372036854775808")
 
-// the user should be able to reach these values.
+// The user should be able to reach these values.
 #test(range(i64-max - 2, i64-max), (9223372036854775805, 9223372036854775806))
 #test(range(i64-min + 2, i64-min, step: -1), (-9223372036854775806, -9223372036854775807))
 #test(range(inclusive: true, i64-max - 2, i64-max), (9223372036854775805, 9223372036854775806, 9223372036854775807))
 #test(range(inclusive: true, i64-min + 2, i64-min, step: -1), (-9223372036854775806, -9223372036854775807, int("-9223372036854775808")))
 
-// stepping would overflow if not caught.
+// Stepping would overflow if not caught.
 #test(range(2, 3, step: i64-max), (2,))
 #test(range(-2, -3, step: i64-min), (-2,))
 #test(range(inclusive: true, i64-max - 1, i64-max, step: 2), (9223372036854775806,))

--- a/tests/suite/foundations/array.typ
+++ b/tests/suite/foundations/array.typ
@@ -140,25 +140,21 @@
 #test(range(inclusive: true, 5, 2, step: -1), (5, 4, 3, 2))
 #test(range(inclusive: true, 0, -2, step: -1), (0, -1, -2))
 
-// verify extremes
-#test(range(inclusive: true, 9223372036854775806, 9223372036854775807), (9223372036854775806, 9223372036854775807))
-#test(range(inclusive: true, -9223372036854775807, int("-9223372036854775808"), step: -1), (-9223372036854775807, int("-9223372036854775808")))
 
---- array-range-basic-overflow eval ---
-// Error: 2-40 result became too large
-#range(2, 3, step: 9223372036854775806)
+#let i64-max = 9223372036854775807
+#let i64-min = int("-9223372036854775808")
 
---- array-range-basic-underflow eval ---
-// Error: 2-43 result became too large
-#range(-2, -3, step: -9223372036854775807)
+// the user should be able to reach these values.
+#test(range(i64-max - 2, i64-max), (9223372036854775805, 9223372036854775806))
+#test(range(i64-min + 2, i64-min, step: -1), (-9223372036854775806, -9223372036854775807))
+#test(range(inclusive: true, i64-max - 2, i64-max), (9223372036854775805, 9223372036854775806, 9223372036854775807))
+#test(range(inclusive: true, i64-min + 2, i64-min, step: -1), (-9223372036854775806, -9223372036854775807, int("-9223372036854775808")))
 
---- array-range-inclusive-overflow eval ---
-// Error: 2-75 result became too large
-#range(inclusive: true, 9223372036854775806, 9223372036854775807, step: 2)
-
---- array-range-inclusive-underflow eval ---
-// Error: 2-85 result became too large
-#range(inclusive: true, -9223372036854775807, int("-9223372036854775808"), step: -2)
+// stepping would overflow if not caught.
+#test(range(2, 3, step: i64-max), (2,))
+#test(range(-2, -3, step: i64-min), (-2,))
+#test(range(inclusive: true, i64-max - 1, i64-max, step: 2), (9223372036854775806,))
+#test(range(inclusive: true, i64-min + 1, i64-min, step: -2), (-9223372036854775807,))
 
 --- array-range-end-missing eval ---
 // Error: 2-9 missing argument: end

--- a/tests/suite/foundations/array.typ
+++ b/tests/suite/foundations/array.typ
@@ -140,6 +140,10 @@
 #test(range(inclusive: true, 5, 2, step: -1), (5, 4, 3, 2))
 #test(range(inclusive: true, 0, -2, step: -1), (0, -1, -2))
 
+// verify extremes
+#test(range(inclusive: true, 9223372036854775806, 9223372036854775807), (9223372036854775806, 9223372036854775807))
+#test(range(inclusive: true, -9223372036854775807, int("-9223372036854775808"), step: -1), (-9223372036854775807, int("-9223372036854775808")))
+
 --- array-range-basic-overflow eval ---
 // Error: 2-40 result became too large
 #range(2, 3, step: 9223372036854775806)
@@ -149,12 +153,12 @@
 #range(-2, -3, step: -9223372036854775807)
 
 --- array-range-inclusive-overflow eval ---
-// Error: 2-66 result became too large
-#range(inclusive: true, 9223372036854775806, 9223372036854775807)
+// Error: 2-75 result became too large
+#range(inclusive: true, 9223372036854775806, 9223372036854775807, step: 2)
 
 --- array-range-inclusive-underflow eval ---
 // Error: 2-85 result became too large
-#range(inclusive: true, -9223372036854775807, int("-9223372036854775808"), step: -1)
+#range(inclusive: true, -9223372036854775807, int("-9223372036854775808"), step: -2)
 
 --- array-range-end-missing eval ---
 // Error: 2-9 missing argument: end

--- a/tests/suite/foundations/array.typ
+++ b/tests/suite/foundations/array.typ
@@ -134,6 +134,12 @@
 #test(range(5, 2, step: -1), (5, 4, 3))
 #test(range(10, 0, step: -3), (10, 7, 4, 1))
 
+#test(range(inclusive: true, 0, 0), (0,))
+#test(range(inclusive: true, -10, -8), (-10, -9, -8))
+#test(range(inclusive: true, -2, 4, step: 2), (-2, 0, 2, 4))
+#test(range(inclusive: true, 5, 2, step: -1), (5, 4, 3, 2))
+#test(range(inclusive: true, 0, -2, step: -1), (0, -1, -2))
+
 --- array-range-end-missing eval ---
 // Error: 2-9 missing argument: end
 #range()

--- a/tests/suite/foundations/array.typ
+++ b/tests/suite/foundations/array.typ
@@ -140,6 +140,22 @@
 #test(range(inclusive: true, 5, 2, step: -1), (5, 4, 3, 2))
 #test(range(inclusive: true, 0, -2, step: -1), (0, -1, -2))
 
+--- array-range-basic-overflow eval ---
+// Error: 2-40 result became too large
+#range(2, 3, step: 9223372036854775806)
+
+--- array-range-basic-underflow eval ---
+// Error: 2-43 result became too large
+#range(-2, -3, step: -9223372036854775807)
+
+--- array-range-inclusive-overflow eval ---
+// Error: 2-66 result became too large
+#range(inclusive: true, 9223372036854775806, 9223372036854775807)
+
+--- array-range-inclusive-underflow eval ---
+// Error: 2-85 result became too large
+#range(inclusive: true, -9223372036854775807, int("-9223372036854775808"), step: -1)
+
 --- array-range-end-missing eval ---
 // Error: 2-9 missing argument: end
 #range()


### PR DESCRIPTION
Closes #8332

---

<details>
<summary>Outdated thanks to Malo</summary>

The docs example is getting somewhat long, but I think the existing cases are doing enough as they are. So two new ones are added to showcase what users can expect, with more elaborate cases in the test suite :)
</details>

The docs showcase various distinct cases, and tests are in place as well

<img width="1534" height="534" alt="image" src="https://github.com/user-attachments/assets/cb5a3558-12e9-45aa-abee-87ebde29b570" />

---

Regarding terminology, using "inclusive" over the inverse ("exclusive") is consistent with how rust handles it: https://doc.rust-lang.org/std/ops/struct.RangeInclusive.html