### PR TITLE
docs: link tutorial to Typst web app

### DIFF
--- a/docs/content/tutorial/1-writing.typ
+++ b/docs/content/tutorial/1-writing.typ
@@ -8,7 +8,7 @@
   description: "Typst's tutorial.",
 )
 
-Let's get started! Suppose you got assigned to write a technical report for university. It will contain prose, maths, headings, and figures. To get started, you create a new project on the Typst app. You'll be taken to the editor where you see two panels: A source panel where you compose your document and a preview panel where you see the rendered document.
+Let's get started! Suppose you got assigned to write a technical report for university. It will contain prose, maths, headings, and figures. To get started, you create a new project in the #link("https://typst.app/play/")[Typst app]. You'll be taken to the editor where you see two panels: A source panel where you compose your document and a preview panel where you see the rendered document.
 
 #docs-figure(
   "1-writing-app.png",

--- a/docs/content/tutorial/index.typ
+++ b/docs/content/tutorial/index.typ
@@ -10,7 +10,7 @@
 )[
   Welcome to Typst's tutorial! In this tutorial, you will learn how to write and format documents in Typst. We will start with everyday tasks and gradually introduce more advanced features. This tutorial does not assume prior knowledge of Typst, other markup languages, or programming. We do assume that you know how to edit a text file.
 
-  The best way to start is to sign up to the Typst app for free and follow along with the steps below. The app gives you instant preview, syntax highlighting and helpful autocompletions. Alternatively, you can follow along in your local text editor with the #link("https://github.com/typst/typst")[open-source CLI].
+  The best way to start is to open the #link("https://typst.app/play/")[Typst app] and follow along with the steps below. The app gives you instant preview, syntax highlighting and helpful autocompletions. Alternatively, you can follow along in your local text editor with the #link("https://github.com/typst/typst")[open-source CLI].
 
   = #short-or-long[When Typst][When to use Typst] <when-typst>
   Before we get started, let's check what Typst is and when to use it. Typst is a markup language for typesetting documents. It is designed to be easy to learn, fast, and versatile. Typst takes text files with markup in them and outputs PDFs.


### PR DESCRIPTION
﻿Closes #7587

## Summary
- Link the tutorial landing page's first Typst app mention to the web app playground.
- Link the first "Writing in Typst" app mention to the same web app entry point.

## Impact
Newcomers can open the browser-based Typst app directly from the tutorial before choosing whether to install or use the CLI.

## Validation
- `git diff --check` - passed
- `cargo docit compile` - passed
