### PR TITLE
Fix overflow on `i64::MIN` in `calc.abs`, `gcd`, and `lcm`

### DIFF
--- a/crates/typst-library/src/foundations/calc.rs
+++ b/crates/typst-library/src/foundations/calc.rs
@@ -83,7 +83,7 @@ pub struct ToAbs(Value);
 
 cast! {
     ToAbs,
-    v: i64 => Self(v.abs().into_value()),
+    v: i64 => Self(v.checked_abs().ok_or_else(too_large)?.into_value()),
     v: f64 => Self(v.abs().into_value()),
     v: Length => Self(Value::Length(v.try_abs()
         .ok_or("cannot take absolute value of this length")?)),
@@ -650,7 +650,7 @@ pub fn gcd(
         a = temp;
     }
 
-    Ok(a.abs())
+    Ok(a.checked_abs().ok_or_else(too_large)?)
 }
 
 /// Calculates the least common multiple of two integers.
@@ -666,12 +666,12 @@ pub fn lcm(
     b: i64,
 ) -> StrResult<i64> {
     if a == b {
-        return Ok(a.abs());
+        return Ok(a.checked_abs().ok_or_else(too_large)?);
     }
 
     Ok(a.checked_div(gcd(a, b)?)
         .and_then(|gcd| gcd.checked_mul(b))
-        .map(|v| v.abs())
+        .and_then(|v| v.checked_abs())
         .ok_or_else(too_large)?)
 }
 

--- a/tests/suite/foundations/calc.typ
+++ b/tests/suite/foundations/calc.typ
@@ -38,6 +38,10 @@
 // Error: 11-22 expected integer, float, length, angle, ratio, fraction, or decimal, found string
 #calc.abs("no number")
 
+--- calc-abs-too-large eval ---
+// Error: 11-38 the result is too large
+#calc.abs(int("-9223372036854775808"))
+
 --- calc-even-and-odd eval ---
 // Test the `even` and `odd` functions.
 #test(calc.even(2), true)
@@ -331,6 +335,10 @@
 // Error: 2-43 the result is too large
 #calc.gcd(int("-9223372036854775808"), -1)
 
+--- calc-gcd-min-int eval ---
+// Error: 2-42 the result is too large
+#calc.gcd(int("-9223372036854775808"), 0)
+
 --- calc-lcm eval ---
 // Test the `lcm` function.
 #test(calc.lcm(112, 77), 1232)
@@ -344,6 +352,10 @@
 --- calc-lcm-too-large eval ---
 // Error: 2-41 the result is too large
 #calc.lcm(15486487489457, 4874879896543)
+
+--- calc-lcm-min-int eval ---
+// Error: 2-42 the result is too large
+#calc.lcm(int("-9223372036854775808"), 1)
 
 --- calc-round-larger-than-max-int eval ---
 #test(calc.round(decimal("9223372036854775809.5")), decimal("9223372036854775810"))


### PR DESCRIPTION
`calc.abs`, `gcd`, and `lcm` overflowed on `i64::MIN` via `i64::abs`, reachable through `int("-9223372036854775808")`; they now error like the other integer operations.