### PR TITLE
Add XHTML support to HTML exporter

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -296,8 +296,8 @@ pub struct CompileArgs {
     #[clap(value_parser = input_value_parser(), value_hint = ValueHint::FilePath)]
     pub input: Input,
 
-    /// Path to output file (PDF, PNG, SVG, or HTML). Use `-` to write output to
-    /// stdout.
+    /// Path to output file (PDF, PNG, SVG, HTML, or XHTML). Use `-` to write
+    /// output to stdout.
     ///
     /// For output formats emitting one file per page (PNG & SVG), a page number
     /// template must be present if the source document renders to multiple
@@ -594,6 +594,7 @@ pub enum OutputFormat {
     Svg,
     Html,
     Bundle,
+    Xhtml,
 }
 
 impl OutputFormat {

--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -55,7 +55,7 @@ pub struct CompileConfig {
     pub watching: bool,
     /// Path to input Typst file or stdin.
     pub input: Input,
-    /// Path to output file (PDF, PNG, SVG, or HTML).
+    /// Path to output file (PDF, PNG, SVG, or (X)HTML).
     pub output: Output,
     /// The format of the output file.
     pub output_format: OutputFormat,
@@ -116,6 +116,7 @@ impl CompileConfig {
                 Some(ext) if ext.eq_ignore_ascii_case("png") => OutputFormat::Png,
                 Some(ext) if ext.eq_ignore_ascii_case("svg") => OutputFormat::Svg,
                 Some(ext) if ext.eq_ignore_ascii_case("html") => OutputFormat::Html,
+                Some(ext) if ext.eq_ignore_ascii_case("xhtml") => OutputFormat::Xhtml,
                 _ => bail!(
                     "could not infer output format for path {}.\n\
                      consider providing the format manually with `--format/-f`",
@@ -137,6 +138,7 @@ impl CompileConfig {
                     OutputFormat::Svg => "svg",
                     OutputFormat::Html => "html",
                     OutputFormat::Bundle => "",
+                    OutputFormat::Xhtml => "xhtml",
                 },
             ))
         });
@@ -324,7 +326,7 @@ fn compile_and_export(
             let result = output.and_then(|document| export_paged(&document, config));
             Warned { output: result, warnings }
         }
-        OutputFormat::Html => {
+        OutputFormat::Html | OutputFormat::Xhtml => {
             let Warned { output, warnings } = typst::compile::<HtmlDocument>(world);
             let result = output.and_then(|document| export_html(&document, config));
             Warned {
@@ -342,7 +344,7 @@ fn compile_and_export(
 
 /// Export to HTML.
 fn export_html(document: &HtmlDocument, config: &CompileConfig) -> SourceResult<()> {
-    let options = HtmlOptions { pretty: config.pretty };
+    let options = html_options(config);
     let html = typst_html::html(document, &options)?;
     let result = config.output.write(html.as_bytes());
 
@@ -371,7 +373,7 @@ fn export_paged(
         OutputFormat::Svg => {
             export_image(document, config, ImageExportFormat::Svg).at(Span::detached())
         }
-        OutputFormat::Html | OutputFormat::Bundle => unreachable!(),
+        OutputFormat::Html | OutputFormat::Bundle | OutputFormat::Xhtml => unreachable!(),
     }
 }
 
@@ -593,7 +595,14 @@ fn export_image_page(
 
 /// Creates options for HTML export.
 fn html_options(config: &CompileConfig) -> HtmlOptions {
-    HtmlOptions { pretty: config.pretty }
+    let mut options = HtmlOptions::default();
+    if config.pretty {
+        options = options.pretty();
+    }
+    if config.output_format == OutputFormat::Xhtml {
+        options = options.xhtml();
+    }
+    options
 }
 
 /// Creates options for PDF export.

--- a/crates/typst-html/src/encode.rs
+++ b/crates/typst-html/src/encode.rs
@@ -1,7 +1,8 @@
 use std::fmt::Write;
 
 use comemo::{Track, Tracked};
-use ecow::{EcoString, eco_format};
+use ecow::{EcoString, EcoVec, eco_format};
+use typst_assets::html as html_data;
 use typst_library::diag::{At, SourceResult, StrResult, bail};
 use typst_library::foundations::Repr;
 use typst_library::model::LateLinkResolver;
@@ -13,16 +14,89 @@ use crate::{
 };
 
 /// Settings for HTML export.
-#[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct HtmlOptions {
     /// Whether to format the HTML in a human-readable way.
     pub pretty: bool,
+    /// Whether to emit an XML declaration before the doctype.
+    xml_declaration: bool,
+    /// Whether text must satisfy XML character restrictions.
+    xml_characters: bool,
+    /// Whether empty elements are serialized with XML syntax.
+    xml_empty_elements: bool,
+    /// Whether attribute values must satisfy XML restrictions.
+    xml_attribute_values: bool,
+    /// Whether known HTML names are lowercased for XML compatibility.
+    normalize_html_names: bool,
+    /// Whether the root `<html>` element must carry the XHTML namespace.
+    xhtml_namespace: bool,
+    /// Whether `lang` and `xml:lang` should be mirrored.
+    mirror_language_attributes: bool,
+    /// Whether empty attributes can be minimized.
+    minimize_empty_attributes: bool,
+    /// Whether empty presence attributes are repeated as their value.
+    repeat_empty_presence_attributes: bool,
+    /// Whether raw text elements are serialized as CDATA.
+    cdata_raw_text: bool,
+    /// Whether to apply the HTML parser's leading newline rule.
+    html_parser_newline_rule: bool,
+    /// Whether bare table rows should be wrapped in explicit table bodies.
+    explicit_table_bodies: bool,
+    /// Whether `<noscript>` is rejected.
+    reject_noscript: bool,
+}
+
+impl HtmlOptions {
+    /// Enable pretty-printing.
+    pub fn pretty(mut self) -> Self {
+        self.pretty = true;
+        self
+    }
+
+    /// Enable XHTML serialization.
+    pub fn xhtml(mut self) -> Self {
+        self.xml_declaration = true;
+        self.xml_characters = true;
+        self.xml_empty_elements = true;
+        self.xml_attribute_values = true;
+        self.normalize_html_names = true;
+        self.xhtml_namespace = true;
+        self.mirror_language_attributes = true;
+        self.minimize_empty_attributes = false;
+        self.repeat_empty_presence_attributes = true;
+        self.cdata_raw_text = true;
+        self.html_parser_newline_rule = false;
+        self.explicit_table_bodies = true;
+        self.reject_noscript = true;
+        self
+    }
+}
+
+impl Default for HtmlOptions {
+    fn default() -> Self {
+        Self {
+            pretty: false,
+            xml_declaration: false,
+            xml_characters: false,
+            xml_empty_elements: false,
+            xml_attribute_values: false,
+            normalize_html_names: false,
+            xhtml_namespace: false,
+            mirror_language_attributes: false,
+            minimize_empty_attributes: true,
+            repeat_empty_presence_attributes: false,
+            cdata_raw_text: false,
+            html_parser_newline_rule: true,
+            explicit_table_bodies: false,
+            reject_noscript: false,
+        }
+    }
 }
 
 /// Encodes an HTML document into a string.
 pub fn html(document: &HtmlDocument, options: &HtmlOptions) -> SourceResult<String> {
     let link_resolver = LateLinkResolver::new(None, document.introspector().as_ref());
-    let w = Writer::new(link_resolver.track(), options.pretty);
+    let w = Writer::new(link_resolver.track(), options);
     html_impl(w, document.root())
 }
 
@@ -35,12 +109,15 @@ pub fn html_in_bundle(
     options: &HtmlOptions,
     link_resolver: Tracked<LateLinkResolver>,
 ) -> SourceResult<String> {
-    let w = Writer::new(link_resolver, options.pretty);
+    let w = Writer::new(link_resolver, options);
     html_impl(w, root)
 }
 
 /// The shared implementation of [`html`] and [`html_in_bundle`].
 fn html_impl(mut w: Writer, root: &HtmlElement) -> SourceResult<String> {
+    if w.options.xml_declaration {
+        w.buf.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>");
+    }
     w.buf.push_str("<!DOCTYPE html>");
     write_indent(&mut w);
     write_element(&mut w, root)?;
@@ -51,7 +128,7 @@ fn html_impl(mut w: Writer, root: &HtmlElement) -> SourceResult<String> {
 }
 
 /// Encodes HTML.
-struct Writer<'a> {
+struct Writer<'a, 'o> {
     /// The output buffer.
     buf: String,
     /// The current indentation level
@@ -61,16 +138,22 @@ struct Writer<'a> {
     link_resolver: Tracked<'a, LateLinkResolver<'a>>,
     /// Whether pretty printing is enabled.
     pretty: bool,
+    /// The HTML export settings.
+    options: &'o HtmlOptions,
 }
 
-impl<'a> Writer<'a> {
+impl<'a, 'o> Writer<'a, 'o> {
     /// Creates a new writer.
-    fn new(link_resolver: Tracked<'a, LateLinkResolver<'a>>, pretty: bool) -> Self {
+    fn new(
+        link_resolver: Tracked<'a, LateLinkResolver<'a>>,
+        options: &'o HtmlOptions,
+    ) -> Self {
         Self {
             buf: String::new(),
             level: 0,
             link_resolver,
-            pretty,
+            pretty: options.pretty,
+            options,
         }
     }
 }
@@ -99,7 +182,10 @@ fn write_node(w: &mut Writer, node: &HtmlNode, escape_text: bool) -> SourceResul
 /// Encodes plain text into the writer.
 fn write_text(w: &mut Writer, text: &str, span: Span, escape: bool) -> SourceResult<()> {
     for c in text.chars() {
-        if escape || !charsets::is_valid_in_normal_element_text(c) {
+        if escape
+            || !charsets::is_valid_in_normal_element_text(c)
+            || w.options.xml_characters && !is_valid_xml_char(c)
+        {
             write_escape(w, c).at(span)?;
         } else {
             w.buf.push(c);
@@ -110,57 +196,100 @@ fn write_text(w: &mut Writer, text: &str, span: Span, escape: bool) -> SourceRes
 
 /// Encodes one element into the writer.
 fn write_element(w: &mut Writer, element: &HtmlElement) -> SourceResult<()> {
+    let tag = normalize_tag(element.tag, w.options);
+    let tag_name = tag.resolve();
+    let tag_name = tag_name.as_str();
+
+    if w.options.reject_noscript && tag == tag::noscript {
+        bail!(element.span, "`<noscript>` is not permitted in XHTML output");
+    }
+
     w.buf.push('<');
-    w.buf.push_str(&element.tag.resolve());
+    w.buf.push_str(tag_name);
 
+    let mut wrote_xhtml_namespace = false;
+    let mut wrote_lang = false;
+    let mut wrote_xml_lang = false;
+    let mut lang = None;
+    let mut xml_lang = None;
     for (attr, value) in &element.attrs.0 {
-        w.buf.push(' ');
-        w.buf.push_str(&attr.resolve());
+        let resolved = attr.resolve();
+        let lower = normalize_attr_name(resolved.as_str(), w.options);
+        let name = lower.as_deref().unwrap_or(resolved.as_str());
 
-        // If the string is empty, we can use shorthand syntax.
-        // `<elem attr="">..</div` is equivalent to `<elem attr>..</div>`
-        if !value.is_empty() {
-            w.buf.push('=');
-            w.buf.push('"');
-            for c in value.chars() {
-                if charsets::is_valid_in_attribute_value(c) {
-                    w.buf.push(c);
-                } else {
-                    write_escape(w, c).at(element.span)?;
-                }
-            }
-            w.buf.push('"');
+        if w.options.xhtml_namespace && tag == tag::html && name == "xmlns" {
+            wrote_xhtml_namespace = true;
+        }
+
+        if w.options.mirror_language_attributes && name == "lang" {
+            wrote_lang = true;
+            lang = Some(value.as_str());
+        }
+
+        if w.options.mirror_language_attributes && name == "xml:lang" {
+            wrote_xml_lang = true;
+            xml_lang = Some(value.as_str());
+        }
+
+        write_attr(w, name, value, element.span)?;
+    }
+
+    if w.options.xhtml_namespace && tag == tag::html && !wrote_xhtml_namespace {
+        write_attr(w, "xmlns", "http://www.w3.org/1999/xhtml", element.span)?;
+    }
+
+    if w.options.mirror_language_attributes {
+        if !wrote_xml_lang && let Some(lang) = lang {
+            write_attr(w, "xml:lang", lang, element.span)?;
+        }
+
+        if !wrote_lang && let Some(xml_lang) = xml_lang {
+            write_attr(w, "lang", xml_lang, element.span)?;
         }
     }
 
-    if tag::is_foreign_self_closing(element.tag) {
+    let foreign_self_closing = tag::is_foreign_self_closing(tag);
+    if foreign_self_closing && !w.options.xml_empty_elements {
         w.buf.push('/');
     }
 
-    w.buf.push('>');
-
-    if tag::is_void(element.tag) || tag::is_foreign_self_closing(element.tag) {
+    if tag::is_void(tag) || foreign_self_closing {
         if !element.children.is_empty() {
             bail!(element.span, "HTML void elements must not have children");
+        }
+        if w.options.xml_empty_elements {
+            w.buf.push_str(" />");
+        } else {
+            w.buf.push('>');
         }
         return Ok(());
     }
 
+    w.buf.push('>');
+
     // See HTML spec § 13.1.2.5.
-    if matches!(element.tag, tag::pre | tag::textarea) && starts_with_newline(element) {
+    if w.options.html_parser_newline_rule
+        && matches!(tag, tag::pre | tag::textarea)
+        && starts_with_newline(element)
+    {
         w.buf.push('\n');
     }
 
-    if tag::is_raw(element.tag) {
-        write_raw(w, element)?;
-    } else if tag::is_escapable_raw(element.tag) {
+    if tag::is_raw(tag) {
+        write_raw(w, tag, element)?;
+    } else if tag::is_escapable_raw(tag) {
         write_escapable_raw(w, element)?;
+    } else if w.options.explicit_table_bodies
+        && tag == tag::table
+        && let Some(table) = table_with_bodies(element, w.options)
+    {
+        write_children(w, &table)?;
     } else if !element.children.is_empty() {
         write_children(w, element)?;
     }
 
     w.buf.push_str("</");
-    w.buf.push_str(&element.tag.resolve());
+    w.buf.push_str(tag_name);
     w.buf.push('>');
 
     Ok(())
@@ -201,6 +330,48 @@ fn write_children(w: &mut Writer, element: &HtmlElement) -> SourceResult<()> {
     Ok(())
 }
 
+/// Returns a table whose bare `<tr>` children are wrapped in `<tbody>`.
+fn table_with_bodies(
+    element: &HtmlElement,
+    options: &HtmlOptions,
+) -> Option<HtmlElement> {
+    let mut wrapped = EcoVec::with_capacity(element.children.len() + 1);
+    let mut rows = EcoVec::new();
+    let mut had_row = false;
+
+    for child in &element.children {
+        if matches!(child, HtmlNode::Element(el) if normalize_tag(el.tag, options) == tag::tr)
+        {
+            rows.push(child.clone());
+            had_row = true;
+        } else {
+            push_tbody(&mut wrapped, &mut rows);
+            wrapped.push(child.clone());
+        }
+    }
+
+    push_tbody(&mut wrapped, &mut rows);
+
+    if had_row {
+        let mut table = element.clone();
+        table.children = wrapped;
+        Some(table)
+    } else {
+        None
+    }
+}
+
+/// Pushes a pending `<tbody>` if there are collected rows.
+fn push_tbody(children: &mut EcoVec<HtmlNode>, rows: &mut EcoVec<HtmlNode>) {
+    if !rows.is_empty() {
+        children.push(
+            HtmlElement::new(tag::tbody)
+                .with_children(core::mem::take(rows))
+                .into(),
+        );
+    }
+}
+
 /// Whether the first character in the element is a newline.
 fn starts_with_newline(element: &HtmlElement) -> bool {
     for child in &element.children {
@@ -214,10 +385,15 @@ fn starts_with_newline(element: &HtmlElement) -> bool {
 }
 
 /// Encodes the contents of a raw text element.
-fn write_raw(w: &mut Writer, element: &HtmlElement) -> SourceResult<()> {
-    let text = collect_raw_text(element)?;
+fn write_raw(w: &mut Writer, tag: HtmlTag, element: &HtmlElement) -> SourceResult<()> {
+    let text = collect_raw_text(element, w.options)?;
 
-    if let Some(closing) = find_closing_tag(&text, element.tag) {
+    if w.options.cdata_raw_text {
+        write_cdata(w, tag, &text);
+        return Ok(());
+    }
+
+    if let Some(closing) = find_closing_tag(&text, tag) {
         bail!(
             element.span,
             "HTML raw text element cannot contain its own closing tag";
@@ -225,7 +401,7 @@ fn write_raw(w: &mut Writer, element: &HtmlElement) -> SourceResult<()> {
         )
     }
 
-    let mode = if w.pretty { RawMode::of(element, &text) } else { RawMode::Keep };
+    let mode = if w.pretty { RawMode::of(tag, element, &text) } else { RawMode::Keep };
     match mode {
         RawMode::Keep => {
             w.buf.push_str(&text);
@@ -251,15 +427,26 @@ fn write_raw(w: &mut Writer, element: &HtmlElement) -> SourceResult<()> {
 
 /// Encodes the contents of an escapable raw text element.
 fn write_escapable_raw(w: &mut Writer, element: &HtmlElement) -> SourceResult<()> {
-    walk_raw_text(element, |piece, span| write_text(w, piece, span, false))
+    walk_raw_text(element, |piece, span| {
+        write_text(w, piece, span, w.options.xml_characters)
+    })
 }
 
 /// Collects the textual contents of a raw text element.
-fn collect_raw_text(element: &HtmlElement) -> SourceResult<String> {
+fn collect_raw_text(
+    element: &HtmlElement,
+    options: &HtmlOptions,
+) -> SourceResult<String> {
     let mut text = String::new();
+    let valid_char: fn(char) -> bool = if options.xml_characters {
+        is_valid_xml_char
+    } else {
+        charsets::is_w3c_text_char
+    };
+
     walk_raw_text(element, |piece, span| {
-        if let Some(c) = piece.chars().find(|&c| !charsets::is_w3c_text_char(c)) {
-            return Err(unencodable(c)).at(span);
+        if let Some(c) = piece.chars().find(|&c| !valid_char(c)) {
+            return Err(unencodable(c, options)).at(span);
         }
         text.push_str(piece);
         Ok(())
@@ -311,8 +498,8 @@ enum RawMode {
 }
 
 impl RawMode {
-    fn of(element: &HtmlElement, text: &str) -> Self {
-        match element.tag {
+    fn of(tag: HtmlTag, element: &HtmlElement, text: &str) -> Self {
+        match tag {
             tag::script
                 if !element.attrs.0.iter().any(|(attr, value)| {
                     *attr == attr::r#type && value != "text/javascript"
@@ -366,25 +553,131 @@ fn wants_pretty_around(element: &HtmlElement) -> bool {
 
 /// Escape a character.
 fn write_escape(w: &mut Writer, c: char) -> StrResult<()> {
-    // See <https://html.spec.whatwg.org/multipage/syntax.html#syntax-charref>
     match c {
         '&' => w.buf.push_str("&amp;"),
         '<' => w.buf.push_str("&lt;"),
         '>' => w.buf.push_str("&gt;"),
         '"' => w.buf.push_str("&quot;"),
         '\'' => w.buf.push_str("&apos;"),
-        c if charsets::is_w3c_text_char(c) && c != '\r' => {
+        c if (charsets::is_w3c_text_char(c)
+            || w.options.xml_characters && is_discouraged_xml_char(c))
+            && (!w.options.xml_characters || is_valid_xml_char(c))
+            && c != '\r' =>
+        {
             write!(w.buf, "&#x{:x};", c as u32).unwrap()
         }
-        _ => return Err(unencodable(c)),
+        _ => return Err(unencodable(c, w.options)),
     }
     Ok(())
 }
 
 /// The error message for a character that cannot be encoded.
 #[cold]
-fn unencodable(c: char) -> EcoString {
-    eco_format!("the character `{}` cannot be encoded in HTML", c.repr())
+fn unencodable(c: char, options: &HtmlOptions) -> EcoString {
+    let format = if options.xml_characters { "XHTML" } else { "HTML" };
+    eco_format!("the character `{}` cannot be encoded in {format}", c.repr())
+}
+
+/// Writes an attribute and escapes its value as needed.
+fn write_attr(w: &mut Writer, name: &str, value: &str, span: Span) -> SourceResult<()> {
+    w.buf.push(' ');
+    w.buf.push_str(name);
+
+    if value.is_empty() && w.options.minimize_empty_attributes {
+        return Ok(());
+    }
+
+    w.buf.push('=');
+    w.buf.push('"');
+    let value = if w.options.repeat_empty_presence_attributes
+        && value.is_empty()
+        && html_data::ATTRS.iter().any(|attr| {
+            attr.name.eq_ignore_ascii_case(name)
+                && matches!(attr.ty, html_data::Type::Presence)
+        }) {
+        name
+    } else {
+        value
+    };
+    for c in value.chars() {
+        if charsets::is_valid_in_attribute_value(c)
+            && (!w.options.xml_attribute_values || c != '<' && is_valid_xml_char(c))
+        {
+            w.buf.push(c);
+        } else {
+            write_escape(w, c).at(span)?;
+        }
+    }
+    w.buf.push('"');
+    Ok(())
+}
+
+/// Whether the character is permitted by XML 1.0.
+///
+/// See <https://www.w3.org/TR/xml/#NT-Char>.
+fn is_valid_xml_char(c: char) -> bool {
+    matches!(
+        c,
+        '\u{9}' | '\u{A}' | '\u{D}'
+            | '\u{20}'..='\u{D7FF}'
+            | '\u{E000}'..='\u{FFFD}'
+            | '\u{10000}'..='\u{10FFFF}'
+    )
+}
+
+/// Whether the character is legal in XML 1.0 but discouraged by the spec.
+fn is_discouraged_xml_char(c: char) -> bool {
+    matches!(c as u32, 0x7F..=0x84 | 0x86..=0x9F | 0xFDD0..=0xFDEF)
+        || matches!(c as u32, code if code > 0xFFFF && code & 0xFFFE == 0xFFFE)
+}
+
+/// Lowercase names in XHTML output so HTML vocabulary stays XML-compatible.
+fn normalize_tag(tag: HtmlTag, options: &HtmlOptions) -> HtmlTag {
+    if !options.normalize_html_names {
+        return tag;
+    }
+
+    let resolved = tag.resolve();
+    if !resolved.as_str().bytes().any(|byte| byte.is_ascii_uppercase())
+        || !html_data::ELEMS
+            .iter()
+            .any(|info| info.name.eq_ignore_ascii_case(resolved.as_str()))
+    {
+        return tag;
+    }
+
+    HtmlTag::intern(&resolved.as_str().to_ascii_lowercase())
+        .expect("lowercasing preserves valid HTML tag names")
+}
+
+/// Lowercase relevant names in XHTML output so HTML vocabulary stays
+/// XML-compatible.
+fn normalize_attr_name(name: &str, options: &HtmlOptions) -> Option<String> {
+    (options.normalize_html_names
+        && name.bytes().any(|byte| byte.is_ascii_uppercase())
+        && (html_data::ATTRS
+            .iter()
+            .any(|info| info.name.eq_ignore_ascii_case(name))
+            || name.eq_ignore_ascii_case("xmlns")
+            || name.eq_ignore_ascii_case("xml:lang")
+            || name
+                .get(..5)
+                .is_some_and(|prefix| prefix.eq_ignore_ascii_case("data-"))))
+    .then(|| name.to_ascii_lowercase())
+}
+
+/// Writes a CDATA-wrapped script or style body.
+fn write_cdata(w: &mut Writer, tag: HtmlTag, text: &str) {
+    assert!(matches!(tag, tag::script | tag::style));
+
+    w.buf.push_str("<![CDATA[");
+    for (i, piece) in text.split("]]>").enumerate() {
+        if i > 0 {
+            w.buf.push_str("]]]]><![CDATA[>");
+        }
+        w.buf.push_str(piece);
+    }
+    w.buf.push_str("]]>");
 }
 
 /// Encode a laid out frame into the writer.

--- a/tests/README.md
+++ b/tests/README.md
@@ -68,6 +68,7 @@ ones:
   - `pdftags`: Produce `pdftags` output.
   - `svg` Produce `svg` output.
 - `html`: Compile the `html` target and produce `html` output.
+- `xhtml`: Compile the `html` target and produce `xhtml` output.
 
 Here's a visual representation of the stage tree:
 
@@ -75,7 +76,8 @@ Here's a visual representation of the stage tree:
                  ╭─> render
       ╭─> paged ─┼─> pdf ───> pdftags
 eval ─┤          ╰─> svg
-      ╰─> html  ───> html
+      ╰─> html  ──┬─> html
+                  ╰─> xhtml
 ```
 
 You can specify multiple stages, separated by commas:
@@ -137,6 +139,7 @@ attributes are currently defined:
 - `eval`: Runs scripting tests that don't generate any output.
 - `paged`: Tests paged output: `render`, `pdf`, `svg`
 - `html`: Tests HTML output against a reference HTML file.
+- `xhtml`: Tests XHTML output against a reference XHTML file.
 - `pdf`: Tests the PDF output specifically. The `pdf` stage is currently the
   only fallible output, due to tagged PDF.
 - `pdftags`: Tests the output of the PDF tag tree.

--- a/tests/ref/xhtml/hashes.txt
+++ b/tests/ref/xhtml/hashes.txt
@@ -1,0 +1,1 @@
+adc2630a099f8da398098aac8dfbe525 xhtml-serialization

--- a/tests/src/args.rs
+++ b/tests/src/args.rs
@@ -163,6 +163,7 @@ pub enum TestStage {
     Pdftags,
     Svg,
     Html,
+    Xhtml,
     Bundle,
 }
 
@@ -176,6 +177,7 @@ impl From<TestStage> for TestStages {
             TestStage::Pdftags => TestStages::PDFTAGS,
             TestStage::Svg => TestStages::SVG,
             TestStage::Html => TestStages::HTML,
+            TestStage::Xhtml => TestStages::XHTML,
             TestStage::Bundle => TestStages::BUNDLE,
         }
     }

--- a/tests/src/collect.rs
+++ b/tests/src/collect.rs
@@ -130,11 +130,12 @@ bitflags! {
     ///                  ╭─> render
     ///       ╭─> paged ─┼─> pdf ───> pdftags
     /// eval ─┤          ╰─> svg
-    ///       ├─> html -───> html
+    ///       ├─> html -─┬─> html
+    ///       │          ╰─> xhtml
     ///       ╰─> bundle ──> bundle
     /// ```
     #[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
-    pub struct TestStages: u8 {
+    pub struct TestStages: u16 {
         const EVAL = 1 << 0;
         const PAGED = 1 << 1;
         const RENDER = 1 << 2;
@@ -143,6 +144,7 @@ bitflags! {
         const SVG = 1 << 5;
         const HTML = 1 << 6;
         const BUNDLE = 1 << 7;
+        const XHTML = 1 << 8;
     }
 }
 
@@ -162,6 +164,7 @@ impl TestStages {
                 TestStages::SVG => TestStages::empty(),
                 TestStages::HTML => TestStages::empty(),
                 TestStages::BUNDLE => TestStages::empty(),
+                TestStages::XHTML => TestStages::empty(),
                 _ => unreachable!(),
             });
         }
@@ -184,6 +187,7 @@ impl TestStages {
                 TestStages::SVG => TestStages::EVAL | TestStages::PAGED,
                 TestStages::HTML => TestStages::EVAL,
                 TestStages::BUNDLE => TestStages::EVAL,
+                TestStages::XHTML => TestStages::EVAL | TestStages::HTML,
                 _ => unreachable!(),
             });
         }
@@ -200,6 +204,7 @@ impl TestStages {
                 TestStages::PAGED => TestStages::PAGED | TestStages::HTML | TestStages::BUNDLE,
                 TestStages::HTML => TestStages::PAGED | TestStages::HTML | TestStages::BUNDLE,
                 TestStages::BUNDLE => TestStages::PAGED | TestStages::HTML | TestStages::BUNDLE,
+                TestStages::XHTML => TestStages::XHTML,
 
                 TestStages::RENDER => TestStages::RENDER | TestStages::PDF | TestStages::SVG,
                 TestStages::PDF => TestStages::RENDER | TestStages::PDF | TestStages::SVG,
@@ -228,6 +233,7 @@ impl Display for TestStages {
                 TestStages::SVG => Display::fmt(&TestOutput::Svg, f),
                 TestStages::HTML => Display::fmt(&TestTarget::Html, f),
                 TestStages::BUNDLE => Display::fmt(&TestTarget::Bundle, f),
+                TestStages::XHTML => Display::fmt(&TestOutput::Xhtml, f),
                 _ => unreachable!(),
             })?;
         }
@@ -254,7 +260,7 @@ impl Display for TestEval {
 
 /// A compilation target, analog to [`typst::Target`].
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-#[repr(u8)]
+#[repr(u16)]
 pub enum TestTarget {
     Paged = TestStages::PAGED.bits(),
     Html = TestStages::HTML.bits(),
@@ -265,7 +271,7 @@ impl TestStage for TestTarget {}
 
 impl From<TestTarget> for TestStages {
     fn from(value: TestTarget) -> Self {
-        TestStages::from_bits(value as u8).unwrap()
+        TestStages::from_bits(value as u16).unwrap()
     }
 }
 
@@ -304,19 +310,27 @@ impl From<Target> for TestTarget {
 
 /// A test output format.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-#[repr(u8)]
+#[repr(u16)]
 pub enum TestOutput {
     Render = TestStages::RENDER.bits(),
     Pdf = TestStages::PDF.bits(),
     Pdftags = TestStages::PDFTAGS.bits(),
     Svg = TestStages::SVG.bits(),
     Html = TestStages::HTML.bits(),
+    Xhtml = TestStages::XHTML.bits(),
     Bundle = TestStages::BUNDLE.bits(),
 }
 
 impl TestOutput {
-    pub const ALL: [Self; 6] =
-        [Self::Render, Self::Svg, Self::Pdf, Self::Pdftags, Self::Html, Self::Bundle];
+    pub const ALL: [Self; 7] = [
+        Self::Render,
+        Self::Svg,
+        Self::Pdf,
+        Self::Pdftags,
+        Self::Html,
+        Self::Xhtml,
+        Self::Bundle,
+    ];
 
     fn from_sub_dir(dir: &str) -> Option<Self> {
         Self::ALL.into_iter().find(|o| o.sub_dir() == dir)
@@ -330,6 +344,7 @@ impl TestOutput {
             Self::Pdftags => "pdftags",
             Self::Svg => "svg",
             Self::Html => "html",
+            Self::Xhtml => "xhtml",
             Self::Bundle => "bundle",
         }
     }
@@ -342,6 +357,7 @@ impl TestOutput {
             Self::Pdftags => "yml",
             Self::Svg => "svg",
             Self::Html => "html",
+            Self::Xhtml => "xhtml",
             Self::Bundle => "tar",
         }
     }
@@ -389,6 +405,7 @@ impl TestOutput {
             TestOutput::Pdftags => TestOutputKind::Hash(output::Pdftags::INDEX),
             TestOutput::Svg => TestOutputKind::Hash(output::Svg::INDEX),
             TestOutput::Html => TestOutputKind::Hash(output::Html::INDEX),
+            TestOutput::Xhtml => TestOutputKind::Hash(output::Xhtml::INDEX),
         }
     }
 }
@@ -397,7 +414,7 @@ impl TestStage for TestOutput {}
 
 impl From<TestOutput> for TestStages {
     fn from(value: TestOutput) -> Self {
-        TestStages::from_bits(value as u8).unwrap()
+        TestStages::from_bits(value as u16).unwrap()
     }
 }
 
@@ -737,6 +754,7 @@ impl<'a> Parser<'a> {
                     }
                 }
                 "html" => self.set_attr(attr_name, &mut stages, TestStages::HTML),
+                "xhtml" => self.set_attr(attr_name, &mut stages, TestStages::XHTML),
                 "bundle" => self.set_attr(attr_name, &mut stages, TestStages::BUNDLE),
                 "large" => self.set_attr(attr_name, &mut flags, AttrFlags::LARGE),
                 "empty" => self.set_attr(attr_name, &mut flags, AttrFlags::EMPTY),

--- a/tests/src/output.rs
+++ b/tests/src/output.rs
@@ -174,8 +174,13 @@ pub trait HashOutputType: OutputType {
 /// the [`HashOutputType::INDEX`].
 ///
 /// NOTE: This has to be kept in sync with the [`HashOutputType::INDEX`].
-pub const HASH_OUTPUTS: [TestOutput; 4] =
-    [TestOutput::Pdf, TestOutput::Pdftags, TestOutput::Svg, TestOutput::Html];
+pub const HASH_OUTPUTS: [TestOutput; 5] = [
+    TestOutput::Pdf,
+    TestOutput::Pdftags,
+    TestOutput::Svg,
+    TestOutput::Html,
+    TestOutput::Xhtml,
+];
 
 pub struct Render;
 
@@ -454,7 +459,7 @@ impl OutputType for Html {
     }
 
     fn make_live(_: &Test, doc: &Self::Doc) -> SourceResult<Self::Live> {
-        let options = HtmlOptions { pretty: true };
+        let options = HtmlOptions::default().pretty();
         typst_html::html(doc, &options)
     }
 
@@ -479,6 +484,62 @@ impl HashOutputType for Html {
     const INDEX: usize = 3;
 }
 
+pub struct Xhtml;
+
+impl OutputType for Xhtml {
+    type Doc = HtmlDocument;
+    type Live = String;
+
+    const OUTPUT: TestOutput = TestOutput::Xhtml;
+
+    fn is_empty(_: &Self::Doc, live: &Self::Live) -> bool {
+        // HACK: This is somewhat volatile, since it needs to be updated,
+        // whenever the default XHTML output changes.
+        const EMPTY_XHTML_DOC: &str = r#"<?xml version="1.0" encoding="UTF-8" ?><!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body></body>
+</html>
+"#;
+        live == EMPTY_XHTML_DOC
+    }
+
+    fn make_live(_: &Test, doc: &Self::Doc) -> SourceResult<Self::Live> {
+        let options = HtmlOptions::default().pretty().xhtml();
+        let live = typst_html::html(doc, &options)?;
+        roxmltree::Document::parse_with_options(
+            &live,
+            roxmltree::ParsingOptions { allow_dtd: true, ..Default::default() },
+        )
+        .map_err(|err| eco_format!("failed to parse XHTML as XML ({err})"))
+        .at(Span::detached())?;
+        Ok(live)
+    }
+
+    fn save_live(_: &Self::Doc, live: &Self::Live) -> impl AsRef<[u8]> {
+        live
+    }
+
+    fn make_hash(live: &Self::Live) -> HashedRef {
+        HashedRef(typst_utils::hash128(live))
+    }
+
+    fn make_report(
+        a: Option<(&Path, Old<&[u8]>)>,
+        b: Result<(&Path, &[u8]), ()>,
+    ) -> ReportFile {
+        let diffs = [html_diff(a, b), text_diff(a, b)];
+        file_report(Self::OUTPUT, a, b, diffs)
+    }
+}
+
+impl HashOutputType for Xhtml {
+    const INDEX: usize = 4;
+}
+
 pub struct Bundle;
 
 impl OutputType for Bundle {
@@ -494,7 +555,7 @@ impl OutputType for Bundle {
     fn make_live(test: &Test, doc: &Self::Doc) -> SourceResult<Self::Live> {
         let standards = test.attrs.pdf_standard.as_slice();
         let options = BundleOptions {
-            html: HtmlOptions { pretty: true },
+            html: HtmlOptions::default().pretty(),
             pdf: pdf_options(standards)?,
             png: RenderOptions {
                 pixel_per_pt: Scalar::new(1.0),

--- a/tests/src/report/html.rs
+++ b/tests/src/report/html.rs
@@ -547,6 +547,7 @@ fn sidebar(parent: &mut HtmlElem, reports: &[TestReport]) {
                 TestOutput::Pdftags => ("Filter PDF tags", icons::PDFTAGS),
                 TestOutput::Svg => ("Filter SVG", icons::SVG),
                 TestOutput::Html => ("Filter HTML", icons::HTML),
+                TestOutput::Xhtml => ("Filter XHTML", icons::HTML),
                 TestOutput::Bundle => ("Filter bundle", icons::BUNDLE),
             };
             parent.label().class("icon-toggle-button").with(|label| {
@@ -586,6 +587,7 @@ fn sidebar(parent: &mut HtmlElem, reports: &[TestReport]) {
                     TestOutput::Pdftags => ("Show PDF tags diffs", icons::PDFTAGS),
                     TestOutput::Svg => ("Show SVG diffs", icons::SVG),
                     TestOutput::Html => ("Show HTML diffs", icons::HTML),
+                    TestOutput::Xhtml => ("Show XHTML diffs", icons::HTML),
                     TestOutput::Bundle => ("Show bundle diffs", icons::BUNDLE),
                 };
 
@@ -732,6 +734,7 @@ fn test_report_header(
                     TestOutput::Pdftags => ("View PDF tags", icons::PDFTAGS),
                     TestOutput::Svg => ("View SVG", icons::SVG),
                     TestOutput::Html => ("View HTML", icons::HTML),
+                    TestOutput::Xhtml => ("View XHTML", icons::HTML),
                     TestOutput::Bundle => ("View bundle", icons::BUNDLE),
                 };
                 let report_file_tab = |parent: &mut HtmlElem| {

--- a/tests/src/report/report.js
+++ b/tests/src/report/report.js
@@ -22,7 +22,7 @@ const reportFiles = []
  */
 
 /**
- * @typedef {"render" | "pdf" | "pdftags" | "svg" | "html"} TestOutput
+ * @typedef {"render" | "pdf" | "pdftags" | "svg" | "html" | "xhtml"} TestOutput
  */
 
 /**
@@ -128,7 +128,7 @@ for (const report of document.getElementsByClassName("test-report")) {
   }
 }
 
-let outputs = ["render", "pdf", "pdftags", "svg", "html"]
+let outputs = ["render", "pdf", "pdftags", "svg", "html", "xhtml"]
 /** @type {HTMLInputElement[]} */
 let filterDiffFormats = []
 for (const output of outputs) {

--- a/tests/src/run.rs
+++ b/tests/src/run.rs
@@ -197,7 +197,12 @@ impl<'a> Runner<'a> {
         // Only compile html document when the html target is specified.
         if self.test.should_run(TestTarget::Html) {
             let doc = self.compile::<HtmlDocument>(evaluated.clone());
-            self.run_hash_test::<output::Html>(doc.as_ref());
+            if self.test.should_check(TestOutput::Html) {
+                self.run_hash_test::<output::Html>(doc.as_ref());
+            }
+            if self.test.should_check(TestOutput::Xhtml) {
+                self.run_hash_test::<output::Xhtml>(doc.as_ref());
+            }
         }
 
         // Only compile bundle when the bundle target is specified.

--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -68,7 +68,7 @@ fn setup() {
     std::env::set_current_dir(workspace_dir).unwrap();
 
     // Create the storage.
-    for dir in ["render", "html", "pdf", "pdftags", "svg", "bundle", "by-hash"] {
+    for dir in ["render", "html", "xhtml", "pdf", "pdftags", "svg", "bundle", "by-hash"] {
         std::fs::create_dir_all(Path::new(STORE_PATH).join(dir)).unwrap();
     }
 
@@ -172,6 +172,7 @@ fn test() {
         run::update_hash_refs::<output::Pdftags>(&hashes);
         run::update_hash_refs::<output::Svg>(&hashes);
         run::update_hash_refs::<output::Html>(&hashes);
+        run::update_hash_refs::<output::Xhtml>(&hashes);
     }
 
     if let Err(err) = logger.into_inner().finish() {

--- a/tests/suite/html/xhtml.typ
+++ b/tests/suite/html/xhtml.typ
@@ -1,0 +1,10 @@
+--- xhtml-serialization xhtml ---
+#set document(title: "X")
+
+#html.elem("HTML", attrs: (LANG: "en"))[
+  #html.elem("BODY")[
+    #html.elem("INPUT", attrs: (CHECKED: ""))
+    #html.elem("SCRIPT")[if (a > b) console.log(a);]
+    $ a #h(1em) b $
+  ]
+]


### PR DESCRIPTION
This introduces `xhtml` as a CLI output format and adds an XHTML serialization mode to `typst-html`.

XHTML output now emits the XML declaration, XHTML namespace, XML-style empty elements, CDATA for raw text elements, and XML-compatible escaping/name normalization.