### PR TITLE
Fix a typo in `key.insert` docs

### DIFF
--- a/crates/typst-library/src/foundations/dict.rs
+++ b/crates/typst-library/src/foundations/dict.rs
@@ -219,7 +219,7 @@ impl Dict {
     /// Inserts a new pair into the dictionary. If the dictionary already
     /// contains this key, the value is updated.
     ///
-    /// To insert multiple pairs at once, you can just alternatively another
+    /// To insert multiple pairs at once, you can alternatively add another
     /// dictionary with the `+=` operator.
     #[func]
     pub fn insert(


### PR DESCRIPTION
<!--
Thanks for your interest in landing a change in Typst! Before opening the PR, please review our contribution guidelines: https://github.com/typst/typst/blob/main/CONTRIBUTING.md

In particular, please keep in mind that we do not accept contributions implemented by an AI model. We would also ask you to refrain from using AI to write your pull request description. Summarizing your work helps organizing your thoughts as much as it helps us with seeing the human thought process behind a particular change.
-->

This typo was introduced by me when I was [applying](https://github.com/typst/typst/pull/6899/commits/c24ea6bae4dd945a85e77eb39418056f84c5b019) [a suggestion](https://github.com/typst/typst/pull/6899#discussion_r2362372395).
I wanted to change `(just → alternatively) add`, but I actually changed `just (add → alternatively)`.

Resolves #8358 (Thanks https://github.com/cady-b for telling me!)