### PR TITLE
Fix overflow on extreme negative `digits` in `calc.round`

### DIFF
--- a/crates/typst-library/src/foundations/decimal.rs
+++ b/crates/typst-library/src/foundations/decimal.rs
@@ -168,7 +168,7 @@ impl Decimal {
         // We received negative digits, so we round to integer digits.
         let mut num = self.0;
         let old_scale = num.scale();
-        let digits = -digits as u32;
+        let digits = digits.unsigned_abs();
 
         let (Ok(_), Some(ten_to_digits)) = (
             // Same as dividing by 10^digits.

--- a/crates/typst-utils/src/round.rs
+++ b/crates/typst-utils/src/round.rs
@@ -84,7 +84,7 @@ pub fn round_int_with_precision(value: i64, precision: i16) -> Option<i64> {
         return Some(value);
     }
 
-    let digits = -precision as u32;
+    let digits = u32::from(precision.unsigned_abs());
     let Some(ten_to_digits) = 10i64.checked_pow(digits - 1) else {
         // Larger than any possible amount of integer digits.
         return Some(0);

--- a/tests/suite/foundations/calc.typ
+++ b/tests/suite/foundations/calc.typ
@@ -21,6 +21,9 @@
 #test(calc.round(decimal("79228162514264337593543950335"), digits: 12), decimal("79228162514264337593543950335"))
 #test(calc.round(decimal("79228162514264337593543950335"), digits: -50), decimal("0"))
 #test(calc.round(decimal("-79228162514264337593543950335"), digits: -2), decimal("-79228162514264337593543950300"))
+#test(calc.round(31114, digits: -4000000000), 0)
+#test(calc.round(238959235.129590203, digits: -4000000000), 0.0)
+#test(calc.round(decimal("238959235.129590203"), digits: -4000000000), decimal("0"))
 
 --- calc-abs eval ---
 // Test the `abs` function.


### PR DESCRIPTION
Noticed `calc.round`'s negative-`digits` path negates the precision before widening: `-precision as u32` in `round_int_with_precision` and `-digits as u32` in `Decimal::round`. Once `digits` saturates to `i16::MIN`/`i32::MIN` (e.g. `calc.round(1, digits: -4000000000)`, the negative twin of the already-tested `digits: 4000000000`) those negations overflow. Switched both to `unsigned_abs`, which folds to 0 like the other out-of-range magnitudes.