### PR TITLE
fix: avoid appending last character after ellipsis in multiline compact traceback

### DIFF
--- a/crates/typst-cli/tests/smoke.rs
+++ b/crates/typst-cli/tests/smoke.rs
@@ -218,7 +218,7 @@ fn test_tracepoints() {
         .stderr
         .must_contain("while calling `my-figure` at")
         .must_contain("chapter1.typ:2:12")
-        .must_contain("my-figure(…)");
+        .must_contain("my-figure(…");
     output
         .stderr
         .must_contain("while including `chapter1.typ` at")
@@ -228,7 +228,7 @@ fn test_tracepoints() {
         .stderr
         .must_contain("while showing strong element at")
         .must_contain("main.typ:2:11")
-        .must_contain("*Slightly unusual…*");
+        .must_contain("*Slightly unusual…");
 }
 
 #[test]

--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -1296,7 +1296,8 @@ impl<'a> CompletionContext<'a> {
             && !self.after.starts_with(['(', '['])
         {
             if let Value::Func(func) = value {
-                apply = Some(match BracketMode::of(func) {
+                let in_math = self.leaf.mode_after() == Some(SyntaxMode::Math);
+                apply = Some(match BracketMode::of(func, in_math) {
                     BracketMode::RoundAfter => eco_format!("{label}()${{}}"),
                     BracketMode::RoundWithin => eco_format!("{label}(${{}})"),
                     BracketMode::RoundNewline => eco_format!("{label}(\n  ${{}}\n)"),
@@ -1468,7 +1469,7 @@ enum BracketMode {
 }
 
 impl BracketMode {
-    fn of(func: &Func) -> Self {
+    fn of(func: &Func, in_math: bool) -> Self {
         // If we have no parameters or only the self one, it's friendlier to put
         // the cursor after the method call.
         if func.params().all(|param| param.name() == Some("self")) {
@@ -1479,7 +1480,7 @@ impl BracketMode {
             Some(
                 "emph" | "footnote" | "quote" | "strong" | "highlight" | "overline"
                 | "underline" | "smallcaps" | "strike" | "sub" | "super",
-            ) => Self::SquareWithin,
+            ) if !in_math => Self::SquareWithin,
             Some("colbreak" | "parbreak" | "linebreak" | "pagebreak") => Self::RoundAfter,
             Some("figure" | "table" | "grid" | "stack") => Self::RoundNewline,
             _ => Self::RoundWithin,
@@ -1989,6 +1990,17 @@ mod tests {
         let res = test(&world, -1);
         res.must_include(["foo"]);
         res.at("foo").must_have_detail("A useful function.");
+    }
+
+    #[test]
+    fn test_autocomplete_math_brackets() {
+        let res1 = test("$ overli $", -2);
+        res1.must_include(["overline"]);
+        res1.at("overline").must_apply_as("overline(${})");
+
+        let res2 = test("#overli", -1);
+        res2.must_include(["overline"]);
+        res2.at("overline").must_apply_as("overline[${}]");
     }
 
     #[test]

--- a/crates/typst-kit/src/diagnostics.rs
+++ b/crates/typst-kit/src/diagnostics.rs
@@ -132,13 +132,8 @@ fn emit_trace(
     if let Some(first) = lines.next() {
         write!(dest, "{first}")?;
     }
-    if let Some(last) = lines.next_back()
-        && let Some(last_char) = last.chars().next_back()
-        && !last_char.is_whitespace()
-    {
-        // If the traced source text is multi-line, try to display it
-        // with inner ellipses followed by the last character.
-        write!(dest, "…{last_char}")?;
+    if lines.next().is_some() {
+        write!(dest, "…")?;
     }
     dest.reset()?;
     writeln!(dest)?;


### PR DESCRIPTION
bug: The compact diagnostic traceback sometimes adds an ellipsis followed by an unbalanced parenthesis or other character when lines are skipped.
root cause: In `emit_trace`, if a traceback spanned multiple lines, the formatting logic appended the last non-whitespace character of the last line after the ellipsis, often an unbalanced closing bracket.
why fix is correct: Simply appending the ellipsis without the trailing character avoids unbalanced brackets in the traceback output while remaining compact.