### PR TITLE
Doc search box improvements

### DIFF
--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -361,6 +361,8 @@ a.chain img {
   position: absolute;
   top: 7px;
   left: 8px;
+  pointer-events: none;
+  user-select: none;
 }
 
 .search input {


### PR DESCRIPTION
This improves the documentation search boxes (including the symbol list search boxes).

The first commit makes the search icon non-selectable and `pointer-events: none;` so that clicking it targets the input box below.

The second commit adds padding to the right of the search box, which is an improvement imo. I can remove it if you disagree.

| Before | After |
|-----|-----|
| <img width="221" height="50" alt="The search box is filled with the letter m, with no padding at the right." src="https://github.com/user-attachments/assets/5f1ff6cf-299b-4071-9701-36325f968c38" /> | <img width="221" height="50" alt="Same, but with padding on the right." src="https://github.com/user-attachments/assets/b7153b40-f928-4ce5-a575-a804126d5abe" /> |