### PR TITLE
fix: make Punjabi LTR by default and RTL for pa-PK

### DIFF
--- a/crates/typst-library/src/text/lang.rs
+++ b/crates/typst-library/src/text/lang.rs
@@ -149,6 +149,17 @@ impl Locale {
         }
         buf
     }
+
+    /// The default direction for the locale.
+    pub fn dir(self) -> Dir {
+        if self.lang == Lang::PUNJABI {
+            if self.region.as_ref().is_some_and(|r| r.as_str() == "PK") {
+                return Dir::RTL;
+            }
+            return Dir::LTR;
+        }
+        self.lang.dir()
+    }
 }
 
 /// An identifier for a natural language.
@@ -487,7 +498,6 @@ impl Lang {
             | Lang::PERSIAN
             | Lang::HEBREW
             | Lang::KASHMIRI
-            | Lang::PUNJABI
             | Lang::PASHTO
             | Lang::SINDHI
             | Lang::UYGHUR

--- a/crates/typst-library/src/text/mod.rs
+++ b/crates/typst-library/src/text/mod.rs
@@ -1176,7 +1176,7 @@ impl Resolve for TextDir {
 
     fn resolve(self, styles: StyleChain) -> Self::Output {
         match self.0 {
-            Smart::Auto => styles.get(TextElem::lang).dir(),
+            Smart::Auto => Locale::get_in(styles).dir(),
             Smart::Custom(dir) => dir,
         }
     }

--- a/crates/typst-library/src/text/smartquote.rs
+++ b/crates/typst-library/src/text/smartquote.rs
@@ -8,7 +8,7 @@ use crate::foundations::{
     elem,
 };
 use crate::layout::Dir;
-use crate::text::{Lang, Region, TextElem};
+use crate::text::{Lang, Locale, Region, TextElem};
 
 /// A language-aware quote that reacts to its context.
 ///
@@ -228,6 +228,7 @@ impl<'s> SmartQuotes<'s> {
         region: Option<Region>,
         alternative: bool,
     ) -> Self {
+        let orig_region = region;
         let region = region.as_ref().map(Region::as_str);
 
         let default = ("‘", "’", "“", "”");
@@ -285,7 +286,7 @@ impl<'s> SmartQuotes<'s> {
             Lang::CROATIAN => ("‘", "’", "„", "”"),
             Lang::BULGARIAN => ("’", "’", "„", "“"),
             Lang::ARABIC if !alternative => ("’", "‘", "«", "»"),
-            _ if lang.dir() == Dir::RTL => ("’", "‘", "”", "“"),
+            _ if Locale::new(lang, orig_region).dir() == Dir::RTL => ("’", "‘", "”", "“"),
             _ => default,
         };
 

--- a/crates/typst-pdf/src/metadata.rs
+++ b/crates/typst-pdf/src/metadata.rs
@@ -13,7 +13,7 @@ pub(crate) fn build_metadata(gc: &GlobalContext, doc_lang: Option<Locale>) -> Me
     // so the metadata and outline entries have an applicable language.
     let lang = doc_lang.unwrap_or(Locale::DEFAULT);
 
-    let dir = if lang.lang.dir() == Dir::RTL {
+    let dir = if lang.dir() == Dir::RTL {
         TextDirection::RightToLeft
     } else {
         TextDirection::LeftToRight


### PR DESCRIPTION
Fixes #8192.

### Root Cause
Punjabi (`pa`) was hardcoded to resolve to RTL text direction by default. However, Punjabi in India (`pa-IN`) uses Gurmukhi which is LTR. In fact, `pa` in general is treated as LTR in other systems (like Swift's Locale).

### Fix
- Added `dir()` method to `Locale` that resolves `pa` with region `PK` as RTL, and defaults to LTR for `pa`.
- Updated text layout resolution and smart quotes to use `Locale::dir()` instead of `Lang::dir()`.
- Updated PDF metadata generation to use `Locale::dir()`.