### PR TITLE
Allow using page bleed in SVG bundle export and merged (test) export

### DIFF
--- a/crates/typst-bundle/src/export.rs
+++ b/crates/typst-bundle/src/export.rs
@@ -11,6 +11,7 @@ use typst_library::introspection::Location;
 use typst_library::model::{LateLinkResolver, PagedFormat};
 use typst_pdf::PdfOptions;
 use typst_render::RenderOptions;
+use typst_svg::SvgOptions;
 use typst_syntax::{Span, VirtualPath};
 use typst_utils::Scalar;
 
@@ -101,6 +102,7 @@ fn export_svg(
     anchors: &[(Location, EcoString)],
     link_resolver: Tracked<LateLinkResolver>,
 ) -> SourceResult<Bytes> {
+    let options = SvgOptions::default();
     let anchors = anchors
         .iter()
         .filter_map(|(loc, name)| {
@@ -113,6 +115,7 @@ fn export_svg(
         .collect::<Vec<_>>();
     Ok(Bytes::from_string(typst_svg::svg_in_bundle(
         &doc.pages()[0],
+        &options,
         &anchors,
         link_resolver,
     )))

--- a/crates/typst-svg/src/lib.rs
+++ b/crates/typst-svg/src/lib.rs
@@ -36,15 +36,13 @@ const XML_WRITE_OPTIONS: xmlwriter::Options = xmlwriter::Options {
 /// Export a frame into an SVG file.
 #[typst_macros::time(name = "svg")]
 pub fn svg(page: &Page, opts: &SvgOptions) -> String {
-    let bleed = if opts.render_bleed { page.bleed } else { Sides::default() };
-    let size = page.frame.size() + bleed.sum_by_axis();
+    let (size, ts) = page_bleed(page, opts);
 
     let mut renderer = SVGRenderer::new();
     let mut xml = XmlWriter::new(XML_WRITE_OPTIONS);
     let mut svg = svg_header(&mut xml, size);
 
     let state = State::new(size);
-    let ts = Transform::translate(bleed.left, bleed.top);
     renderer.render_page(&mut svg, &state, ts, page);
     renderer.finalize(svg);
     xml.end_document()
@@ -59,15 +57,18 @@ pub fn svg(page: &Page, opts: &SvgOptions) -> String {
 #[typst_macros::time(name = "svg in bundle")]
 pub fn svg_in_bundle(
     page: &Page,
+    opts: &SvgOptions,
     anchors: &[(Point, EcoString)],
     link_resolver: Tracked<LateLinkResolver>,
 ) -> String {
+    let (size, ts) = page_bleed(page, opts);
+
     let mut renderer = SVGRenderer::with_options(Some(link_resolver));
     let mut xml = XmlWriter::new(XML_WRITE_OPTIONS);
-    let mut svg = svg_header(&mut xml, page.frame.size());
+    let mut svg = svg_header(&mut xml, size);
 
-    let state = State::new(page.frame.size());
-    renderer.render_page(&mut svg, &state, Transform::identity(), page);
+    let state = State::new(size);
+    renderer.render_page(&mut svg, &state, ts, page);
 
     for (pos, id) in anchors {
         renderer.render_anchor(&mut svg, *pos, id);
@@ -129,38 +130,45 @@ pub fn svg_in_html(
 /// Export a document with potentially multiple pages into a single SVG file.
 ///
 /// The gap will be added between the individual pages.
-pub fn svg_merged(document: &PagedDocument, gap: Abs) -> String {
-    let width = document
-        .pages()
-        .iter()
-        .map(|page| page.frame.width())
-        .max()
-        .unwrap_or_default();
-    let height = document.pages().len().saturating_sub(1) as f64 * gap
-        + document.pages().iter().map(|page| page.frame.height()).sum::<Abs>();
+pub fn svg_merged(document: &PagedDocument, opts: &SvgOptions, gap: Abs) -> String {
+    let num_gaps = document.pages().len().saturating_sub(1) as f64;
+    let mut size = Size::new(Abs::zero(), num_gaps * gap);
+    for page in document.pages() {
+        let (page_size, _ts) = page_bleed(page, opts);
+        size.x.set_max(page_size.x);
+        size.y += page_size.y;
+    }
 
     let mut renderer = SVGRenderer::new();
     let mut xml = XmlWriter::new(XML_WRITE_OPTIONS);
-    let mut svg = svg_header(&mut xml, Size::new(width, height));
+    let mut svg = svg_header(&mut xml, size);
 
     let mut y = Abs::zero();
     for page in document.pages() {
-        let state = State::new(page.frame.size());
+        let (page_size, bleed_ts) = page_bleed(page, opts);
+        let state = State::new(page_size);
         renderer.render_page(
             &mut svg,
             &state,
-            Transform::translate(Abs::zero(), y),
+            Transform::translate(Abs::zero(), y).pre_concat(bleed_ts),
             page,
         );
-        y += page.frame.height() + gap;
+        y += page_size.y + gap;
     }
 
     renderer.finalize(svg);
     xml.end_document()
 }
 
+fn page_bleed(page: &Page, opts: &SvgOptions) -> (Size, Transform) {
+    let bleed = if opts.render_bleed { page.bleed } else { Sides::default() };
+    let size = page.frame.size() + bleed.sum_by_axis();
+    let ts = Transform::translate(bleed.left, bleed.top);
+    (size, ts)
+}
+
 /// Settings for SVG export.
-#[derive(Default, Clone)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
 pub struct SvgOptions {
     /// By default, SVG documents are bounded to the page size. In some
     /// circumstances, such as when preparing documents for print, it may be

--- a/tests/src/output.rs
+++ b/tests/src/output.rs
@@ -19,6 +19,7 @@ use typst_bundle::{BundleOptions, VirtualFs};
 use typst_html::HtmlDocument;
 use typst_layout::PagedDocument;
 use typst_pdf::{PdfOptions, PdfStandard, PdfStandards};
+use typst_svg::SvgOptions;
 use typst_syntax::Span;
 
 use crate::collect::{Test, TestOutput};
@@ -387,7 +388,8 @@ impl OutputType for Svg {
     }
 
     fn make_live(_: &Test, doc: &Self::Doc) -> SourceResult<Self::Live> {
-        Ok(typst_svg::svg_merged(doc, Abs::pt(1.0)))
+        let options = SvgOptions::default();
+        Ok(typst_svg::svg_merged(doc, &options, Abs::pt(1.0)))
     }
 
     fn save_live(_: &Self::Doc, live: &Self::Live) -> impl AsRef<[u8]> {


### PR DESCRIPTION
Follow up to #6357

Align the configuration between bundle and non-bundle export.