### PR TITLE
Add `--pretty` CLI flag and minify HTML and SVG by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3481,6 +3481,7 @@ dependencies = [
  "typst-library",
  "typst-macros",
  "typst-timing",
+ "typst-utils",
 ]
 
 [[package]]

--- a/crates/typst-bundle/src/export.rs
+++ b/crates/typst-bundle/src/export.rs
@@ -3,7 +3,7 @@ use ecow::EcoString;
 use indexmap::IndexMap;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use rustc_hash::FxBuildHasher;
-use typst_html::HtmlElement;
+use typst_html::{HtmlElement, HtmlOptions};
 use typst_layout::PagedDocument;
 use typst_library::diag::{At, ParallelCollectCombinedResult, SourceResult};
 use typst_library::foundations::Bytes;
@@ -13,7 +13,6 @@ use typst_pdf::PdfOptions;
 use typst_render::RenderOptions;
 use typst_svg::SvgOptions;
 use typst_syntax::{Span, VirtualPath};
-use typst_utils::Scalar;
 
 use crate::{Bundle, BundleDocument, BundleFile};
 
@@ -41,12 +40,16 @@ pub fn export(bundle: &Bundle, options: &BundleOptions) -> SourceResult<VirtualF
 }
 
 /// Settings for bundle export.
-#[derive(Debug)]
-pub struct BundleOptions<'a> {
-    /// The number of pixels per point to render at when exporting a PNG.
-    pub pixel_per_pt: f32,
+#[derive(Debug, Default)]
+pub struct BundleOptions {
+    /// Options for exporting HTML documents.
+    pub html: HtmlOptions,
     /// Options for exporting PDF documents.
-    pub pdf: typst_pdf::PdfOptions<'a>,
+    pub pdf: PdfOptions,
+    /// Options for exporting PNG documents.
+    pub png: RenderOptions,
+    /// Options for exporting SVG documents.
+    pub svg: SvgOptions,
 }
 
 /// Exports a single document.
@@ -60,10 +63,14 @@ fn export_document(
             PagedFormat::Pdf => {
                 export_pdf(doc, &options.pdf, &extras.anchors, link_resolver)
             }
-            PagedFormat::Png => export_png(doc, Scalar::new(options.pixel_per_pt as _)),
-            PagedFormat::Svg => export_svg(doc, &extras.anchors, link_resolver),
+            PagedFormat::Png => export_png(doc, &options.png),
+            PagedFormat::Svg => {
+                export_svg(doc, &options.svg, &extras.anchors, link_resolver)
+            }
         },
-        BundleDocument::Html(doc) => export_html(doc.root(), link_resolver),
+        BundleDocument::Html(doc) => {
+            export_html(doc.root(), &options.html, link_resolver)
+        }
     }
 }
 
@@ -82,12 +89,8 @@ fn export_pdf(
 /// Exports a PNG document.
 #[comemo::memoize]
 #[typst_macros::time(name = "export png")]
-fn export_png(doc: &PagedDocument, pixel_per_pt: Scalar) -> SourceResult<Bytes> {
-    let opts = RenderOptions {
-        pixel_per_pt: pixel_per_pt.get() as f32,
-        render_bleed: false,
-    };
-    typst_render::render(&doc.pages()[0], &opts)
+fn export_png(doc: &PagedDocument, options: &RenderOptions) -> SourceResult<Bytes> {
+    typst_render::render(&doc.pages()[0], options)
         .encode_png()
         .map(Bytes::new)
         .map_err(|_| "failed to encode PNG")
@@ -99,10 +102,10 @@ fn export_png(doc: &PagedDocument, pixel_per_pt: Scalar) -> SourceResult<Bytes> 
 #[typst_macros::time(name = "export svg")]
 fn export_svg(
     doc: &PagedDocument,
+    options: &SvgOptions,
     anchors: &[(Location, EcoString)],
     link_resolver: Tracked<LateLinkResolver>,
 ) -> SourceResult<Bytes> {
-    let options = SvgOptions::default();
     let anchors = anchors
         .iter()
         .filter_map(|(loc, name)| {
@@ -115,7 +118,7 @@ fn export_svg(
         .collect::<Vec<_>>();
     Ok(Bytes::from_string(typst_svg::svg_in_bundle(
         &doc.pages()[0],
-        &options,
+        options,
         &anchors,
         link_resolver,
     )))
@@ -132,7 +135,8 @@ fn export_svg(
 #[typst_macros::time(name = "export html")]
 fn export_html(
     root: &HtmlElement,
+    options: &HtmlOptions,
     link_resolver: Tracked<LateLinkResolver>,
 ) -> SourceResult<Bytes> {
-    typst_html::html_in_bundle(root, link_resolver).map(Bytes::from_string)
+    typst_html::html_in_bundle(root, options, link_resolver).map(Bytes::from_string)
 }

--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -319,6 +319,14 @@ pub struct CompileArgs {
     #[clap(flatten)]
     pub world: WorldArgs,
 
+    /// Whether to pretty-print produced output.
+    ///
+    /// This formats the output in a more human-readable, but less
+    /// space-efficient way. Affects HTML, SVG, and PDF export, but not PNG
+    /// export.
+    #[arg(long = "pretty")]
+    pub pretty: bool,
+
     /// Which pages to export. When unspecified, all pages are exported.
     ///
     /// Pages to export are separated by commas, and can be either simple page
@@ -346,7 +354,7 @@ pub struct CompileArgs {
 
     /// The PPI (pixels per inch) to use for PNG export.
     #[arg(long = "ppi", default_value_t = 144.0)]
-    pub ppi: f32,
+    pub ppi: f64,
 
     /// File path to which a Makefile with the current compilation's
     /// dependencies will be written.

--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -13,10 +13,13 @@ use typst::foundations::{Datetime, Smart};
 use typst::layout::PageRanges;
 use typst::syntax::Span;
 use typst_bundle::{Bundle, BundleOptions, VirtualFs};
-use typst_html::HtmlDocument;
+use typst_html::{HtmlDocument, HtmlOptions};
 use typst_kit::timer::Timer;
 use typst_layout::{Page, PagedDocument};
 use typst_pdf::{PdfOptions, PdfStandards, Timestamp};
+use typst_render::RenderOptions;
+use typst_svg::SvgOptions;
+use typst_utils::Scalar;
 
 use crate::args::{
     CompileArgs, CompileCommand, DepsFormat, DiagnosticFormat, Input, Output,
@@ -55,6 +58,8 @@ pub struct CompileConfig {
     pub output: Output,
     /// The format of the output file.
     pub output_format: OutputFormat,
+    /// Whether to make the serialized document pretty.
+    pub pretty: bool,
     /// Which pages to export.
     pub pages: Option<PageRanges>,
     /// The document's creation date formatted as a UNIX timestamp, with UTC suffix.
@@ -73,7 +78,7 @@ pub struct CompileConfig {
     /// The format to use for dependencies.
     pub deps_format: DepsFormat,
     /// The PPI (pixels per inch) to use for PNG export.
-    pub ppi: f32,
+    pub ppi: f64,
     /// The export cache for images, used for caching output files in `typst
     /// watch` sessions with images.
     pub export_cache: ExportCache,
@@ -221,6 +226,7 @@ impl CompileConfig {
             input,
             output,
             output_format,
+            pretty: args.pretty,
             pages,
             pdf_standards,
             tagged,
@@ -335,7 +341,8 @@ fn compile_and_export(
 
 /// Export to HTML.
 fn export_html(document: &HtmlDocument, config: &CompileConfig) -> SourceResult<()> {
-    let html = typst_html::html(document)?;
+    let options = HtmlOptions { pretty: config.pretty };
+    let html = typst_html::html(document, &options)?;
     let result = config.output.write(html.as_bytes());
 
     #[cfg(feature = "http-server")]
@@ -379,37 +386,13 @@ fn export_pdf(document: &PagedDocument, config: &CompileConfig) -> SourceResult<
     Ok(())
 }
 
-/// Creates options for PDF export.
-fn pdf_options(config: &CompileConfig) -> PdfOptions<'static> {
-    // If the timestamp is provided through the CLI, use UTC suffix,
-    // else, use the current local time and timezone.
-    let timestamp = match config.creation_timestamp {
-        Some(timestamp) => convert_datetime(timestamp).map(Timestamp::new_utc),
-        None => {
-            let local_datetime = chrono::Local::now();
-            convert_datetime(local_datetime).and_then(|datetime| {
-                Timestamp::new_local(
-                    datetime,
-                    local_datetime.offset().local_minus_utc() / 60,
-                )
-            })
-        }
-    };
-
-    PdfOptions {
-        ident: Smart::Auto,
-        timestamp,
-        page_ranges: config.pages.clone(),
-        standards: config.pdf_standards.clone(),
-        tagged: config.tagged,
-    }
-}
-
 /// Export to a bundle, a collection of files in a directory.
 fn export_bundle(bundle: Bundle, config: &CompileConfig) -> SourceResult<Vec<Output>> {
     let options = BundleOptions {
-        pixel_per_pt: config.ppi / 72.0,
+        html: html_options(config),
         pdf: pdf_options(config),
+        png: png_options(config),
+        svg: svg_options(config),
     };
 
     let fs = typst_bundle::export(&bundle, &options)?;
@@ -585,11 +568,8 @@ fn export_image_page(
 ) -> StrResult<()> {
     match fmt {
         ImageExportFormat::Png => {
-            let opts = typst_render::RenderOptions {
-                pixel_per_pt: config.ppi / 72.0,
-                render_bleed: false,
-            };
-            let pixmap = typst_render::render(page, &opts);
+            let options = png_options(config);
+            let pixmap = typst_render::render(page, &options);
             let buf = pixmap
                 .encode_png()
                 .map_err(|err| eco_format!("failed to encode PNG file ({err})"))?;
@@ -598,14 +578,59 @@ fn export_image_page(
                 .map_err(|err| eco_format!("failed to write PNG file ({err})"))?;
         }
         ImageExportFormat::Svg => {
-            let opts = typst_svg::SvgOptions { render_bleed: false };
-            let svg = typst_svg::svg(page, &opts);
+            let options = svg_options(config);
+            let svg = typst_svg::svg(page, &options);
             output
                 .write(svg.as_bytes())
                 .map_err(|err| eco_format!("failed to write SVG file ({err})"))?;
         }
     }
     Ok(())
+}
+
+/// Creates options for HTML export.
+fn html_options(config: &CompileConfig) -> HtmlOptions {
+    HtmlOptions { pretty: config.pretty }
+}
+
+/// Creates options for PDF export.
+fn pdf_options(config: &CompileConfig) -> PdfOptions {
+    // If the timestamp is provided through the CLI, use UTC suffix,
+    // else, use the current local time and timezone.
+    let timestamp = match config.creation_timestamp {
+        Some(timestamp) => convert_datetime(timestamp).map(Timestamp::new_utc),
+        None => {
+            let local_datetime = chrono::Local::now();
+            convert_datetime(local_datetime).and_then(|datetime| {
+                Timestamp::new_local(
+                    datetime,
+                    local_datetime.offset().local_minus_utc() / 60,
+                )
+            })
+        }
+    };
+
+    PdfOptions {
+        ident: Smart::Auto,
+        timestamp,
+        page_ranges: config.pages.clone(),
+        standards: config.pdf_standards.clone(),
+        tagged: config.tagged,
+        pretty: config.pretty,
+    }
+}
+
+/// Creates options for SVG export.
+fn svg_options(config: &CompileConfig) -> SvgOptions {
+    SvgOptions { render_bleed: false, pretty: config.pretty }
+}
+
+/// Creates options for PNG export.
+fn png_options(config: &CompileConfig) -> RenderOptions {
+    RenderOptions {
+        pixel_per_pt: Scalar::new(config.ppi / 72.0),
+        render_bleed: false,
+    }
 }
 
 /// Caches exported files so that we can avoid re-exporting them if they haven't

--- a/crates/typst-html/src/encode.rs
+++ b/crates/typst-html/src/encode.rs
@@ -12,10 +12,17 @@ use crate::{
     tag,
 };
 
+/// Settings for HTML export.
+#[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
+pub struct HtmlOptions {
+    /// Whether to format the HTML in a human-readable way.
+    pub pretty: bool,
+}
+
 /// Encodes an HTML document into a string.
-pub fn html(document: &HtmlDocument) -> SourceResult<String> {
+pub fn html(document: &HtmlDocument, options: &HtmlOptions) -> SourceResult<String> {
     let link_resolver = LateLinkResolver::new(None, document.introspector().as_ref());
-    let w = Writer::new(link_resolver.track(), true);
+    let w = Writer::new(link_resolver.track(), options.pretty);
     html_impl(w, document.root())
 }
 
@@ -25,9 +32,10 @@ pub fn html(document: &HtmlDocument) -> SourceResult<String> {
 /// root element instead of the document.
 pub fn html_in_bundle(
     root: &HtmlElement,
+    options: &HtmlOptions,
     link_resolver: Tracked<LateLinkResolver>,
 ) -> SourceResult<String> {
-    let w = Writer::new(link_resolver, true);
+    let w = Writer::new(link_resolver, options.pretty);
     html_impl(w, root)
 }
 
@@ -384,6 +392,7 @@ fn write_frame(w: &mut Writer, frame: &HtmlFrame) {
     let svg = typst_svg::svg_in_html(
         &frame.inner,
         frame.text_size,
+        w.pretty,
         frame.id.as_deref(),
         &eco_format!("{}", frame.css.to_inline()),
         &frame.anchors,

--- a/crates/typst-html/src/lib.rs
+++ b/crates/typst-html/src/lib.rs
@@ -19,7 +19,7 @@ mod typed;
 
 pub use self::document::{html_document, html_document_for_bundle};
 pub use self::dom::*;
-pub use self::encode::{html, html_in_bundle};
+pub use self::encode::{HtmlOptions, html, html_in_bundle};
 pub use self::introspect::HtmlIntrospector;
 pub use self::link::create_link_anchors;
 pub use self::rules::{html_mathml_body, html_span_filled, register};

--- a/crates/typst-pdf/src/convert.rs
+++ b/crates/typst-pdf/src/convert.rs
@@ -50,13 +50,13 @@ pub fn convert(
     let settings = SerializeSettings {
         compress_content_streams: true,
         no_device_cs: true,
-        ascii_compatible: false,
+        ascii_compatible: options.pretty,
         xmp_metadata: true,
         cmyk_profile: None,
         configuration: options.standards.config,
         enable_tagging: options.tagged,
         render_svg_glyph_fn: render_svg_glyph,
-        pretty: false,
+        pretty: options.pretty,
     };
 
     let mut document = Document::new_with(settings);
@@ -280,7 +280,7 @@ pub(crate) struct GlobalContext<'a> {
     /// The document to convert.
     pub(crate) document: &'a PagedDocument,
     /// Options for PDF export.
-    pub(crate) options: &'a PdfOptions<'a>,
+    pub(crate) options: &'a PdfOptions,
     /// Used to resolve cross-document links in bundle export.
     pub(crate) link_resolver: Option<Tracked<'a, LateLinkResolver<'a>>>,
     /// Mapping between locations in the document and named destinations.

--- a/crates/typst-pdf/src/lib.rs
+++ b/crates/typst-pdf/src/lib.rs
@@ -55,7 +55,7 @@ pub fn pdf_in_bundle(
 
 /// Settings for PDF export.
 #[derive(Debug, Hash)]
-pub struct PdfOptions<'a> {
+pub struct PdfOptions {
     /// If not `Smart::Auto`, shall be a string that uniquely and stably
     /// identifies the document. It should not change between compilations of
     /// the same document.  **If you cannot provide such a stable identifier,
@@ -67,7 +67,7 @@ pub struct PdfOptions<'a> {
     /// document identifier (the identifier itself is not leaked). If `ident` is
     /// `Auto`, a hash of the document's title and author is used instead (which
     /// is reasonably unique and stable).
-    pub ident: Smart<&'a str>,
+    pub ident: Smart<String>,
     /// If not `None`, shall be the creation timestamp of the document. It will
     /// only be used if `set document(date: ..)` is `auto`.
     pub timestamp: Option<Timestamp>,
@@ -81,9 +81,11 @@ pub struct PdfOptions<'a> {
     /// circumstances, for example when trying to reduce the size of a document,
     /// it can be desirable to disable tagged PDF.
     pub tagged: bool,
+    /// Whether to format the PDF in a human-readable way.
+    pub pretty: bool,
 }
 
-impl PdfOptions<'_> {
+impl PdfOptions {
     /// Returns the accessibility validator. Returns `Some` for PDF/UA-1, and in
     /// the future maybe PDF/UA-2.
     pub(crate) fn accessibility_validator(&self) -> Option<Accessibility> {
@@ -91,7 +93,7 @@ impl PdfOptions<'_> {
     }
 }
 
-impl Default for PdfOptions<'_> {
+impl Default for PdfOptions {
     fn default() -> Self {
         Self {
             ident: Smart::Auto,
@@ -99,6 +101,7 @@ impl Default for PdfOptions<'_> {
             page_ranges: None,
             standards: PdfStandards::default(),
             tagged: true,
+            pretty: false,
         }
     }
 }

--- a/crates/typst-pdf/src/metadata.rs
+++ b/crates/typst-pdf/src/metadata.rs
@@ -33,7 +33,7 @@ pub(crate) fn build_metadata(gc: &GlobalContext, doc_lang: Option<Locale>) -> Me
         metadata = metadata.description(description.to_string());
     }
 
-    if let Some(ident) = gc.options.ident.custom() {
+    if let Some(ident) = gc.options.ident.as_ref().custom() {
         metadata = metadata.document_id(ident.to_string());
     }
 

--- a/crates/typst-pdf/src/tags/resolve/mod.rs
+++ b/crates/typst-pdf/src/tags/resolve/mod.rs
@@ -33,7 +33,7 @@ pub enum TagNode {
 }
 
 struct Resolver<'a> {
-    options: &'a PdfOptions<'a>,
+    options: &'a PdfOptions,
     ctx: &'a Ctx,
     groups: &'a IdVec<Group>,
     tags: &'a mut TagStorage,

--- a/crates/typst-pdf/src/tags/tree/build.rs
+++ b/crates/typst-pdf/src/tags/tree/build.rs
@@ -54,7 +54,7 @@ use crate::tags::util::{ArtifactKindExt, PropertyValCopied};
 use crate::util::ValidatorsExt;
 
 pub struct TreeBuilder<'a> {
-    options: &'a PdfOptions<'a>,
+    options: &'a PdfOptions,
 
     /// Each [`FrameItem::Tag`] and each [`FrameItem::Group`] with a parent
     /// will append a progression to this tree. This list of progressions is

--- a/crates/typst-render/Cargo.toml
+++ b/crates/typst-render/Cargo.toml
@@ -18,6 +18,7 @@ typst-layout = { workspace = true }
 typst-library = { workspace = true }
 typst-macros = { workspace = true }
 typst-timing = { workspace = true }
+typst-utils = { workspace = true }
 bytemuck = { workspace = true }
 comemo = { workspace = true }
 hayro = { workspace = true }

--- a/crates/typst-render/src/lib.rs
+++ b/crates/typst-render/src/lib.rs
@@ -11,6 +11,7 @@ use typst_library::layout::{
     Abs, Axes, Frame, FrameItem, FrameKind, GroupItem, Point, Sides, Size, Transform,
 };
 use typst_library::visualize::{Color, Geometry, Paint};
+use typst_utils::Scalar;
 
 /// Export a page into a raster image.
 ///
@@ -21,7 +22,7 @@ pub fn render(page: &Page, opts: &RenderOptions) -> sk::Pixmap {
     let bleed = if opts.render_bleed { page.bleed } else { Sides::default() };
 
     let size = page.frame.size() + bleed.sum_by_axis();
-    let pixel_per_pt = opts.pixel_per_pt;
+    let pixel_per_pt = opts.pixel_per_pt.get() as f32;
     let pxw = (pixel_per_pt * size.x.to_f32()).round().max(1.0) as u32;
     let pxh = (pixel_per_pt * size.y.to_f32()).round().max(1.0) as u32;
 
@@ -56,7 +57,8 @@ pub fn render_merged(
     let pixmaps: Vec<_> =
         document.pages().iter().map(|page| render(page, opts)).collect();
 
-    let gap = (opts.pixel_per_pt * gap.to_f32()).round() as u32;
+    let pixel_per_pt = opts.pixel_per_pt.get() as f32;
+    let gap = (pixel_per_pt * gap.to_f32()).round() as u32;
     let pxw = pixmaps.iter().map(sk::Pixmap::width).max().unwrap_or_default();
     let pxh = pixmaps.iter().map(|pixmap| pixmap.height()).sum::<u32>()
         + gap * pixmaps.len().saturating_sub(1) as u32;
@@ -84,7 +86,7 @@ pub fn render_merged(
 }
 
 /// Settings for raster image export.
-#[derive(Clone)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct RenderOptions {
     /// Controls the scale of the rendered output in pixels per typographic
     /// point. By default, a value of `1.0` is used, meaning one pixel is
@@ -92,7 +94,7 @@ pub struct RenderOptions {
     /// images, while lower values reduce the output size and rendering cost.
     /// This can be useful when adjusting the final image quality for display or
     /// printing purposes.
-    pub pixel_per_pt: f32,
+    pub pixel_per_pt: Scalar,
     /// By default, rendered pages are bounded to the page size. In some
     /// circumstances, such as when preparing documents for print, it may be
     /// desirable to include content beyond these bounds to account for bleed
@@ -103,7 +105,10 @@ pub struct RenderOptions {
 
 impl Default for RenderOptions {
     fn default() -> Self {
-        Self { pixel_per_pt: 1.0, render_bleed: false }
+        Self {
+            pixel_per_pt: Scalar::new(2.0),
+            render_bleed: false,
+        }
     }
 }
 

--- a/crates/typst-svg/src/lib.rs
+++ b/crates/typst-svg/src/lib.rs
@@ -27,19 +27,13 @@ use crate::paint::{GradientRef, SVGSubGradient, TilingRef};
 use crate::text::RenderedGlyph;
 use crate::write::{SvgDisplay, SvgElem, SvgTransform, SvgUrl, SvgWrite};
 
-const XML_WRITE_OPTIONS: xmlwriter::Options = xmlwriter::Options {
-    use_single_quote: false,
-    indent: xmlwriter::Indent::Spaces(2),
-    attributes_indent: xmlwriter::Indent::None,
-};
-
 /// Export a frame into an SVG file.
 #[typst_macros::time(name = "svg")]
 pub fn svg(page: &Page, opts: &SvgOptions) -> String {
     let (size, ts) = page_bleed(page, opts);
 
     let mut renderer = SVGRenderer::new();
-    let mut xml = XmlWriter::new(XML_WRITE_OPTIONS);
+    let mut xml = XmlWriter::new(xml_options(opts.pretty));
     let mut svg = svg_header(&mut xml, size);
 
     let state = State::new(size);
@@ -64,7 +58,7 @@ pub fn svg_in_bundle(
     let (size, ts) = page_bleed(page, opts);
 
     let mut renderer = SVGRenderer::with_options(Some(link_resolver));
-    let mut xml = XmlWriter::new(XML_WRITE_OPTIONS);
+    let mut xml = XmlWriter::new(xml_options(opts.pretty));
     let mut svg = svg_header(&mut xml, size);
 
     let state = State::new(size);
@@ -88,6 +82,7 @@ pub fn svg_in_bundle(
 pub fn svg_in_html(
     frame: &Frame,
     text_size: Abs,
+    pretty: bool,
     id: Option<&str>,
     styles: &str,
     anchors: &[(Point, EcoString)],
@@ -96,7 +91,7 @@ pub fn svg_in_html(
     let mut renderer = SVGRenderer::with_options(Some(link_resolver));
     let mut xml = XmlWriter::new(xmlwriter::Options {
         indent: xmlwriter::Indent::None,
-        ..XML_WRITE_OPTIONS
+        ..xml_options(pretty)
     });
     let mut svg = svg_header_with_custom_attrs(&mut xml, frame.size(), |svg| {
         if let Some(id) = id {
@@ -140,7 +135,7 @@ pub fn svg_merged(document: &PagedDocument, opts: &SvgOptions, gap: Abs) -> Stri
     }
 
     let mut renderer = SVGRenderer::new();
-    let mut xml = XmlWriter::new(XML_WRITE_OPTIONS);
+    let mut xml = XmlWriter::new(xml_options(opts.pretty));
     let mut svg = svg_header(&mut xml, size);
 
     let mut y = Abs::zero();
@@ -167,6 +162,18 @@ fn page_bleed(page: &Page, opts: &SvgOptions) -> (Size, Transform) {
     (size, ts)
 }
 
+fn xml_options(pretty: bool) -> xmlwriter::Options {
+    xmlwriter::Options {
+        use_single_quote: false,
+        indent: if pretty {
+            xmlwriter::Indent::Spaces(2)
+        } else {
+            xmlwriter::Indent::None
+        },
+        attributes_indent: xmlwriter::Indent::None,
+    }
+}
+
 /// Settings for SVG export.
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
 pub struct SvgOptions {
@@ -176,6 +183,8 @@ pub struct SvgOptions {
     /// margins. This field allows expanding the document area to include such
     /// bleed.
     pub render_bleed: bool,
+    /// Whether to format the SVG in a human-readable way.
+    pub pretty: bool,
 }
 
 /// Renders one or multiple frames to an SVG file.

--- a/docs/src/example.rs
+++ b/docs/src/example.rs
@@ -24,7 +24,7 @@ use typst::visualize::{
 use typst::{Features, Library, LibraryExt, World, WorldExt};
 use typst_layout::{Page, PagedDocument};
 use typst_render::RenderOptions;
-use typst_utils::LazyHash;
+use typst_utils::{LazyHash, Scalar};
 
 /// Processes a code example in the docs and returns an array of `image`
 /// elements with the resulting rendered pages.
@@ -159,7 +159,10 @@ fn trim_page(page: &mut Page, Zoom { x, y, w, h }: &Zoom, styles: StyleChain) {
 
 /// Turns a compiled `Page` into a Typst `image` element by rendering it.
 fn page_to_image(page: Page) -> Content {
-    let opts = RenderOptions { pixel_per_pt: 2.0, render_bleed: false };
+    let opts = RenderOptions {
+        pixel_per_pt: Scalar::new(2.0),
+        render_bleed: false,
+    };
     let pixmap = typst_render::render(&page, &opts);
     let format = ImageFormat::Raster(RasterFormat::Pixel(PixelFormat {
         encoding: PixelEncoding::Rgba8,

--- a/docs/src/main.rs
+++ b/docs/src/main.rs
@@ -182,7 +182,7 @@ fn export_website(mut bundle: Bundle, config: &Config) -> SourceResult<()> {
         BundleFile::Asset(Bytes::new(serde_json::to_vec(&index).unwrap())),
     );
 
-    let options = BundleOptions { pixel_per_pt: 1.0, pdf: PdfOptions::default() };
+    let options = BundleOptions::default();
     let fs = typst_bundle::export(&bundle, &options)?;
 
     if let Some(path) = &config.output {
@@ -210,7 +210,7 @@ fn write_virtual_fs(root: &Path, fs: &VirtualFs) {
 
 /// Exports a document to PDF and writes it to disk.
 fn export_pdf(document: &PagedDocument, config: &Config) -> SourceResult<()> {
-    let data = typst_pdf::pdf(document, &typst_pdf::PdfOptions::default())?;
+    let data = typst_pdf::pdf(document, &PdfOptions::default())?;
     if let Some(path) = &config.output {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).unwrap();

--- a/tests/fuzz/src/bin/html.rs
+++ b/tests/fuzz/src/bin/html.rs
@@ -2,12 +2,13 @@
 
 use libfuzzer_sys::fuzz_target;
 use typst_fuzz::FuzzWorld;
-use typst_html::HtmlDocument;
+use typst_html::{HtmlDocument, HtmlOptions};
 
 fuzz_target!(|text: &str| {
     let world = FuzzWorld::new(text);
+    let options = HtmlOptions::default();
     if let Ok(document) = typst::compile::<HtmlDocument>(&world).output {
-        _ = std::hint::black_box(typst_html::html(&document));
+        _ = std::hint::black_box(typst_html::html(&document, &options));
     }
     comemo::evict(10);
 });

--- a/tests/src/output.rs
+++ b/tests/src/output.rs
@@ -18,11 +18,13 @@ use typst::model::ParbreakElem;
 use typst::text::SpaceElem;
 use typst::visualize::Color;
 use typst_bundle::{BundleOptions, VirtualFs};
-use typst_html::HtmlDocument;
+use typst_html::{HtmlDocument, HtmlOptions};
 use typst_layout::PagedDocument;
 use typst_pdf::{PdfOptions, PdfStandard, PdfStandards};
+use typst_render::RenderOptions;
 use typst_svg::SvgOptions;
 use typst_syntax::Span;
+use typst_utils::Scalar;
 
 use crate::collect::{Test, TestOutput};
 use crate::report::{Diff, File, Old, ReportFile};
@@ -395,7 +397,7 @@ impl OutputType for Svg {
     }
 
     fn make_live(_: &Test, doc: &Self::Doc) -> SourceResult<Self::Live> {
-        let options = SvgOptions::default();
+        let options = SvgOptions { pretty: true, ..Default::default() };
         Ok(typst_svg::svg_merged(doc, &options, Abs::pt(1.0)))
     }
 
@@ -444,7 +446,8 @@ impl OutputType for Html {
     }
 
     fn make_live(_: &Test, doc: &Self::Doc) -> SourceResult<Self::Live> {
-        typst_html::html(doc)
+        let options = HtmlOptions { pretty: true };
+        typst_html::html(doc, &options)
     }
 
     fn save_live(_: &Self::Doc, live: &Self::Live) -> impl AsRef<[u8]> {
@@ -484,8 +487,13 @@ impl OutputType for Bundle {
         let standards =
             PdfStandards::new(test.attrs.pdf_standard.as_slice()).at(Span::detached())?;
         let options = BundleOptions {
-            pixel_per_pt: 1.0,
+            html: HtmlOptions { pretty: true },
             pdf: PdfOptions { standards, ..Default::default() },
+            png: RenderOptions {
+                pixel_per_pt: Scalar::new(1.0),
+                ..Default::default()
+            },
+            svg: SvgOptions { pretty: true, ..Default::default() },
         };
         typst_bundle::export(doc, &options)
     }
@@ -577,7 +585,10 @@ fn render(document: &PagedDocument, pixel_per_pt: f32) -> sk::Pixmap {
     }
 
     let gap = Abs::pt(1.0);
-    let opts = typst_render::RenderOptions { pixel_per_pt, render_bleed: false };
+    let opts = typst_render::RenderOptions {
+        pixel_per_pt: Scalar::new(pixel_per_pt as f64),
+        render_bleed: false,
+    };
     let mut pixmap =
         typst_render::render_merged(document, &opts, gap, Some(Color::BLACK));
 


### PR DESCRIPTION
Based on #8370

This changes the default output to be non-pretty (minimized).

The test suite still produces pretty output, which may be undesirable, we probably want to test a mix of both, but I don't wan to add more special cased test suite options like `pdf-standard`. Once the format options are settable we can also get rid of that one, and easily test format options in the test suite.

Also interacts with #8294, so either this PR needs to be updated to change PDF output to be `pretty` or the other one.