### PR TITLE
saturate start + count in array/str slice

### DIFF
--- a/crates/typst-library/src/foundations/array.rs
+++ b/crates/typst-library/src/foundations/array.rs
@@ -294,7 +294,7 @@ impl Array {
             bail!("`end` and `count` are mutually exclusive");
         }
         let start = self.locate(start, true)?;
-        let end = end.or(count.map(|c| start as i64 + c));
+        let end = end.or(count.map(|c| (start as i64).saturating_add(c)));
         let end = self.locate(end.unwrap_or(self.len() as i64), true)?.max(start);
         Ok(self.0[start..end].into())
     }

--- a/crates/typst-library/src/foundations/str.rs
+++ b/crates/typst-library/src/foundations/str.rs
@@ -267,7 +267,7 @@ impl Str {
             bail!("`end` and `count` are mutually exclusive");
         }
         let start = self.locate(start)?;
-        let end = end.or(count.map(|c| start as i64 + c));
+        let end = end.or(count.map(|c| (start as i64).saturating_add(c)));
         let end = self.locate(end.unwrap_or(self.len() as i64))?.max(start);
         Ok(self.0[start..end].into())
     }

--- a/tests/suite/foundations/array.typ
+++ b/tests/suite/foundations/array.typ
@@ -259,6 +259,10 @@
 // Error: 2-30 array index out of bounds (index: 12, len: 10)
 #range(10).slice(9, count: 3)
 
+--- array-slice-count-overflow eval ---
+// Error: 2-48 array index out of bounds (index: 9223372036854775807, len: 3)
+#(1, 2, 3).slice(1, count: 9223372036854775807)
+
 --- array-slice-out-of-bounds-from-back eval ---
 // Error: 2-31 array index out of bounds (index: 12, len: 10)
 #range(10).slice(-2, count: 4)

--- a/tests/suite/foundations/str.typ
+++ b/tests/suite/foundations/str.typ
@@ -161,6 +161,10 @@
 // Error: 2-29 `end` and `count` are mutually exclusive
 #"abc".slice(0, 1, count: 2)
 
+--- string-slice-count-overflow eval ---
+// Error: 2-44 string index out of bounds (index: 9223372036854775807, len: 3)
+#"abc".slice(1, count: 9223372036854775807)
+
 --- string-slice-not-a-char-boundary eval ---
 // Error: 2-21 string index -1 is not a character boundary
 #"🏳️‍🌈".slice(0, -1)


### PR DESCRIPTION
With the dev profile's overflow checks:

    thread panicked at crates/typst-library/src/foundations/str.rs:270:40:
    attempt to add with overflow

`#str.slice(1, count: 9223372036854775807)` (same in `array.slice`) overflows `start + count`. Saturate so an out-of-range count yields the usual out-of-bounds error.