### PR TITLE
Add alignment to html export

### DIFF
--- a/crates/typst-html/src/attr.rs
+++ b/crates/typst-html/src/attr.rs
@@ -10,6 +10,7 @@ pub const accept: HtmlAttr = HtmlAttr::constant("accept");
 pub const accept_charset: HtmlAttr = HtmlAttr::constant("accept-charset");
 pub const accesskey: HtmlAttr = HtmlAttr::constant("accesskey");
 pub const action: HtmlAttr = HtmlAttr::constant("action");
+pub const align: HtmlAttr = HtmlAttr::constant("align");
 pub const allow: HtmlAttr = HtmlAttr::constant("allow");
 pub const allowfullscreen: HtmlAttr = HtmlAttr::constant("allowfullscreen");
 pub const alpha: HtmlAttr = HtmlAttr::constant("alpha");

--- a/crates/typst-html/src/convert.rs
+++ b/crates/typst-html/src/convert.rs
@@ -393,10 +393,10 @@ fn handle_align(
 
     // Default VAlignment is VAlignment::Top, so this has not effect anyways.
     // Hence, no warning is reported.
-    let has_valignment = match elem.alignment.get(styles).y() {
-        Some(VAlignment::Bottom) | Some(VAlignment::Horizon) => true,
-        _ => false
-    };
+    let has_valignment = matches!(
+        elem.alignment.get(styles).y(),
+        Some(VAlignment::Bottom) | Some(VAlignment::Horizon)
+    );
 
     if has_valignment {
         converter.engine.sink.warn(warning!(

--- a/crates/typst-html/src/convert.rs
+++ b/crates/typst-html/src/convert.rs
@@ -4,7 +4,7 @@ use typst_library::engine::Engine;
 use typst_library::foundations::{Content, Packed, StyleChain, Target, TargetElem};
 use typst_library::introspection::{SplitLocator, TagElem};
 use typst_library::layout::{
-    Abs, Axes, BlockBody, BlockElem, BoxElem, HElem, Region, Size,
+    Abs, AlignElem, Axes, BlockBody, BlockElem, BoxElem, HAlignment, HElem, Region, Size, VAlignment
 };
 use typst_library::routines::Pair;
 use typst_library::text::{
@@ -152,6 +152,8 @@ fn handle(
         // be wrapped in a `box` to omit the `display` annotation.
         make_block_level(&mut node).unwrap();
         converter.push(node);
+    } else if let Some(elem) = child.to_packed::<AlignElem>() {
+        handle_align(converter, elem, styles)?;
     } else {
         converter.engine.sink.warn(warning!(
             child.span(),
@@ -361,6 +363,51 @@ fn handle_box(
         // TODO: This is rather incomplete.
         HtmlElement::new(tag::span)
             .with_css(css::Properties::new().with("display", "inline-block"))
+            .with_children(children)
+            .spanned(elem.span()),
+    );
+
+    Ok(())
+}
+
+/// Processes an align element.
+fn handle_align(
+    converter: &mut Converter,
+    elem: &Packed<AlignElem>,
+    styles: StyleChain,
+) -> SourceResult<()> {
+    let children = html_block_fragment(
+        converter.engine,
+        &elem.body,
+        converter.locator.next(&elem.span()),
+        styles,
+        converter.whitespace,
+    )?;
+
+    let halignment = match elem.alignment.get(styles).x() {
+        Some(HAlignment::End) | Some(HAlignment::Right) => "right",
+        Some(HAlignment::Center) => "center",
+        // Default to left
+        Some(HAlignment::Start) | Some(HAlignment::Left) | _ => "left"
+    };
+
+    // Default VAlignment is VAlignment::Top, so this has not effect anyways.
+    // Hence, no warning is reported.
+    let has_valignment = match elem.alignment.get(styles).y() {
+        Some(VAlignment::Bottom) | Some(VAlignment::Horizon) => true,
+        _ => false
+    };
+
+    if has_valignment {
+        converter.engine.sink.warn(warning!(
+            elem.span(),
+            "Vertical alignment was ignored during HTML export",
+        ));
+    }
+
+    converter.push(
+        HtmlElement::new(tag::div)
+            .with_attr(attr::align, halignment)
             .with_children(children)
             .spanned(elem.span()),
     );


### PR DESCRIPTION
This PR adds alignment to HTML.

I've limited this PR to just horizontal alignment, as vertical alignment is somewhat ambiguous on a webpage (e.g. does it align to the bottom of the page, the frame, the block, etc?).

This PR also doesn't manage alternative directions of writing (e.g. RTL in Arabic) because it doesn't seem to be implemented elsewhere within typst-html, and there's probably a better way of doing it than on a per-element basis.

The following page is produced with the below code:

<img width="1896" height="343" alt="image" src="https://github.com/user-attachments/assets/0c681cfb-bac7-4741-91bc-88dd57d6ea64" />

```typst
#align(
  right,
  figure(
    block("hello world"),
    caption: "A greeting"
  )
)

#align(
  center,
  [
    center
    $
    f: RR -> RR\
    f(x) = x^2
    $
  ]
)

#align(
  left,
  [ This is on the right ]
)

#align(
  start,
  [ This is at the start ]
)

#align(
  end,
  [ This is at the end ]
)

#align(
  top + right,
  [ This is only on the right ]
)

#align(
  bottom + right,
  [ This is bottom right. ignore bottom ]
)

```


<!--
Thanks for your interest in landing a change in Typst! Before opening the PR, please review our contribution guidelines: https://github.com/typst/typst/blob/main/CONTRIBUTING.md

In particular, please keep in mind that we do not accept contributions implemented by an AI model. We would also ask you to refrain from using AI to write your pull request description. Summarizing your work helps organizing your thoughts as much as it helps us with seeing the human thought process behind a particular change.
-->
