### PR TITLE
feat(typst-kit): support multiple package_path directories

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -443,8 +443,16 @@ pub struct ProcessArgs {
 #[derive(Debug, Clone, Args)]
 pub struct PackageArgs {
     /// Custom path to local packages, defaults to system-dependent location.
-    #[clap(long = "package-path", env = "TYPST_PACKAGE_PATH", value_name = "DIR")]
-    pub package_path: Option<PathBuf>,
+    ///
+    /// If multiple paths are specified, they are separated by the system's path
+    /// separator (`:` on Unix-like systems and `;` on Windows).
+    #[clap(
+        long = "package-path",
+        env = "TYPST_PACKAGE_PATH",
+        value_name = "DIR",
+        value_delimiter = ENV_PATH_SEP,
+    )]
+    pub package_path: Vec<PathBuf>,
 
     /// Custom path to package cache, defaults to system-dependent location.
     #[clap(

--- a/crates/typst-cli/src/info.rs
+++ b/crates/typst-cli/src/info.rs
@@ -161,21 +161,17 @@ impl Fonts {
 #[derive(Default, Serialize)]
 #[serde(rename_all = "kebab-case")]
 struct Packages {
-    /// The resolved package path.
-    package_path: Option<PathBuf>,
+    /// The resolved package paths.
+    package_paths: Vec<PathBuf>,
 
     /// The resolved package cache path.
     package_cache_path: Option<PathBuf>,
 }
 
 impl Packages {
-    /// Return the resolved package paths.
-    fn paths(&self) -> impl Iterator<Item = (&'static str, Value<'_>)> {
-        let Self { package_path, package_cache_path } = self;
-
-        [("Package path", package_path), ("Package cache path", package_cache_path)]
-            .into_iter()
-            .map(|(k, v)| (k, v.as_deref().map(Value::Path).unwrap_or(Value::Unset)))
+    /// Return the custom package paths.
+    fn custom_paths(&self) -> impl Iterator<Item = Value<'_>> {
+        self.package_paths.iter().map(|p| Value::Path(p))
     }
 }
 
@@ -341,11 +337,14 @@ pub fn info(command: &InfoCommand) -> StrResult<()> {
                 .unwrap_or(false),
         },
         packages: Packages {
-            package_path: env
+            package_paths: env
                 .typst_package_path
-                .as_ref()
+                .as_deref()
+                .unwrap_or_default()
+                .split(':')
+                .filter(|s| !s.is_empty())
                 .map(PathBuf::from)
-                .or_else(|| FsPackages::system_data().map(|fs| fs.path().into())),
+                .collect(),
             package_cache_path: env
                 .typst_package_cache_path
                 .as_ref()
@@ -598,14 +597,30 @@ fn format_human_readable(value: &Info) -> io::Result<()> {
 
     writeln!(out)?;
     writeln!(out, "Packages")?;
-    let key_pad = value.packages.paths().map(|(name, _)| name.len()).max();
-    for (key, val) in value.packages.paths() {
-        write!(out, "  ")?;
-        write_key(&mut out, key, key_pad)?;
+    write!(out, "  ")?;
+    write_key(&mut out, "Package paths", None)?;
+    if value.packages.package_paths.is_empty() {
         write!(out, " ")?;
-        val.format(&mut out, None)?;
+        write_value_special(&mut out, "<none>", None)?;
         writeln!(out)?;
+    } else {
+        writeln!(out)?;
+        for path in value.packages.custom_paths() {
+            write!(out, "    - ")?;
+            path.format(&mut out, None)?;
+            writeln!(out)?;
+        }
     }
+
+    write!(out, "  ")?;
+    write_key(&mut out, "Package cache path", None)?;
+    write!(out, " ")?;
+    value.packages.package_cache_path
+        .as_deref()
+        .map(Value::Path)
+        .unwrap_or(Value::Unset)
+        .format(&mut out, None)?;
+    writeln!(out)?;
 
     writeln!(out)?;
     writeln!(out, "Environment variables")?;

--- a/crates/typst-cli/src/info.rs
+++ b/crates/typst-cli/src/info.rs
@@ -615,7 +615,9 @@ fn format_human_readable(value: &Info) -> io::Result<()> {
     write!(out, "  ")?;
     write_key(&mut out, "Package cache path", None)?;
     write!(out, " ")?;
-    value.packages.package_cache_path
+    value
+        .packages
+        .package_cache_path
         .as_deref()
         .map(Value::Path)
         .unwrap_or(Value::Unset)

--- a/crates/typst-cli/src/packages.rs
+++ b/crates/typst-cli/src/packages.rs
@@ -5,10 +5,7 @@ use crate::args::PackageArgs;
 /// Returns a new package storage for the given args.
 pub fn system(args: &PackageArgs) -> SystemPackages {
     SystemPackages::from_parts(
-        args.package_path
-            .iter()
-            .map(FsPackages::new)
-            .collect(),
+        args.package_path.iter().map(FsPackages::new).collect(),
         args.package_cache_path
             .clone()
             .map(FsPackages::new)

--- a/crates/typst-cli/src/packages.rs
+++ b/crates/typst-cli/src/packages.rs
@@ -7,7 +7,7 @@ pub fn system(args: &PackageArgs) -> SystemPackages {
     SystemPackages::from_parts(
         args.package_path
             .iter()
-            .map(|p| FsPackages::new(p))
+            .map(FsPackages::new)
             .collect(),
         args.package_cache_path
             .clone()

--- a/crates/typst-cli/src/packages.rs
+++ b/crates/typst-cli/src/packages.rs
@@ -6,9 +6,9 @@ use crate::args::PackageArgs;
 pub fn system(args: &PackageArgs) -> SystemPackages {
     SystemPackages::from_parts(
         args.package_path
-            .clone()
-            .map(FsPackages::new)
-            .or_else(FsPackages::system_data),
+            .iter()
+            .map(|p| FsPackages::new(p))
+            .collect(),
         args.package_cache_path
             .clone()
             .map(FsPackages::new)

--- a/crates/typst-kit/src/packages.rs
+++ b/crates/typst-kit/src/packages.rs
@@ -21,11 +21,11 @@ use {
 ///
 /// In order of priority, this tries to obtain a package from
 ///
-/// - a package data directory (that is intended for system-wide storage of user
-///   packages)
-/// - a package cache directory (that is intended for caching of automatically
+/// - one or more package data directories (intended for system-wide storage of
+///   user packages), searched in order
+/// - a package cache directory (intended for caching of automatically
 ///   downloaded packages)
-/// - by downloading it from Typst Universe or a mirror of it (if it's namespace
+/// - by downloading it from Typst Universe or a mirror of it (if its namespace
 ///   matches the one Typst Universe serves)
 ///
 /// With default configuration, this loads packages from the same sources as the
@@ -33,7 +33,7 @@ use {
 #[cfg(feature = "system-packages")]
 #[derive(Debug)]
 pub struct SystemPackages {
-    data: Option<FsPackages>,
+    data: Vec<FsPackages>,
     cache: Option<FsPackages>,
     universe: UniversePackages,
 }
@@ -51,7 +51,7 @@ impl SystemPackages {
     /// configuration.
     pub fn new(downloader: impl Downloader) -> Self {
         Self::from_parts(
-            FsPackages::system_data(),
+            FsPackages::system_data().into_iter().collect(),
             FsPackages::system_cache(),
             UniversePackages::new(downloader),
         )
@@ -59,16 +59,16 @@ impl SystemPackages {
 
     /// Creates a new system package loader from custom configured parts.
     pub fn from_parts(
-        data: Option<FsPackages>,
+        data: Vec<FsPackages>,
         cache: Option<FsPackages>,
         universe: UniversePackages,
     ) -> Self {
         Self { data, cache, universe }
     }
 
-    /// Returns a handle to the data package directory.
-    pub fn data(&self) -> Option<&FsPackages> {
-        self.data.as_ref()
+    /// Returns handles to the data package directories.
+    pub fn data(&self) -> &[FsPackages] {
+        &self.data
     }
 
     /// Returns a handle to the cache package directory.
@@ -93,10 +93,11 @@ impl SystemPackages {
     /// [`FileStore`](crate::files::FileStore), this is already the case since
     /// it acquires a lock during file loading.
     pub fn obtain(&self, spec: &PackageSpec) -> PackageResult<FsRoot> {
-        if let Some(packages) = &self.data
-            && let Some(root) = packages.obtain(spec)
-        {
-            return Ok(root);
+        // Search all data directories in order; return on first hit.
+        for packages in &self.data {
+            if let Some(root) = packages.obtain(spec) {
+                return Ok(root);
+            }
         }
 
         if let Some(cache) = &self.cache {
@@ -131,12 +132,12 @@ impl SystemPackages {
         if spec.namespace == UniversePackages::NAMESPACE {
             self.universe.latest_version(spec)
         } else {
-            // For other namespaces, search locally. We only search in the data
-            // directory and not the cache directory, because the latter is not
-            // intended for storage of local packages.
+            // For other namespaces, search locally across all data directories.
+            // We only search in the data directories and not the cache directory,
+            // because the latter is not intended for storage of local packages.
             self.data
-                .as_ref()
-                .and_then(|pkgs| pkgs.latest_version(spec))
+                .iter()
+                .find_map(|pkgs| pkgs.latest_version(spec))
                 .ok_or_else(|| eco_format!("please specify the desired version"))
         }
     }


### PR DESCRIPTION
Closes #8183

Changes SystemPackages.data from Option<FsPackages> to Vec<FsPackages>, allowing multiple local package directories to be searched in order. The first directory containing the requested package wins.

Also updates the CLI to accept multiple paths consistent with --font-path/TYPST_FONT_PATHS.