### PR TITLE
Don't fail-fast test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
   test-matrix:
     name: Tests
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
         bits: [64]


### PR DESCRIPTION
When tests fail for one of the three platforms (Linux 64-bit, Linux 32-bit, Windows 64-bit), currently other in-progress tests will be canceled. If there is a platform-specific failure, this is a bit annoying.
