### PR TITLE
Fix overflow panic in `duration` constructor

### DIFF
--- a/crates/typst-library/src/foundations/duration.rs
+++ b/crates/typst-library/src/foundations/duration.rs
@@ -4,6 +4,7 @@ use std::ops::{Add, Div, Mul, Neg, Sub};
 use ecow::{EcoString, eco_format};
 use time::ext::NumericalDuration;
 
+use crate::diag::StrResult;
 use crate::foundations::{Repr, func, repr, scope, ty};
 
 /// Represents a positive or negative span of time.
@@ -69,14 +70,20 @@ impl Duration {
         #[named]
         #[default(0)]
         weeks: i64,
-    ) -> Duration {
-        Duration::from(
-            time::Duration::seconds(seconds)
-                + time::Duration::minutes(minutes)
-                + time::Duration::hours(hours)
-                + time::Duration::days(days)
-                + time::Duration::weeks(weeks),
-        )
+    ) -> StrResult<Duration> {
+        // The `time::Duration` constructors and additions multiply by the unit
+        // size and panic on overflow, so accumulate the total in seconds with
+        // checked arithmetic before handing it off.
+        let mut total = seconds;
+        for (value, factor) in
+            [(minutes, 60), (hours, 3_600), (days, 86_400), (weeks, 604_800)]
+        {
+            total = value
+                .checked_mul(factor)
+                .and_then(|v| total.checked_add(v))
+                .ok_or("duration is too large")?;
+        }
+        Ok(Duration::from(time::Duration::seconds(total)))
     }
 
     /// The duration expressed in seconds.

--- a/tests/suite/foundations/duration.typ
+++ b/tests/suite/foundations/duration.typ
@@ -116,3 +116,7 @@
 #test(duration(minutes: 20) < duration(minutes: 10), false)
 #test(duration(minutes: 20) <= duration(minutes: 10), false)
 #test(duration(minutes: 20) == duration(minutes: 10), false)
+
+--- duration-too-large eval ---
+// Error: 2-35 duration is too large
+#duration(weeks: 9999999999999999)


### PR DESCRIPTION
duration() builds its result via time::Duration::weeks/days/hours/minutes, which multiply by the unit size and panic through expect_opt! when the product overflows i64. So #duration(weeks: 9999999999999999) crashes the compiler instead of reporting an error. Accumulate the total in seconds with checked arithmetic and surface a too-large error like the calc functions do.