### PR TITLE
Rename `SyntaxNode::{text, into_text}` to `{leaf_text, full_text}`

### DIFF
--- a/crates/typst-eval/src/call.rs
+++ b/crates/typst-eval/src/call.rs
@@ -129,7 +129,7 @@ fn eval_math_call(vm: &mut Vm, math_call: ast::MathCall) -> SourceResult<Value> 
                     span,
                     "cannot call mutating methods in math";
                     hint: "try using code mode to call the method: `#{}`",
-                        math_call.to_untyped().clone().into_text();
+                        math_call.to_untyped().full_text();
                 );
             }
             eval_field_callee(
@@ -263,7 +263,6 @@ fn eval_field_callee<'a, 'b>(
         target.field(field, sink).at(field_span)?
     } else {
         // Otherwise we cannot call this field and produce an error.
-        let full_text = || access.clone().into_text();
         match target.field(field, sink) {
             // The field does exist.
             Ok(callee_value) => {
@@ -299,7 +298,7 @@ fn eval_field_callee<'a, 'b>(
                             in parentheses: `{}({})(..)`",
                         if in_math { "use code mode and " } else { "" },
                         if in_math { "#" } else { "" },
-                        full_text()
+                        access.full_text(),
                     ));
                 } else if in_math {
                     err.hint("try adding a space before the parentheses");
@@ -307,7 +306,7 @@ fn eval_field_callee<'a, 'b>(
                     err.hint(eco_format!(
                         "to access the `{field}` {}, remove the function arguments: `{}`",
                         if is_dict { "key" } else { "field" },
-                        full_text(),
+                        access.full_text(),
                     ));
                 }
                 if is_dict {
@@ -513,9 +512,8 @@ fn unparse_math_args(
                 body.push(expr.eval(vm)?.display().spanned(expr.span()));
             }
             ast::MathArgItem::Arg(ast::Arg::Named(named)) => {
-                let name = callee.to_untyped().clone().into_text();
-                let fixed =
-                    named.to_untyped().clone().into_text().replacen(":", "\\:", 1);
+                let name = callee.to_untyped().full_text();
+                let fixed = named.to_untyped().full_text().replacen(":", "\\:", 1);
                 errors.push(error!(
                     named.span(), "named-argument syntax can only be used with functions";
                     hint[callee.span()]: "`{name}` is not a function";
@@ -523,9 +521,8 @@ fn unparse_math_args(
                 ));
             }
             ast::MathArgItem::Arg(ast::Arg::Spread(spread)) => {
-                let name = callee.to_untyped().clone().into_text();
-                let fixed =
-                    spread.to_untyped().clone().into_text().replacen("..", ".. ", 1);
+                let name = callee.to_untyped().full_text();
+                let fixed = spread.to_untyped().full_text().replacen("..", ".. ", 1);
                 errors.push(error!(
                     spread.span(), "spread-argument syntax can only be used with functions";
                     hint[callee.span()]: "`{name}` is not a function";

--- a/crates/typst-eval/src/code.rs
+++ b/crates/typst-eval/src/code.rs
@@ -261,8 +261,7 @@ impl Eval for ast::Array<'_> {
                             ),
                         )) =>
                     {
-                        let fixed =
-                            self.to_untyped().clone().into_text().replacen("(", "(: ", 1);
+                        let fixed = self.to_untyped().full_text().replacen("(", "(: ", 1);
                         bail!(
                             spread.span(), "cannot spread {} into array", v.ty();
                             hint: "add a colon to create a dictionary instead: `{fixed}`";

--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -115,7 +115,9 @@ pub enum CompletionKind {
 fn complete_field_accesses(ctx: &mut CompletionContext) -> bool {
     let (after_dot, textual_dot) = match ctx.leaf.kind() {
         SyntaxKind::Dot => (true, false),
-        SyntaxKind::Text | SyntaxKind::MathText if ctx.leaf.text() == "." => (true, true),
+        SyntaxKind::Text | SyntaxKind::MathText if ctx.leaf.leaf_text() == "." => {
+            (true, true)
+        }
         _ => (false, false),
     };
 
@@ -240,7 +242,7 @@ fn field_access_completions(
 /// Complete half-finished labels.
 fn complete_open_labels(ctx: &mut CompletionContext) -> bool {
     // A label anywhere in code: "(<la|".
-    if ctx.leaf.kind().is_error() && ctx.leaf.text().starts_with('<') {
+    if ctx.leaf.kind().is_error() && ctx.leaf.leaf_text().starts_with('<') {
         ctx.from = ctx.leaf.offset() + 1;
         ctx.label_completions();
         return true;

--- a/crates/typst-ide/src/tooltip.rs
+++ b/crates/typst-ide/src/tooltip.rs
@@ -186,8 +186,10 @@ fn length_tooltip(length: Length) -> Option<Tooltip> {
 /// Tooltip for a hovered reference or label.
 fn label_tooltip(output: impl AsOutput, leaf: &LinkedNode) -> Option<Tooltip> {
     let target = match leaf.kind() {
-        SyntaxKind::RefMarker => leaf.text().trim_start_matches('@'),
-        SyntaxKind::Label => leaf.text().trim_start_matches('<').trim_end_matches('>'),
+        SyntaxKind::RefMarker => leaf.leaf_text().trim_start_matches('@'),
+        SyntaxKind::Label => {
+            leaf.leaf_text().trim_start_matches('<').trim_end_matches('>')
+        }
         _ => return None,
     };
 

--- a/crates/typst-library/src/foundations/decimal.rs
+++ b/crates/typst-library/src/foundations/decimal.rs
@@ -332,7 +332,7 @@ fn warn_on_float_literal(engine: &mut Engine, span: Span) -> Option<()> {
             "creating a decimal using imprecise float literal";
             hint: "use a string in the decimal constructor to avoid loss \
                    of precision: `decimal({})`",
-            node.text().repr();
+            node.leaf_text().repr();
         ));
     }
     Some(())

--- a/crates/typst-syntax/src/ast.rs
+++ b/crates/typst-syntax/src/ast.rs
@@ -203,7 +203,7 @@ node! {
 impl<'a> LineComment<'a> {
     /// The contents of the line comment.
     pub fn text(&self) -> &'a str {
-        let text = self.0.text();
+        let text = self.0.leaf_text();
         text.strip_prefix("//").unwrap_or(text)
     }
 }
@@ -216,7 +216,7 @@ node! {
 impl<'a> BlockComment<'a> {
     /// The contents of the block comment.
     pub fn text(&self) -> &'a str {
-        let text = self.0.text();
+        let text = self.0.leaf_text();
         text.strip_prefix("/*")
             .and_then(|text| text.strip_suffix("*/"))
             .unwrap_or(text)
@@ -586,7 +586,7 @@ node! {
 impl<'a> Text<'a> {
     /// Get the text.
     pub fn get(self) -> &'a EcoString {
-        self.0.text()
+        self.0.leaf_text()
     }
 }
 
@@ -614,7 +614,7 @@ node! {
 impl Escape<'_> {
     /// Get the escaped character.
     pub fn get(self) -> char {
-        let mut s = Scanner::new(self.0.text());
+        let mut s = Scanner::new(self.0.leaf_text());
         s.expect('\\');
         if s.eat_if("u{") {
             let hex = s.eat_while(char::is_ascii_hexdigit);
@@ -647,7 +647,7 @@ impl Shorthand<'_> {
 
     /// Get the shorthanded character.
     pub fn get(self) -> char {
-        let text = self.0.text();
+        let text = self.0.leaf_text();
         Self::LIST
             .iter()
             .find(|&&(s, _)| s == text)
@@ -663,7 +663,7 @@ node! {
 impl SmartQuote<'_> {
     /// Whether this is a double quote.
     pub fn double(self) -> bool {
-        self.0.text() == "\""
+        self.0.leaf_text() == "\""
     }
 }
 
@@ -719,7 +719,8 @@ impl<'a> Raw<'a> {
             .try_cast_first()
             .is_some_and(|delim: RawDelim| delim.0.len() >= 3)
             && self.0.children().any(|e| {
-                e.kind() == SyntaxKind::RawTrimmed && e.text().chars().any(is_newline)
+                e.kind() == SyntaxKind::RawTrimmed
+                    && e.leaf_text().chars().any(is_newline)
             })
     }
 }
@@ -732,7 +733,7 @@ node! {
 impl<'a> RawLang<'a> {
     /// Get the language tag.
     pub fn get(self) -> &'a EcoString {
-        self.0.text()
+        self.0.leaf_text()
     }
 }
 
@@ -749,7 +750,7 @@ node! {
 impl<'a> Link<'a> {
     /// Get the URL.
     pub fn get(self) -> &'a EcoString {
-        self.0.text()
+        self.0.leaf_text()
     }
 }
 
@@ -761,7 +762,7 @@ node! {
 impl<'a> Label<'a> {
     /// Get the label's text.
     pub fn get(self) -> &'a str {
-        self.0.text().trim_start_matches('<').trim_end_matches('>')
+        self.0.leaf_text().trim_start_matches('<').trim_end_matches('>')
     }
 }
 
@@ -778,7 +779,7 @@ impl<'a> Ref<'a> {
         self.0
             .children()
             .find(|node| node.kind() == SyntaxKind::RefMarker)
-            .map(|node| node.text().trim_start_matches('@'))
+            .map(|node| node.leaf_text().trim_start_matches('@'))
             .unwrap_or_default()
     }
 
@@ -830,7 +831,7 @@ impl<'a> EnumItem<'a> {
     /// The explicit numbering, if any: `23.`.
     pub fn number(self) -> Option<u64> {
         self.0.children().find_map(|node| match node.kind() {
-            SyntaxKind::EnumMarker => node.text().trim_end_matches('.').parse().ok(),
+            SyntaxKind::EnumMarker => node.leaf_text().trim_end_matches('.').parse().ok(),
             _ => Option::None,
         })
     }
@@ -914,7 +915,7 @@ pub enum MathTextKind<'a> {
 impl<'a> MathText<'a> {
     /// Return the underlying text.
     pub fn get(self) -> MathTextKind<'a> {
-        let text = self.0.text();
+        let text = self.0.leaf_text();
         if text.chars().next().unwrap_or_default().is_numeric() {
             // Numbers are potentially grouped as multiple characters. This is
             // done in `Lexer::math_text()`.
@@ -933,7 +934,7 @@ node! {
 impl<'a> MathIdent<'a> {
     /// Get the identifier.
     pub fn get(self) -> &'a EcoString {
-        self.0.text()
+        self.0.leaf_text()
     }
 
     /// Get the identifier as a string slice.
@@ -1049,7 +1050,7 @@ impl MathShorthand<'_> {
 
     /// Get the shorthanded character.
     pub fn get(self) -> char {
-        let text = self.0.text();
+        let text = self.0.leaf_text();
         Self::LIST
             .iter()
             .find(|&&(s, _)| s == text)
@@ -1244,7 +1245,7 @@ impl MathPrimes<'_> {
     /// The number of grouped primes.
     pub fn count(self) -> usize {
         // We can use byte length since single quotes are one byte.
-        self.0.text().len()
+        self.0.leaf_text().len()
     }
 }
 
@@ -1273,7 +1274,7 @@ node! {
 impl<'a> MathRoot<'a> {
     /// The index of the root.
     pub fn index(self) -> Option<u8> {
-        match self.0.children().next().map(|node| node.text().as_str()) {
+        match self.0.children().next().map(|node| node.leaf_text().as_str()) {
             Some("∜") => Some(4),
             Some("∛") => Some(3),
             Some("√") => Option::None,
@@ -1295,7 +1296,7 @@ node! {
 impl<'a> Ident<'a> {
     /// Get the identifier.
     pub fn get(self) -> &'a EcoString {
-        self.0.text()
+        self.0.leaf_text()
     }
 
     /// Get the identifier as a string slice.
@@ -1332,7 +1333,7 @@ node! {
 impl Bool<'_> {
     /// Get the boolean value.
     pub fn get(self) -> bool {
-        self.0.text() == "true"
+        self.0.leaf_text() == "true"
     }
 }
 
@@ -1344,7 +1345,7 @@ node! {
 impl Int<'_> {
     /// Get the integer value.
     pub fn get(self) -> i64 {
-        let text = self.0.text();
+        let text = self.0.leaf_text();
         if let Some(rest) = text.strip_prefix("0x") {
             i64::from_str_radix(rest, 16)
         } else if let Some(rest) = text.strip_prefix("0o") {
@@ -1366,7 +1367,7 @@ node! {
 impl Float<'_> {
     /// Get the floating-point value.
     pub fn get(self) -> f64 {
-        self.0.text().parse().unwrap_or_default()
+        self.0.leaf_text().parse().unwrap_or_default()
     }
 }
 
@@ -1378,7 +1379,7 @@ node! {
 impl Numeric<'_> {
     /// Get the numeric value and unit.
     pub fn get(self) -> (f64, Unit) {
-        let text = self.0.text();
+        let text = self.0.leaf_text();
         let count = text
             .chars()
             .rev()
@@ -1435,7 +1436,7 @@ node! {
 impl Str<'_> {
     /// Get the string value with resolved escape sequences.
     pub fn get(self) -> EcoString {
-        let text = self.0.text();
+        let text = self.0.leaf_text();
         let unquoted = &text[1..text.len() - 1];
         if !unquoted.contains('\\') {
             return unquoted.into();

--- a/crates/typst-syntax/src/highlight.rs
+++ b/crates/typst-syntax/src/highlight.rs
@@ -406,7 +406,7 @@ fn highlight_html_impl(html: &mut String, node: &LinkedNode) {
         html.push_str("\">");
     }
 
-    let text = node.text();
+    let text = node.leaf_text();
     if !text.is_empty() {
         for c in text.chars() {
             match c {

--- a/crates/typst-syntax/src/node.rs
+++ b/crates/typst-syntax/src/node.rs
@@ -244,7 +244,7 @@ impl SyntaxNode {
     /// The text of the node if it is a leaf or error node.
     ///
     /// Returns the empty string if this is an inner node.
-    pub fn text(&self) -> &EcoString {
+    pub fn leaf_text(&self) -> &EcoString {
         static EMPTY: EcoString = EcoString::new();
         match self.node_ref() {
             NodeRef::Leaf(text) => text,
@@ -253,14 +253,11 @@ impl SyntaxNode {
         }
     }
 
-    /// Extract the text from the node.
-    ///
-    /// Builds the string if this is an inner node.
-    pub fn into_text(self) -> EcoString {
-        // This isn't fully efficient for warnings, but the efficient
-        // version is more complicated to read/write due to partial moves.
-        match self.data {
-            Node::Leaf(text, _) => text,
+    /// Clone the full text from the node. If this is an inner node, it will
+    /// traverse the tree to build the text which may be expensive.
+    pub fn full_text(&self) -> EcoString {
+        match &self.data {
+            Node::Leaf(leaf, _) => leaf.clone(),
             Node::Error(err, _) => err.text.clone(),
             Node::Inner(_, _) | Node::Warning(_, _) => {
                 let mut buffer = EcoString::with_capacity(self.len());
@@ -471,7 +468,7 @@ impl SyntaxNode {
     /// Convert the child to an error, if it isn't already one.
     pub(super) fn convert_to_error(&mut self, message: impl Into<EcoString>) {
         if !self.kind().is_error() {
-            let text = std::mem::take(self).into_text();
+            let text = std::mem::take(self).full_text();
             *self = SyntaxNode::error(message.into(), text);
         }
     }
@@ -484,7 +481,7 @@ impl SyntaxNode {
         if kind.is_keyword() && matches!(expected, "identifier" | "pattern") {
             self.hint(eco_format!(
                 "keyword `{text}` is not allowed as an identifier; try `{text}_` instead",
-                text = self.text(),
+                text = self.leaf_text(),
             ));
         }
     }
@@ -993,7 +990,7 @@ impl Debug for WarningWrapper {
         let full_text = LazyCell::new(|| {
             let data = self.child.clone();
             let temp_node = SyntaxNode { data, span: Span::detached() };
-            temp_node.into_text()
+            temp_node.full_text()
         });
         let debug_field = |field, message, sub_range: Option<SubRange>| {
             // Inner closure has `move`, so need to explicitly capture by ref.
@@ -1583,17 +1580,17 @@ Markup: 9 [
         // Find "text" with Before.
         let node = LinkedNode::new(source.root()).leaf_at(7, Side::Before).unwrap();
         assert_eq!(node.offset(), 5);
-        assert_eq!(node.text(), "text");
+        assert_eq!(node.leaf_text(), "text");
 
         // Find "text" with After.
         let node = LinkedNode::new(source.root()).leaf_at(7, Side::After).unwrap();
         assert_eq!(node.offset(), 5);
-        assert_eq!(node.text(), "text");
+        assert_eq!(node.leaf_text(), "text");
 
         // Go back to "#set". Skips the space.
         let prev = node.prev_sibling().unwrap();
         assert_eq!(prev.offset(), 1);
-        assert_eq!(prev.text(), "set");
+        assert_eq!(prev.leaf_text(), "set");
     }
 
     #[test]
@@ -1601,24 +1598,24 @@ Markup: 9 [
         let source = Source::detached("#set fun(12pt, red)");
         let leaf = LinkedNode::new(source.root()).leaf_at(6, Side::Before).unwrap();
         let prev = leaf.prev_leaf().unwrap();
-        assert_eq!(leaf.text(), "fun");
-        assert_eq!(prev.text(), "set");
+        assert_eq!(leaf.leaf_text(), "fun");
+        assert_eq!(prev.leaf_text(), "set");
 
         // Check position 9 with Before.
         let source = Source::detached("#let x = 10");
         let leaf = LinkedNode::new(source.root()).leaf_at(9, Side::Before).unwrap();
         let prev = leaf.prev_leaf().unwrap();
         let next = leaf.next_leaf().unwrap();
-        assert_eq!(prev.text(), "=");
-        assert_eq!(leaf.text(), " ");
-        assert_eq!(next.text(), "10");
+        assert_eq!(prev.leaf_text(), "=");
+        assert_eq!(leaf.leaf_text(), " ");
+        assert_eq!(next.leaf_text(), "10");
 
         // Check position 9 with After.
         let source = Source::detached("#let x = 10");
         let leaf = LinkedNode::new(source.root()).leaf_at(9, Side::After).unwrap();
         let prev = leaf.prev_leaf().unwrap();
         assert!(leaf.next_leaf().is_none());
-        assert_eq!(prev.text(), "=");
-        assert_eq!(leaf.text(), "10");
+        assert_eq!(prev.leaf_text(), "=");
+        assert_eq!(leaf.leaf_text(), "10");
     }
 }

--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -1796,8 +1796,10 @@ impl<'s> Parser<'s> {
     fn wrap_error(&mut self, from: Marker, message: impl Into<EcoString>) {
         let to = self.before_trivia().0;
         let from = from.0.min(to);
-        let text: EcoString =
-            self.nodes.drain(from..to).map(SyntaxNode::into_text).collect();
+        let len: usize = self.nodes.drain(from..to).map(|node| node.len()).sum();
+        let end = self.token.prev_end;
+        let start = end - len;
+        let text = &self.text[start..end];
         self.nodes.insert(from, SyntaxNode::error(message.into(), text));
     }
 

--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -464,8 +464,8 @@ fn math_unparen(p: &mut Parser, m: Marker) {
     }
 
     if let [first, .., last] = node.children_mut()
-        && first.text() == "("
-        && last.text() == ")"
+        && first.leaf_text() == "("
+        && last.leaf_text() == ")"
     {
         first.convert_to_kind(SyntaxKind::LeftParen);
         last.convert_to_kind(SyntaxKind::RightParen);

--- a/crates/typst-syntax/src/reparser.rs
+++ b/crates/typst-syntax/src/reparser.rs
@@ -265,8 +265,8 @@ fn expand(node: &SyntaxNode) -> bool {
     kind.is_trivia()
         || kind.is_error()
         || kind == SyntaxKind::Semicolon
-        || node.text() == "/"
-        || node.text() == ":"
+        || node.leaf_text() == "/"
+        || node.leaf_text() == ":"
 }
 
 /// Whether `at_start` would still be true after this node given the
@@ -275,7 +275,7 @@ fn next_at_start(node: &SyntaxNode, at_start: &mut bool) {
     let kind = node.kind();
     if kind.is_trivia() {
         *at_start |= kind == SyntaxKind::Parbreak
-            || (kind == SyntaxKind::Space && node.text().chars().any(is_newline));
+            || (kind == SyntaxKind::Space && node.leaf_text().chars().any(is_newline));
     } else {
         *at_start = false;
     }
@@ -284,7 +284,7 @@ fn next_at_start(node: &SyntaxNode, at_start: &mut bool) {
 /// Update `nesting` based on the node.
 fn next_nesting(node: &SyntaxNode, nesting: &mut usize) {
     if node.kind() == SyntaxKind::Text {
-        match node.text().as_str() {
+        match node.leaf_text().as_str() {
             "[" => *nesting += 1,
             "]" if *nesting > 0 => *nesting -= 1,
             _ => {}


### PR DESCRIPTION
This was mentioned in https://github.com/typst/typst/pull/8188#discussion_r3233728925

I'm just renaming for now and changing `full_text` to use `&self` instead of `self`. I'll leave implementing some kind of `summarize` method for later (or someone else).