### PR TITLE
error instead of panic on out-of-range datetime arithmetic

### DIFF
--- a/crates/typst-library/src/foundations/datetime.rs
+++ b/crates/typst-library/src/foundations/datetime.rs
@@ -527,41 +527,57 @@ impl PartialOrd for Datetime {
 }
 
 impl Add<Duration> for Datetime {
-    type Output = Self;
+    type Output = StrResult<Self>;
 
     fn add(self, rhs: Duration) -> Self::Output {
         let rhs: time::Duration = rhs.into();
-        match self {
-            Self::Datetime(datetime) => Self::Datetime(datetime + rhs),
+        Ok(match self {
+            Self::Datetime(datetime) => {
+                Self::Datetime(datetime.checked_add(rhs).ok_or_else(out_of_range)?)
+            }
             Self::Date(date) => {
                 use time::Time;
-                match PrimitiveDateTime::new(date, Time::MIDNIGHT) + rhs {
+                let dt = PrimitiveDateTime::new(date, Time::MIDNIGHT)
+                    .checked_add(rhs)
+                    .ok_or_else(out_of_range)?;
+                match dt {
                     dt if dt.time() == Time::MIDNIGHT => Self::Date(dt.date()),
                     dt => Self::Datetime(dt),
                 }
             }
             Self::Time(time) => Self::Time(time + rhs),
-        }
+        })
     }
 }
 
 impl Sub<Duration> for Datetime {
-    type Output = Self;
+    type Output = StrResult<Self>;
 
     fn sub(self, rhs: Duration) -> Self::Output {
         let rhs: time::Duration = rhs.into();
-        match self {
-            Self::Datetime(datetime) => Self::Datetime(datetime - rhs),
+        Ok(match self {
+            Self::Datetime(datetime) => {
+                Self::Datetime(datetime.checked_sub(rhs).ok_or_else(out_of_range)?)
+            }
             Self::Date(date) => {
                 use time::Time;
-                match PrimitiveDateTime::new(date, Time::MIDNIGHT) - rhs {
+                let dt = PrimitiveDateTime::new(date, Time::MIDNIGHT)
+                    .checked_sub(rhs)
+                    .ok_or_else(out_of_range)?;
+                match dt {
                     dt if dt.time() == Time::MIDNIGHT => Self::Date(dt.date()),
                     dt => Self::Datetime(dt),
                 }
             }
             Self::Time(time) => Self::Time(time - rhs),
-        }
+        })
     }
+}
+
+/// The error message produced when datetime arithmetic leaves the range of
+/// representable dates.
+fn out_of_range() -> EcoString {
+    "the resulting datetime is outside the representable range".into()
 }
 
 impl Sub for Datetime {

--- a/crates/typst-library/src/foundations/ops.rs
+++ b/crates/typst-library/src/foundations/ops.rs
@@ -153,8 +153,8 @@ pub fn add(lhs: Value, rhs: Value) -> HintedStrResult<Value> {
         }
 
         (Duration(a), Duration(b)) => Duration(a + b),
-        (Datetime(a), Duration(b)) => Datetime(a + b),
-        (Duration(a), Datetime(b)) => Datetime(b + a),
+        (Datetime(a), Duration(b)) => Datetime((a + b)?),
+        (Duration(a), Datetime(b)) => Datetime((b + a)?),
 
         (Dyn(a), Dyn(b)) => {
             // Alignments can be summed.
@@ -208,7 +208,7 @@ pub fn sub(lhs: Value, rhs: Value) -> HintedStrResult<Value> {
         (Fraction(a), Fraction(b)) => Fraction(a - b),
 
         (Duration(a), Duration(b)) => Duration(a - b),
-        (Datetime(a), Duration(b)) => Datetime(a - b),
+        (Datetime(a), Duration(b)) => Datetime((a - b)?),
         (Datetime(a), Datetime(b)) => Duration((a - b)?),
 
         (a, b) => mismatch!("cannot subtract {1} from {0}", a, b),

--- a/tests/suite/foundations/datetime.typ
+++ b/tests/suite/foundations/datetime.typ
@@ -124,3 +124,11 @@
 --- datetime-display-insufficient-information eval ---
 // Error: 2-36 failed to format datetime (insufficient information)
 #datetime.today().display("[hour]")
+
+--- datetime-add-out-of-range eval ---
+// Error: 3-63 the resulting datetime is outside the representable range
+#(datetime(year: 9999, month: 12, day: 31) + duration(days: 1))
+
+--- datetime-sub-out-of-range eval ---
+// Error: 3-62 the resulting datetime is outside the representable range
+#(datetime(year: -9999, month: 1, day: 1) - duration(days: 1))


### PR DESCRIPTION
Noticed that adding a duration to a datetime goes straight to the time crate's `+`, which panics when the result leaves the representable date range. `datetime(year: 9999, month: 12, day: 31) + duration(days: 1)` takes down the whole compile. Switched the `Add`/`Sub` impls to `checked_add`/`checked_sub` returning a `StrResult`, matching how the datetime difference arm already reports errors.