### PR TITLE
Store required features in bindings

### DIFF
--- a/crates/typst-eval/src/call.rs
+++ b/crates/typst-eval/src/call.rs
@@ -5,8 +5,8 @@ use typst_library::diag::{
 };
 use typst_library::engine::{Engine, Sink, Traced};
 use typst_library::foundations::{
-    Arg, Args, Binding, Capturer, Closure, ClosureNode, Content, Context, Func,
-    NativeElement, Scope, Scopes, SequenceElem, SymbolElem, Value,
+    Arg, Args, Binding, BindingAccess, Capturer, Closure, ClosureNode, Content, Context,
+    Func, NativeElement, Scope, Scopes, SequenceElem, SymbolElem, Value,
 };
 use typst_library::introspection::Introspector;
 use typst_library::math::LrElem;
@@ -244,17 +244,26 @@ fn eval_field_callee<'a, 'b>(
     target: Value,
     in_math: bool,
 ) -> SourceResult<FieldCallee> {
-    let sink = (&mut vm.engine, field_span);
+    let sink = vm.engine.sink(field_span);
 
     let mut is_method_call = false;
     let callee_value = if let Some(method) = target.ty().scope().get(field) {
         is_method_call = true;
-        method.read_checked(sink).clone()
+        let ty = target.ty().short_name();
+        method
+            .read_checked(sink)
+            .what(format_args!("cannot call method `{field}` on value of type `{ty}`"))
+            .at(field_span)?
+            .clone()
     } else if let Value::Content(content) = &target
         && let Some(method) = content.elem().scope().get(field)
     {
         is_method_call = true;
-        method.read_checked(sink).clone()
+        method
+            .read_checked(sink)
+            .what(format_args!("cannot call method `{field}` on content"))
+            .at(field_span)?
+            .clone()
     } else if matches!(
         target,
         Value::Symbol(_) | Value::Func(_) | Value::Type(_) | Value::Module(_)

--- a/crates/typst-eval/src/code.rs
+++ b/crates/typst-eval/src/code.rs
@@ -2,8 +2,8 @@ use ecow::{EcoVec, eco_vec};
 use typst_library::diag::{At, SourceResult, bail, error, warning};
 use typst_library::engine::Engine;
 use typst_library::foundations::{
-    Array, Capturer, Closure, ClosureNode, Content, ContextElem, Dict, Func,
-    NativeElement, Selector, Str, Value, ops,
+    Array, BindingAccess, Capturer, Closure, ClosureNode, Content, ContextElem, Dict,
+    Func, NativeElement, Selector, Str, Value, ops,
 };
 use typst_library::introspection::{Counter, State};
 use typst_syntax::Span;
@@ -162,7 +162,9 @@ impl Eval for ast::Ident<'_> {
             .scopes
             .get(&self)
             .at(span)?
-            .read_checked((&mut vm.engine, span))
+            .read_checked(vm.engine.sink(span))
+            .what(format_args!("cannot access variable `{}`", self.get()))
+            .at(span)?
             .clone())
     }
 }
@@ -361,7 +363,7 @@ pub(crate) fn access_field(
     field: &str,
     field_span: Span,
 ) -> SourceResult<Value> {
-    let err = match target.field(field, (&mut vm.engine, field_span)).at(field_span) {
+    let err = match target.field(field, vm.engine.sink(field_span)).at(field_span) {
         Ok(value) => return Ok(value),
         Err(err) => err,
     };

--- a/crates/typst-eval/src/math.rs
+++ b/crates/typst-eval/src/math.rs
@@ -1,6 +1,8 @@
 use ecow::eco_format;
 use typst_library::diag::{At, SourceResult};
-use typst_library::foundations::{Content, NativeElement, Symbol, SymbolElem, Value};
+use typst_library::foundations::{
+    BindingAccess, Content, NativeElement, Symbol, SymbolElem, Value,
+};
 use typst_library::math::{
     AlignPointElem, AttachElem, EquationElem, FracElem, LrElem, PrimesElem, RootElem,
 };
@@ -51,7 +53,9 @@ impl Eval for ast::MathIdent<'_> {
             .scopes
             .get_in_math(&self)
             .at(span)?
-            .read_checked((&mut vm.engine, span))
+            .read_checked(vm.engine.sink(span))
+            .what(format_args!("cannot access variable `{}`", self.get()))
+            .at(span)?
             .clone())
     }
 }

--- a/crates/typst-html/src/encode.rs
+++ b/crates/typst-html/src/encode.rs
@@ -398,5 +398,13 @@ fn write_frame(w: &mut Writer, frame: &HtmlFrame) {
         &frame.anchors,
         w.link_resolver,
     );
-    w.buf.push_str(&svg);
+
+    // Indent the SVG after generation. This ensures the frame is cached no
+    // matter the current indentation of the outer HTML.
+    for (i, line) in svg.lines().enumerate() {
+        if i != 0 {
+            write_indent(w);
+        }
+        w.buf.push_str(line);
+    }
 }

--- a/crates/typst-html/src/rules.rs
+++ b/crates/typst-html/src/rules.rs
@@ -790,7 +790,7 @@ const IMAGE_RULE: ShowFn<ImageElem> = |elem, engine, styles| {
     attrs.push(attr::width, cast(image.width()));
     attrs.push(attr::height, cast(image.height()));
 
-    let mut css = css::Properties::build((engine, elem.span()));
+    let mut css = css::Properties::build(engine.sink(elem.span()));
 
     // TODO: Exclude in semantic profile.
     if let Some(value) = typst_svg::convert_image_scaling(image.scaling()) {

--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 use ecow::{EcoString, eco_format};
 use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
+use typst::diag::{BindingSink, HintedString, WarningSink};
 use typst::foundations::{
     AsOutput, AutoValue, CastInfo, Func, Label, NativeElement, NoneValue, Output,
     ParamInfo, Repr, StyleChain, Styles, Type, Value, fields_on, repr,
@@ -161,7 +162,7 @@ fn complete_field_accesses(ctx: &mut CompletionContext) -> bool {
 
 /// Add completions for all fields on a value.
 fn field_access_completions(
-    ctx: &mut CompletionContext,
+    mut ctx: &mut CompletionContext,
     value: &Value,
     styles: &Option<Styles>,
 ) {
@@ -195,9 +196,11 @@ fn field_access_completions(
         // Complete the field name along with its value. Notes:
         // 1. No parentheses since function fields cannot currently be called
         // with method syntax;
-        // 2. We can unwrap the field's value since it's a field belonging to
-        // this value's type, so accessing it should not fail.
-        ctx.value_completion(field, &value.field(field, ()).unwrap());
+        // 2. The field *should* be present on the value, but it maybe be
+        // feature gated, so accessing it may fail.
+        if let Ok(value) = value.field(field, &mut ctx) {
+            ctx.value_completion(field, &value);
+        }
     }
 
     match value {
@@ -1464,6 +1467,18 @@ impl<'a> CompletionContext<'a> {
                 self.value_completion_full(Some(name.clone()), value, parens, None, None);
             }
         }
+    }
+}
+
+impl BindingSink for CompletionContext<'_> {
+    fn features(&self) -> &typst::Features {
+        &self.world.library().features
+    }
+}
+
+impl WarningSink for CompletionContext<'_> {
+    fn emit(&mut self, _message: HintedString) {
+        // Just discard warnings when gathering completions.
     }
 }
 

--- a/crates/typst-library/src/diag.rs
+++ b/crates/typst-library/src/diag.rs
@@ -24,7 +24,7 @@ use utf8_iter::ErrorReportingUtf8Chars;
 
 use crate::engine::Engine;
 use crate::loading::{LoadSource, Loaded};
-use crate::{World, WorldExt};
+use crate::{Features, World, WorldExt};
 
 /// Early-return with an error for common result types used in Typst. If you
 /// need to interact with the produced errors more, consider using `error!` or
@@ -409,21 +409,51 @@ impl From<SyntaxDiagnostic> for SourceDiagnostic {
 }
 
 /// Destination for a warning message.
+pub trait BindingSink: WarningSink {
+    /// The features enabled in the current [`crate::Library`].
+    fn features(&self) -> &Features;
+}
+
+impl<T: BindingSink> BindingSink for &mut T {
+    fn features(&self) -> &Features {
+        T::features(self)
+    }
+}
+
+/// Destination for a warning message.
 pub trait WarningSink {
     /// Emits the message as a warning.
     fn emit(&mut self, message: HintedString);
+}
+
+impl<T: WarningSink> WarningSink for &mut T {
+    fn emit(&mut self, message: HintedString) {
+        T::emit(self, message);
+    }
 }
 
 impl WarningSink for () {
     fn emit(&mut self, _: HintedString) {}
 }
 
-impl WarningSink for (&mut Engine<'_>, Span) {
-    fn emit(&mut self, hinted: HintedString) {
-        self.0.sink.warn(
-            SourceDiagnostic::warning(self.1, hinted.message())
-                .with_hints(hinted.hints().iter().cloned()),
+/// A stuct that implements [`BindingSink`].
+pub struct EngineSink<'x, 'y> {
+    pub engine: &'x mut Engine<'y>,
+    pub span: Span,
+}
+
+impl WarningSink for EngineSink<'_, '_> {
+    fn emit(&mut self, message: HintedString) {
+        self.engine.sink.warn(
+            SourceDiagnostic::warning(self.span, message.message())
+                .with_hints(message.hints().iter().cloned()),
         );
+    }
+}
+
+impl BindingSink for EngineSink<'_, '_> {
+    fn features(&self) -> &Features {
+        &self.engine.library.features
     }
 }
 

--- a/crates/typst-library/src/engine.rs
+++ b/crates/typst-library/src/engine.rs
@@ -9,7 +9,9 @@ use rustc_hash::FxHashSet;
 use typst_syntax::{FileId, Span};
 use typst_utils::{LazyHash, Protected};
 
-use crate::diag::{HintedStrResult, SourceDiagnostic, SourceResult, StrResult, bail};
+use crate::diag::{
+    EngineSink, HintedStrResult, SourceDiagnostic, SourceResult, StrResult, bail,
+};
 use crate::foundations::{Styles, Value};
 use crate::introspection::{Introspect, Introspection, Introspector};
 use crate::{Library, World};
@@ -35,7 +37,7 @@ pub struct Engine<'a> {
     pub route: Route<'a>,
 }
 
-impl Engine<'_> {
+impl<'y> Engine<'y> {
     /// Handles a result without immediately terminating execution. Instead, it
     /// produces a delayed error that is only promoted to a fatal one if it
     /// remains by the end of the introspection loop.
@@ -114,6 +116,11 @@ impl Engine<'_> {
         let output = introspection.introspect(self, introspector);
         self.sink.introspection(Introspection::new(introspection));
         output
+    }
+
+    /// Create a struct that implements [`crate::diag::BindingSink`].
+    pub fn sink<'x>(&'x mut self, span: Span) -> EngineSink<'x, 'y> {
+        EngineSink { engine: self, span }
     }
 }
 

--- a/crates/typst-library/src/foundations/content/element.rs
+++ b/crates/typst-library/src/foundations/content/element.rs
@@ -81,6 +81,21 @@ impl Element {
         self.can_type_id(TypeId::of::<C>())
     }
 
+    /// Whether the element is locatable.
+    pub fn is_locatable(self) -> bool {
+        self.vtable().introspection.locatable
+    }
+
+    /// Whether the element is unqueriable.
+    pub fn is_unqueriable(self) -> bool {
+        self.vtable().introspection.unqueriable
+    }
+
+    /// Whether the element is tagged in PDF files.
+    pub fn is_tagged(self) -> bool {
+        self.vtable().introspection.tagged
+    }
+
     /// Whether the element has the given capability where the capability is
     /// given by a `TypeId`.
     pub fn can_type_id(self, type_id: TypeId) -> bool {

--- a/crates/typst-library/src/foundations/content/mod.rs
+++ b/crates/typst-library/src/foundations/content/mod.rs
@@ -7,7 +7,7 @@ mod vtable;
 pub use self::element::*;
 pub use self::field::*;
 pub use self::packed::Packed;
-pub use self::vtable::{ContentVtable, FieldVtable};
+pub use self::vtable::{ContentVtable, FieldVtable, IntrospectionCapabilities};
 #[doc(inline)]
 pub use typst_macros::elem;
 
@@ -278,6 +278,21 @@ impl Content {
         C: ?Sized + 'static,
     {
         self.elem().can::<C>()
+    }
+
+    /// Whether the contained element is locatable.
+    pub fn is_locatable(&self) -> bool {
+        self.elem().is_locatable()
+    }
+
+    /// Whether the contained element is unqueriable.
+    pub fn is_unqueriable(&self) -> bool {
+        self.elem().is_unqueriable()
+    }
+
+    /// Whether the contained element is tagged in PDF files.
+    pub fn is_tagged(&self) -> bool {
+        self.elem().is_tagged()
     }
 
     /// Cast to a trait object if the contained element has the given

--- a/crates/typst-library/src/foundations/content/vtable.rs
+++ b/crates/typst-library/src/foundations/content/vtable.rs
@@ -109,6 +109,8 @@ pub struct ContentVtable<T: 'static = RawContent> {
     /// pointer to a native Rust vtable of `Packed<Self>` w.r.t to the trait `C`
     /// where `capability` is `TypeId::of::<dyn C>()`.
     pub(super) capability: fn(capability: TypeId) -> Option<NonNull<()>>,
+    /// Introspection capabilities of the type.
+    pub(super) introspection: IntrospectionCapabilities,
 
     /// The `Drop` impl (for the whole raw content). The content must have a
     /// reference count of zero and may not be used anymore after `drop` was
@@ -147,6 +149,7 @@ impl ContentVtable {
         fields: &'static [FieldVtable<Packed<E>>],
         field_id: fn(name: &str) -> Option<u8>,
         capability: fn(TypeId) -> Option<NonNull<()>>,
+        introspection: IntrospectionCapabilities,
         store: fn() -> &'static LazyElementStore,
     ) -> ContentVtable<Packed<E>> {
         ContentVtable {
@@ -162,6 +165,7 @@ impl ContentVtable {
             local_name: None,
             scope: || Scope::new(),
             capability,
+            introspection,
             drop: RawContent::drop_impl::<E>,
             clone: RawContent::clone_impl::<E>,
             hash: |elem| typst_utils::hash128(elem.as_ref()),
@@ -305,6 +309,16 @@ impl ContentHandle<(&RawContent, &RawContent)> {
         let (a, b) = self.0;
         unsafe { self.1.eq.map(|f| f(a, b)) }
     }
+}
+
+/// A set of introspection capabilties available for the element.
+pub struct IntrospectionCapabilities {
+    /// Makes an element available in the introspector.
+    pub locatable: bool,
+    /// Marks an element as not queriable for the user.
+    pub unqueriable: bool,
+    /// Marks an element as tagged in PDF files.
+    pub tagged: bool,
 }
 
 /// A vtable for performing field-specific actions on type-erased

--- a/crates/typst-library/src/foundations/context.rs
+++ b/crates/typst-library/src/foundations/context.rs
@@ -5,7 +5,7 @@ use crate::engine::Engine;
 use crate::foundations::{
     Args, Construct, Content, Func, ShowFn, StyleChain, Value, elem,
 };
-use crate::introspection::{Locatable, Location};
+use crate::introspection::Location;
 
 /// Data that is contextually made available to code.
 ///

--- a/crates/typst-library/src/foundations/func.rs
+++ b/crates/typst-library/src/foundations/func.rs
@@ -11,11 +11,11 @@ use either::Either;
 use typst_syntax::{Span, Spanned, SyntaxNode, ast};
 use typst_utils::{DefSite, LazyHash, Static, singleton};
 
-use crate::diag::{At, SourceResult, StrResult, WarningSink, bail};
+use crate::diag::{At, BindingSink, SourceResult, StrResult, bail};
 use crate::engine::Engine;
 use crate::foundations::{
-    Args, Bytes, CastInfo, Content, Context, Element, IntoArgs, PluginFunc, Repr, Scope,
-    Selector, Type, Value, cast, scope, ty,
+    Args, BindingAccess, Bytes, CastInfo, Content, Context, Element, IntoArgs,
+    PluginFunc, Repr, Scope, Selector, Type, Value, cast, scope, ty,
 };
 
 /// A mapping from argument values to a return value.
@@ -280,12 +280,14 @@ impl Func {
     pub fn field(
         &self,
         field: &str,
-        sink: impl WarningSink,
+        sink: impl BindingSink,
     ) -> StrResult<&'static Value> {
         let scope =
             self.scope().ok_or("cannot access fields on user-defined functions")?;
         match scope.get(field) {
-            Some(binding) => Ok(binding.read_checked(sink)),
+            Some(binding) => binding
+                .read_checked(sink)
+                .what(format_args!("cannot access field `{field}`")),
             None => match self.name() {
                 Some(name) => bail!("function `{name}` does not contain field `{field}`"),
                 None => bail!("function does not contain field `{field}`"),

--- a/crates/typst-library/src/foundations/module.rs
+++ b/crates/typst-library/src/foundations/module.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use ecow::{EcoString, eco_format};
 use typst_syntax::FileId;
 
-use crate::diag::{StrResult, WarningSink, bail};
-use crate::foundations::{Content, Repr, Scope, Value, ty};
+use crate::diag::{BindingSink, StrResult, bail};
+use crate::foundations::{BindingAccess, Content, Repr, Scope, Value, ty};
 
 /// A collection of variables and functions that are commonly related to a
 /// single theme.
@@ -136,9 +136,11 @@ impl Module {
     }
 
     /// Try to access a definition in the module.
-    pub fn field(&self, field: &str, sink: impl WarningSink) -> StrResult<&Value> {
+    pub fn field(&self, field: &str, sink: impl BindingSink) -> StrResult<&Value> {
         match self.scope().get(field) {
-            Some(binding) => Ok(binding.read_checked(sink)),
+            Some(binding) => binding
+                .read_checked(sink)
+                .what(format_args!("cannot access field `{field}`")),
             None => match &self.name {
                 Some(name) => bail!("module `{name}` does not contain `{field}`"),
                 None => bail!("module does not contain `{field}`"),

--- a/crates/typst-library/src/foundations/scope.rs
+++ b/crates/typst-library/src/foundations/scope.rs
@@ -1,10 +1,12 @@
 use std::fmt::{self, Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};
+use std::num::NonZeroU16;
+use std::sync::{LazyLock, RwLock};
 
 use ecow::{EcoString, eco_format};
 use indexmap::IndexMap;
 use indexmap::map::Entry;
-use rustc_hash::FxBuildHasher;
+use rustc_hash::{FxBuildHasher, FxHashMap};
 use typst_syntax::Span;
 
 use crate::diag::{BindingSink, HintedStrResult, HintedString, StrResult, bail};
@@ -253,11 +255,21 @@ pub struct Binding {
     /// A span associated with the binding.
     span: Span,
     /// The category of the binding.
+    ///
+    /// This lives on the binding directly and not in the [`BindingInfo`],
+    /// because it is automatically set during definition, currently doesn't
+    /// increase the size of the binding, and would require re-interning the
+    /// information when other properties are set.
     category: Option<Category>,
-    /// A feature required to access this binding.
-    feature: Option<Feature>,
-    /// The deprecation information if this item is deprecated.
-    deprecation: Option<Box<Deprecation>>,
+    /// Whether this binding has additional checks that should be performed
+    /// before accessing it. This boolean is just an optimization, so the happy
+    /// path stays fast. The concrete checks are performed on the properties of
+    /// additional binding information in [`Self::info`].
+    check_access: bool,
+    /// Infrequently accessed properties of the binding that are stored out of
+    /// band. These should only ever be set for built-in bindings in the
+    /// standard library.
+    info: Option<InfoId>,
 }
 
 /// The different kinds of slots.
@@ -277,8 +289,8 @@ impl Binding {
             span,
             kind: BindingKind::Normal,
             category: None,
-            feature: None,
-            deprecation: None,
+            check_access: false,
+            info: None,
         }
     }
 
@@ -287,15 +299,12 @@ impl Binding {
         Self::new(value, Span::detached())
     }
 
-    /// Gates this binding behind the given [`Feature`].
-    pub fn feature(&mut self, feature: Feature) -> &mut Self {
-        self.feature = Some(feature);
-        self
-    }
-
-    /// Marks this binding as deprecated, with the given `message`.
-    pub fn deprecated(&mut self, deprecation: Deprecation) -> &mut Self {
-        self.deprecation = Some(Box::new(deprecation));
+    /// Add more information to this binding.
+    pub fn with_info(&mut self, info: BindingInfo) -> &mut Self {
+        if !info.is_empty() {
+            self.check_access = info.has_checked_access();
+            self.info = Some(InfoId::new(info));
+        }
         self
     }
 
@@ -309,19 +318,28 @@ impl Binding {
     /// As the `sink`
     /// - pass `()` to ignore the message.
     /// - pass `(&mut engine, span)` to emit a warning into the engine.
-    pub fn read_checked(
-        &self,
-        mut sink: impl BindingSink,
-    ) -> Result<&Value, FeatureError> {
-        if let Some(feature) = self.feature
+    pub fn read_checked(&self, sink: impl BindingSink) -> Result<&Value, FeatureError> {
+        if self.check_access {
+            self.check_access(sink)?;
+        }
+        Ok(&self.value)
+    }
+
+    #[cold]
+    fn check_access(&self, mut sink: impl BindingSink) -> Result<(), FeatureError> {
+        let Some(info) = self.info() else { return Ok(()) };
+
+        if let Some(feature) = info.feature
             && !sink.features().is_enabled(feature)
         {
             return Err(FeatureError(feature));
         }
-        if let Some(message) = &self.deprecation {
-            sink.emit((**message).into());
+
+        if let Some(message) = info.deprecation {
+            sink.emit(message.into());
         }
-        Ok(&self.value)
+
+        Ok(())
     }
 
     /// Try to write to the value.
@@ -354,14 +372,108 @@ impl Binding {
         self.span
     }
 
-    /// A deprecation message for the value, if any.
-    pub fn deprecation(&self) -> Option<&Deprecation> {
-        self.deprecation.as_deref()
-    }
-
     /// The category of the value, if any.
     pub fn category(&self) -> Option<Category> {
         self.category
+    }
+
+    /// Get additional information about this binding.
+    pub fn info(&self) -> Option<&BindingInfo> {
+        Some(self.info?.get())
+    }
+}
+
+/// The global interner for rooted paths.
+static INTERNER: LazyLock<RwLock<Interner>> = LazyLock::new(|| {
+    RwLock::new(Interner { to_id: FxHashMap::default(), from_id: Vec::new() })
+});
+
+/// An interner for rooted paths.
+struct Interner {
+    to_id: FxHashMap<&'static BindingInfo, InfoId>,
+    from_id: Vec<&'static BindingInfo>,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
+struct InfoId(NonZeroU16);
+
+impl InfoId {
+    /// Create new interned binding information.
+    fn new(info: BindingInfo) -> Self {
+        // Try to find an existing entry that we can reuse.
+        //
+        // We could check with just a read lock, but if the pair is not yet
+        // present, we would then need to recheck after acquiring a write lock,
+        // which is probably not worth it.
+        let mut interner = INTERNER.write().unwrap();
+        if let Some(&id) = interner.to_id.get(&info) {
+            return id;
+        }
+
+        // Create a new entry forever by leaking the pair. We can't leak more
+        // than 2^16 pair (and typically will leak a lot less), so its not a
+        // big deal.
+        let num = u16::try_from(interner.from_id.len() + 1)
+            .and_then(NonZeroU16::try_from)
+            .expect("out of file ids");
+
+        let id = InfoId(num);
+        let leaked = Box::leak(Box::new(info));
+        interner.to_id.insert(leaked, id);
+        interner.from_id.push(leaked);
+        id
+    }
+
+    fn get(self) -> &'static BindingInfo {
+        INTERNER.read().unwrap().from_id[usize::from(self.0.get() - 1)]
+    }
+}
+
+impl Debug for InfoId {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        self.get().fmt(f)
+    }
+}
+
+/// Infrequently accessed information related to a binding.
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Hash)]
+pub struct BindingInfo {
+    /// A feature required to access this binding.
+    pub feature: Option<Feature>,
+    /// The deprecation information if this item is deprecated.
+    pub deprecation: Option<Deprecation>,
+}
+
+impl BindingInfo {
+    /// Empty binding information.
+    pub const EMPTY: Self = Self { feature: None, deprecation: None };
+
+    /// Create new empty binding information.
+    pub const fn new() -> Self {
+        Self::EMPTY
+    }
+
+    /// Whether this binding is empty.
+    pub fn is_empty(self) -> bool {
+        self == Self::EMPTY
+    }
+
+    /// Whether the binding info has a property set that requires checking
+    /// it when it's accessed.
+    pub fn has_checked_access(self) -> bool {
+        self.feature.is_some() || self.deprecation.is_some()
+    }
+
+    /// Gates this binding behind the given [`Feature`].
+    pub fn feature(mut self, feature: Feature) -> Self {
+        self.feature = Some(feature);
+        self
+    }
+
+    /// Marks this binding as deprecated, with the given `message`.
+    pub fn deprecated(mut self, deprecation: Deprecation) -> Self {
+        self.deprecation = Some(deprecation);
+        self
     }
 }
 

--- a/crates/typst-library/src/foundations/scope.rs
+++ b/crates/typst-library/src/foundations/scope.rs
@@ -1,4 +1,4 @@
-use std::fmt::{self, Debug, Formatter};
+use std::fmt::{self, Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};
 
 use ecow::{EcoString, eco_format};
@@ -7,11 +7,11 @@ use indexmap::map::Entry;
 use rustc_hash::FxBuildHasher;
 use typst_syntax::Span;
 
-use crate::diag::{HintedStrResult, HintedString, StrResult, WarningSink, bail};
+use crate::diag::{BindingSink, HintedStrResult, HintedString, StrResult, bail};
 use crate::foundations::{
     Func, IntoValue, NativeElement, NativeFunc, NativeFuncData, NativeType, Value,
 };
-use crate::{Category, Library};
+use crate::{Category, Feature, Library};
 
 /// A stack of scopes.
 #[derive(Debug, Default, Clone)]
@@ -254,6 +254,8 @@ pub struct Binding {
     span: Span,
     /// The category of the binding.
     category: Option<Category>,
+    /// A feature required to access this binding.
+    feature: Option<Feature>,
     /// The deprecation information if this item is deprecated.
     deprecation: Option<Box<Deprecation>>,
 }
@@ -275,6 +277,7 @@ impl Binding {
             span,
             kind: BindingKind::Normal,
             category: None,
+            feature: None,
             deprecation: None,
         }
     }
@@ -282,6 +285,12 @@ impl Binding {
     /// Create a binding without a span.
     pub fn detached(value: impl IntoValue) -> Self {
         Self::new(value, Span::detached())
+    }
+
+    /// Gates this binding behind the given [`Feature`].
+    pub fn feature(&mut self, feature: Feature) -> &mut Self {
+        self.feature = Some(feature);
+        self
     }
 
     /// Marks this binding as deprecated, with the given `message`.
@@ -300,11 +309,19 @@ impl Binding {
     /// As the `sink`
     /// - pass `()` to ignore the message.
     /// - pass `(&mut engine, span)` to emit a warning into the engine.
-    pub fn read_checked(&self, mut sink: impl WarningSink) -> &Value {
+    pub fn read_checked(
+        &self,
+        mut sink: impl BindingSink,
+    ) -> Result<&Value, FeatureError> {
+        if let Some(feature) = self.feature
+            && !sink.features().is_enabled(feature)
+        {
+            return Err(FeatureError(feature));
+        }
         if let Some(message) = &self.deprecation {
             sink.emit((**message).into());
         }
-        &self.value
+        Ok(&self.value)
     }
 
     /// Try to write to the value.
@@ -345,6 +362,24 @@ impl Binding {
     /// The category of the value, if any.
     pub fn category(&self) -> Option<Category> {
         self.category
+    }
+}
+
+/// A binding has been accessed but the feature that gates it isn't enabled.
+pub struct FeatureError(Feature);
+
+pub trait BindingAccess<T> {
+    fn what(self, binding: impl Display) -> StrResult<T>;
+}
+
+impl<T> BindingAccess<T> for Result<T, FeatureError> {
+    fn what(self, what: impl Display) -> StrResult<T> {
+        match self {
+            Ok(val) => Ok(val),
+            Err(FeatureError(feature)) => {
+                bail!("{what} because the `{feature}` feature is not enabled")
+            }
+        }
     }
 }
 

--- a/crates/typst-library/src/foundations/selector.rs
+++ b/crates/typst-library/src/foundations/selector.rs
@@ -12,7 +12,7 @@ use crate::foundations::{
     CastInfo, Content, Context, Dict, Element, FromValue, Func, Label, Reflect, Regex,
     Repr, Str, StyleChain, Symbol, Type, Value, cast, func, repr, scope, ty,
 };
-use crate::introspection::{Locatable, Location, QueryUniqueIntrospection, Unqueriable};
+use crate::introspection::{Location, QueryUniqueIntrospection};
 
 /// A helper macro to create a field selector used in [`Selector::Elem`]
 #[macro_export]
@@ -423,7 +423,7 @@ impl FromValue for LocatableSelector {
         fn validate(selector: &Selector) -> StrResult<()> {
             match selector {
                 Selector::Elem(elem, _) => {
-                    if !elem.can::<dyn Locatable>() || elem.can::<dyn Unqueriable>() {
+                    if !elem.is_locatable() || elem.is_unqueriable() {
                         Err(eco_format!("{} is not locatable", elem.name()))?
                     }
                 }

--- a/crates/typst-library/src/foundations/ty.rs
+++ b/crates/typst-library/src/foundations/ty.rs
@@ -8,9 +8,10 @@ use std::sync::LazyLock;
 use ecow::{EcoString, eco_format};
 use typst_utils::{DefSite, Static};
 
-use crate::diag::{StrResult, WarningSink, bail};
+use crate::diag::{BindingSink, StrResult, bail};
 use crate::foundations::{
-    AutoValue, Func, NativeFuncData, NoneValue, Repr, Scope, Value, cast, func,
+    AutoValue, BindingAccess, Func, NativeFuncData, NoneValue, Repr, Scope, Value, cast,
+    func,
 };
 
 /// Describes a kind of value.
@@ -118,10 +119,12 @@ impl Type {
     pub fn field(
         &self,
         field: &str,
-        sink: impl WarningSink,
+        sink: impl BindingSink,
     ) -> StrResult<&'static Value> {
         match self.scope().get(field) {
-            Some(binding) => Ok(binding.read_checked(sink)),
+            Some(binding) => binding
+                .read_checked(sink)
+                .what(format_args!("cannot access field `{field}` of type `{self}`")),
             None => bail!("type {self} does not contain field `{field}`"),
         }
     }

--- a/crates/typst-library/src/foundations/value.rs
+++ b/crates/typst-library/src/foundations/value.rs
@@ -10,7 +10,7 @@ use serde::de::{Error, MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use typst_syntax::{Span, ast};
 
-use crate::diag::{HintedStrResult, HintedString, StrResult, WarningSink};
+use crate::diag::{BindingSink, HintedStrResult, HintedString, StrResult};
 use crate::foundations::{
     Args, Array, AutoValue, Bytes, CastInfo, Content, Datetime, Decimal, Dict, Duration,
     Fold, FromValue, Func, IntoValue, Label, Module, NativeElement, NativeType,
@@ -154,7 +154,7 @@ impl Value {
     }
 
     /// Try to access a field on the value.
-    pub fn field(&self, field: &str, sink: impl WarningSink) -> StrResult<Value> {
+    pub fn field(&self, field: &str, sink: impl BindingSink) -> StrResult<Value> {
         match self {
             Self::Symbol(symbol) => {
                 symbol.clone().modified(sink, field).map(Self::Symbol)

--- a/crates/typst-library/src/introspection/counter.rs
+++ b/crates/typst-library/src/introspection/counter.rs
@@ -17,8 +17,7 @@ use crate::foundations::{
     StyleChain, Value, cast, elem, func, scope, select_where, ty,
 };
 use crate::introspection::{
-    History, Introspect, Introspector, Locatable, Location, QueryFirstIntrospection, Tag,
-    Unqueriable,
+    History, Introspect, Introspector, Location, QueryFirstIntrospection, Tag,
 };
 use crate::layout::{Frame, FrameItem, PageElem};
 use crate::math::EquationElem;

--- a/crates/typst-library/src/introspection/location.rs
+++ b/crates/typst-library/src/introspection/location.rs
@@ -15,15 +15,6 @@ use crate::introspection::{
 use crate::layout::Abs;
 use crate::model::Numbering;
 
-/// Makes an element available in the introspector.
-pub trait Locatable {}
-
-/// Marks an element as not queriable for the user.
-pub trait Unqueriable: Locatable {}
-
-/// Marks an element as tagged in PDF files.
-pub trait Tagged {}
-
 /// Identifies an element in the document.
 ///
 /// A location uniquely identifies an element in the document and lets you

--- a/crates/typst-library/src/introspection/metadata.rs
+++ b/crates/typst-library/src/introspection/metadata.rs
@@ -1,5 +1,4 @@
 use crate::foundations::{Value, elem};
-use crate::introspection::Locatable;
 
 /// Exposes a value to the query system without producing visible content.
 ///

--- a/crates/typst-library/src/introspection/state.rs
+++ b/crates/typst-library/src/introspection/state.rs
@@ -9,7 +9,7 @@ use crate::foundations::{
     Args, Construct, Content, Context, Func, LocatableSelector, NativeElement, Repr,
     Selector, Str, Value, cast, elem, func, scope, select_where, ty,
 };
-use crate::introspection::{History, Introspect, Introspector, Locatable, Location};
+use crate::introspection::{History, Introspect, Introspector, Location};
 use crate::{Library, World};
 
 /// Manages stateful parts of your document.

--- a/crates/typst-library/src/introspection/tag.rs
+++ b/crates/typst-library/src/introspection/tag.rs
@@ -47,10 +47,10 @@ impl Debug for Tag {
 pub struct TagFlags {
     /// Whether the element will be inserted into the
     /// [`Introspector`](super::Introspector).
-    /// Either because it is [`Locatable`](super::Locatable), has been labelled,
-    /// or a location has been manually set.
+    /// Either because it is `Locatable`, has been labelled, or a location has
+    /// been manually set.
     pub introspectable: bool,
-    /// Whether the element is [`Tagged`](super::Tagged).
+    /// Whether the element is `Tagged`.
     pub tagged: bool,
 }
 

--- a/crates/typst-library/src/layout/grid/mod.rs
+++ b/crates/typst-library/src/layout/grid/mod.rs
@@ -13,7 +13,6 @@ use crate::foundations::{
     Array, CastInfo, Content, Context, Fold, FromValue, Func, IntoValue, Packed, Reflect,
     Resolve, Smart, StyleChain, Synthesize, Value, cast, elem, scope,
 };
-use crate::introspection::Tagged;
 use crate::layout::resolve::{CellGrid, grid_to_cellgrid};
 use crate::layout::{
     Alignment, Length, OuterHAlignment, OuterVAlignment, Rel, Sides, Sizing,

--- a/crates/typst-library/src/layout/hide.rs
+++ b/crates/typst-library/src/layout/hide.rs
@@ -1,5 +1,4 @@
 use crate::foundations::{Content, elem};
-use crate::introspection::Tagged;
 
 /// Hides content without affecting layout.
 ///

--- a/crates/typst-library/src/layout/layout.rs
+++ b/crates/typst-library/src/layout/layout.rs
@@ -1,7 +1,6 @@
 use typst_syntax::Span;
 
 use crate::foundations::{Content, Func, NativeElement, elem, func};
-use crate::introspection::Locatable;
 
 /// Provides access to the current outer container's (or page's, if none)
 /// dimensions (width and height).

--- a/crates/typst-library/src/layout/place.rs
+++ b/crates/typst-library/src/layout/place.rs
@@ -1,5 +1,4 @@
 use crate::foundations::{Cast, Content, Smart, elem, scope};
-use crate::introspection::{Locatable, Tagged, Unqueriable};
 use crate::layout::{Alignment, Em, Length, Rel};
 
 /// Places content relatively to its parent container.

--- a/crates/typst-library/src/layout/repeat.rs
+++ b/crates/typst-library/src/layout/repeat.rs
@@ -1,5 +1,4 @@
 use crate::foundations::{Content, elem};
-use crate::introspection::Tagged;
 use crate::layout::Length;
 
 /// Repeats content to the available space.

--- a/crates/typst-library/src/lib.rs
+++ b/crates/typst-library/src/lib.rs
@@ -35,7 +35,8 @@ use typst_utils::{LazyHash, SmallBitSet};
 
 use crate::diag::FileResult;
 use crate::foundations::{
-    Array, Binding, Bytes, Datetime, Dict, Duration, Module, NativeRuleMap, Scope, Styles,
+    Array, Binding, BindingInfo, Bytes, Datetime, Dict, Duration, Module, NativeRuleMap,
+    Scope, Styles,
 };
 use crate::layout::{Alignment, Dir};
 use crate::routines::Routines;
@@ -351,7 +352,9 @@ fn global(routines: &Routines, math: Module, inputs: Dict) -> Module {
 
     global.define("math", math);
     global.define("pdf", self::pdf::module());
-    global.define("html", (routines.html_module)()).feature(Feature::Html);
+    global
+        .define("html", (routines.html_module)())
+        .with_info(BindingInfo::new().feature(Feature::Html));
 
     prelude(&mut global);
 

--- a/crates/typst-library/src/lib.rs
+++ b/crates/typst-library/src/lib.rs
@@ -26,6 +26,7 @@ pub mod symbols;
 pub mod text;
 pub mod visualize;
 
+use std::fmt::Display;
 use std::ops::{Deref, Range};
 
 use serde::{Deserialize, Serialize};
@@ -221,7 +222,7 @@ impl LibraryBuilder {
     pub fn build(self) -> Library {
         let math = math::module();
         let inputs = self.inputs.unwrap_or_default();
-        let global = global(self.routines, math.clone(), inputs, &self.features);
+        let global = global(self.routines, math.clone(), inputs);
         Library {
             routines: self.routines,
             global: global.clone(),
@@ -283,6 +284,16 @@ impl Feature {
     }
 }
 
+impl Display for Feature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Feature::Html => "html",
+            Feature::Bundle => "bundle",
+            Feature::A11yExtras => "a11y-extras",
+        })
+    }
+}
+
 /// A group of related standard library definitions.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -326,16 +337,11 @@ impl Category {
 }
 
 /// Construct the module with global definitions.
-fn global(
-    routines: &Routines,
-    math: Module,
-    inputs: Dict,
-    features: &Features,
-) -> Module {
+fn global(routines: &Routines, math: Module, inputs: Dict) -> Module {
     let mut global = Scope::deduplicating();
 
     self::foundations::define(&mut global, inputs);
-    self::model::define(&mut global, features);
+    self::model::define(&mut global);
     self::text::define(&mut global);
     self::layout::define(&mut global);
     self::visualize::define(&mut global);
@@ -344,10 +350,8 @@ fn global(
     self::symbols::define(&mut global);
 
     global.define("math", math);
-    global.define("pdf", self::pdf::module(features));
-    if features.is_enabled(Feature::Html) {
-        global.define("html", (routines.html_module)());
-    }
+    global.define("pdf", self::pdf::module());
+    global.define("html", (routines.html_module)()).feature(Feature::Html);
 
     prelude(&mut global);
 

--- a/crates/typst-library/src/math/equation.rs
+++ b/crates/typst-library/src/math/equation.rs
@@ -9,7 +9,7 @@ use crate::engine::Engine;
 use crate::foundations::{
     Content, NativeElement, Packed, ShowSet, Smart, StyleChain, Styles, Synthesize, elem,
 };
-use crate::introspection::{Count, Counter, CounterUpdate, Locatable, Tagged};
+use crate::introspection::{Count, Counter, CounterUpdate};
 use crate::layout::{
     AlignElem, Alignment, BlockElem, OuterHAlignment, SpecificAlignment, VAlignment,
 };

--- a/crates/typst-library/src/model/asset.rs
+++ b/crates/typst-library/src/model/asset.rs
@@ -2,7 +2,6 @@ use typst_macros::elem;
 
 use crate::diag::bail;
 use crate::foundations::{BundlePath, Bytes, ShowFn, Str, cast};
-use crate::introspection::Locatable;
 
 /// Adds a custom file to a bundle.
 ///

--- a/crates/typst-library/src/model/bibliography.rs
+++ b/crates/typst-library/src/model/bibliography.rs
@@ -32,8 +32,7 @@ use crate::foundations::{
     Selector, ShowSet, Smart, StyleChain, Styles, Synthesize, Value, elem,
 };
 use crate::introspection::{
-    EmptyIntrospector, History, Introspect, Introspector, Locatable, Location,
-    QueryIntrospection,
+    EmptyIntrospector, History, Introspect, Introspector, Location, QueryIntrospection,
 };
 use crate::layout::{BlockElem, Em, HElem, PadElem};
 use crate::loading::{DataSource, Load, LoadSource, Loaded, format_yaml_error};

--- a/crates/typst-library/src/model/cite.rs
+++ b/crates/typst-library/src/model/cite.rs
@@ -5,7 +5,6 @@ use crate::engine::Engine;
 use crate::foundations::{
     Cast, Content, Derived, Label, Packed, Smart, StyleChain, Synthesize, cast, elem,
 };
-use crate::introspection::Locatable;
 use crate::model::bibliography::Works;
 use crate::model::{CslSource, CslStyle};
 use crate::text::{Lang, Region, TextElem};

--- a/crates/typst-library/src/model/document.rs
+++ b/crates/typst-library/src/model/document.rs
@@ -6,7 +6,6 @@ use crate::foundations::{
     Array, BundlePath, Cast, Content, Datetime, OneOrMultiple, Packed, ShowFn, ShowSet,
     Smart, StyleChain, Styles, Target, Value, cast, elem,
 };
-use crate::introspection::Locatable;
 use crate::text::{Locale, TextElem};
 
 /// Manages metadata and is used to add a document file to a bundle.

--- a/crates/typst-library/src/model/emph.rs
+++ b/crates/typst-library/src/model/emph.rs
@@ -1,5 +1,4 @@
 use crate::foundations::{Content, elem};
-use crate::introspection::{Locatable, Tagged};
 
 /// Emphasizes content by toggling italics.
 ///

--- a/crates/typst-library/src/model/enum.rs
+++ b/crates/typst-library/src/model/enum.rs
@@ -6,7 +6,6 @@ use crate::diag::{bail, warning};
 use crate::foundations::{
     Array, Content, Packed, Reflect, Smart, Styles, cast, elem, scope,
 };
-use crate::introspection::{Locatable, Tagged};
 use crate::layout::{Alignment, Em, HAlignment, Length};
 use crate::model::{ListItemLike, ListLike, Numbering, NumberingPattern};
 

--- a/crates/typst-library/src/model/figure.rs
+++ b/crates/typst-library/src/model/figure.rs
@@ -11,9 +11,7 @@ use crate::foundations::{
     Content, Element, NativeElement, Packed, Selector, ShowSet, Smart, StyleChain,
     Styles, Synthesize, cast, elem, scope, select_where,
 };
-use crate::introspection::{
-    Count, Counter, CounterKey, CounterUpdate, Locatable, Location, Tagged,
-};
+use crate::introspection::{Count, Counter, CounterKey, CounterUpdate, Location};
 use crate::layout::{
     AlignElem, Alignment, BlockElem, Em, Length, OuterVAlignment, PlacementScope,
     VAlignment,

--- a/crates/typst-library/src/model/footnote.rs
+++ b/crates/typst-library/src/model/footnote.rs
@@ -11,7 +11,7 @@ use crate::foundations::{
     elem, scope,
 };
 use crate::introspection::{
-    Count, Counter, CounterUpdate, Locatable, Location, QueryLabelIntrospection, Tagged,
+    Count, Counter, CounterUpdate, Location, QueryLabelIntrospection,
 };
 use crate::layout::{Em, Length, Ratio};
 use crate::model::{DirectLinkElem, Numbering, NumberingPattern, ParElem};

--- a/crates/typst-library/src/model/heading.rs
+++ b/crates/typst-library/src/model/heading.rs
@@ -8,7 +8,7 @@ use crate::engine::Engine;
 use crate::foundations::{
     Content, NativeElement, Packed, ShowSet, Smart, StyleChain, Styles, Synthesize, elem,
 };
-use crate::introspection::{Count, Counter, CounterUpdate, Locatable, Tagged};
+use crate::introspection::{Count, Counter, CounterUpdate};
 use crate::layout::{BlockElem, Em, Length};
 use crate::model::{Numbering, Outlinable, Refable, Supplement};
 use crate::text::{FontWeight, LocalName, TextElem, TextSize};

--- a/crates/typst-library/src/model/link.rs
+++ b/crates/typst-library/src/model/link.rs
@@ -14,9 +14,8 @@ use crate::foundations::{
     Smart, StyleChain, Styles, cast, elem,
 };
 use crate::introspection::{
-    Counter, CounterKey, History, Introspect, Introspector, Locatable, Location,
-    PagedPosition, PathIntrospection, QueryFirstIntrospection, QueryLabelIntrospection,
-    Tagged,
+    Counter, CounterKey, History, Introspect, Introspector, Location, PagedPosition,
+    PathIntrospection, QueryFirstIntrospection, QueryLabelIntrospection,
 };
 use crate::layout::PageElem;
 use crate::model::{NumberingPattern, Refable};

--- a/crates/typst-library/src/model/list.rs
+++ b/crates/typst-library/src/model/list.rs
@@ -6,7 +6,6 @@ use crate::foundations::{
     Array, Content, Context, Depth, Func, NativeElement, Packed, Smart, StyleChain,
     Styles, Value, cast, elem, scope,
 };
-use crate::introspection::{Locatable, Tagged};
 use crate::layout::{Alignment, Em, HAlignment, Length};
 use crate::text::TextElem;
 

--- a/crates/typst-library/src/model/mod.rs
+++ b/crates/typst-library/src/model/mod.rs
@@ -46,16 +46,14 @@ pub use self::table::*;
 pub use self::terms::*;
 pub use self::title::*;
 
+use crate::Feature;
 use crate::foundations::Scope;
-use crate::{Feature, Features};
 
 /// Hook up all `model` definitions.
-pub fn define(global: &mut Scope, features: &Features) {
+pub fn define(global: &mut Scope) {
     global.start_category(crate::Category::Model);
     global.define_elem::<DocumentElem>();
-    if features.is_enabled(Feature::Bundle) {
-        global.define_elem::<AssetElem>();
-    }
+    global.define_elem::<AssetElem>().feature(Feature::Bundle);
     global.define_elem::<ParElem>();
     global.define_elem::<ParbreakElem>();
     global.define_elem::<StrongElem>();

--- a/crates/typst-library/src/model/mod.rs
+++ b/crates/typst-library/src/model/mod.rs
@@ -47,13 +47,15 @@ pub use self::terms::*;
 pub use self::title::*;
 
 use crate::Feature;
-use crate::foundations::Scope;
+use crate::foundations::{BindingInfo, Scope};
 
 /// Hook up all `model` definitions.
 pub fn define(global: &mut Scope) {
     global.start_category(crate::Category::Model);
     global.define_elem::<DocumentElem>();
-    global.define_elem::<AssetElem>().feature(Feature::Bundle);
+    global
+        .define_elem::<AssetElem>()
+        .with_info(BindingInfo::new().feature(Feature::Bundle));
     global.define_elem::<ParElem>();
     global.define_elem::<ParbreakElem>();
     global.define_elem::<StrongElem>();

--- a/crates/typst-library/src/model/outline.rs
+++ b/crates/typst-library/src/model/outline.rs
@@ -13,8 +13,8 @@ use crate::foundations::{
     Resolve, ShowSet, Smart, StyleChain, Styles, cast, elem, func, scope, select_where,
 };
 use crate::introspection::{
-    Counter, CounterKey, Locatable, Location, Locator, LocatorLink,
-    PageNumberingIntrospection, QueryIntrospection, Tagged, Unqueriable,
+    Counter, CounterKey, Location, Locator, LocatorLink, PageNumberingIntrospection,
+    QueryIntrospection,
 };
 use crate::layout::{
     Abs, Axes, BlockBody, BlockElem, BoxElem, Dir, Em, Fr, HElem, Length, Region, Rel,

--- a/crates/typst-library/src/model/par.rs
+++ b/crates/typst-library/src/model/par.rs
@@ -8,7 +8,7 @@ use crate::foundations::{
     IntoValue, NativeElement, Packed, Reflect, Smart, Unlabellable, Value, cast, dict,
     elem, scope,
 };
-use crate::introspection::{Count, CounterUpdate, Locatable, Tagged, Unqueriable};
+use crate::introspection::{Count, CounterUpdate};
 use crate::layout::{Abs, Em, HAlignment, Length, OuterHAlignment, Ratio, Rel};
 use crate::model::Numbering;
 

--- a/crates/typst-library/src/model/quote.rs
+++ b/crates/typst-library/src/model/quote.rs
@@ -4,7 +4,6 @@ use crate::foundations::{
     Content, Depth, Label, NativeElement, Packed, ShowSet, Smart, StyleChain, Styles,
     cast, elem,
 };
-use crate::introspection::{Locatable, Tagged};
 use crate::layout::{BlockElem, Em, PadElem};
 use crate::model::{CitationForm, CiteElem};
 use crate::text::{SmartQuotes, SpaceElem, TextElem};

--- a/crates/typst-library/src/model/reference.rs
+++ b/crates/typst-library/src/model/reference.rs
@@ -8,8 +8,8 @@ use crate::foundations::{
     StyleChain, Synthesize, cast, elem,
 };
 use crate::introspection::{
-    Counter, CounterKey, Locatable, PageNumberingIntrospection,
-    PageSupplementIntrospection, QueryLabelIntrospection, Tagged,
+    Counter, CounterKey, PageNumberingIntrospection, PageSupplementIntrospection,
+    QueryLabelIntrospection,
 };
 use crate::math::EquationElem;
 use crate::model::{

--- a/crates/typst-library/src/model/strong.rs
+++ b/crates/typst-library/src/model/strong.rs
@@ -1,5 +1,4 @@
 use crate::foundations::{Content, elem};
-use crate::introspection::{Locatable, Tagged};
 
 /// Strongly emphasizes content by increasing the font weight.
 ///

--- a/crates/typst-library/src/model/table.rs
+++ b/crates/typst-library/src/model/table.rs
@@ -9,7 +9,6 @@ use crate::engine::Engine;
 use crate::foundations::{
     Content, Packed, Smart, StyleChain, Synthesize, cast, elem, scope,
 };
-use crate::introspection::{Locatable, Tagged};
 use crate::layout::resolve::{CellGrid, table_to_cellgrid};
 use crate::layout::{
     Abs, Alignment, Celled, GridCell, GridFooter, GridHLine, GridHeader, GridVLine,

--- a/crates/typst-library/src/model/terms.rs
+++ b/crates/typst-library/src/model/terms.rs
@@ -2,7 +2,6 @@ use crate::diag::{bail, warning};
 use crate::foundations::{
     Array, Content, NativeElement, Packed, Reflect, Smart, Styles, cast, elem, scope,
 };
-use crate::introspection::{Locatable, Tagged};
 use crate::layout::{Em, HElem, Length};
 use crate::model::{ListItemLike, ListLike};
 

--- a/crates/typst-library/src/model/title.rs
+++ b/crates/typst-library/src/model/title.rs
@@ -1,6 +1,5 @@
 use crate::diag::{Hint, HintedStrResult};
 use crate::foundations::{Content, Packed, ShowSet, Smart, StyleChain, Styles, elem};
-use crate::introspection::{Locatable, Tagged};
 use crate::layout::{BlockElem, Em};
 use crate::model::DocumentElem;
 use crate::text::{FontWeight, TextElem, TextSize};

--- a/crates/typst-library/src/pdf/accessibility.rs
+++ b/crates/typst-library/src/pdf/accessibility.rs
@@ -8,7 +8,6 @@ use crate::diag::SourceResult;
 use crate::diag::bail;
 use crate::engine::Engine;
 use crate::foundations::{Args, Construct, Content, NativeElement, Smart};
-use crate::introspection::Tagged;
 use crate::model::{TableCell, TableElem};
 
 /// Marks content as a PDF artifact.

--- a/crates/typst-library/src/pdf/attach.rs
+++ b/crates/typst-library/src/pdf/attach.rs
@@ -4,7 +4,6 @@ use typst_syntax::Spanned;
 use crate::World;
 use crate::diag::At;
 use crate::foundations::{Bytes, Cast, Derived, PathOrStr, elem};
-use crate::introspection::Locatable;
 
 /// A file that will be attached to the output PDF.
 ///

--- a/crates/typst-library/src/pdf/mod.rs
+++ b/crates/typst-library/src/pdf/mod.rs
@@ -7,7 +7,7 @@ pub use self::accessibility::*;
 pub use self::attach::*;
 
 use crate::Feature;
-use crate::foundations::{Module, Scope};
+use crate::foundations::{BindingInfo, Module, Scope};
 
 /// Hook up all `pdf` definitions.
 pub fn module() -> Module {
@@ -16,9 +16,12 @@ pub fn module() -> Module {
     pdf.define_elem::<AttachElem>();
     pdf.define_elem::<ArtifactElem>();
 
-    pdf.define_func::<table_summary>().feature(Feature::A11yExtras);
-    pdf.define_func::<header_cell>().feature(Feature::A11yExtras);
-    pdf.define_func::<data_cell>().feature(Feature::A11yExtras);
+    pdf.define_func::<table_summary>()
+        .with_info(BindingInfo::new().feature(Feature::A11yExtras));
+    pdf.define_func::<header_cell>()
+        .with_info(BindingInfo::new().feature(Feature::A11yExtras));
+    pdf.define_func::<data_cell>()
+        .with_info(BindingInfo::new().feature(Feature::A11yExtras));
 
     Module::new("pdf", pdf)
 }

--- a/crates/typst-library/src/pdf/mod.rs
+++ b/crates/typst-library/src/pdf/mod.rs
@@ -6,19 +6,19 @@ mod attach;
 pub use self::accessibility::*;
 pub use self::attach::*;
 
+use crate::Feature;
 use crate::foundations::{Module, Scope};
-use crate::{Feature, Features};
 
 /// Hook up all `pdf` definitions.
-pub fn module(features: &Features) -> Module {
+pub fn module() -> Module {
     let mut pdf = Scope::deduplicating();
     pdf.start_category(crate::Category::Pdf);
     pdf.define_elem::<AttachElem>();
     pdf.define_elem::<ArtifactElem>();
-    if features.is_enabled(Feature::A11yExtras) {
-        pdf.define_func::<table_summary>();
-        pdf.define_func::<header_cell>();
-        pdf.define_func::<data_cell>();
-    }
+
+    pdf.define_func::<table_summary>().feature(Feature::A11yExtras);
+    pdf.define_func::<header_cell>().feature(Feature::A11yExtras);
+    pdf.define_func::<data_cell>().feature(Feature::A11yExtras);
+
     Module::new("pdf", pdf)
 }

--- a/crates/typst-library/src/symbols.rs
+++ b/crates/typst-library/src/symbols.rs
@@ -1,6 +1,6 @@
 //! Modifiable symbols.
 
-use crate::foundations::{Deprecation, Module, Scope, Symbol, Value};
+use crate::foundations::{BindingInfo, Deprecation, Module, Scope, Symbol, Value};
 
 /// Hook up all `symbol` definitions.
 pub(super) fn define(global: &mut Scope) {
@@ -23,7 +23,9 @@ fn extend_scope_from_codex_module(scope: &mut Scope, module: codex::Module) {
 
         let scope_binding = scope.define(name, value);
         if let Some(message) = binding.deprecation {
-            scope_binding.deprecated(Deprecation::new().with_message(message));
+            scope_binding.with_info(
+                BindingInfo::new().deprecated(Deprecation::new().with_message(message)),
+            );
         }
     }
 }

--- a/crates/typst-library/src/text/deco.rs
+++ b/crates/typst-library/src/text/deco.rs
@@ -1,5 +1,4 @@
 use crate::foundations::{Content, Smart, elem};
-use crate::introspection::{Locatable, Tagged};
 use crate::layout::{Abs, Corners, Length, Rel, Sides};
 use crate::text::{BottomEdge, BottomEdgeMetric, TopEdge, TopEdgeMetric};
 use crate::visualize::{Color, FixedStroke, Paint, Stroke};

--- a/crates/typst-library/src/text/raw.rs
+++ b/crates/typst-library/src/text/raw.rs
@@ -20,7 +20,6 @@ use crate::foundations::{
     Bytes, Content, Derived, OneOrMultiple, Packed, PlainText, ShowSet, Smart,
     StyleChain, Styles, Synthesize, Target, TargetElem, cast, elem, scope,
 };
-use crate::introspection::{Locatable, Tagged};
 use crate::layout::{Em, HAlignment};
 use crate::loading::{DataSource, Load};
 use crate::model::{Figurable, ParElem};

--- a/crates/typst-library/src/text/shift.rs
+++ b/crates/typst-library/src/text/shift.rs
@@ -1,4 +1,3 @@
-use crate::introspection::Tagged;
 use ttf_parser::Tag;
 
 use crate::foundations::{Content, Smart, elem};

--- a/crates/typst-library/src/visualize/image/mod.rs
+++ b/crates/typst-library/src/visualize/image/mod.rs
@@ -24,7 +24,6 @@ use crate::engine::Engine;
 use crate::foundations::{
     Bytes, Cast, Derived, Packed, Smart, StyleChain, Synthesize, cast, elem,
 };
-use crate::introspection::{Locatable, Tagged};
 use crate::layout::{Length, Rel, Sizing};
 use crate::loading::{DataSource, Load, Loaded};
 use crate::model::Figurable;

--- a/crates/typst-macros/src/elem.rs
+++ b/crates/typst-macros/src/elem.rs
@@ -49,11 +49,6 @@ impl Elem {
     fn cannot(&self, name: &str) -> bool {
         !self.can(name)
     }
-
-    /// Whether the element has the given trait listed as a capability.
-    fn with(&self, name: &str) -> Option<&Ident> {
-        self.capabilities.iter().find(|capability| *capability == name)
-    }
 }
 
 impl Elem {
@@ -251,21 +246,12 @@ fn create(element: &Elem) -> Result<TokenStream> {
 
     // Implementations.
     let inherent_impl = create_inherent_impl(element);
-    let native_element_impl = create_native_elem_impl(element);
+    let native_element_impl = create_native_elem_impl(element)?;
     let field_impls =
         element.fields.iter().map(|field| create_field_impl(element, field));
     let construct_impl =
         element.cannot("Construct").then(|| create_construct_impl(element));
     let set_impl = element.cannot("Set").then(|| create_set_impl(element));
-    let unqueriable_impl = element
-        .with("Unqueriable")
-        .map(|cap| create_introspection_impl(element, cap));
-    let locatable_impl = element
-        .with("Locatable")
-        .map(|cap| create_introspection_impl(element, cap));
-    let tagged_impl = element
-        .with("Tagged")
-        .map(|cap| create_introspection_impl(element, cap));
     let mathy_impl = element.can("Mathy").then(|| create_mathy_impl(element));
 
     // We use a const block to create an anonymous scope, as to not leak any
@@ -279,9 +265,6 @@ fn create(element: &Elem) -> Result<TokenStream> {
             #(#field_impls)*
             #construct_impl
             #set_impl
-            #unqueriable_impl
-            #locatable_impl
-            #tagged_impl
             #mathy_impl
         };
     })
@@ -393,7 +376,7 @@ fn create_with_field_method(field: &Field) -> TokenStream {
 }
 
 /// Creates the element's `NativeElement` implementation.
-fn create_native_elem_impl(element: &Elem) -> TokenStream {
+fn create_native_elem_impl(element: &Elem) -> Result<TokenStream> {
     let Elem { name, ident, title, scope, keywords, docs, .. } = element;
     let def_site_key = ident.to_string();
 
@@ -430,6 +413,7 @@ fn create_native_elem_impl(element: &Elem) -> TokenStream {
     };
 
     let capable_func = create_capable_func(element);
+    let introspection = create_introspection_capabilities(element)?;
 
     let with_keywords =
         (!keywords.is_empty()).then(|| quote! { .with_keywords(&[#(#keywords),*]) });
@@ -438,7 +422,7 @@ fn create_native_elem_impl(element: &Elem) -> TokenStream {
     let with_local_name = element.can("LocalName").then(|| quote! { .with_local_name() });
     let with_scope = scope.then(|| quote! { .with_scope() });
 
-    quote! {
+    Ok(quote! {
         unsafe impl #foundations::NativeElement for #ident {
             const ELEM: #foundations::Element = #foundations::Element::from_vtable({
                 static STORE: #foundations::LazyElementStore
@@ -452,6 +436,7 @@ fn create_native_elem_impl(element: &Elem) -> TokenStream {
                         &[#(#fields),*],
                         #field_id,
                         #capable_func,
+                        #introspection,
                         || &STORE,
                     ) #with_keywords
                     #with_repr
@@ -462,7 +447,7 @@ fn create_native_elem_impl(element: &Elem) -> TokenStream {
                 &VTABLE
             });
         }
-    }
+    })
 }
 
 /// Creates the appropriate trait implementation for a field.
@@ -657,9 +642,22 @@ fn create_field_parser(field: &Field) -> (TokenStream, TokenStream) {
 
 /// Creates the element's casting vtable.
 fn create_capable_func(element: &Elem) -> TokenStream {
-    // Forbidden capabilities (i.e capabilities that are not object safe).
-    const FORBIDDEN: &[&str] =
-        &["Debug", "PartialEq", "Hash", "Construct", "Set", "Repr", "LocalName"];
+    // Forbidden capabilities, i.e capabilities that are not object safe or
+    // introspection capabilities that are handled otherwise.
+    const FORBIDDEN: &[&str] = &[
+        // Not object safe.
+        "Debug",
+        "PartialEq",
+        "Hash",
+        "Construct",
+        "Set",
+        "Repr",
+        "LocalName",
+        // Introspection capabilities.
+        "Locatable",
+        "Unqueriable",
+        "Tagged",
+    ];
 
     let ident = &element.ident;
     let relevant = element
@@ -688,10 +686,29 @@ fn create_capable_func(element: &Elem) -> TokenStream {
     }
 }
 
-/// Creates the element's introspection capability implementation.
-fn create_introspection_impl(element: &Elem, capability: &Ident) -> TokenStream {
-    let ident = &element.ident;
-    quote! { impl ::typst_library::introspection::#capability for #foundations::Packed<#ident> {} }
+/// Creates the element's casting vtable.
+fn create_introspection_capabilities(element: &Elem) -> Result<TokenStream> {
+    let find_cap = |name| element.capabilities.iter().find(|ident| *ident == name);
+    let locatable = find_cap("Locatable");
+    let unqueriable = find_cap("Unqueriable");
+    let tagged = find_cap("Tagged");
+
+    if let Some(unqueriable) = unqueriable
+        && locatable.is_none()
+    {
+        bail!(unqueriable, "only `Locatable` element can be marked `Unqueriable`");
+    }
+
+    let locatable = locatable.is_some();
+    let unqueriable = unqueriable.is_some();
+    let tagged = tagged.is_some();
+    Ok(quote! {
+        #foundations::IntrospectionCapabilities {
+            locatable: #locatable,
+            unqueriable: #unqueriable,
+            tagged: #tagged,
+        }
+    })
 }
 
 /// Creates the element's `Mathy` implementation.

--- a/crates/typst-realize/src/lib.rs
+++ b/crates/typst-realize/src/lib.rs
@@ -21,9 +21,7 @@ use typst_library::foundations::{
     Recipe, RecipeIndex, Selector, SequenceElem, ShowSet, Style, StyleChain, StyledElem,
     Styles, SymbolElem, Synthesize, Target, TargetElem, Transformation,
 };
-use typst_library::introspection::{
-    Locatable, LocationKey, SplitLocator, Tag, TagElem, TagFlags, Tagged,
-};
+use typst_library::introspection::{LocationKey, SplitLocator, Tag, TagElem, TagFlags};
 use typst_library::layout::{
     AlignElem, BoxElem, HElem, InlineElem, PageElem, PagebreakElem, VElem,
 };
@@ -520,8 +518,8 @@ fn verdict<'a>(
             elem.label().is_none()
                 && elem.location().is_none()
                 && !elem.can::<dyn ShowSet>()
-                && !elem.can::<dyn Locatable>()
-                && !elem.can::<dyn Tagged>()
+                && !elem.is_locatable()
+                && !elem.is_tagged()
                 && !elem.can::<dyn Synthesize>()
         })
     {
@@ -547,10 +545,10 @@ fn prepare(
     // when it stems from a query.
     let key = typst_utils::hash128(&elem);
     let flags = TagFlags {
-        introspectable: elem.can::<dyn Locatable>()
+        introspectable: elem.is_locatable()
             || elem.label().is_some()
             || elem.location().is_some(),
-        tagged: elem.can::<dyn Tagged>(),
+        tagged: elem.is_tagged(),
     };
     if elem.location().is_none() && flags.any() {
         let loc = locator.next_location(engine, key, elem.span());

--- a/crates/typst-svg/src/lib.rs
+++ b/crates/typst-svg/src/lib.rs
@@ -89,10 +89,7 @@ pub fn svg_in_html(
     link_resolver: Tracked<LateLinkResolver>,
 ) -> String {
     let mut renderer = SVGRenderer::with_options(Some(link_resolver));
-    let mut xml = XmlWriter::new(xmlwriter::Options {
-        indent: xmlwriter::Indent::None,
-        ..xml_options(pretty)
-    });
+    let mut xml = XmlWriter::new(xml_options(pretty));
     let mut svg = svg_header_with_custom_attrs(&mut xml, frame.size(), |svg| {
         if let Some(id) = id {
             svg.attr("id", id);

--- a/docs/src/reflect.rs
+++ b/docs/src/reflect.rs
@@ -27,7 +27,8 @@ pub fn binding(module: Module, name: EcoString) -> Option<Dict> {
     let binding = module.scope().get(&name)?;
     Some(dict! {
         "category" => binding.category().map(|c| c.name()),
-        "deprecation" => binding.deprecation().map(|d| dict! {
+        "feature" => binding.info().and_then(|i| i.feature).map(|f| f.to_string()),
+        "deprecation" => binding.info().and_then(|i| i.deprecation).map(|d| dict! {
             "message" => d.message(),
             "until" => d.until(),
         })

--- a/tests/ref/bundle/link-bundle-html-frame.txt
+++ b/tests/ref/bundle/link-bundle-html-frame.txt
@@ -1,2 +1,2 @@
 5caa14f2425347763746e46baed2a725 index.html
-7719c156941e5d000349af0abf2337de folder/a.html
+1fe4c62d11dc09f78c89e735f7ce9f0c folder/a.html

--- a/tests/ref/html/hashes.txt
+++ b/tests/ref/html/hashes.txt
@@ -20,13 +20,13 @@ c456aecc3b410f0b4f8705fc87e6d499 bibliography-group-mixed-styles
 805860e9a2d6bc7f9e466517c058eeec block-box-html
 2771d670b32a96e330e3db46aebd5f5b block-display-html
 ffa25d90e2baac1e02b03a60cae89720 block-html-block
-3c77f2f38c8f3fa6c90b1beb10c5d722 block-html-frame
+408fa53d2d35abe39c279f182a7c5df3 block-html-frame
 56e9ac9cf5876bc5ebbdd43b1a640a99 block-html-inline
 083d9124f7249ddd06de82bab51e932d block-html-multiple
 0b57400a2448caf6d434728014f5f047 block-html-text
 2b2857e0703e2211a74a25da543ec421 block-invalid-html
 33daaa5982a84b668f506461b070bf11 box-block-html
-800ffd92f70fed0affed4b5731aab0d1 box-html-frame
+627d1c6c247afedf8cba16543c7889bf box-html-frame
 33daaa5982a84b668f506461b070bf11 box-html-inline
 8aeeb8c8a69284b88f9c1464ecab9795 box-html-multiple
 9c97626487e554505316c09c201e2672 box-html-text
@@ -58,7 +58,7 @@ e34ea44e32ada9e0685b72d6e82ecfd5 html-elem-attrs-fold
 2ea76ccf8bdc8f8a39f586aab6ed80c9 html-elem-custom
 52de31c777d4b7b8d356b54138b5fe14 html-elem-metadata
 0a1d1443e72ef554d74d15ae49cd076c html-escapable-raw-text-contains-closing-tag
-30c425a860c27388ccda71cdd5d49e5f html-frame
+41d47680056dc0777c4060cf3ecc8c6a html-frame
 1e1005b4ac5db07bd074e5d12aa2162e html-pre-starting-with-newline
 9ddbaca4b63c936215a967cb76b0327a html-script
 de4b0b9e9a41128ffdb982bae7550178 html-space-collapsing
@@ -95,8 +95,8 @@ b1b17f3b81e381628200be8eee0a7e27 issue-7437-math-accent-text-presentation
 51719643a3ad5c5a58e9a93141653d28 issue-8261-string-as-non-numeric
 08eef154f592feabbe8e2ef7915d1f73 issue-math-realize-scripting
 44fbc75996ca7154896d82a2cc32da32 link-basic
-64f6d891e22ff529a703605d80ac4ab7 link-html-frame
-3ba326b82bb0c42ddea6c3266fda9c87 link-html-frame-ref
+a401e6e8dbbfb91c6fcd9f50b0812f00 link-html-frame
+aecca822229f41f10fdcfae3954413f1 link-html-frame-ref
 49c235cf678e473ea05818dfa2846180 link-html-here
 85145829d953d451be76af5b4f9369cb link-html-id-attach
 5ffe20ca590c5e8ce14f77537aae6b31 link-html-id-existing


### PR DESCRIPTION
Based on #8571 

This defers providing enabled library features until accessing a binding.
It also allows generating a nicer error message for feature gated bindings, instead of just saying it is undefined.

Here's an example of an error message before:
```
error: unknown variable: html
  ┌─ test.typ:1:1
  │
1 │ #html.div()
  │  ^^^^
```
and here the same one after:
```
error: cannot access variable `html` because the `html` feature is not enabled
  ┌─ test.typ:1:1
  │
1 │ #html.div()
  │  ^^^^
```

We still have to check that this doesn't hurt performance, since `read_checked` is a somewhat hot function.

There are currently no tests implemented, because that would require changing the `TestWorld` features, which is a bit of a pain and I first want to check for performance regressions.
