### PR TITLE
Specify introducing versions in documentation

### DIFF
--- a/crates/typst-html/src/lib.rs
+++ b/crates/typst-html/src/lib.rs
@@ -61,7 +61,7 @@ pub fn module() -> Module {
 ///   A div with _Typst content_ inside!
 /// ]
 /// ```
-#[elem(name = "elem")]
+#[elem(name = "elem", since = "0.13.0")]
 pub struct HtmlElem {
     /// The element's tag.
     #[required]
@@ -133,7 +133,7 @@ impl HtmlElem {
 /// used for PDF, SVG, and PNG export to render a part of your document exactly
 /// how it would appear when exported in one of these formats. It embeds the
 /// content as an inline SVG.
-#[elem]
+#[elem(since = "0.13.0")]
 pub struct FrameElem {
     /// The content that shall be laid out.
     #[positional]

--- a/crates/typst-html/src/typed.rs
+++ b/crates/typst-html/src/typed.rs
@@ -59,6 +59,7 @@ fn create_func_data(
             title[0..1].make_ascii_uppercase();
             title
         },
+        since: None,
         docs: element.docs,
         def_site: None,
         keywords: &["typed-html"],

--- a/crates/typst-html/src/typed.rs
+++ b/crates/typst-html/src/typed.rs
@@ -16,7 +16,7 @@ use typst_library::engine::Engine;
 use typst_library::foundations::{
     Args, Array, AutoValue, CastInfo, Content, Context, Datetime, Dict, Duration,
     FromValue, IntoValue, NativeFuncData, NativeFuncPtr, NativeParamInfo, NoneValue,
-    PositiveF64, Reflect, Scope, Str, Type, Value,
+    PositiveF64, Reflect, Scope, Since, Str, Type, Value,
 };
 use typst_library::layout::{Axes, Axis, Dir, Length};
 use typst_library::text::TextElem;
@@ -59,7 +59,7 @@ fn create_func_data(
             title[0..1].make_ascii_uppercase();
             title
         },
-        since: None,
+        since: Some(Since::Version([0, 14, 0])),
         docs: element.docs,
         def_site: None,
         keywords: &["typed-html"],

--- a/crates/typst-library/src/foundations/args.rs
+++ b/crates/typst-library/src/foundations/args.rs
@@ -50,7 +50,7 @@ use crate::foundations::{
 /// #let dict = (fill: blue)
 /// #text(..dict)[Hello]
 /// ```
-#[ty(scope, cast, name = "arguments")]
+#[ty(scope, cast, name = "arguments", since = "forever")]
 #[derive(Clone, Hash)]
 pub struct Args {
     /// The callsite span for the function. This is not the span of the argument
@@ -327,7 +327,7 @@ impl Args {
     /// #let args = arguments(stroke: red, inset: 1em, [Body])
     /// #box(..args)
     /// ```
-    #[func(constructor)]
+    #[func(constructor, since = "0.10.0")]
     pub fn construct(
         args: &mut Args,
         /// The arguments to construct.
@@ -339,7 +339,7 @@ impl Args {
     }
 
     /// The number of arguments, positional or named.
-    #[func(title = "Length")]
+    #[func(title = "Length", since = "0.15.0")]
     pub fn len(&self) -> usize {
         self.items.len()
     }
@@ -355,7 +355,7 @@ impl Args {
     /// Named arguments can also be accessed with field syntax (e.g.
     /// `{arguments(key: 42).key}`) if no default is needed. Unlike
     /// @dictionary[dictionaries], fields on arguments cannot be modified.
-    #[func]
+    #[func(since = "0.12.0")]
     pub fn at(
         &self,
         /// The index or name of the argument to get.
@@ -371,7 +371,7 @@ impl Args {
     }
 
     /// Returns the captured positional arguments as an array.
-    #[func(name = "pos", title = "Positional")]
+    #[func(name = "pos", title = "Positional", since = "forever")]
     pub fn to_pos(&self) -> Array {
         self.items
             .iter()
@@ -381,7 +381,7 @@ impl Args {
     }
 
     /// Returns the captured named arguments as a dictionary.
-    #[func(name = "named")]
+    #[func(name = "named", since = "forever")]
     pub fn to_named(&self) -> Dict {
         self.items
             .iter()
@@ -398,7 +398,7 @@ impl Args {
     ///     .filter(v => v > 0)
     /// }
     /// ```
-    #[func]
+    #[func(since = "0.15.0")]
     pub fn filter(
         self,
         engine: &mut Engine,
@@ -427,7 +427,7 @@ impl Args {
     ///     .map(v => v + 1)
     /// }
     /// ```
-    #[func]
+    #[func(since = "0.15.0")]
     pub fn map(
         self,
         engine: &mut Engine,

--- a/crates/typst-library/src/foundations/array.rs
+++ b/crates/typst-library/src/foundations/array.rs
@@ -69,7 +69,7 @@ pub use crate::__array as array;
 /// #(("A", "B", "C")
 ///     .join(", ", last: " and "))
 /// ```
-#[ty(scope, cast)]
+#[ty(scope, cast, since = "forever")]
 #[derive(Default, Clone, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Array(EcoVec<Value>);
@@ -160,7 +160,7 @@ impl Array {
     /// #let hi = "Hello 😃"
     /// #array(bytes(hi))
     /// ```
-    #[func(constructor)]
+    #[func(constructor, since = "0.7.0")]
     pub fn construct(
         /// The value that should be converted to an array.
         value: ToArray,
@@ -169,7 +169,7 @@ impl Array {
     }
 
     /// The number of values in the array.
-    #[func(title = "Length")]
+    #[func(title = "Length", since = "forever")]
     pub fn len(&self) -> usize {
         self.0.len()
     }
@@ -177,7 +177,7 @@ impl Array {
     /// Returns the first item in the array. May be used on the left-hand side of
     /// an assignment. Returns the default value if the array is empty or fails
     /// with an error if no default value was specified.
-    #[func]
+    #[func(since = "forever")]
     pub fn first(
         &self,
         /// A default value to return if the array is empty.
@@ -190,7 +190,7 @@ impl Array {
     /// Returns the last item in the array. May be used on the left-hand side of
     /// an assignment. Returns the default value if the array is empty or fails
     /// with an error if no default value was specified.
-    #[func]
+    #[func(since = "forever")]
     pub fn last(
         &self,
         /// A default value to return if the array is empty.
@@ -204,7 +204,7 @@ impl Array {
     /// left-hand side of an assignment. Returns the default value if the index
     /// is out of bounds or fails with an error if no default value was
     /// specified.
-    #[func]
+    #[func(since = "forever")]
     pub fn at(
         &self,
         /// The index at which to retrieve the item. If negative, indexes from
@@ -221,7 +221,7 @@ impl Array {
     }
 
     /// Adds a value to the end of the array.
-    #[func]
+    #[func(since = "forever")]
     pub fn push(
         &mut self,
         /// The value to insert at the end of the array.
@@ -232,7 +232,7 @@ impl Array {
 
     /// Removes the last item from the array and returns it. Fails with an error
     /// if the array is empty.
-    #[func]
+    #[func(since = "forever")]
     pub fn pop(&mut self) -> StrResult<Value> {
         self.0.pop().ok_or_else(array_is_empty)
     }
@@ -242,7 +242,7 @@ impl Array {
     /// out of bounds.
     ///
     /// To replace an element of an array, use @array.at[`at`].
-    #[func]
+    #[func(since = "forever")]
     pub fn insert(
         &mut self,
         /// The index at which to insert the item. If negative, indexes from the
@@ -257,7 +257,7 @@ impl Array {
     }
 
     /// Removes the value at the specified index from the array and return it.
-    #[func]
+    #[func(since = "forever")]
     pub fn remove(
         &mut self,
         /// The index at which to remove the item. If negative, indexes from the
@@ -275,7 +275,7 @@ impl Array {
 
     /// Extracts a subslice of the array. Fails with an error if the start or
     /// end index is out of bounds.
-    #[func]
+    #[func(since = "forever")]
     pub fn slice(
         &self,
         /// The start index (inclusive). If negative, indexes from the back.
@@ -303,7 +303,7 @@ impl Array {
     ///
     /// This method also has dedicated syntax: You can write `{2 in (1, 2, 3)}`
     /// instead of `{(1, 2, 3).contains(2)}`.
-    #[func]
+    #[func(since = "forever")]
     pub fn contains(
         &self,
         /// The value to search for.
@@ -314,7 +314,7 @@ impl Array {
 
     /// Searches for an item for which the given function returns `{true}` and
     /// returns the first match or `{none}` if there is no match.
-    #[func]
+    #[func(since = "forever")]
     pub fn find(
         &self,
         engine: &mut Engine,
@@ -336,7 +336,7 @@ impl Array {
 
     /// Searches for an item for which the given function returns `{true}` and
     /// returns the index of the first match or `{none}` if there is no match.
-    #[func]
+    #[func(since = "forever")]
     pub fn position(
         &self,
         engine: &mut Engine,
@@ -380,7 +380,7 @@ impl Array {
     /// #range(21, step: 4) \
     /// #range(5, 2, step: -1)
     /// ```
-    #[func]
+    #[func(since = "forever")]
     pub fn range(
         args: &mut Args,
         /// The start of the range (inclusive).
@@ -444,7 +444,7 @@ impl Array {
 
     /// Produces a new array with only the items from the original one for which
     /// the given function returns `{true}`.
-    #[func]
+    #[func(since = "forever")]
     pub fn filter(
         &self,
         engine: &mut Engine,
@@ -467,7 +467,7 @@ impl Array {
 
     /// Produces a new array in which all items from the original one were
     /// transformed with the given function.
-    #[func]
+    #[func(since = "forever")]
     pub fn map(
         self,
         engine: &mut Engine,
@@ -494,7 +494,7 @@ impl Array {
     ///
     /// #("A", "B", "C").enumerate(start: 1)
     /// ```
-    #[func]
+    #[func(since = "0.2.0")]
     pub fn enumerate(
         self,
         /// The index returned for the first pair of the returned list.
@@ -528,7 +528,7 @@ impl Array {
     /// This function is variadic, meaning that you can zip multiple arrays
     /// together at once: `{(1, 2).zip(("A", "B"), (10, 20))}` yields
     /// `{((1, "A", 10), (2, "B", 20))}`.
-    #[func]
+    #[func(since = "0.3.0")]
     pub fn zip(
         self,
         args: &mut Args,
@@ -618,7 +618,7 @@ impl Array {
     /// #let array = (1, 2, 3, 4)
     /// #array.fold(0, (acc, x) => acc + x)
     /// ```
-    #[func]
+    #[func(since = "forever")]
     pub fn fold(
         self,
         engine: &mut Engine,
@@ -637,7 +637,7 @@ impl Array {
     }
 
     /// Sums all items (works for all types that can be added).
-    #[func]
+    #[func(since = "0.3.0")]
     pub fn sum(
         self,
         /// What to return if the array is empty. Must be set if the array can
@@ -658,7 +658,7 @@ impl Array {
 
     /// Calculates the product of all items (works for all types that can be
     /// multiplied).
-    #[func]
+    #[func(since = "0.3.0")]
     pub fn product(
         self,
         /// What to return if the array is empty. Must be set if the array can
@@ -678,7 +678,7 @@ impl Array {
     }
 
     /// Whether the given function returns `{true}` for any item in the array.
-    #[func]
+    #[func(since = "forever")]
     pub fn any(
         self,
         engine: &mut Engine,
@@ -696,7 +696,7 @@ impl Array {
     }
 
     /// Whether the given function returns `{true}` for all items in the array.
-    #[func]
+    #[func(since = "forever")]
     pub fn all(
         self,
         engine: &mut Engine,
@@ -714,7 +714,7 @@ impl Array {
     }
 
     /// Combine all nested arrays into a single flat one.
-    #[func]
+    #[func(since = "forever")]
     pub fn flatten(self) -> Array {
         let mut flat = EcoVec::with_capacity(self.0.len());
         for item in self {
@@ -728,7 +728,7 @@ impl Array {
     }
 
     /// Return a new array with the same items, but in reverse order.
-    #[func(title = "Reverse")]
+    #[func(title = "Reverse", since = "forever")]
     pub fn rev(self) -> Array {
         self.into_iter().rev().collect()
     }
@@ -738,7 +738,7 @@ impl Array {
     /// ```example
     /// #(1, 1, 2, 3, 2, 4, 5).split(2)
     /// ```
-    #[func]
+    #[func(since = "forever")]
     pub fn split(
         &self,
         /// The value to split at.
@@ -751,7 +751,7 @@ impl Array {
     }
 
     /// Combine all items in the array into one.
-    #[func]
+    #[func(since = "forever")]
     pub fn join(
         self,
         /// A value to insert between each item of the array.
@@ -798,7 +798,7 @@ impl Array {
     /// ```example
     /// #("A", "B", "C").intersperse("-")
     /// ```
-    #[func]
+    #[func(since = "0.8.0")]
     pub fn intersperse(
         self,
         /// The value that will be placed between each adjacent element.
@@ -837,7 +837,7 @@ impl Array {
     /// #array.chunks(3) \
     /// #array.chunks(3, exact: true)
     /// ```
-    #[func]
+    #[func(since = "0.11.0")]
     pub fn chunks(
         self,
         /// How many elements each chunk may at most contain.
@@ -865,7 +865,7 @@ impl Array {
     /// #let array = (1, 2, 3, 4, 5, 6, 7, 8)
     /// #array.windows(5)
     /// ```
-    #[func]
+    #[func(since = "0.12.0")]
     pub fn windows(
         self,
         /// How many elements each window will contain.
@@ -896,7 +896,7 @@ impl Array {
     /// )
     /// #array.sorted(key: it => (it.a, it.b))
     /// ```
-    #[func]
+    #[func(since = "forever")]
     pub fn sorted(
         self,
         engine: &mut Engine,
@@ -1058,7 +1058,7 @@ impl Array {
     /// ```example
     /// #(3, 3, 1, 2, 3).dedup()
     /// ```
-    #[func(title = "Deduplicate")]
+    #[func(title = "Deduplicate", since = "0.7.0")]
     pub fn dedup(
         self,
         engine: &mut Engine,
@@ -1114,7 +1114,7 @@ impl Array {
     ///   ("apples", 5),
     /// ).to-dict()
     /// ```
-    #[func]
+    #[func(since = "0.12.0")]
     pub fn to_dict(self) -> StrResult<Dict> {
         self.into_iter()
             .map(|value| {
@@ -1151,7 +1151,7 @@ impl Array {
     /// #let array = (2, 1, 4, 3)
     /// #array.reduce((acc, x) => calc.max(acc, x))
     /// ```
-    #[func]
+    #[func(since = "0.12.0")]
     pub fn reduce(
         self,
         engine: &mut Engine,

--- a/crates/typst-library/src/foundations/auto.rs
+++ b/crates/typst-library/src/foundations/auto.rs
@@ -17,7 +17,7 @@ use crate::foundations::{
 /// contextual behaviour. A good example is the @text.dir[text direction]
 /// parameter. Setting it to `{auto}` lets Typst automatically determine the
 /// direction from the @text.lang[text language].
-#[ty(cast, name = "auto")]
+#[ty(cast, name = "auto", since = "forever")]
 #[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct AutoValue;
 

--- a/crates/typst-library/src/foundations/bool.rs
+++ b/crates/typst-library/src/foundations/bool.rs
@@ -13,7 +13,7 @@ use crate::foundations::{Repr, ty};
 /// #true \
 /// #(1 < 2)
 /// ```
-#[ty(cast, title = "Boolean")]
+#[ty(cast, title = "Boolean", since = "forever")]
 type bool;
 
 impl Repr for bool {

--- a/crates/typst-library/src/foundations/bytes.rs
+++ b/crates/typst-library/src/foundations/bytes.rs
@@ -41,7 +41,7 @@ use crate::foundations::{Array, Reflect, Repr, Str, Value, cast, func, scope, ty
 /// #array(data.slice(0, 4)) \
 /// #str(data.slice(1, 4))
 /// ```
-#[ty(scope, cast)]
+#[ty(scope, cast, since = "0.7.0")]
 #[derive(Clone, Hash)]
 pub struct Bytes(Arc<LazyHash<dyn Bytelike>>);
 
@@ -239,7 +239,7 @@ impl Bytes {
     /// #bytes("Hello 😃") \
     /// #bytes((123, 160, 22, 0))
     /// ```
-    #[func(constructor)]
+    #[func(constructor, since = "0.7.0")]
     pub fn construct(
         /// The value that should be converted to bytes.
         value: ToBytes,
@@ -248,7 +248,7 @@ impl Bytes {
     }
 
     /// The length in bytes.
-    #[func(title = "Length")]
+    #[func(title = "Length", since = "0.7.0")]
     pub fn len(&self) -> usize {
         self.as_slice().len()
     }
@@ -256,7 +256,7 @@ impl Bytes {
     /// Returns the byte at the specified index. Returns the default value if
     /// the index is out of bounds or fails with an error if no default value
     /// was specified.
-    #[func]
+    #[func(since = "0.7.0")]
     pub fn at(
         &self,
         /// The index at which to retrieve the byte.
@@ -273,7 +273,7 @@ impl Bytes {
 
     /// Extracts a subslice of the bytes. Fails with an error if the start or
     /// end index is out of bounds.
-    #[func]
+    #[func(since = "0.7.0")]
     pub fn slice(
         &self,
         /// The start index (inclusive).

--- a/crates/typst-library/src/foundations/calc.rs
+++ b/crates/typst-library/src/foundations/calc.rs
@@ -70,7 +70,7 @@ pub fn module() -> Module {
 /// #calc.abs(2fr) \
 /// #calc.abs(decimal("-342.440"))
 /// ```
-#[func(title = "Absolute")]
+#[func(title = "Absolute", since = "forever")]
 pub fn abs(
     /// The value whose absolute value to calculate.
     value: ToAbs,
@@ -99,7 +99,7 @@ cast! {
 /// #calc.pow(2, 3) \
 /// #calc.pow(decimal("2.5"), 2)
 /// ```
-#[func(title = "Power")]
+#[func(title = "Power", since = "forever")]
 pub fn pow(
     span: Span,
     /// The base of the power.
@@ -160,7 +160,7 @@ pub fn pow(
 /// ```example
 /// #calc.exp(1)
 /// ```
-#[func(title = "Exponential")]
+#[func(title = "Exponential", since = "0.5.0")]
 pub fn exp(
     span: Span,
     /// The exponent of the power.
@@ -190,7 +190,7 @@ pub fn exp(
 /// #calc.sqrt(16) \
 /// #calc.sqrt(2.5)
 /// ```
-#[func(title = "Square Root")]
+#[func(title = "Square Root", since = "forever")]
 pub fn sqrt(
     /// The number whose square root to calculate. Must be non-negative.
     value: Spanned<Num>,
@@ -209,7 +209,7 @@ pub fn sqrt(
 /// #calc.root(16.0, 4) \
 /// #calc.root(27.0, 3)
 /// ```
-#[func]
+#[func(since = "0.11.0")]
 pub fn root(
     /// The expression to take the root of.
     radicand: f64,
@@ -240,7 +240,7 @@ pub fn root(
 /// #calc.sin(1.5) \
 /// #calc.sin(90deg)
 /// ```
-#[func(title = "Sine")]
+#[func(title = "Sine", since = "forever")]
 pub fn sin(
     /// The angle whose sine to calculate.
     angle: AngleLike,
@@ -260,7 +260,7 @@ pub fn sin(
 /// #calc.cos(1.5) \
 /// #calc.cos(90deg)
 /// ```
-#[func(title = "Cosine")]
+#[func(title = "Cosine", since = "forever")]
 pub fn cos(
     /// The angle whose cosine to calculate.
     angle: AngleLike,
@@ -280,7 +280,7 @@ pub fn cos(
 /// #calc.tan(1.5) \
 /// #calc.tan(90deg)
 /// ```
-#[func(title = "Tangent")]
+#[func(title = "Tangent", since = "forever")]
 pub fn tan(
     /// The angle whose tangent to calculate.
     angle: AngleLike,
@@ -298,7 +298,7 @@ pub fn tan(
 /// #calc.asin(0) \
 /// #calc.asin(1)
 /// ```
-#[func(title = "Arcsine")]
+#[func(title = "Arcsine", since = "forever")]
 pub fn asin(
     /// The number whose arcsine to calculate. Must be between $-1$ and $1$.
     value: Spanned<Num>,
@@ -316,7 +316,7 @@ pub fn asin(
 /// #calc.acos(0) \
 /// #calc.acos(1)
 /// ```
-#[func(title = "Arccosine")]
+#[func(title = "Arccosine", since = "forever")]
 pub fn acos(
     /// The number whose arccosine to calculate. Must be between $-1$ and $1$.
     value: Spanned<Num>,
@@ -334,7 +334,7 @@ pub fn acos(
 /// #calc.atan(0) \
 /// #calc.atan(1)
 /// ```
-#[func(title = "Arctangent")]
+#[func(title = "Arctangent", since = "forever")]
 pub fn atan(
     /// The number whose arctangent to calculate.
     value: Num,
@@ -355,7 +355,7 @@ pub fn atan(
 /// #calc.atan2(1, 1) \
 /// #calc.atan2(-2, -3)
 /// ```
-#[func(title = "Four-quadrant Arctangent")]
+#[func(title = "Four-quadrant Arctangent", since = "0.3.0")]
 pub fn atan2(
     /// The $x$ coordinate.
     x: Num,
@@ -374,7 +374,7 @@ pub fn atan2(
 /// #calc.sinh(0) \
 /// #calc.sinh(1.5)
 /// ```
-#[func(title = "Hyperbolic Sine")]
+#[func(title = "Hyperbolic Sine", since = "forever")]
 pub fn sinh(
     /// The hyperbolic angle whose hyperbolic sine to calculate.
     value: f64,
@@ -391,7 +391,7 @@ pub fn sinh(
 /// #calc.cosh(0) \
 /// #calc.cosh(1.5)
 /// ```
-#[func(title = "Hyperbolic Cosine")]
+#[func(title = "Hyperbolic Cosine", since = "forever")]
 pub fn cosh(
     /// The hyperbolic angle whose hyperbolic cosine to calculate.
     value: f64,
@@ -408,7 +408,7 @@ pub fn cosh(
 /// #calc.tanh(0) \
 /// #calc.tanh(1.5)
 /// ```
-#[func(title = "Hyperbolic Tangent")]
+#[func(title = "Hyperbolic Tangent", since = "forever")]
 pub fn tanh(
     /// The hyperbolic angle whose hyperbolic tangent to calculate.
     value: f64,
@@ -425,7 +425,7 @@ pub fn tanh(
 /// #calc.asinh(0) \
 /// #calc.asinh(1)
 /// ```
-#[func(title = "Inverse Hyperbolic Sine")]
+#[func(title = "Inverse Hyperbolic Sine", since = "0.15.0")]
 pub fn asinh(
     /// The number whose inverse hyperbolic sine to calculate.
     value: f64,
@@ -442,7 +442,7 @@ pub fn asinh(
 /// #calc.acosh(1) \
 /// #calc.acosh(2.5)
 /// ```
-#[func(title = "Inverse Hyperbolic Cosine")]
+#[func(title = "Inverse Hyperbolic Cosine", since = "0.15.0")]
 pub fn acosh(
     /// The number whose inverse hyperbolic cosine to calculate. Must be greater
     /// than or equal to $1$.
@@ -464,7 +464,7 @@ pub fn acosh(
 /// #calc.atanh(0) \
 /// #calc.atanh(0.5)
 /// ```
-#[func(title = "Inverse Hyperbolic Tangent")]
+#[func(title = "Inverse Hyperbolic Tangent", since = "0.15.0")]
 pub fn atanh(
     /// The number whose inverse hyperbolic tangent to calculate. Must be
     /// between $-1$ and $1$ (exclusive).
@@ -484,7 +484,7 @@ pub fn atanh(
 /// ```example
 /// #calc.log(100)
 /// ```
-#[func(title = "Logarithm")]
+#[func(title = "Logarithm", since = "forever")]
 pub fn log(
     span: Span,
     /// The number whose logarithm to calculate. Must be strictly positive.
@@ -525,7 +525,7 @@ pub fn log(
 /// ```example
 /// #calc.ln(calc.e)
 /// ```
-#[func(title = "Natural Logarithm")]
+#[func(title = "Natural Logarithm", since = "0.5.0")]
 pub fn ln(
     span: Span,
     /// The number whose logarithm to calculate. Must be strictly positive.
@@ -552,7 +552,7 @@ pub fn ln(
 /// ```example
 /// #calc.erf(0.2)
 /// ```
-#[func(title = "Error Function")]
+#[func(title = "Error Function", since = "0.15.0")]
 pub fn erf(
     /// The number at which to calculate the error function.
     value: f64,
@@ -565,7 +565,7 @@ pub fn erf(
 /// ```example
 /// #calc.fact(5)
 /// ```
-#[func(title = "Factorial")]
+#[func(title = "Factorial", since = "0.3.0")]
 pub fn fact(
     /// The number whose factorial to calculate. Must be non-negative.
     number: u64,
@@ -587,7 +587,7 @@ pub fn fact(
 /// ```example
 /// #calc.perm(5, 3)
 /// ```
-#[func(title = "Permutation")]
+#[func(title = "Permutation", since = "0.3.0")]
 pub fn perm(
     /// The value of $n$: The number of items to choose from. Must be
     /// non-negative.
@@ -634,7 +634,7 @@ fn fact_impl(start: u64, end: u64) -> Option<i64> {
 /// ```example
 /// #calc.binom(10, 5)
 /// ```
-#[func(title = "Binomial")]
+#[func(title = "Binomial", since = "0.3.0")]
 pub fn binom(
     /// The value of $n$: The numbers of items to choose from. Must be
     /// non-negative.
@@ -675,7 +675,7 @@ fn binom_impl(n: u64, k: u64) -> Option<i64> {
 /// ```example
 /// #calc.gcd(7, 42)
 /// ```
-#[func(title = "Greatest Common Divisor")]
+#[func(title = "Greatest Common Divisor", since = "0.3.0")]
 pub fn gcd(
     /// The first integer.
     a: i64,
@@ -697,7 +697,7 @@ pub fn gcd(
 /// ```example
 /// #calc.lcm(96, 13)
 /// ```
-#[func(title = "Least Common Multiple")]
+#[func(title = "Least Common Multiple", since = "0.3.0")]
 pub fn lcm(
     /// The first integer.
     a: i64,
@@ -728,7 +728,7 @@ pub fn lcm(
 /// #assert(calc.floor(3.14) == 3)
 /// #assert(calc.floor(decimal("-3.14")) == -4)
 /// ```
-#[func]
+#[func(since = "forever")]
 pub fn floor(
     /// The number to round down.
     value: DecNum,
@@ -755,7 +755,7 @@ pub fn floor(
 /// #assert(calc.ceil(3.14) == 4)
 /// #assert(calc.ceil(decimal("-3.14")) == -3)
 /// ```
-#[func]
+#[func(since = "forever")]
 pub fn ceil(
     /// The number to round up.
     value: DecNum,
@@ -782,7 +782,7 @@ pub fn ceil(
 /// #assert(calc.trunc(-3.7) == -3)
 /// #assert(calc.trunc(decimal("8493.12949582390")) == 8493)
 /// ```
-#[func(title = "Truncate")]
+#[func(title = "Truncate", since = "0.3.0")]
 pub fn trunc(
     /// The number to truncate.
     value: DecNum,
@@ -804,7 +804,7 @@ pub fn trunc(
 /// #assert(calc.fract(3) == 0)
 /// #assert(calc.fract(decimal("234.23949211")) == decimal("0.23949211"))
 /// ```
-#[func(title = "Fractional")]
+#[func(title = "Fractional", since = "0.3.0")]
 pub fn fract(
     /// The number to truncate.
     value: DecNum,
@@ -850,7 +850,7 @@ pub fn fract(
 /// #assert(calc.round(decimal("3333.45"), digits: -2) == decimal("3300"))
 /// #assert(calc.round(decimal("-48953.45"), digits: -3) == decimal("-49000"))
 /// ```
-#[func]
+#[func(since = "forever")]
 pub fn round(
     /// The number to round.
     value: DecNum,
@@ -885,7 +885,7 @@ pub fn round(
 /// #assert(calc.clamp(decimal("5.45"), 2, decimal("45.9")) == decimal("5.45"))
 /// #assert(calc.clamp(decimal("5.45"), decimal("6.75"), 12) == decimal("6.75"))
 /// ```
-#[func]
+#[func(since = "forever")]
 pub fn clamp(
     span: Span,
     /// The number to clamp.
@@ -917,7 +917,7 @@ pub fn clamp(
 /// #calc.min(1, -3, -5, 20, 3, 6) \
 /// #calc.min("typst", "is", "cool")
 /// ```
-#[func(title = "Minimum")]
+#[func(title = "Minimum", since = "forever")]
 pub fn min(
     span: Span,
     /// The sequence of values from which to extract the minimum. Must not be
@@ -934,7 +934,7 @@ pub fn min(
 /// #calc.max(1, -3, -5, 20, 3, 6) \
 /// #calc.max("typst", "is", "cool")
 /// ```
-#[func(title = "Maximum")]
+#[func(title = "Maximum", since = "forever")]
 pub fn max(
     span: Span,
     /// The sequence of values from which to extract the maximum. Must not be
@@ -973,7 +973,7 @@ fn minmax(
 /// #calc.even(5) \
 /// #range(10).filter(calc.even)
 /// ```
-#[func]
+#[func(since = "forever")]
 pub fn even(
     /// The number to check for evenness.
     value: i64,
@@ -988,7 +988,7 @@ pub fn even(
 /// #calc.odd(5) \
 /// #range(10).filter(calc.odd)
 /// ```
-#[func]
+#[func(since = "forever")]
 pub fn odd(
     /// The number to check for oddness.
     value: i64,
@@ -1011,7 +1011,7 @@ pub fn odd(
 /// #calc.rem(-7, -3) \
 /// #calc.rem(1.75, 0.5)
 /// ```
-#[func(title = "Remainder")]
+#[func(title = "Remainder", since = "0.3.0")]
 pub fn rem(
     span: Span,
     /// The dividend of the remainder.
@@ -1055,7 +1055,7 @@ pub fn rem(
 /// #calc.div-euclid(1.75, 0.5) \
 /// #calc.div-euclid(decimal("1.75"), decimal("0.5"))
 /// ```
-#[func(title = "Euclidean Division")]
+#[func(title = "Euclidean Division", since = "0.10.0")]
 pub fn div_euclid(
     span: Span,
     /// The dividend of the division.
@@ -1098,7 +1098,7 @@ pub fn div_euclid(
 /// #calc.rem-euclid(1.75, 0.5) \
 /// #calc.rem-euclid(decimal("1.75"), decimal("0.5"))
 /// ```
-#[func(title = "Euclidean Remainder", keywords = ["modulo", "modulus"])]
+#[func(title = "Euclidean Remainder", since = "0.10.0", keywords = ["modulo", "modulus"])]
 pub fn rem_euclid(
     span: Span,
     /// The dividend of the remainder.
@@ -1136,7 +1136,7 @@ pub fn rem_euclid(
 ///   "quo"(14, 5) &= #calc.quo(14, 5) \
 ///   "quo"(3.46, 0.5) &= #calc.quo(3.46, 0.5) $
 /// ```
-#[func(title = "Quotient")]
+#[func(title = "Quotient", since = "0.3.0")]
 pub fn quo(
     span: Span,
     /// The dividend of the quotient.
@@ -1186,7 +1186,7 @@ pub fn quo(
 /// #calc.norm(1, 2, -3, 0.5) \
 /// #calc.norm(p: 3, 1, 2)
 /// ```
-#[func(title = "𝑝-Norm")]
+#[func(title = "𝑝-Norm", since = "0.13.0")]
 pub fn norm(
     /// The value of $p$. Must be greater than zero.
     ///

--- a/crates/typst-library/src/foundations/content/element.rs
+++ b/crates/typst-library/src/foundations/content/element.rs
@@ -11,7 +11,7 @@ use typst_utils::{DefSite, Static};
 use crate::diag::SourceResult;
 use crate::engine::Engine;
 use crate::foundations::{
-    Args, Content, ContentVtable, Func, NativeParamInfo, Repr, Scope, Selector,
+    Args, Content, ContentVtable, Func, NativeParamInfo, Repr, Scope, Selector, Since,
     StyleChain, Styles, Value, cast,
 };
 use crate::text::{Lang, Region};
@@ -40,6 +40,11 @@ impl Element {
     /// (e.g. `Numbered List`).
     pub fn title(self) -> &'static str {
         self.vtable().title
+    }
+
+    /// The version of Typst the element was introduced in.
+    pub fn since(&self) -> Option<Since> {
+        self.vtable().since.clone()
     }
 
     /// Documentation for the element (as Markdown).

--- a/crates/typst-library/src/foundations/content/mod.rs
+++ b/crates/typst-library/src/foundations/content/mod.rs
@@ -78,7 +78,7 @@ use crate::text::UnderlineElem;
 /// In the web app, you can hover over a content variable to see exactly which
 /// elements the content is composed of and what fields they have.
 /// Alternatively, you can inspect the output of the @repr function.
-#[ty(scope, cast)]
+#[ty(scope, cast, since = "forever")]
 #[derive(Clone, PartialEq, Hash)]
 #[repr(transparent)]
 pub struct Content(raw::RawContent);
@@ -528,13 +528,13 @@ impl Content {
     /// element contained in this content. It can be used in set and show rules
     /// for the element. Can be compared with global functions to check whether
     /// you have a specific kind of element.
-    #[func]
+    #[func(since = "forever")]
     pub fn func(&self) -> Element {
         self.elem()
     }
 
     /// Whether the content has the specified field.
-    #[func]
+    #[func(since = "forever")]
     pub fn has(
         &self,
         /// The field to look for.
@@ -557,7 +557,7 @@ impl Content {
     /// Access the specified field on the content. Returns the default value if
     /// the field does not exist or fails with an error if no default value was
     /// specified.
-    #[func]
+    #[func(since = "forever")]
     pub fn at(
         &self,
         /// The field to access.
@@ -579,7 +579,7 @@ impl Content {
     ///   height: 10cm,
     /// ).fields()
     /// ```
-    #[func]
+    #[func(since = "0.5.0")]
     pub fn fields(&self) -> Dict {
         let mut dict = Dict::new();
         for field in self.0.handle().fields() {
@@ -598,7 +598,7 @@ impl Content {
     /// @reference:styling:show-rules[show rule], for other content it will be
     /// `{none}`. The resulting location can be used with @counter[counters],
     /// @state[state] and @query[queries].
-    #[func]
+    #[func(since = "forever")]
     pub fn location(&self) -> Option<Location> {
         self.0.meta().location
     }

--- a/crates/typst-library/src/foundations/content/vtable.rs
+++ b/crates/typst-library/src/foundations/content/vtable.rs
@@ -46,7 +46,7 @@ use crate::diag::SourceResult;
 use crate::engine::Engine;
 use crate::foundations::{
     Args, CastInfo, Construct, Content, LazyElementStore, NativeElement, NativeScope,
-    Packed, Repr, Scope, Set, StyleChain, Styles, Value,
+    Packed, Repr, Scope, Set, Since, StyleChain, Styles, Value,
 };
 use crate::text::{Lang, LocalName, Region};
 
@@ -83,6 +83,8 @@ pub struct ContentVtable<T: 'static = RawContent> {
     pub(super) name: &'static str,
     /// The element's title-cased name.
     pub(super) title: &'static str,
+    /// The version of Typst the element was introduced in.
+    pub(super) since: Option<Since>,
     /// The element's documentation (as Markdown).
     pub(super) docs: &'static str,
     /// Whether the element is defined in the source code.
@@ -144,6 +146,7 @@ impl ContentVtable {
     pub const fn new<E: NativeElement>(
         name: &'static str,
         title: &'static str,
+        since: Option<Since>,
         docs: &'static str,
         def_site: DefSite,
         fields: &'static [FieldVtable<Packed<E>>],
@@ -155,6 +158,7 @@ impl ContentVtable {
         ContentVtable {
             name,
             title,
+            since,
             docs,
             def_site,
             keywords: &[],

--- a/crates/typst-library/src/foundations/datetime.rs
+++ b/crates/typst-library/src/foundations/datetime.rs
@@ -140,7 +140,7 @@ use crate::foundations::{
 /// will be stored as a plain date internally, meaning that you cannot use
 /// components such as `hour` or `minute`, which would only work on datetimes
 /// that have a specified time.
-#[ty(scope, cast)]
+#[ty(scope, cast, since = "0.5.0")]
 #[derive(Debug, Copy, Clone, PartialEq, Hash)]
 pub enum Datetime {
     /// Representation as a date.
@@ -262,7 +262,7 @@ impl Datetime {
     ///   day: 3,
     /// ).display()
     /// ```
-    #[func(constructor)]
+    #[func(constructor, since = "0.5.0")]
     pub fn construct(
         /// The year of the datetime.
         #[named]
@@ -366,7 +366,7 @@ impl Datetime {
     /// Today's date is
     /// #datetime.today().display().
     /// ```
-    #[func]
+    #[func(since = "0.5.0")]
     pub fn today(
         engine: &mut Engine,
         /// An offset to apply to the current UTC date. If set to `{auto}`, the
@@ -391,7 +391,7 @@ impl Datetime {
     /// `[[year]-[month]-[day] [hour]:[minute]:[second]]`.
     ///
     /// See the @datetime:format[format syntax] for more information.
-    #[func]
+    #[func(since = "0.5.0")]
     pub fn display(
         &self,
         /// The format used to display the datetime.
@@ -418,7 +418,7 @@ impl Datetime {
     }
 
     /// The year if it was specified, or `{none}` for times without a date.
-    #[func]
+    #[func(since = "0.5.0")]
     pub fn year(&self) -> Option<i32> {
         match self {
             Self::Date(date) => Some(date.year()),
@@ -428,7 +428,7 @@ impl Datetime {
     }
 
     /// The month if it was specified, or `{none}` for times without a date.
-    #[func]
+    #[func(since = "0.5.0")]
     pub fn month(&self) -> Option<u8> {
         match self {
             Self::Date(date) => Some(date.month().into()),
@@ -438,7 +438,7 @@ impl Datetime {
     }
 
     /// The weekday (counting Monday as 1) or `{none}` for times without a date.
-    #[func]
+    #[func(since = "0.5.0")]
     pub fn weekday(&self) -> Option<u8> {
         match self {
             Self::Date(date) => Some(date.weekday().number_from_monday()),
@@ -448,7 +448,7 @@ impl Datetime {
     }
 
     /// The day if it was specified, or `{none}` for times without a date.
-    #[func]
+    #[func(since = "0.5.0")]
     pub fn day(&self) -> Option<u8> {
         match self {
             Self::Date(date) => Some(date.day()),
@@ -458,7 +458,7 @@ impl Datetime {
     }
 
     /// The hour if it was specified, or `{none}` for dates without a time.
-    #[func]
+    #[func(since = "0.5.0")]
     pub fn hour(&self) -> Option<u8> {
         match self {
             Self::Date(_) => None,
@@ -468,7 +468,7 @@ impl Datetime {
     }
 
     /// The minute if it was specified, or `{none}` for dates without a time.
-    #[func]
+    #[func(since = "0.5.0")]
     pub fn minute(&self) -> Option<u8> {
         match self {
             Self::Date(_) => None,
@@ -478,7 +478,7 @@ impl Datetime {
     }
 
     /// The second if it was specified, or `{none}` for dates without a time.
-    #[func]
+    #[func(since = "0.5.0")]
     pub fn second(&self) -> Option<u8> {
         match self {
             Self::Date(_) => None,
@@ -488,7 +488,7 @@ impl Datetime {
     }
 
     /// The ordinal (day of the year), or `{none}` for times without a date.
-    #[func]
+    #[func(since = "0.5.0")]
     pub fn ordinal(&self) -> Option<u16> {
         match self {
             Self::Datetime(datetime) => Some(datetime.ordinal()),

--- a/crates/typst-library/src/foundations/decimal.rs
+++ b/crates/typst-library/src/foundations/decimal.rs
@@ -89,7 +89,7 @@ use crate::foundations::{Repr, Str, cast, func, repr, scope, ty};
 /// push a number's fractional digits beyond the limits described above, leading
 /// to rounding. When those two operations do not surpass the digit limits, they
 /// are fully precise.
-#[ty(scope, cast)]
+#[ty(scope, cast, since = "0.12.0")]
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Decimal(rust_decimal::Decimal);
 
@@ -294,7 +294,7 @@ impl Decimal {
     /// ```example
     /// #decimal("1.222222222222222")
     /// ```
-    #[func(constructor)]
+    #[func(constructor, since = "0.12.0")]
     pub fn construct(
         engine: &mut Engine,
         /// The value that should be converted to a decimal.

--- a/crates/typst-library/src/foundations/dict.rs
+++ b/crates/typst-library/src/foundations/dict.rs
@@ -75,7 +75,7 @@ pub use crate::__dict as dict;
 /// #dict.insert("city", "Berlin")
 /// #("name" in dict)
 /// ```
-#[ty(scope, cast, name = "dictionary")]
+#[ty(scope, cast, name = "dictionary", since = "forever")]
 #[derive(Default, Clone, PartialEq)]
 pub struct Dict(Arc<IndexMap<Str, Value, FxBuildHasher>>);
 
@@ -181,7 +181,7 @@ impl Dict {
     /// ```example
     /// #dictionary(sys).at("version")
     /// ```
-    #[func(constructor)]
+    #[func(constructor, since = "forever")]
     pub fn construct(
         /// The value that should be converted to a dictionary.
         value: ToDict,
@@ -190,7 +190,7 @@ impl Dict {
     }
 
     /// The number of pairs in the dictionary.
-    #[func(title = "Length")]
+    #[func(title = "Length", since = "forever")]
     pub fn len(&self) -> usize {
         self.0.len()
     }
@@ -204,7 +204,7 @@ impl Dict {
     ///
     /// Values may also be accessed with field syntax (e.g. `{(key: 42).key}`)
     /// if no default is needed.
-    #[func]
+    #[func(since = "forever")]
     pub fn at(
         &self,
         /// The key at which to retrieve the item.
@@ -225,7 +225,7 @@ impl Dict {
     ///
     /// To insert multiple pairs at once, you can alternatively add another
     /// dictionary with the `+=` operator.
-    #[func]
+    #[func(since = "forever")]
     pub fn insert(
         &mut self,
         /// The key of the pair that should be inserted.
@@ -237,7 +237,7 @@ impl Dict {
     }
 
     /// Removes a pair from the dictionary by key and return the value.
-    #[func]
+    #[func(since = "forever")]
     pub fn remove(
         &mut self,
         /// The key of the pair to remove.
@@ -253,20 +253,20 @@ impl Dict {
     }
 
     /// Returns the keys of the dictionary as an array in insertion order.
-    #[func]
+    #[func(since = "forever")]
     pub fn keys(&self) -> Array {
         self.0.keys().cloned().map(Value::Str).collect()
     }
 
     /// Returns the values of the dictionary as an array in insertion order.
-    #[func]
+    #[func(since = "forever")]
     pub fn values(&self) -> Array {
         self.0.values().cloned().collect()
     }
 
     /// Returns the keys and values of the dictionary as an array of pairs. Each
     /// pair is represented as an array of length two.
-    #[func]
+    #[func(since = "forever")]
     pub fn pairs(&self) -> Array {
         self.0
             .iter()
@@ -298,7 +298,7 @@ impl Dict {
     ///   }
     ///   ```
     /// )
-    #[func]
+    #[func(since = "0.15.0")]
     pub fn filter(
         self,
         engine: &mut Engine,
@@ -322,7 +322,7 @@ impl Dict {
     /// ```example
     /// #(a: 0, b: 1, c: 2).map(v => v + 1)
     /// ```
-    #[func]
+    #[func(since = "0.15.0")]
     pub fn map(
         self,
         engine: &mut Engine,

--- a/crates/typst-library/src/foundations/duration.rs
+++ b/crates/typst-library/src/foundations/duration.rs
@@ -7,7 +7,7 @@ use time::ext::NumericalDuration;
 use crate::foundations::{Repr, func, repr, scope, ty};
 
 /// Represents a positive or negative span of time.
-#[ty(scope, cast)]
+#[ty(scope, cast, since = "0.8.0")]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Duration(time::Duration);
 
@@ -47,7 +47,7 @@ impl Duration {
     ///   hours: 12,
     /// ).hours()
     /// ```
-    #[func(constructor)]
+    #[func(constructor, since = "0.8.0")]
     pub fn construct(
         /// The number of seconds.
         #[named]
@@ -84,7 +84,7 @@ impl Duration {
     /// This function returns the total duration represented in seconds as a
     /// floating-point number, rather than the seconds component of the
     /// duration.
-    #[func]
+    #[func(since = "0.8.0")]
     pub fn seconds(&self) -> f64 {
         self.0.as_seconds_f64()
     }
@@ -94,7 +94,7 @@ impl Duration {
     /// This function returns the total duration represented in minutes as a
     /// floating-point number, rather than the minutes component of the
     /// duration.
-    #[func]
+    #[func(since = "0.8.0")]
     pub fn minutes(&self) -> f64 {
         self.seconds() / 60.0
     }
@@ -103,7 +103,7 @@ impl Duration {
     ///
     /// This function returns the total duration represented in hours as a
     /// floating-point number, rather than the hours component of the duration.
-    #[func]
+    #[func(since = "0.8.0")]
     pub fn hours(&self) -> f64 {
         self.seconds() / 3_600.0
     }
@@ -112,7 +112,7 @@ impl Duration {
     ///
     /// This function returns the total duration represented in days as a
     /// floating-point number, rather than the days component of the duration.
-    #[func]
+    #[func(since = "0.8.0")]
     pub fn days(&self) -> f64 {
         self.seconds() / 86_400.0
     }
@@ -121,7 +121,7 @@ impl Duration {
     ///
     /// This function returns the total duration represented in weeks as a
     /// floating-point number, rather than the weeks component of the duration.
-    #[func]
+    #[func(since = "0.8.0")]
     pub fn weeks(&self) -> f64 {
         self.seconds() / 604_800.0
     }

--- a/crates/typst-library/src/foundations/float.rs
+++ b/crates/typst-library/src/foundations/float.rs
@@ -26,7 +26,7 @@ use crate::layout::Ratio;
 /// #1e4 \
 /// #(10 / 4)
 /// ```
-#[ty(scope, cast, name = "float")]
+#[ty(scope, cast, name = "float", since = "forever")]
 type f64;
 
 #[scope(ext)]
@@ -56,7 +56,7 @@ impl f64 {
     /// #float("2.7") \
     /// #float("1e5")
     /// ```
-    #[func(constructor)]
+    #[func(constructor, since = "forever")]
     pub fn construct(
         /// The value that should be converted to a float.
         value: ToFloat,
@@ -74,7 +74,7 @@ impl f64 {
     /// #float.is-nan(1) \
     /// #float.is-nan(float.nan)
     /// ```
-    #[func]
+    #[func(since = "0.11.0")]
     pub fn is_nan(self) -> bool {
         f64::is_nan(self)
     }
@@ -89,7 +89,7 @@ impl f64 {
     /// #float.is-infinite(1) \
     /// #float.is-infinite(float.inf)
     /// ```
-    #[func]
+    #[func(since = "0.11.0")]
     pub fn is_infinite(self) -> bool {
         f64::is_infinite(self)
     }
@@ -106,7 +106,7 @@ impl f64 {
     /// #(0.0).signum() \
     /// #float.nan.signum()
     /// ```
-    #[func]
+    #[func(since = "0.11.0")]
     pub fn signum(self) -> f64 {
         f64::signum(self)
     }
@@ -117,7 +117,7 @@ impl f64 {
     /// #float.from-bytes(bytes((0, 0, 0, 0, 0, 0, 240, 63))) \
     /// #float.from-bytes(bytes((63, 240, 0, 0, 0, 0, 0, 0)), endian: "big")
     /// ```
-    #[func]
+    #[func(since = "0.12.0")]
     pub fn from_bytes(
         /// The bytes that should be converted to a float.
         ///
@@ -154,7 +154,7 @@ impl f64 {
     /// #array(1.0.to-bytes(endian: "big")) \
     /// #array(1.0.to-bytes())
     /// ```
-    #[func]
+    #[func(since = "0.12.0")]
     pub fn to_bytes(
         self,
         /// The endianness of the conversion.

--- a/crates/typst-library/src/foundations/func.rs
+++ b/crates/typst-library/src/foundations/func.rs
@@ -15,7 +15,7 @@ use crate::diag::{At, SourceResult, StrResult, WarningSink, bail};
 use crate::engine::Engine;
 use crate::foundations::{
     Args, Bytes, CastInfo, Content, Context, Element, IntoArgs, PluginFunc, Repr, Scope,
-    Selector, Type, Value, cast, scope, ty,
+    Selector, Since, Type, Value, cast, scope, ty,
 };
 
 /// A mapping from argument values to a return value.
@@ -183,6 +183,17 @@ impl Func {
             FuncInner::Closure(_) => None,
             FuncInner::Plugin(_) => None,
             FuncInner::With(with) => with.0.title(),
+        }
+    }
+
+    /// The version of Typst the function was introduced in.
+    pub fn since(&self) -> Option<Since> {
+        match &self.inner {
+            FuncInner::Native(native) => native.since.clone(),
+            FuncInner::Element(elem) => elem.since(),
+            FuncInner::Closure(_) => None,
+            FuncInner::Plugin(_) => None,
+            FuncInner::With(with) => with.0.since(),
         }
     }
 
@@ -626,6 +637,8 @@ pub struct NativeFuncData {
     pub name: &'static str,
     /// The function's title case name (e.g. `Align`).
     pub title: &'static str,
+    /// The version of Typst the function was introduced in.
+    pub since: Option<Since>,
     /// The documentation for this function as a string.
     pub docs: &'static str,
     /// Where the function is defined in the source code.

--- a/crates/typst-library/src/foundations/func.rs
+++ b/crates/typst-library/src/foundations/func.rs
@@ -135,7 +135,7 @@ use crate::foundations::{
 /// The only exception are built-in methods like
 /// @array.push[`array.push(value)`]. These can modify the values they are
 /// called on.
-#[ty(scope, cast, name = "function")]
+#[ty(scope, cast, name = "function", since = "forever")]
 #[derive(Clone, Hash)]
 pub struct Func {
     /// The internal representation.
@@ -391,7 +391,7 @@ impl Func {
 #[scope]
 impl Func {
     /// Returns a new function that has the given arguments pre-applied.
-    #[func]
+    #[func(since = "forever")]
     pub fn with(
         self,
         args: &mut Args,
@@ -416,7 +416,7 @@ impl Func {
     /// == Subsection
     /// === Sub-subsection
     /// ```
-    #[func]
+    #[func(since = "forever")]
     pub fn where_(
         self,
         args: &mut Args,

--- a/crates/typst-library/src/foundations/int.rs
+++ b/crates/typst-library/src/foundations/int.rs
@@ -65,7 +65,7 @@ use crate::foundations::{
 ///
 /// This also means that if you want to embed a negative integer in markup, you
 /// will need to use parentheses to group the negation operator: `[#(-6)]`.
-#[ty(scope, cast, name = "int", title = "Integer")]
+#[ty(scope, cast, name = "int", title = "Integer", since = "forever")]
 type i64;
 
 #[scope(ext)]
@@ -95,7 +95,7 @@ impl i64 {
     /// #(int("27") + int("4")) \
     /// #int("beef", base: 16)
     /// ```
-    #[func(constructor)]
+    #[func(constructor, since = "forever")]
     pub fn construct(
         /// The value that should be converted to an integer.
         value: Spanned<ToInt>,
@@ -156,7 +156,7 @@ impl i64 {
     /// #(-5).signum() \
     /// #(0).signum()
     /// ```
-    #[func]
+    #[func(since = "0.11.0")]
     pub fn signum(self) -> i64 {
         i64::signum(self)
     }
@@ -170,7 +170,7 @@ impl i64 {
     /// #4.bit-not() \
     /// #(-1).bit-not()
     /// ```
-    #[func(title = "Bitwise NOT")]
+    #[func(title = "Bitwise NOT", since = "0.11.0")]
     pub fn bit_not(self) -> i64 {
         !self
     }
@@ -183,7 +183,7 @@ impl i64 {
     /// ```example
     /// #128.bit-and(192)
     /// ```
-    #[func(title = "Bitwise AND")]
+    #[func(title = "Bitwise AND", since = "0.11.0")]
     pub fn bit_and(
         self,
         /// The right-hand operand of the bitwise AND.
@@ -200,7 +200,7 @@ impl i64 {
     /// ```example
     /// #64.bit-or(32)
     /// ```
-    #[func(title = "Bitwise OR")]
+    #[func(title = "Bitwise OR", since = "0.11.0")]
     pub fn bit_or(
         self,
         /// The right-hand operand of the bitwise OR.
@@ -217,7 +217,7 @@ impl i64 {
     /// ```example
     /// #64.bit-xor(96)
     /// ```
-    #[func(title = "Bitwise XOR")]
+    #[func(title = "Bitwise XOR", since = "0.11.0")]
     pub fn bit_xor(
         self,
         /// The right-hand operand of the bitwise XOR.
@@ -236,7 +236,7 @@ impl i64 {
     /// #33.bit-lshift(2) \
     /// #(-1).bit-lshift(3)
     /// ```
-    #[func(title = "Bitwise Left Shift")]
+    #[func(title = "Bitwise Left Shift", since = "0.11.0")]
     pub fn bit_lshift(
         self,
         /// The amount of bits to shift. Must not be negative.
@@ -258,7 +258,7 @@ impl i64 {
     /// #(-8).bit-rshift(2) \
     /// #(-8).bit-rshift(2, logical: true)
     /// ```
-    #[func(title = "Bitwise Right Shift")]
+    #[func(title = "Bitwise Right Shift", since = "0.11.0")]
     pub fn bit_rshift(
         self,
         /// The amount of bits to shift. Must not be negative.
@@ -312,7 +312,7 @@ impl i64 {
     /// #int.from-bytes(bytes((0, 0, 0, 0, 0, 0, 0, 1))) \
     /// #int.from-bytes(bytes((1, 0, 0, 0, 0, 0, 0, 0)), endian: "big")
     /// ```
-    #[func]
+    #[func(since = "0.12.0")]
     pub fn from_bytes(
         /// The bytes that should be converted to an integer.
         ///
@@ -378,7 +378,7 @@ impl i64 {
     /// #array(10000.to-bytes(endian: "big")) \
     /// #array(10000.to-bytes(size: 4))
     /// ```
-    #[func]
+    #[func(since = "0.12.0")]
     pub fn to_bytes(
         self,
         /// The endianness of the conversion.

--- a/crates/typst-library/src/foundations/label.rs
+++ b/crates/typst-library/src/foundations/label.rs
@@ -46,7 +46,7 @@ use crate::foundations::{Repr, Str, bail, func, scope, ty};
 ///
 /// Currently, labels can only be attached to elements in markup mode, not in
 /// code mode. This might change in the future.
-#[ty(scope, cast)]
+#[ty(scope, cast, since = "forever")]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Label(PicoStr);
 
@@ -73,7 +73,7 @@ impl Label {
 #[scope]
 impl Label {
     /// Creates a label from a string.
-    #[func(constructor)]
+    #[func(constructor, since = "forever")]
     pub fn construct(
         /// The name of the label.
         ///

--- a/crates/typst-library/src/foundations/mod.rs
+++ b/crates/typst-library/src/foundations/mod.rs
@@ -132,7 +132,7 @@ pub(super) fn define(global: &mut Scope, inputs: Dict) {
 /// ```typ
 /// #panic("this is wrong")
 /// ```
-#[func(keywords = ["error"])]
+#[func(since = "forever", keywords = ["error"])]
 pub fn panic(
     /// The values to panic with and display to the user.
     #[variadic]
@@ -166,7 +166,7 @@ pub fn panic(
 /// ```typ
 /// #assert(1 < 2, message: "math broke")
 /// ```
-#[func(scope)]
+#[func(scope, since = "forever")]
 pub fn assert(
     /// The condition that must be true for the assertion to pass.
     condition: bool,
@@ -194,7 +194,7 @@ impl assert {
     /// ```typ
     /// #assert.eq(10, 10)
     /// ```
-    #[func(title = "Assert Equal")]
+    #[func(title = "Assert Equal", since = "0.4.0")]
     pub fn eq(
         /// The first value to compare.
         left: Value,
@@ -227,7 +227,7 @@ impl assert {
     /// ```typ
     /// #assert.ne(3, 4)
     /// ```
-    #[func(title = "Assert Not Equal")]
+    #[func(title = "Assert Not Equal", since = "0.4.0")]
     pub fn ne(
         /// The first value to compare.
         left: Value,
@@ -263,7 +263,7 @@ impl assert {
 /// #eval("(1, 2, 3, 4)").len() \
 /// #eval("*Markup!*", mode: "markup") \
 /// ```
-#[func(title = "Evaluate")]
+#[func(title = "Evaluate", since = "forever")]
 pub fn eval(
     engine: &mut Engine,
     /// A string of Typst code to evaluate.

--- a/crates/typst-library/src/foundations/module.rs
+++ b/crates/typst-library/src/foundations/module.rs
@@ -44,7 +44,7 @@ use crate::foundations::{Content, Repr, Scope, Value, ty};
 /// Alternatively, it is possible to convert a module to a dictionary, and
 /// therefore access its contents dynamically, using the
 /// @dictionary.constructor[dictionary constructor].
-#[ty(cast)]
+#[ty(cast, since = "forever")]
 #[derive(Clone, Hash)]
 pub struct Module {
     /// The module's name.

--- a/crates/typst-library/src/foundations/none.rs
+++ b/crates/typst-library/src/foundations/none.rs
@@ -21,7 +21,7 @@ use crate::foundations::{
 /// ```example
 /// Not visible: #none
 /// ```
-#[ty(cast, name = "none")]
+#[ty(cast, name = "none", since = "forever")]
 #[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct NoneValue;
 

--- a/crates/typst-library/src/foundations/path.rs
+++ b/crates/typst-library/src/foundations/path.rs
@@ -131,7 +131,7 @@ use crate::foundations::{Repr, Str, cast, func, scope, ty};
 /// transferring paths across files in your project and packages. In the future,
 /// it may enable additional capabilities like checking for the existence of a
 /// file or enumerating files in a directory.
-#[ty(scope, name = "path")]
+#[ty(scope, name = "path", since = "0.14.2")]
 #[derive(Debug, Clone, PartialEq, Hash)]
 type RootedPath;
 
@@ -148,7 +148,7 @@ impl RootedPath {
     /// // An absolute path with a leading slash.
     /// #path("/absolute/path/to/file.typ")
     /// ```
-    #[func(constructor)]
+    #[func(constructor, since = "0.14.2")]
     pub fn construct(
         /// Converts a string or path to a path.
         ///

--- a/crates/typst-library/src/foundations/plugin.rs
+++ b/crates/typst-library/src/foundations/plugin.rs
@@ -145,7 +145,7 @@ use crate::loading::{DataSource, Load};
 ///   examples
 /// - Wrappers to help you write your plugin in Rust
 /// - A stubber for WASI
-#[func(scope)]
+#[func(scope, since = "0.8.0")]
 pub fn plugin(
     engine: &mut Engine,
     /// A path to a WebAssembly file or raw WebAssembly bytes.
@@ -189,7 +189,7 @@ impl plugin {
     /// #assert.eq(base.get(), "[]")
     /// #assert.eq(mutated.get(), "[hello]")
     /// ```
-    #[func]
+    #[func(since = "0.13.0")]
     pub fn transition(
         /// The plugin function to call.
         func: PluginFunc,

--- a/crates/typst-library/src/foundations/repr.rs
+++ b/crates/typst-library/src/foundations/repr.rs
@@ -38,7 +38,7 @@ pub const MINUS_SIGN: &str = "\u{2212}";
 ///
 /// #repr(x => x + 1)
 /// ```
-#[func(title = "Representation")]
+#[func(title = "Representation", since = "forever")]
 pub fn repr(
     /// The value whose string representation to produce.
     value: Value,

--- a/crates/typst-library/src/foundations/selector.rs
+++ b/crates/typst-library/src/foundations/selector.rs
@@ -71,7 +71,7 @@ pub use crate::__select_where as select_where;
 /// == So will this
 /// === But this will not.
 /// ```
-#[ty(scope, cast)]
+#[ty(scope, cast, since = "0.3.0")]
 #[derive(Debug, Clone, PartialEq, Hash)]
 pub enum Selector {
     /// Matches a specific type of element.
@@ -163,7 +163,7 @@ impl Selector {
     /// - A `{<label>}`.
     /// - A @location.
     /// - A more complex selector like `{heading.where(level: 1)}`.
-    #[func(constructor)]
+    #[func(constructor, since = "0.3.0")]
     pub fn construct(
         /// Can be an element function like a `heading` or `figure`, a
         /// `{<label>}` or a more complex selector like
@@ -174,7 +174,7 @@ impl Selector {
     }
 
     /// Selects all elements that match this or any of the other selectors.
-    #[func]
+    #[func(since = "0.3.0")]
     pub fn or(
         self,
         /// The other selectors to match on.
@@ -185,7 +185,7 @@ impl Selector {
     }
 
     /// Selects all elements that match this and all of the other selectors.
-    #[func]
+    #[func(since = "0.3.0")]
     pub fn and(
         self,
         /// The other selectors to match on.
@@ -200,7 +200,7 @@ impl Selector {
     ///
     /// _Note:_ This selector is currently only supported with introspection
     /// functions, not in show rules.
-    #[func]
+    #[func(since = "0.3.0")]
     pub fn before(
         self,
         /// The original selection will end at the first match of `end`.
@@ -223,7 +223,7 @@ impl Selector {
     ///
     /// _Note:_ This selector is currently only supported with introspection
     /// functions, not in show rules.
-    #[func]
+    #[func(since = "0.3.0")]
     pub fn after(
         self,
         /// The original selection will start at the first match of `start`.
@@ -281,7 +281,7 @@ impl Selector {
     ///
     /// _Note:_ This selector is currently only supported with introspection
     /// functions, not in show rules.
-    #[func]
+    #[func(since = "0.15.0")]
     pub fn within(
         self,
         /// Only matches of `self` that are descendants of any element matching

--- a/crates/typst-library/src/foundations/str.rs
+++ b/crates/typst-library/src/foundations/str.rs
@@ -71,7 +71,7 @@ pub use crate::__format_str as format_str;
 /// - `[\r]` for a carriage return
 /// - `[\t]` for a tab
 /// - `[\u{1f600}]` for a hexadecimal Unicode escape sequence
-#[ty(scope, cast, title = "String")]
+#[ty(scope, cast, title = "String", since = "forever")]
 #[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[derive(Serialize, Deserialize)]
 #[serde(transparent)]
@@ -149,7 +149,7 @@ impl Str {
     /// #str(1e8) \
     /// #str(<intro>)
     /// ```
-    #[func(constructor)]
+    #[func(constructor, since = "forever")]
     pub fn construct(
         /// The value that should be converted to a string.
         value: ToStr,
@@ -182,7 +182,7 @@ impl Str {
     }
 
     /// The length of the string in UTF-8 encoded bytes.
-    #[func(title = "Length")]
+    #[func(title = "Length", since = "forever")]
     pub fn len(&self) -> usize {
         self.0.len()
     }
@@ -191,7 +191,7 @@ impl Str {
     ///
     /// Returns the provided default value if the string is empty or fails with
     /// an error if no default value was specified.
-    #[func]
+    #[func(since = "forever")]
     pub fn first(
         &self,
         /// A default value to return if the string is empty.
@@ -210,7 +210,7 @@ impl Str {
     ///
     /// Returns the provided default value if the string is empty or fails with
     /// an error if no default value was specified.
-    #[func]
+    #[func(since = "forever")]
     pub fn last(
         &self,
         /// A default value to return if the string is empty.
@@ -228,7 +228,7 @@ impl Str {
     /// Extracts the first grapheme cluster after the specified index. Returns
     /// the default value if the index is out of bounds or fails with an error
     /// if no default value was specified.
-    #[func]
+    #[func(since = "forever")]
     pub fn at(
         &self,
         /// The byte index. If negative, indexes from the back.
@@ -246,7 +246,7 @@ impl Str {
 
     /// Extracts a substring of the string. Fails with an error if the start or
     /// end index is out of bounds.
-    #[func]
+    #[func(since = "forever")]
     pub fn slice(
         &self,
         /// The start byte index (inclusive). If negative, indexes from the
@@ -273,13 +273,13 @@ impl Str {
     }
 
     /// Returns the grapheme clusters of the string as an array of substrings.
-    #[func]
+    #[func(since = "forever")]
     pub fn clusters(&self) -> Array {
         self.as_str().graphemes(true).map(|s| Value::Str(s.into())).collect()
     }
 
     /// Returns the Unicode codepoints of the string as an array of substrings.
-    #[func]
+    #[func(since = "forever")]
     pub fn codepoints(&self) -> Array {
         self.chars().map(|c| Value::Str(c.into())).collect()
     }
@@ -292,7 +292,7 @@ impl Str {
     ///    .codepoints()
     ///    .map(str.to-unicode))
     /// ```
-    #[func]
+    #[func(since = "0.5.0")]
     pub fn to_unicode(
         /// The character that should be converted.
         character: char,
@@ -305,7 +305,7 @@ impl Str {
     /// ```example
     /// #str.from-unicode(97)
     /// ```
-    #[func]
+    #[func(since = "0.5.0")]
     pub fn from_unicode(
         /// The code point that should be converted.
         value: u32,
@@ -325,7 +325,7 @@ impl Str {
     /// #assert.eq("é".normalize(form: "nfd"), "e\u{0301}")
     /// #assert.eq("ſ́".normalize(form: "nfkc"), "ś")
     /// ```
-    #[func]
+    #[func(since = "0.14.0")]
     pub fn normalize(
         &self,
         #[named]
@@ -344,7 +344,7 @@ impl Str {
     ///
     /// This method also has dedicated syntax: You can write `{"bc" in "abcd"}`
     /// instead of `{"abcd".contains("bc")}`.
-    #[func]
+    #[func(since = "forever")]
     pub fn contains(
         &self,
         /// The pattern to search for.
@@ -357,7 +357,7 @@ impl Str {
     }
 
     /// Whether the string starts with the specified pattern.
-    #[func]
+    #[func(since = "forever")]
     pub fn starts_with(
         &self,
         /// The pattern the string might start with.
@@ -370,7 +370,7 @@ impl Str {
     }
 
     /// Whether the string ends with the specified pattern.
-    #[func]
+    #[func(since = "forever")]
     pub fn ends_with(
         &self,
         /// The pattern the string might end with.
@@ -397,7 +397,7 @@ impl Str {
 
     /// Searches for the specified pattern in the string and returns the first
     /// match as a string or `{none}` if there is no match.
-    #[func]
+    #[func(since = "forever")]
     pub fn find(
         &self,
         /// The pattern to search for.
@@ -411,7 +411,7 @@ impl Str {
 
     /// Searches for the specified pattern in the string and returns the index
     /// of the first match as an integer or `{none}` if there is no match.
-    #[func]
+    #[func(since = "forever")]
     pub fn position(
         &self,
         /// The pattern to search for.
@@ -452,7 +452,7 @@ impl Str {
     ///   #"The time of my life.".match(regex("[mit]+e"))
     ///   ```
     /// )
-    #[func]
+    #[func(since = "forever")]
     pub fn match_(
         &self,
         /// The pattern to search for.
@@ -473,7 +473,7 @@ impl Str {
     /// ```example
     /// #"Day by Day.".matches("Day")
     /// ```
-    #[func]
+    #[func(since = "forever")]
     pub fn matches(
         &self,
         /// The pattern to search for.
@@ -497,7 +497,7 @@ impl Str {
     /// Replace at most `count` occurrences of the given pattern with a
     /// replacement string or function (beginning from the start). If no count
     /// is given, all occurrences are replaced.
-    #[func]
+    #[func(since = "forever")]
     pub fn replace(
         &self,
         engine: &mut Engine,
@@ -567,7 +567,7 @@ impl Str {
 
     /// Removes matches of a pattern from one or both sides of the string, once
     /// or repeatedly and returns the resulting string.
-    #[func]
+    #[func(since = "forever")]
     pub fn trim(
         &self,
         /// The pattern to search for. If `{none}`, trims white spaces.
@@ -658,7 +658,7 @@ impl Str {
     /// beginning and end of the string. In practice, this means that the
     /// resulting list of parts will contain the empty string at the start and
     /// end of the list.
-    #[func]
+    #[func(since = "forever")]
     pub fn split(
         &self,
         /// The pattern to split at. Defaults to whitespace.
@@ -685,7 +685,7 @@ impl Str {
     /// ```example
     /// #"Pirate flag: 🏴‍☠️".rev()
     /// ```
-    #[func(title = "Reverse")]
+    #[func(title = "Reverse", since = "0.8.0")]
     pub fn rev(&self) -> Str {
         let mut s = EcoString::with_capacity(self.0.len());
         for grapheme in self.as_str().graphemes(true).rev() {
@@ -985,7 +985,7 @@ fn string_is_empty() -> EcoString {
 ///
 /// The numbers 1 to 10.
 /// ```
-#[ty(scope)]
+#[ty(scope, since = "forever")]
 #[derive(Debug, Clone)]
 pub struct Regex(regex::Regex);
 
@@ -999,7 +999,7 @@ impl Regex {
 #[scope]
 impl Regex {
     /// Create a regular expression from a string.
-    #[func(constructor)]
+    #[func(constructor, since = "forever")]
     pub fn construct(
         /// The regular expression as a string.
         ///

--- a/crates/typst-library/src/foundations/symbol.rs
+++ b/crates/typst-library/src/foundations/symbol.rs
@@ -46,7 +46,7 @@ use crate::foundations::{
 /// $arrow.r$ \
 /// $arrow.t.quad$
 /// ```
-#[ty(scope, cast)]
+#[ty(scope, cast, since = "forever")]
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Symbol(SymbolInner);
 
@@ -215,7 +215,7 @@ impl Symbol {
     /// #envelope.lightning
     /// #envelope.fly
     /// ```
-    #[func(constructor)]
+    #[func(constructor, since = "forever")]
     pub fn construct(
         span: Span,
         /// The variants of the symbol.

--- a/crates/typst-library/src/foundations/target.rs
+++ b/crates/typst-library/src/foundations/target.rs
@@ -131,7 +131,7 @@ pub struct TargetElem {
 ///
 /// Press #kbd("F1") for help.
 /// ```
-#[func(contextual)]
+#[func(contextual, since = "0.13.0")]
 pub fn target(context: Tracked<Context>) -> HintedStrResult<Target> {
     Ok(context.styles()?.get(TargetElem::target))
 }

--- a/crates/typst-library/src/foundations/ty.rs
+++ b/crates/typst-library/src/foundations/ty.rs
@@ -10,7 +10,7 @@ use typst_utils::{DefSite, Static};
 
 use crate::diag::{StrResult, WarningSink, bail};
 use crate::foundations::{
-    AutoValue, Func, NativeFuncData, NoneValue, Repr, Scope, Value, cast, func,
+    AutoValue, Func, NativeFuncData, NoneValue, Repr, Scope, Since, Value, cast, func,
 };
 
 /// Describes a kind of value.
@@ -83,6 +83,11 @@ impl Type {
     /// The type's title case name, for use in documentation (e.g. `String`).
     pub fn title(&self) -> &'static str {
         self.0.title
+    }
+
+    /// The version of Typst this type was introduced in.
+    pub fn since(&self) -> Option<Since> {
+        self.0.since.clone()
     }
 
     /// Documentation for the type (as Markdown).
@@ -209,11 +214,13 @@ pub struct NativeTypeData {
     pub name: &'static str,
     /// The type's long name (e.g. `string`), for error messages.
     pub long_name: &'static str,
-    /// The function's title case name (e.g. `String`).
+    /// The type's title case name (e.g. `String`).
     pub title: &'static str,
+    /// The version of Typst this type was introduced in.
+    pub since: Option<Since>,
     /// The documentation for this type as a string.
     pub docs: &'static str,
-    /// Where the function is defined in the source code.
+    /// Where the type is defined in the source code.
     pub def_site: DefSite,
     /// A list of alternate search terms for this type.
     pub keywords: &'static [&'static str],

--- a/crates/typst-library/src/foundations/ty.rs
+++ b/crates/typst-library/src/foundations/ty.rs
@@ -60,7 +60,7 @@ use crate::foundations::{
 /// Note that `type` will return @content for all document elements. To
 /// programmatically determine which kind of content you are dealing with, see
 /// @content.func.
-#[ty(scope, cast)]
+#[ty(scope, cast, since = "0.8.0")]
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Type(Static<NativeTypeData>);
 
@@ -145,7 +145,7 @@ impl Type {
     /// #type(x => x + 1) \
     /// #type(type)
     /// ```
-    #[func(constructor)]
+    #[func(constructor, since = "0.8.0")]
     pub fn construct(
         /// The value whose type's to determine.
         value: Value,

--- a/crates/typst-library/src/foundations/version.rs
+++ b/crates/typst-library/src/foundations/version.rs
@@ -22,7 +22,7 @@ use crate::foundations::{Repr, cast, func, repr, scope, ty};
 ///
 /// You can convert a version to an array of explicitly given components using
 /// the @array constructor.
-#[ty(scope, cast)]
+#[ty(scope, cast, since = "0.9.0")]
 #[derive(Debug, Default, Clone, Hash)]
 pub struct Version(EcoVec<u32>);
 
@@ -86,7 +86,7 @@ impl Version {
     ///   #(version(3, 2, 0) > version(4, 1, 0))
     ///   ```
     /// )
-    #[func(constructor)]
+    #[func(constructor, since = "0.9.0")]
     pub fn construct(
         /// The components of the version (array arguments are flattened)
         #[variadic]
@@ -110,7 +110,7 @@ impl Version {
     ///
     /// The returned integer is always non-negative. Returns `0` if the version
     /// isn't specified to the necessary length.
-    #[func]
+    #[func(since = "0.9.0")]
     pub fn at(
         &self,
         /// The index at which to retrieve the component. If negative, indexes

--- a/crates/typst-library/src/foundations/version.rs
+++ b/crates/typst-library/src/foundations/version.rs
@@ -214,3 +214,31 @@ cast! {
     v: u32 => Self::Single(v),
     v: Vec<u32> => Self::Multiple(v)
 }
+
+/// When a feature was introduced.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum Since {
+    /// The feature was introduced before Typst 0.1.0.
+    Forever,
+    /// The feature was introduced in a version released after Typst 0.1.0.
+    Version([u32; 3]),
+    /// The feature is not present in any official Typst release.
+    Unreleased,
+}
+
+cast! {
+    Since,
+    self => match self {
+        Self::Forever => "forever".into_value(),
+        Self::Version(v) => Version::from_iter(v.into_iter()).into_value(),
+        Self::Unreleased => "unreleased".into_value(),
+    },
+    "forever" => Self::Forever,
+    "unreleased" => Self::Unreleased,
+    v: Version => {
+        let &[major, minor, patch] = v.values() else {
+            bail!("expected a version with exactly three components")
+        };
+        Self::Version([major, minor, patch])
+    },
+}

--- a/crates/typst-library/src/introspection/counter.rs
+++ b/crates/typst-library/src/introspection/counter.rs
@@ -214,7 +214,7 @@ use crate::{Library, World};
 /// The `counter` type is closely related to @state[state] type. Read its
 /// documentation for more details on state management in Typst and why it
 /// doesn't just use normal variables for counters.
-#[ty(scope)]
+#[ty(scope, since = "forever")]
 #[derive(Debug, Clone, PartialEq, Hash)]
 pub struct Counter(CounterKey);
 
@@ -336,7 +336,7 @@ impl Counter {
 #[scope]
 impl Counter {
     /// Create a new counter identified by a key.
-    #[func(constructor)]
+    #[func(constructor, since = "forever")]
     pub fn construct(
         /// The key that identifies this counter globally.
         ///
@@ -361,7 +361,7 @@ impl Counter {
     /// returns an array of integers, even if the counter has just one number.
     ///
     /// This is equivalent to `{counter.at(here())}`.
-    #[func(contextual)]
+    #[func(contextual, since = "0.11.0")]
     pub fn get(
         &self,
         engine: &mut Engine,
@@ -379,7 +379,7 @@ impl Counter {
     /// counted element and the current location, respectively).
     ///
     /// Returns the formatted output.
-    #[func(contextual)]
+    #[func(contextual, since = "forever")]
     pub fn display(
         self,
         engine: &mut Engine,
@@ -452,7 +452,7 @@ impl Counter {
     /// The `selector` must match exactly one element in the document. The most
     /// useful kinds of selectors for this are @label[labels] and
     /// @location[locations].
-    #[func(contextual)]
+    #[func(contextual, since = "forever")]
     pub fn at(
         &self,
         engine: &mut Engine,
@@ -467,7 +467,7 @@ impl Counter {
 
     /// Retrieves the value of the counter at the end of the document. Always
     /// returns an array of integers, even if the counter has just one number.
-    #[func(contextual)]
+    #[func(contextual, since = "forever")]
     pub fn final_(
         &self,
         engine: &mut Engine,
@@ -486,7 +486,7 @@ impl Counter {
     /// write `{let _ = counter(page).step()}`. Counter updates are always
     /// applied in layout order and in that case, Typst wouldn't know when to
     /// step the counter.
-    #[func]
+    #[func(since = "forever")]
     pub fn step(
         self,
         span: Span,
@@ -502,7 +502,7 @@ impl Counter {
     ///
     /// Just like with `step`, the update only occurs if you put the resulting
     /// content into the document.
-    #[func]
+    #[func(since = "forever")]
     pub fn update(
         self,
         span: Span,

--- a/crates/typst-library/src/introspection/here.rs
+++ b/crates/typst-library/src/introspection/here.rs
@@ -46,7 +46,7 @@ use crate::introspection::Location;
 /// ```
 ///
 /// Refer to the @selector type for more details on before/after selectors.
-#[func(contextual)]
+#[func(contextual, since = "0.11.0")]
 pub fn here(context: Tracked<Context>) -> HintedStrResult<Location> {
     context.location()
 }

--- a/crates/typst-library/src/introspection/locate.rs
+++ b/crates/typst-library/src/introspection/locate.rs
@@ -24,7 +24,7 @@ use crate::introspection::Location;
 ///
 /// = Introduction <intro>
 /// ```
-#[func(contextual)]
+#[func(contextual, since = "forever")]
 pub fn locate(
     engine: &mut Engine,
     context: Tracked<Context>,

--- a/crates/typst-library/src/introspection/location.rs
+++ b/crates/typst-library/src/introspection/location.rs
@@ -49,7 +49,7 @@ use crate::model::Numbering;
 ///
 /// Note that you can still observe elements that are not locatable in queries
 /// through other means, for instance, when they have a label attached to them.
-#[ty(scope)]
+#[ty(scope, since = "forever")]
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Location(u128);
 
@@ -93,7 +93,7 @@ impl Location {
     ///   page #here().page()
     /// ]
     /// ```
-    #[func]
+    #[func(since = "forever")]
     pub fn page(self, engine: &mut Engine, span: Span) -> NonZeroUsize {
         engine.introspect(PageIntrospection(self, span))
     }
@@ -104,7 +104,7 @@ impl Location {
     ///
     /// If you only need the page number, use `page()` instead as it allows
     /// Typst to skip unnecessary work.
-    #[func]
+    #[func(since = "forever")]
     pub fn position(self, engine: &mut Engine, span: Span) -> PagedPosition {
         engine.introspect(PositionIntrospection(self, span))
     }
@@ -116,7 +116,7 @@ impl Location {
     ///
     /// If the page numbering is set to `{none}` at that location, this function
     /// returns `{none}`.
-    #[func]
+    #[func(since = "forever")]
     pub fn page_numbering(self, engine: &mut Engine, span: Span) -> Option<Numbering> {
         engine.introspect(PageNumberingIntrospection(self, span))
     }

--- a/crates/typst-library/src/introspection/metadata.rs
+++ b/crates/typst-library/src/introspection/metadata.rs
@@ -20,7 +20,7 @@ use crate::foundations::{Value, elem};
 ///   query(<note>).first().value
 /// }
 /// ```
-#[elem(Locatable)]
+#[elem(since = "0.7.0", Locatable)]
 pub struct MetadataElem {
     /// The value to embed into the document.
     #[required]

--- a/crates/typst-library/src/introspection/query.rs
+++ b/crates/typst-library/src/introspection/query.rs
@@ -156,7 +156,7 @@ use crate::introspection::Introspector;
 /// In case you need to query a document when exporting for a specific target,
 /// you can use the `--target` argument. Valid values are `paged`, and `html`
 /// (if the @html feature is enabled).
-#[func(contextual)]
+#[func(contextual, since = "forever")]
 pub fn query(
     engine: &mut Engine,
     context: Tracked<Context>,

--- a/crates/typst-library/src/introspection/state.rs
+++ b/crates/typst-library/src/introspection/state.rs
@@ -186,7 +186,7 @@ use crate::{Library, World};
 /// values or functions that compute the new value from the previous value.
 /// Sometimes, it cannot be helped, but in those cases it is up to you to ensure
 /// that the result converges.
-#[ty(scope)]
+#[ty(scope, since = "forever")]
 #[derive(Debug, Clone, PartialEq, Hash)]
 pub struct State {
     /// The key that identifies the state.
@@ -215,7 +215,7 @@ impl State {
 #[scope]
 impl State {
     /// Create a new state identified by a key.
-    #[func(constructor)]
+    #[func(constructor, since = "forever")]
     pub fn construct(
         /// The key that identifies this state.
         ///
@@ -253,7 +253,7 @@ impl State {
     ///
     /// This is equivalent to `{state.at(here())}`.
     #[typst_macros::time(name = "state.get", span = span)]
-    #[func(contextual)]
+    #[func(contextual, since = "0.11.0")]
     pub fn get(
         &self,
         engine: &mut Engine,
@@ -270,7 +270,7 @@ impl State {
     /// useful kinds of selectors for this are @label[labels] and
     /// @location[locations].
     #[typst_macros::time(name = "state.at", span = span)]
-    #[func(contextual)]
+    #[func(contextual, since = "forever")]
     pub fn at(
         &self,
         engine: &mut Engine,
@@ -284,7 +284,7 @@ impl State {
     }
 
     /// Retrieves the value of the state at the end of the document.
-    #[func(contextual)]
+    #[func(contextual, since = "forever")]
     pub fn final_(
         &self,
         engine: &mut Engine,
@@ -326,7 +326,7 @@ impl State {
     /// @reference:context[context]. This is because, to create the state
     /// update, we do not need to know where in the document we are. We only
     /// need this information to resolve the state's value.
-    #[func]
+    #[func(since = "forever")]
     pub fn update(
         self,
         span: Span,

--- a/crates/typst-library/src/layout/align.rs
+++ b/crates/typst-library/src/layout/align.rs
@@ -75,7 +75,7 @@ use crate::text::TextElem;
 /// ```example
 /// Start #h(1fr) End
 /// ```
-#[elem]
+#[elem(since = "forever")]
 pub struct AlignElem {
     /// The @alignment[alignment] along both axes.
     ///
@@ -139,7 +139,7 @@ pub struct AlignElem {
 /// #left.x \
 /// #left.y (none)
 /// ```
-#[ty(scope)]
+#[ty(scope, since = "forever")]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum Alignment {
     H(HAlignment),
@@ -193,7 +193,7 @@ impl Alignment {
     /// #left.axis() \
     /// #bottom.axis()
     /// ```
-    #[func]
+    #[func(since = "0.7.0")]
     pub const fn axis(self) -> Option<Axis> {
         match self {
             Self::H(_) => Some(Axis::X),
@@ -210,7 +210,7 @@ impl Alignment {
     /// #center.inv() \
     /// #(left + bottom).inv()
     /// ```
-    #[func(title = "Inverse")]
+    #[func(title = "Inverse", since = "0.7.0")]
     pub const fn inv(self) -> Alignment {
         match self {
             Self::H(h) => Self::H(h.inv()),

--- a/crates/typst-library/src/layout/angle.rs
+++ b/crates/typst-library/src/layout/angle.rs
@@ -20,7 +20,7 @@ use crate::layout::Ratio;
 /// ```example
 /// #rotate(10deg)[Hello there!]
 /// ```
-#[ty(scope, cast)]
+#[ty(scope, cast, since = "forever")]
 #[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Angle(Scalar);
 
@@ -140,13 +140,13 @@ impl Angle {
 #[scope]
 impl Angle {
     /// Converts this angle to radians.
-    #[func(name = "rad", title = "Radians")]
+    #[func(name = "rad", title = "Radians", since = "0.7.0")]
     pub fn to_rad(self) -> f64 {
         self.to_unit(AngleUnit::Rad)
     }
 
     /// Converts this angle to degrees.
-    #[func(name = "deg", title = "Degrees")]
+    #[func(name = "deg", title = "Degrees", since = "0.7.0")]
     pub fn to_deg(self) -> f64 {
         self.to_unit(AngleUnit::Deg)
     }

--- a/crates/typst-library/src/layout/columns.rs
+++ b/crates/typst-library/src/layout/columns.rs
@@ -57,7 +57,7 @@ use crate::layout::{Length, Ratio, Rel};
 ///   #lorem(40)
 ///   ```
 /// )
-#[elem]
+#[elem(since = "forever")]
 pub struct ColumnsElem {
     /// The number of columns.
     #[positional]
@@ -96,7 +96,7 @@ pub struct ColumnsElem {
 /// understanding of the fundamental
 /// laws of nature.
 /// ```
-#[elem(title = "Column Break")]
+#[elem(title = "Column Break", since = "forever")]
 pub struct ColbreakElem {
     /// If `{true}`, the column break is skipped if the current column is
     /// already empty.

--- a/crates/typst-library/src/layout/container.rs
+++ b/crates/typst-library/src/layout/container.rs
@@ -27,7 +27,7 @@ use crate::visualize::{Paint, Stroke};
 /// )
 /// for more information.
 /// ```
-#[elem]
+#[elem(since = "forever")]
 pub struct BoxElem {
     /// The width of the box.
     ///
@@ -247,7 +247,7 @@ pub enum InlineItem {
 /// = Blocky
 /// More text.
 /// ```
-#[elem]
+#[elem(since = "forever")]
 pub struct BlockElem {
     /// The block's width.
     ///

--- a/crates/typst-library/src/layout/dir.rs
+++ b/crates/typst-library/src/layout/dir.rs
@@ -18,7 +18,7 @@ use crate::layout::{Axis, Side};
 /// #stack(dir: rtl)[A][B][C]
 /// #stack(dir: direction.rtl)[A][B][C]
 /// ```
-#[ty(scope, name = "direction")]
+#[ty(scope, name = "direction", since = "forever")]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum Dir {
     /// Left to right.
@@ -58,7 +58,7 @@ impl Dir {
     /// #direction.from(top) \
     /// #direction.from(bottom)
     /// ```
-    #[func]
+    #[func(since = "0.14.0")]
     pub const fn from(side: Side) -> Dir {
         match side {
             Side::Left => Self::LTR,
@@ -76,7 +76,7 @@ impl Dir {
     /// #direction.to(top) \
     /// #direction.to(bottom)
     /// ```
-    #[func]
+    #[func(since = "0.14.0")]
     pub const fn to(side: Side) -> Dir {
         match side {
             Side::Right => Self::LTR,
@@ -93,7 +93,7 @@ impl Dir {
     /// #ltr.axis() \
     /// #ttb.axis()
     /// ```
-    #[func]
+    #[func(since = "0.7.0")]
     pub const fn axis(self) -> Axis {
         match self {
             Self::LTR | Self::RTL => Axis::X,
@@ -109,7 +109,7 @@ impl Dir {
     /// #ttb.sign() \
     /// #btt.sign()
     /// ```
-    #[func]
+    #[func(since = "0.14.0")]
     pub const fn sign(self) -> i64 {
         match self {
             Self::LTR | Self::TTB => 1,
@@ -125,7 +125,7 @@ impl Dir {
     /// #ttb.start() \
     /// #btt.start()
     /// ```
-    #[func]
+    #[func(since = "0.7.0")]
     pub const fn start(self) -> Side {
         match self {
             Self::LTR => Side::Left,
@@ -143,7 +143,7 @@ impl Dir {
     /// #ttb.end() \
     /// #btt.end()
     /// ```
-    #[func]
+    #[func(since = "0.7.0")]
     pub const fn end(self) -> Side {
         match self {
             Self::LTR => Side::Right,
@@ -161,7 +161,7 @@ impl Dir {
     /// #ttb.inv() \
     /// #btt.inv()
     /// ```
-    #[func(title = "Inverse")]
+    #[func(title = "Inverse", since = "forever")]
     pub const fn inv(self) -> Dir {
         match self {
             Self::LTR => Self::RTL,

--- a/crates/typst-library/src/layout/fr.rs
+++ b/crates/typst-library/src/layout/fr.rs
@@ -20,7 +20,7 @@ use crate::layout::Abs;
 /// ```example
 /// Left #h(1fr) Left-ish #h(2fr) Right
 /// ```
-#[ty(cast, name = "fraction")]
+#[ty(cast, name = "fraction", since = "forever")]
 #[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Fr(Scalar);
 

--- a/crates/typst-library/src/layout/grid/mod.rs
+++ b/crates/typst-library/src/layout/grid/mod.rs
@@ -177,7 +177,7 @@ use crate::visualize::{Paint, Stroke};
 /// positioned them using @grid.cell.x[`grid.cell`'s `x` and `y` arguments],
 /// cells will be read row by row, from left to right (in left-to-right
 /// documents). A cell will be read when its position is first reached.
-#[elem(scope, Synthesize, Tagged)]
+#[elem(scope, since = "forever", Synthesize, Tagged)]
 pub struct GridElem {
     /// The column sizes.
     ///
@@ -576,7 +576,7 @@ impl TryFrom<Content> for GridItem {
 /// If `repeat` is set to `true`, the header will be repeated across pages. For
 /// an example, refer to the @table.header element and the @grid.stroke
 /// parameter.
-#[elem(name = "header", title = "Grid Header")]
+#[elem(name = "header", title = "Grid Header", since = "0.11.0")]
 pub struct GridHeader {
     /// Whether this header should be repeated across pages.
     #[default(true)]
@@ -604,7 +604,7 @@ pub struct GridHeader {
 /// page of the grid.
 ///
 /// No other grid cells may be placed after the footer.
-#[elem(name = "footer", title = "Grid Footer")]
+#[elem(name = "footer", title = "Grid Footer", since = "0.11.0")]
 pub struct GridFooter {
     /// Whether this footer should be repeated across pages.
     #[default(true)]
@@ -622,7 +622,7 @@ pub struct GridFooter {
 /// `column-gutter` option.
 ///
 /// An example for this function can be found at the @table.hline element.
-#[elem(name = "hline", title = "Grid Horizontal Line")]
+#[elem(name = "hline", title = "Grid Horizontal Line", since = "0.11.0")]
 pub struct GridHLine {
     /// The row above which the horizontal line is placed (zero-indexed). If the
     /// `position` field is set to `{bottom}`, the line is placed below the row
@@ -673,7 +673,7 @@ pub struct GridHLine {
 /// Overrides any per-cell stroke, including stroke specified through the grid's
 /// `stroke` field. Can cross spacing between cells created through the grid's
 /// `row-gutter` option.
-#[elem(name = "vline", title = "Grid Vertical Line")]
+#[elem(name = "vline", title = "Grid Vertical Line", since = "0.11.0")]
 pub struct GridVLine {
     /// The column before which the vertical line is placed (zero-indexed). If
     /// the `position` field is set to `{end}`, the line is placed after the
@@ -764,7 +764,7 @@ pub struct GridVLine {
 /// You may also apply a show rule on `grid.cell` to style all cells at once,
 /// which allows you, for example, to apply styles based on a cell's position.
 /// Refer to the examples of the @table.cell element to learn more about this.
-#[elem(name = "cell", title = "Grid Cell")]
+#[elem(name = "cell", title = "Grid Cell", since = "0.11.0")]
 pub struct GridCell {
     /// The cell's body.
     #[required]

--- a/crates/typst-library/src/layout/hide.rs
+++ b/crates/typst-library/src/layout/hide.rs
@@ -21,7 +21,7 @@ use crate::foundations::{Content, elem};
 /// Note that, depending on the circumstances, it may be possible for content to
 /// be reverse engineered based on its size in the layout. We thus do not
 /// recommend using this function to hide highly sensitive information.
-#[elem(Tagged)]
+#[elem(since = "forever", Tagged)]
 pub struct HideElem {
     /// The content to hide.
     #[required]

--- a/crates/typst-library/src/layout/layout.rs
+++ b/crates/typst-library/src/layout/layout.rs
@@ -61,7 +61,7 @@ use crate::foundations::{Content, Func, NativeElement, elem, func};
 ///
 /// Note that the width or height provided by `layout` will be infinite if the
 /// corresponding page dimension is set to `{auto}`.
-#[func]
+#[func(since = "0.2.0")]
 pub fn layout(
     span: Span,
     /// A function to call with the outer container's size. Its return value is

--- a/crates/typst-library/src/layout/length.rs
+++ b/crates/typst-library/src/layout/length.rs
@@ -39,7 +39,7 @@ use crate::layout::{Abs, Em};
 /// - `abs`: A length with just the absolute component of the current length
 ///   (that is, excluding the `em` component).
 /// - `em`: The amount of `em` units in this length, as a @float[float].
-#[ty(scope, cast)]
+#[ty(scope, cast, since = "forever")]
 #[derive(Default, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Length {
     /// The absolute part.
@@ -101,7 +101,7 @@ impl Length {
     /// `5em + 2pt` instead of just `2pt`). Use the `abs` field (such as in
     /// `(5em + 2pt).abs.pt()`) to ignore the `em` component of the length (thus
     /// converting only its absolute component).
-    #[func(name = "pt", title = "Points")]
+    #[func(name = "pt", title = "Points", since = "0.7.0")]
     pub fn to_pt(&self, span: Span) -> SourceResult<f64> {
         self.ensure_that_em_is_zero(span, "pt")?;
         Ok(self.abs.to_pt())
@@ -111,7 +111,7 @@ impl Length {
     ///
     /// Fails with an error if this length has non-zero `em` units. See the
     /// @length.pt[`pt`] method for more details.
-    #[func(name = "mm", title = "Millimeters")]
+    #[func(name = "mm", title = "Millimeters", since = "0.7.0")]
     pub fn to_mm(&self, span: Span) -> SourceResult<f64> {
         self.ensure_that_em_is_zero(span, "mm")?;
         Ok(self.abs.to_mm())
@@ -121,7 +121,7 @@ impl Length {
     ///
     /// Fails with an error if this length has non-zero `em` units. See the
     /// @length.pt[`pt`] method for more details.
-    #[func(name = "cm", title = "Centimeters")]
+    #[func(name = "cm", title = "Centimeters", since = "0.7.0")]
     pub fn to_cm(&self, span: Span) -> SourceResult<f64> {
         self.ensure_that_em_is_zero(span, "cm")?;
         Ok(self.abs.to_cm())
@@ -131,7 +131,7 @@ impl Length {
     ///
     /// Fails with an error if this length has non-zero `em` units. See the
     /// @length.pt[`pt`] method for more details.
-    #[func(name = "inches")]
+    #[func(name = "inches", since = "0.7.0")]
     pub fn to_inches(&self, span: Span) -> SourceResult<f64> {
         self.ensure_that_em_is_zero(span, "inches")?;
         Ok(self.abs.to_inches())
@@ -154,7 +154,7 @@ impl Length {
     ///   #(10em).to-absolute()
     /// ]
     /// ```
-    #[func]
+    #[func(since = "0.11.0")]
     pub fn to_absolute(&self, context: Tracked<Context>) -> HintedStrResult<Length> {
         Ok(self.resolve(context.styles()?).into())
     }

--- a/crates/typst-library/src/layout/measure.rs
+++ b/crates/typst-library/src/layout/measure.rs
@@ -43,7 +43,7 @@ use crate::layout::{Abs, Axes, Length, Region, Size};
 ///
 /// The measure function returns a dictionary with the entries `width` and
 /// `height`, both of type @length.
-#[func(contextual)]
+#[func(contextual, since = "forever")]
 pub fn measure(
     engine: &mut Engine,
     context: Tracked<Context>,

--- a/crates/typst-library/src/layout/pad.rs
+++ b/crates/typst-library/src/layout/pad.rs
@@ -14,7 +14,7 @@ use crate::layout::{Length, Rel};
 /// _Typing speeds can be
 ///  measured in words per minute._
 /// ```
-#[elem(title = "Padding")]
+#[elem(title = "Padding", since = "forever")]
 pub struct PadElem {
     /// The padding at the left side.
     #[parse(

--- a/crates/typst-library/src/layout/page.rs
+++ b/crates/typst-library/src/layout/page.rs
@@ -50,7 +50,7 @@ use crate::visualize::Paint;
 /// instead configure the @page.header[`header`], @page.footer[`footer`],
 /// @page.background[`background`], and @page.foreground[`foreground`]
 /// properties with a set rule.
-#[elem(Construct)]
+#[elem(since = "forever", Construct)]
 pub struct PageElem {
     /// A standard paper size to set width and height.
     ///
@@ -549,7 +549,7 @@ impl LocalName for PageElem {
 /// Pagination tries to avoid single lines of text at the top or bottom of a
 /// page (these are called _widows_ and _orphans_). You can adjust the
 /// @text.costs parameter to disable this behavior.
-#[elem(title = "Page Break")]
+#[elem(title = "Page Break", since = "forever")]
 pub struct PagebreakElem {
     /// If `{true}`, the page break is skipped if the current page is already
     /// empty.

--- a/crates/typst-library/src/layout/place.rs
+++ b/crates/typst-library/src/layout/place.rs
@@ -71,7 +71,7 @@ use crate::layout::{Alignment, Em, Length, Rel};
 /// where it logically appears in the document, regardless of where this
 /// function physically moved it. Put its markup where it would make the most
 /// sense in the reading order.
-#[elem(scope, Unqueriable, Locatable, Tagged)]
+#[elem(scope, since = "forever", Unqueriable, Locatable, Tagged)]
 pub struct PlaceElem {
     /// Relative to which position in the parent container to place the content.
     ///
@@ -209,5 +209,5 @@ pub enum PlacementScope {
 ///
 /// This text appears after the figure.
 /// ```
-#[elem]
+#[elem(since = "0.12.0")]
 pub struct FlushElem {}

--- a/crates/typst-library/src/layout/ratio.rs
+++ b/crates/typst-library/src/layout/ratio.rs
@@ -59,7 +59,7 @@ use crate::foundations::{Repr, repr, ty};
 ///
 /// When ratios are @repr[displayed] in the document, they are rounded to two
 /// significant digits for readability.
-#[ty(cast)]
+#[ty(cast, since = "forever")]
 #[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Ratio(Scalar);
 

--- a/crates/typst-library/src/layout/rel.rs
+++ b/crates/typst-library/src/layout/rel.rs
@@ -73,7 +73,7 @@ use crate::layout::{Abs, Em, Length, Ratio};
 /// #(100% - 50pt).length \
 /// #(100% - 50pt).ratio
 /// ```
-#[ty(cast, name = "relative", title = "Relative Length")]
+#[ty(cast, name = "relative", title = "Relative Length", since = "forever")]
 #[derive(Default, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Rel<T: NumericLength = Length> {
     /// The relative part.

--- a/crates/typst-library/src/layout/repeat.rs
+++ b/crates/typst-library/src/layout/repeat.rs
@@ -27,7 +27,7 @@ use crate::layout::Length;
 /// Repeated content is automatically marked as an @pdf.artifact[artifact] and
 /// hidden from Assistive Technology (AT). Do not use this function to create
 /// content that contributes to the meaning of your document.
-#[elem(Tagged)]
+#[elem(since = "forever", Tagged)]
 pub struct RepeatElem {
     /// The content to repeat.
     #[required]

--- a/crates/typst-library/src/layout/spacing.rs
+++ b/crates/typst-library/src/layout/spacing.rs
@@ -30,7 +30,7 @@ use crate::layout::{Abs, Em, Fr, Length, Ratio, Rel};
 /// In @math[mathematical formulas], you can additionally use these constants to
 /// add spacing between elements: `thin` (1/6 em), `med` (2/9 em), `thick`
 /// (5/18 em), `quad` (1 em), `wide` (2 em).
-#[elem(title = "Spacing (H)")]
+#[elem(title = "Spacing (H)", since = "forever")]
 pub struct HElem {
     /// How much spacing to insert.
     #[required]
@@ -92,7 +92,7 @@ impl HElem {
 ///   [A #v(1fr) B],
 /// )
 /// ```
-#[elem(title = "Spacing (V)")]
+#[elem(title = "Spacing (V)", since = "forever")]
 pub struct VElem {
     /// How much spacing to insert.
     #[required]

--- a/crates/typst-library/src/layout/stack.rs
+++ b/crates/typst-library/src/layout/stack.rs
@@ -22,7 +22,7 @@ use crate::layout::{Dir, Spacing};
 /// Stacks do not carry any special semantics. The contents of the stack are
 /// read by Assistive Technology (AT) in the order in which they have been
 /// passed to this function.
-#[elem]
+#[elem(since = "forever")]
 pub struct StackElem {
     /// The direction along which the items are stacked. Possible values are:
     ///

--- a/crates/typst-library/src/layout/transform.rs
+++ b/crates/typst-library/src/layout/transform.rs
@@ -25,7 +25,7 @@ use crate::layout::{Abs, Alignment, Angle, HAlignment, Length, Ratio, Rel, VAlig
 /// read in the order it appears in the source, regardless of any visual
 /// movement. If you need to hide content from AT altogether in PDF export,
 /// consider using @pdf.artifact.
-#[elem]
+#[elem(since = "forever")]
 pub struct MoveElem {
     /// The horizontal displacement of the content.
     pub dx: Rel<Length>,
@@ -52,7 +52,7 @@ pub struct MoveElem {
 ///     .map(i => rotate(24deg * i)[X]),
 /// )
 /// ```
-#[elem]
+#[elem(since = "forever")]
 pub struct RotateElem {
     /// The amount of rotation.
     ///
@@ -108,7 +108,7 @@ pub struct RotateElem {
 /// #scale(x: -100%)[This is mirrored.]
 /// #scale(x: -100%, reflow: true)[This is mirrored.]
 /// ```
-#[elem]
+#[elem(since = "forever")]
 pub struct ScaleElem {
     /// The scaling factor for both axes, as a positional argument. This is just
     /// an optional shorthand notation for setting `x` and `y` to the same
@@ -190,7 +190,7 @@ cast! {
 ///   This is some fake italic text.
 /// ]
 /// ```
-#[elem]
+#[elem(since = "0.12.0")]
 pub struct SkewElem {
     /// The horizontal skewing angle.
     ///

--- a/crates/typst-library/src/loading/cbor.rs
+++ b/crates/typst-library/src/loading/cbor.rs
@@ -70,7 +70,7 @@ use crate::loading::{DataSource, Load};
 ///
 /// - The `repr` function is @repr:debugging-only[for debugging purposes only],
 ///   and its output is not guaranteed to be stable across Typst versions.
-#[func(scope, title = "CBOR")]
+#[func(scope, title = "CBOR", since = "0.8.0")]
 pub fn cbor(
     engine: &mut Engine,
     /// A path to a CBOR file or raw CBOR bytes.
@@ -100,7 +100,7 @@ fn format_cbor_error(error: Error<std::io::Error>) -> LoadError {
 #[scope]
 impl cbor {
     /// Encode structured data into CBOR bytes.
-    #[func(title = "Encode CBOR")]
+    #[func(title = "Encode CBOR", since = "0.8.0")]
     pub fn encode(
         /// Value to be encoded.
         value: Spanned<Value>,

--- a/crates/typst-library/src/loading/csv.rs
+++ b/crates/typst-library/src/loading/csv.rs
@@ -23,7 +23,7 @@ use crate::loading::{DataSource, Load};
 ///   ..results.flatten(),
 /// )
 /// ```
-#[func(title = "CSV")]
+#[func(title = "CSV", since = "forever")]
 pub fn csv(
     engine: &mut Engine,
     /// A path to a CSV file or raw CSV bytes.

--- a/crates/typst-library/src/loading/json.rs
+++ b/crates/typst-library/src/loading/json.rs
@@ -97,7 +97,7 @@ use crate::loading::{DataSource, Load};
 ///
 /// - The `repr` function is @repr:debugging-only[for debugging purposes only],
 ///   and its output is not guaranteed to be stable across Typst versions.
-#[func(scope, title = "JSON")]
+#[func(scope, title = "JSON", since = "forever")]
 pub fn json(
     engine: &mut Engine,
     /// A path to a JSON file or raw JSON bytes.
@@ -130,7 +130,7 @@ pub fn json(
 #[scope]
 impl json {
     /// Encodes structured data into a JSON string.
-    #[func(title = "Encode JSON")]
+    #[func(title = "Encode JSON", since = "0.8.0")]
     pub fn encode(
         /// Value to be encoded.
         value: Spanned<Value>,

--- a/crates/typst-library/src/loading/read.rs
+++ b/crates/typst-library/src/loading/read.rs
@@ -20,7 +20,7 @@ use crate::loading::{DataSource, Load, Readable};
 /// Raw bytes:
 /// #read("tiger.jpg", encoding: none)
 /// ```
-#[func]
+#[func(since = "forever")]
 pub fn read(
     engine: &mut Engine,
     /// Path to a file.

--- a/crates/typst-library/src/loading/toml.rs
+++ b/crates/typst-library/src/loading/toml.rs
@@ -89,7 +89,7 @@ use crate::loading::{DataSource, Load};
 ///
 /// - The `repr` function is @repr:debugging-only[for debugging purposes only],
 ///   and its output is not guaranteed to be stable across Typst versions.
-#[func(scope, title = "TOML")]
+#[func(scope, title = "TOML", since = "0.3.0")]
 pub fn toml(
     engine: &mut Engine,
     /// A path to a TOML file or raw TOML bytes.
@@ -103,7 +103,7 @@ pub fn toml(
 #[scope]
 impl toml {
     /// Encodes structured data into a TOML string.
-    #[func(title = "Encode TOML")]
+    #[func(title = "Encode TOML", since = "0.8.0")]
     pub fn encode(
         /// Value to be encoded.
         ///

--- a/crates/typst-library/src/loading/xml.rs
+++ b/crates/typst-library/src/loading/xml.rs
@@ -54,7 +54,7 @@ use crate::loading::{DataSource, Load};
 ///   }
 /// }
 /// ```
-#[func(title = "XML")]
+#[func(title = "XML", since = "forever")]
 pub fn xml(
     engine: &mut Engine,
     /// A path to an XML file or raw XML bytes.

--- a/crates/typst-library/src/loading/yaml.rs
+++ b/crates/typst-library/src/loading/yaml.rs
@@ -92,7 +92,7 @@ use crate::loading::{DataSource, Load};
 ///
 /// - The `repr` function is @repr:debugging-only[for debugging purposes only],
 ///   and its output is not guaranteed to be stable across Typst versions.
-#[func(scope, title = "YAML")]
+#[func(scope, title = "YAML", since = "0.1.0")]
 pub fn yaml(
     engine: &mut Engine,
     /// A path to a YAML file or raw YAML bytes.
@@ -107,7 +107,7 @@ pub fn yaml(
 #[scope]
 impl yaml {
     /// Encode structured data into a YAML string.
-    #[func(title = "Encode YAML")]
+    #[func(title = "Encode YAML", since = "0.8.0")]
     pub fn encode(
         /// Value to be encoded.
         value: Spanned<Value>,

--- a/crates/typst-library/src/math/accent.rs
+++ b/crates/typst-library/src/math/accent.rs
@@ -29,7 +29,7 @@ pub const ACCENT_SHORT_FALL: Em = Em::new(0.5);
 /// $arrow(a) = accent(a, arrow)$ \
 /// $tilde(a) = accent(a, \u{0303})$
 /// ```
-#[elem(Mathy)]
+#[elem(since = "forever", Mathy)]
 pub struct AccentElem {
     /// The base to which the accent is applied. May consist of multiple
     /// letters.

--- a/crates/typst-library/src/math/accent.rs
+++ b/crates/typst-library/src/math/accent.rs
@@ -273,6 +273,7 @@ fn create_accent_func_data(accent: char, bump: &'static Bump) -> NativeFuncData 
         )),
         name: "(..) => ..",
         title,
+        since: None,
         docs,
         def_site: None,
         keywords: &[],

--- a/crates/typst-library/src/math/attach.rs
+++ b/crates/typst-library/src/math/attach.rs
@@ -16,7 +16,7 @@ use crate::math::{EquationElem, MathSize, Mathy};
 ///
 /// If you want to add accents (hats, tildes, arrows, etc.) instead of scripts
 /// or corner attachments, use the @math.accent[`accent`] function instead.
-#[elem(Mathy)]
+#[elem(since = "forever", Mathy)]
 pub struct AttachElem {
     /// The base to which things are attached.
     #[required]
@@ -58,7 +58,7 @@ pub struct AttachElem {
 /// This function has dedicated syntax: use apostrophes instead of primes. They
 /// will automatically attach to the previous element, moving superscripts to
 /// the next level.
-#[elem(Mathy)]
+#[elem(since = "0.11.0", Mathy)]
 pub struct PrimesElem {
     /// The number of grouped primes.
     #[required]
@@ -70,7 +70,7 @@ pub struct PrimesElem {
 /// ```example
 /// $ scripts(sum)_1^2 != sum_1^2 $
 /// ```
-#[elem(Mathy)]
+#[elem(since = "forever", Mathy)]
 pub struct ScriptsElem {
     /// The base to attach the scripts to.
     #[required]
@@ -82,7 +82,7 @@ pub struct ScriptsElem {
 /// ```example
 /// $ limits(A)_1^2 != A_1^2 $
 /// ```
-#[elem(Mathy)]
+#[elem(since = "forever", Mathy)]
 pub struct LimitsElem {
     /// The base to attach the limits to.
     #[required]
@@ -111,7 +111,7 @@ pub struct LimitsElem {
 /// $ x stretch(harpoons.ltrb, size: #3em) y
 ///     stretch(\[, size: #150%) z $
 /// ```
-#[elem(Mathy)]
+#[elem(since = "0.12.0", Mathy)]
 pub struct StretchElem {
     /// The glyph to stretch.
     #[required]

--- a/crates/typst-library/src/math/cancel.rs
+++ b/crates/typst-library/src/math/cancel.rs
@@ -14,7 +14,7 @@ use crate::visualize::Stroke;
 /// $ (a dot b dot cancel(x)) /
 ///     cancel(x) $
 /// ```
-#[elem(Mathy)]
+#[elem(since = "0.3.0", Mathy)]
 pub struct CancelElem {
     /// The content over which the line should be placed.
     #[required]

--- a/crates/typst-library/src/math/equation.rs
+++ b/crates/typst-library/src/math/equation.rs
@@ -44,7 +44,17 @@ use crate::text::{FontFamily, FontList, FontWeight, LocalName, Locale, TextElem}
 /// dollar signs to create an equation. Starting and ending the equation with
 /// whitespace lifts it into a separate block that is centered horizontally. For
 /// more details about math syntax, see the @math[main math page].
-#[elem(Locatable, Tagged, Synthesize, ShowSet, Count, LocalName, Refable, Outlinable)]
+#[elem(
+    since = "forever",
+    Locatable,
+    Tagged,
+    Synthesize,
+    ShowSet,
+    Count,
+    LocalName,
+    Refable,
+    Outlinable
+)]
 pub struct EquationElem {
     /// Whether the equation is displayed as a separate block.
     #[default(false)]

--- a/crates/typst-library/src/math/frac.rs
+++ b/crates/typst-library/src/math/frac.rs
@@ -21,7 +21,7 @@ pub const FRAC_PADDING: Em = Em::new(0.1);
 /// expressions into a fraction. Multiple atoms can be grouped into a single
 /// expression using round grouping parentheses. Such parentheses are removed
 /// from the output, but you can nest multiple to force them.
-#[elem(title = "Fraction", Mathy)]
+#[elem(title = "Fraction", since = "forever", Mathy)]
 pub struct FracElem {
     /// The fraction's numerator.
     #[required]
@@ -130,7 +130,7 @@ pub enum FracStyle {
 /// $ binom(n, k) $
 /// $ binom(n, k_1, k_2, k_3, ..., k_m) $
 /// ```
-#[elem(title = "Binomial", Mathy)]
+#[elem(title = "Binomial", since = "forever", Mathy)]
 pub struct BinomElem {
     /// The binomial's upper index.
     #[required]

--- a/crates/typst-library/src/math/lr.rs
+++ b/crates/typst-library/src/math/lr.rs
@@ -20,7 +20,7 @@ pub const DELIM_SHORT_FALL: Em = Em::new(0.1);
 ///
 /// While matched delimiters scale by default, this can be used to scale
 /// unmatched delimiters and to control the delimiter scaling more precisely.
-#[elem(title = "Left/Right", Mathy)]
+#[elem(title = "Left/Right", since = "forever", Mathy)]
 pub struct LrElem {
     /// The size of the brackets, relative to the height of the wrapped content.
     #[default(Rel::one())]
@@ -42,7 +42,7 @@ pub struct LrElem {
 /// ```example
 /// $ { x mid(|) sum_(i=1)^n w_i abs(f_i (x)) < 1 } $
 /// ```
-#[elem(Mathy)]
+#[elem(since = "0.10.0", Mathy)]
 pub struct MidElem {
     /// The content to be scaled.
     #[required]
@@ -54,7 +54,7 @@ pub struct MidElem {
 /// ```example
 /// $ floor(x/2) $
 /// ```
-#[func]
+#[func(since = "forever")]
 pub fn floor(
     /// The size of the brackets, relative to the height of the wrapped content.
     ///
@@ -72,7 +72,7 @@ pub fn floor(
 /// ```example
 /// $ ceil(x/2) $
 /// ```
-#[func]
+#[func(since = "forever")]
 pub fn ceil(
     /// The size of the brackets, relative to the height of the wrapped content.
     ///
@@ -90,7 +90,7 @@ pub fn ceil(
 /// ```example
 /// $ round(x/2) $
 /// ```
-#[func]
+#[func(since = "forever")]
 pub fn round(
     /// The size of the brackets, relative to the height of the wrapped content.
     ///
@@ -108,7 +108,7 @@ pub fn round(
 /// ```example
 /// $ abs(x/2) $
 /// ```
-#[func]
+#[func(since = "forever")]
 pub fn abs(
     /// The size of the brackets, relative to the height of the wrapped content.
     ///
@@ -126,7 +126,7 @@ pub fn abs(
 /// ```example
 /// $ norm(x/2) $
 /// ```
-#[func]
+#[func(since = "forever")]
 pub fn norm(
     /// The size of the brackets, relative to the height of the wrapped content.
     ///

--- a/crates/typst-library/src/math/lr.rs
+++ b/crates/typst-library/src/math/lr.rs
@@ -221,6 +221,7 @@ fn create_lr_func_data(left: char, right: char, bump: &'static Bump) -> NativeFu
         )),
         name: "(..) => ..",
         title,
+        since: None,
         docs,
         def_site: None,
         keywords: &[],

--- a/crates/typst-library/src/math/matrix.rs
+++ b/crates/typst-library/src/math/matrix.rs
@@ -29,7 +29,7 @@ const DEFAULT_COL_GAP: Em = Em::new(0.5);
 /// $ vec(a, b, c) dot vec(1, 2, 3)
 ///     = a + 2b + 3c $
 /// ```
-#[elem(title = "Vector", Mathy)]
+#[elem(title = "Vector", since = "forever", Mathy)]
 pub struct VecElem {
     /// The delimiter to use.
     ///
@@ -88,7 +88,7 @@ pub struct VecElem {
 ///   10, 10, ..., 10;
 /// ) $
 /// ```
-#[elem(title = "Matrix", Mathy)]
+#[elem(title = "Matrix", since = "forever", Mathy)]
 pub struct MatElem {
     /// The delimiter to use.
     ///
@@ -234,7 +234,7 @@ pub struct MatElem {
 ///   4 "else",
 /// ) $
 /// ```
-#[elem(Mathy)]
+#[elem(since = "forever", Mathy)]
 pub struct CasesElem {
     /// The delimiter to use.
     ///

--- a/crates/typst-library/src/math/mod.rs
+++ b/crates/typst-library/src/math/mod.rs
@@ -111,7 +111,7 @@ pub fn module() -> Module {
 pub trait Mathy {}
 
 /// A math alignment point: `&`, `&&`.
-#[elem(title = "Alignment Point", Mathy)]
+#[elem(title = "Alignment Point", since = "forever", Mathy)]
 pub struct AlignPointElem {}
 
 impl AlignPointElem {
@@ -138,7 +138,7 @@ impl AlignPointElem {
 ///
 /// $x loves y and y loves 5$
 /// ```
-#[elem(Mathy)]
+#[elem(since = "forever", Mathy)]
 pub struct ClassElem {
     /// The class to apply to the content.
     #[required]

--- a/crates/typst-library/src/math/op.rs
+++ b/crates/typst-library/src/math/op.rs
@@ -21,7 +21,7 @@ use crate::text::TextElem;
 /// `gcd`, `lcm`, `hom`, `id`, `im`, `inf`, `ker`, `lg`, `lim`, `liminf`,
 /// `limsup`, `ln`, `log`, `max`, `min`, `mod`, `Pr`, `sec`, `sech`, `sin`,
 /// `sinc`, `sinh`, `sup`, `tan`, `tanh`, `tg` and `tr`.
-#[elem(title = "Text Operator", Mathy)]
+#[elem(title = "Text Operator", since = "forever", Mathy)]
 pub struct OpElem {
     /// The operator's text.
     #[required]

--- a/crates/typst-library/src/math/root.rs
+++ b/crates/typst-library/src/math/root.rs
@@ -8,7 +8,7 @@ use crate::math::Mathy;
 /// ```example
 /// $ sqrt(3 - 2 sqrt(2)) = sqrt(2) - 1 $
 /// ```
-#[func(title = "Square Root")]
+#[func(title = "Square Root", since = "forever")]
 pub fn sqrt(
     span: Span,
     /// The expression to take the square root of.
@@ -22,7 +22,7 @@ pub fn sqrt(
 /// ```example
 /// $ root(3, x) $
 /// ```
-#[elem(Mathy)]
+#[elem(since = "forever", Mathy)]
 pub struct RootElem {
     /// Which root of the radicand to take.
     #[positional]

--- a/crates/typst-library/src/math/style.rs
+++ b/crates/typst-library/src/math/style.rs
@@ -11,7 +11,7 @@ use crate::text::{FontFeatures, Tag, TextElem};
 /// ```example
 /// $ bold(A) := B^+ $
 /// ```
-#[func(keywords = ["mathbf"])]
+#[func(since = "forever", keywords = ["mathbf"])]
 pub fn bold(
     /// The content to style.
     body: Content,
@@ -24,7 +24,7 @@ pub fn bold(
 /// ```example
 /// $ upright(A) != A $
 /// ```
-#[func(keywords = ["mathup"])]
+#[func(since = "forever", keywords = ["mathup"])]
 pub fn upright(
     /// The content to style.
     body: Content,
@@ -35,7 +35,7 @@ pub fn upright(
 /// Italic font style in math.
 ///
 /// For roman letters and greek lowercase letters, this is already the default.
-#[func(keywords = ["mathit"])]
+#[func(since = "forever", keywords = ["mathit"])]
 pub fn italic(
     /// The content to style.
     body: Content,
@@ -46,7 +46,7 @@ pub fn italic(
 /// Serif (roman) font style in math.
 ///
 /// This is already the default.
-#[func(keywords = ["mathrm"])]
+#[func(since = "forever", keywords = ["mathrm"])]
 pub fn serif(
     /// The content to style.
     body: Content,
@@ -59,7 +59,7 @@ pub fn serif(
 /// ```example
 /// $ sans(A B C) $
 /// ```
-#[func(title = "Sans Serif", keywords = ["mathsf"])]
+#[func(title = "Sans Serif", since = "forever", keywords = ["mathsf"])]
 pub fn sans(
     /// The content to style.
     body: Content,
@@ -75,7 +75,7 @@ pub fn sans(
 ///
 /// This is the default calligraphic/script style for most math fonts. See
 /// @math.scr[`scr`] for more on how to get the other style (roundhand).
-#[func(title = "Calligraphic", keywords = ["mathcal", "chancery"])]
+#[func(title = "Calligraphic", since = "forever", keywords = ["mathcal", "chancery"])]
 pub fn cal(
     /// The content to style.
     body: Content,
@@ -110,7 +110,7 @@ pub fn cal(
 ///   We establish $cal(P) != scr(P)$.
 ///   ```
 /// )
-#[func(title = "Script Style", keywords = ["mathscr", "roundhand"])]
+#[func(title = "Script Style", since = "0.14.0", keywords = ["mathscr", "roundhand"])]
 pub fn scr(
     /// The content to style.
     body: Content,
@@ -123,7 +123,7 @@ pub fn scr(
 /// ```example
 /// $ frak(P) $
 /// ```
-#[func(title = "Fraktur", keywords = ["mathfrak"])]
+#[func(title = "Fraktur", since = "forever", keywords = ["mathfrak"])]
 pub fn frak(
     /// The content to style.
     body: Content,
@@ -136,7 +136,7 @@ pub fn frak(
 /// ```example
 /// $ mono(x + y = z) $
 /// ```
-#[func(title = "Monospace", keywords = ["mathtt"])]
+#[func(title = "Monospace", since = "forever", keywords = ["mathtt"])]
 pub fn mono(
     /// The content to style.
     body: Content,
@@ -154,7 +154,7 @@ pub fn mono(
 /// $ bb(N) = NN $
 /// $ f: NN -> RR $
 /// ```
-#[func(title = "Blackboard Bold", keywords = ["mathbb"])]
+#[func(title = "Blackboard Bold", since = "forever", keywords = ["mathbb"])]
 pub fn bb(
     /// The content to style.
     body: Content,
@@ -169,7 +169,7 @@ pub fn bb(
 /// ```example
 /// $sum_i x_i/2 = display(sum_i x_i/2)$
 /// ```
-#[func(title = "Display Size", keywords = ["displaystyle"])]
+#[func(title = "Display Size", since = "0.5.0", keywords = ["displaystyle"])]
 pub fn display(
     /// The content to size.
     body: Content,
@@ -191,7 +191,7 @@ pub fn display(
 /// $ sum_i x_i/2
 ///     = inline(sum_i x_i/2) $
 /// ```
-#[func(title = "Inline Size", keywords = ["textstyle"])]
+#[func(title = "Inline Size", since = "0.5.0", keywords = ["textstyle"])]
 pub fn inline(
     /// The content to size.
     body: Content,
@@ -212,7 +212,7 @@ pub fn inline(
 /// ```example
 /// $sum_i x_i/2 = script(sum_i x_i/2)$
 /// ```
-#[func(title = "Script Size", keywords = ["scriptstyle"])]
+#[func(title = "Script Size", since = "0.5.0", keywords = ["scriptstyle"])]
 pub fn script(
     /// The content to size.
     body: Content,
@@ -234,7 +234,7 @@ pub fn script(
 /// ```example
 /// $sum_i x_i/2 = sscript(sum_i x_i/2)$
 /// ```
-#[func(title = "Script-Script Size", keywords = ["scriptscriptstyle"])]
+#[func(title = "Script-Script Size", since = "0.5.0", keywords = ["scriptscriptstyle"])]
 pub fn sscript(
     /// The content to size.
     body: Content,

--- a/crates/typst-library/src/math/underover.rs
+++ b/crates/typst-library/src/math/underover.rs
@@ -6,7 +6,7 @@ use crate::math::Mathy;
 /// ```example
 /// $ underline(1 + 2 + ... + 5) $
 /// ```
-#[elem(Mathy)]
+#[elem(since = "forever", Mathy)]
 pub struct UnderlineElem {
     /// The content above the line.
     #[required]
@@ -18,7 +18,7 @@ pub struct UnderlineElem {
 /// ```example
 /// $ overline(1 + 2 + ... + 5) $
 /// ```
-#[elem(Mathy)]
+#[elem(since = "forever", Mathy)]
 pub struct OverlineElem {
     /// The content below the line.
     #[required]
@@ -30,7 +30,7 @@ pub struct OverlineElem {
 /// ```example
 /// $ underbrace(0 + 1 + dots.c + n, n + 1 "numbers") $
 /// ```
-#[elem(Mathy)]
+#[elem(since = "forever", Mathy)]
 pub struct UnderbraceElem {
     /// The content above the brace.
     #[required]
@@ -46,7 +46,7 @@ pub struct UnderbraceElem {
 /// ```example
 /// $ overbrace(0 + 1 + dots.c + n, n + 1 "numbers") $
 /// ```
-#[elem(Mathy)]
+#[elem(since = "forever", Mathy)]
 pub struct OverbraceElem {
     /// The content below the brace.
     #[required]
@@ -62,7 +62,7 @@ pub struct OverbraceElem {
 /// ```example
 /// $ underbracket(0 + 1 + dots.c + n, n + 1 "numbers") $
 /// ```
-#[elem(Mathy)]
+#[elem(since = "forever", Mathy)]
 pub struct UnderbracketElem {
     /// The content above the bracket.
     #[required]
@@ -78,7 +78,7 @@ pub struct UnderbracketElem {
 /// ```example
 /// $ overbracket(0 + 1 + dots.c + n, n + 1 "numbers") $
 /// ```
-#[elem(Mathy)]
+#[elem(since = "forever", Mathy)]
 pub struct OverbracketElem {
     /// The content below the bracket.
     #[required]
@@ -94,7 +94,7 @@ pub struct OverbracketElem {
 /// ```example
 /// $ underparen(0 + 1 + dots.c + n, n + 1 "numbers") $
 /// ```
-#[elem(Mathy)]
+#[elem(since = "forever", Mathy)]
 pub struct UnderparenElem {
     /// The content above the parenthesis.
     #[required]
@@ -110,7 +110,7 @@ pub struct UnderparenElem {
 /// ```example
 /// $ overparen(0 + 1 + dots.c + n, n + 1 "numbers") $
 /// ```
-#[elem(Mathy)]
+#[elem(since = "forever", Mathy)]
 pub struct OverparenElem {
     /// The content below the parenthesis.
     #[required]
@@ -127,7 +127,7 @@ pub struct OverparenElem {
 /// ```example
 /// $ undershell(0 + 1 + dots.c + n, n + 1 "numbers") $
 /// ```
-#[elem(Mathy)]
+#[elem(since = "forever", Mathy)]
 pub struct UndershellElem {
     /// The content above the tortoise shell bracket.
     #[required]
@@ -144,7 +144,7 @@ pub struct UndershellElem {
 /// ```example
 /// $ overshell(0 + 1 + dots.c + n, n + 1 "numbers") $
 /// ```
-#[elem(Mathy)]
+#[elem(since = "forever", Mathy)]
 pub struct OvershellElem {
     /// The content below the tortoise shell bracket.
     #[required]

--- a/crates/typst-library/src/model/asset.rs
+++ b/crates/typst-library/src/model/asset.rs
@@ -49,7 +49,7 @@ use crate::foundations::{BundlePath, Bytes, ShowFn, Str, cast};
 /// ```
 ///
 /// This function may only be used in the @reference:bundle[bundle] target.
-#[elem(Locatable)]
+#[elem(since = "0.15.0", Locatable)]
 pub struct AssetElem {
     /// The path in the bundle at which the asset will be placed.
     ///

--- a/crates/typst-library/src/model/bibliography.rs
+++ b/crates/typst-library/src/model/bibliography.rs
@@ -107,7 +107,7 @@ use crate::text::{Lang, LocalName, Region, SmallcapsElem, SubElem, SuperElem, Te
 /// thematic bibliographies. For more fine-grained control, citations can be
 /// explicitly targeted by a bibliography through a
 /// @bibliography.target[`target`] selector.
-#[elem(Locatable, Synthesize, ShowSet, LocalName)]
+#[elem(since = "forever", Locatable, Synthesize, ShowSet, LocalName)]
 pub struct BibliographyElem {
     /// One or multiple paths to or raw bytes for Hayagriva `.yaml` and/or
     /// BibLaTeX `.bib` files.

--- a/crates/typst-library/src/model/cite.rs
+++ b/crates/typst-library/src/model/cite.rs
@@ -40,7 +40,7 @@ use crate::text::{Lang, Region, TextElem};
 /// This function indirectly has dedicated syntax. @ref[References] can be used
 /// to cite works from the bibliography. The label then corresponds to the
 /// citation key.
-#[elem(Locatable, Synthesize)]
+#[elem(since = "forever", Locatable, Synthesize)]
 pub struct CiteElem {
     /// The citation key that identifies the entry in the bibliography that
     /// shall be cited, as a label.

--- a/crates/typst-library/src/model/divider.rs
+++ b/crates/typst-library/src/model/divider.rs
@@ -37,7 +37,7 @@ use crate::visualize::{LineElem, Stroke};
 /// #divider()
 /// Chapter 2
 /// ```
-#[elem(ShowSet)]
+#[elem(since = "0.15.0", ShowSet)]
 pub struct DividerElem {}
 
 impl ShowSet for Packed<DividerElem> {

--- a/crates/typst-library/src/model/document.rs
+++ b/crates/typst-library/src/model/document.rs
@@ -122,7 +122,7 @@ use crate::text::{Locale, TextElem};
 ///   #context document.title
 /// ]
 /// ```
-#[elem(Locatable, ShowSet)]
+#[elem(since = "forever", Locatable, ShowSet)]
 pub struct DocumentElem {
     /// The path in the bundle at which the exported document will be placed.
     ///

--- a/crates/typst-library/src/model/emph.rs
+++ b/crates/typst-library/src/model/emph.rs
@@ -23,7 +23,7 @@ use crate::foundations::{Content, elem};
 /// This function also has dedicated syntax: To emphasize content, simply
 /// enclose it in underscores (`_`). Note that this only works at word
 /// boundaries. To emphasize part of a word, you have to use the function.
-#[elem(title = "Emphasis", keywords = ["italic"], Locatable, Tagged)]
+#[elem(title = "Emphasis", since = "forever", keywords = ["italic"], Locatable, Tagged)]
 pub struct EmphElem {
     /// The content to emphasize.
     #[required]

--- a/crates/typst-library/src/model/enum.rs
+++ b/crates/typst-library/src/model/enum.rs
@@ -66,7 +66,7 @@ use crate::model::{ListItemLike, ListLike, Numbering, NumberingPattern};
 /// Enumeration items can contain multiple paragraphs and other block-level
 /// content. All content that is indented more than an item's marker becomes
 /// part of that item.
-#[elem(scope, title = "Numbered List", Locatable, Tagged)]
+#[elem(scope, title = "Numbered List", since = "forever", Locatable, Tagged)]
 pub struct EnumElem {
     /// Defines the default @enum.spacing[spacing] of the enumeration. If it is
     /// `{false}`, the items are spaced apart with
@@ -242,7 +242,7 @@ impl EnumElem {
 }
 
 /// An enumeration item.
-#[elem(name = "item", title = "Numbered List Item", Tagged)]
+#[elem(name = "item", title = "Numbered List Item", since = "0.4.0", Tagged)]
 pub struct EnumItem {
     /// The item's number.
     #[positional]

--- a/crates/typst-library/src/model/figure.rs
+++ b/crates/typst-library/src/model/figure.rs
@@ -117,7 +117,17 @@ use crate::visualize::ImageElem;
 /// AT will always read the figure at the point where it appears in the
 /// document, regardless of its @figure.placement[`placement`]. Put its markup
 /// where it would make the most sense in the reading order.
-#[elem(scope, Locatable, Tagged, Synthesize, Count, ShowSet, Refable, Outlinable)]
+#[elem(
+    scope,
+    since = "forever",
+    Locatable,
+    Tagged,
+    Synthesize,
+    Count,
+    ShowSet,
+    Refable,
+    Outlinable
+)]
 pub struct FigureElem {
     /// The content of the figure. Often, an @image[image].
     #[required]
@@ -497,7 +507,7 @@ impl Outlinable for Packed<FigureElem> {
 ///   caption: [A rectangle],
 /// )
 /// ```
-#[elem(name = "caption", Locatable, Tagged, Synthesize)]
+#[elem(name = "caption", since = "0.8.0", Locatable, Tagged, Synthesize)]
 pub struct FigureCaption {
     /// The caption's position in the figure. Either `{top}` or `{bottom}`.
     ///

--- a/crates/typst-library/src/model/footnote.rs
+++ b/crates/typst-library/src/model/footnote.rs
@@ -59,7 +59,7 @@ use crate::visualize::{LineElem, Stroke};
 /// Footnotes will be read by Assistive Technology (AT) immediately after the
 /// spot in the text where they are referenced, just like how they appear in
 /// markup.
-#[elem(scope, Locatable, Tagged, Count)]
+#[elem(scope, since = "0.4.0", Locatable, Tagged, Count)]
 pub struct FootnoteElem {
     /// How to number footnotes. Accepts a
     /// @numbering[numbering pattern or function] taking a single number.
@@ -212,7 +212,14 @@ cast! {
 /// page run is a sequence of pages without an explicit pagebreak in between).
 /// For this reason, set and show rules for footnote entries should be defined
 /// before any page content, typically at the very start of the document.
-#[elem(name = "entry", title = "Footnote Entry", Locatable, Tagged, ShowSet)]
+#[elem(
+    name = "entry",
+    title = "Footnote Entry",
+    since = "0.4.0",
+    Locatable,
+    Tagged,
+    ShowSet
+)]
 pub struct FootnoteEntry {
     /// The footnote for this entry. Its location can be used to determine the
     /// footnote counter state.

--- a/crates/typst-library/src/model/heading.rs
+++ b/crates/typst-library/src/model/heading.rs
@@ -73,7 +73,17 @@ use crate::text::{FontWeight, LocalName, TextElem, TextSize};
 /// For this reason, in HTML export, a @title element will turn into an `<h1>`
 /// and headings turn into `<h2>` and lower (a level 1 heading thus turns into
 /// `<h2>`, a level 2 heading into `<h3>`, etc).
-#[elem(Locatable, Tagged, Synthesize, Count, ShowSet, LocalName, Refable, Outlinable)]
+#[elem(
+    since = "forever",
+    Locatable,
+    Tagged,
+    Synthesize,
+    Count,
+    ShowSet,
+    LocalName,
+    Refable,
+    Outlinable
+)]
 pub struct HeadingElem {
     /// The absolute nesting depth of the heading, starting from one. If set to
     /// `{auto}`, it is computed from `{offset + depth}`.

--- a/crates/typst-library/src/model/link.rs
+++ b/crates/typst-library/src/model/link.rs
@@ -144,7 +144,7 @@ use crate::text::{LocalName, TextElem};
 /// into the built-in link handling. That said, in HTML export, depending on
 /// your use case, it may be possible to adjust the built-in link handling with
 /// a show rule on `{html.elem.where(tag: "a")}`.
-#[elem(Locatable)]
+#[elem(since = "forever", Locatable)]
 pub struct LinkElem {
     /// The destination the link points to.
     ///

--- a/crates/typst-library/src/model/list.rs
+++ b/crates/typst-library/src/model/list.rs
@@ -40,7 +40,7 @@ use crate::text::TextElem;
 /// followed by a space to create a list item. A list item can contain multiple
 /// paragraphs and other block-level content. All content that is indented more
 /// than an item's marker becomes part of that item.
-#[elem(scope, title = "Bullet List", Locatable, Tagged)]
+#[elem(scope, title = "Bullet List", since = "forever", Locatable, Tagged)]
 pub struct ListElem {
     /// Defines the default @list.spacing[spacing] of the list. If it is
     /// `{false}`, the items are spaced apart with
@@ -163,7 +163,7 @@ impl ListElem {
 }
 
 /// A bullet list item.
-#[elem(name = "item", title = "Bullet List Item", Tagged)]
+#[elem(name = "item", title = "Bullet List Item", since = "0.4.0", Tagged)]
 pub struct ListItem {
     /// The item's body.
     #[required]

--- a/crates/typst-library/src/model/numbering.rs
+++ b/crates/typst-library/src/model/numbering.rs
@@ -51,7 +51,7 @@ use crate::foundations::{Context, Func, Str, Value, cast, func};
 /// = Second heading
 /// = Third heading
 /// ```
-#[func]
+#[func(since = "forever")]
 pub fn numbering(
     engine: &mut Engine,
     context: Tracked<Context>,

--- a/crates/typst-library/src/model/outline.rs
+++ b/crates/typst-library/src/model/outline.rs
@@ -147,7 +147,7 @@ use crate::text::{LocalName, SpaceElem, TextElem};
 /// = About ACME Corp.
 /// == History
 /// ```
-#[elem(scope, keywords = ["Table of Contents", "toc"], ShowSet, LocalName, Locatable, Tagged)]
+#[elem(scope, since = "forever", keywords = ["Table of Contents", "toc"], ShowSet, LocalName, Locatable, Tagged)]
 pub struct OutlineElem {
     /// The title of the outline.
     ///
@@ -470,7 +470,14 @@ pub trait Outlinable: Refable {
 /// With show-set and show rules on outline entries, you can richly customize
 /// the outline's appearance. See the
 /// @outline:styling-the-outline[section on styling the outline] for details.
-#[elem(scope, name = "entry", title = "Outline Entry", Locatable, Tagged)]
+#[elem(
+    scope,
+    name = "entry",
+    title = "Outline Entry",
+    since = "0.6.0",
+    Locatable,
+    Tagged
+)]
 pub struct OutlineEntry {
     /// The nesting level of this outline entry. Starts at `{1}` for top-level
     /// entries.
@@ -529,7 +536,7 @@ impl OutlineEntry {
     /// indented, but the inner contents are simply offset from the prefix by
     /// the specified `gap`, rather than aligning outline-wide. For a visual
     /// explanation, see @outline.indent.
-    #[func(contextual)]
+    #[func(contextual, since = "0.13.0")]
     pub fn indented(
         &self,
         engine: &mut Engine,
@@ -626,7 +633,7 @@ impl OutlineEntry {
     /// This also appends the element's supplement in case of figures or
     /// equations. For instance, it would output `1.1` for a heading, but
     /// `Figure 1` for a figure, as is usual for outlines.
-    #[func(contextual)]
+    #[func(contextual, since = "0.13.0")]
     pub fn prefix(
         &self,
         engine: &mut Engine,
@@ -646,7 +653,7 @@ impl OutlineEntry {
     /// Creates the default inner content of the entry.
     ///
     /// This includes the body, the fill, and page number.
-    #[func(contextual)]
+    #[func(contextual, since = "0.13.0")]
     pub fn inner(
         &self,
         engine: &mut Engine,
@@ -661,14 +668,14 @@ impl OutlineEntry {
     /// The content which is displayed in place of the referred element at its
     /// entry in the outline. For a heading, this is its @heading.body[`body`];
     /// for a figure a caption and for equations, it is empty.
-    #[func]
+    #[func(since = "0.13.0")]
     pub fn body(&self) -> StrResult<Content> {
         Ok(self.outlinable()?.body())
     }
 
     /// The page number of this entry's element, formatted with the numbering
     /// set for the referenced page.
-    #[func(contextual)]
+    #[func(contextual, since = "0.13.0")]
     pub fn page(
         &self,
         engine: &mut Engine,

--- a/crates/typst-library/src/model/par.rs
+++ b/crates/typst-library/src/model/par.rs
@@ -95,7 +95,7 @@ use crate::model::Numbering;
 /// let $a$ be the smallest of the
 /// three integers. Then, we ...
 /// ```
-#[elem(scope, title = "Paragraph", Locatable, Tagged)]
+#[elem(scope, title = "Paragraph", since = "forever", Locatable, Tagged)]
 pub struct ParElem {
     /// The spacing between lines.
     ///
@@ -722,7 +722,7 @@ impl Fold for FirstLineIndent {
 /// = Syntax <syntax>
 /// Instead of calling this function, you can insert a blank line into your
 /// markup to create a paragraph break.
-#[elem(title = "Paragraph Break", Unlabellable)]
+#[elem(title = "Paragraph Break", since = "forever", Unlabellable)]
 pub struct ParbreakElem {}
 
 impl ParbreakElem {
@@ -787,7 +787,7 @@ impl Unlabellable for Packed<ParbreakElem> {}
 /// @par.line.number-margin[margin]. In addition, you can control whether the
 /// numbering is reset on each page through the
 /// @par.line.numbering-scope[`numbering-scope`] option.
-#[elem(name = "line", title = "Paragraph Line", keywords = ["line numbering"], Construct, Locatable)]
+#[elem(name = "line", title = "Paragraph Line", since = "0.12.0", keywords = ["line numbering"], Construct, Locatable)]
 pub struct ParLine {
     /// How to number each line. Accepts a
     /// @numbering[numbering pattern or function] taking a single number.

--- a/crates/typst-library/src/model/quote.rs
+++ b/crates/typst-library/src/model/quote.rs
@@ -41,7 +41,7 @@ use crate::text::{SmartQuotes, SpaceElem, TextElem};
 ///   flame of Udûn. Go back to the Shadow! You cannot pass.
 /// ]
 /// ```
-#[elem(Locatable, Tagged, ShowSet)]
+#[elem(since = "0.9.0", Locatable, Tagged, ShowSet)]
 pub struct QuoteElem {
     /// Whether this is a block quote.
     ///

--- a/crates/typst-library/src/model/reference.rs
+++ b/crates/typst-library/src/model/reference.rs
@@ -135,7 +135,7 @@ use crate::text::TextElem;
 /// In @beginning we prove @pythagoras.
 /// $ a^2 + b^2 = c^2 $ <pythagoras>
 /// ```
-#[elem(title = "Reference", Locatable, Tagged, Synthesize)]
+#[elem(title = "Reference", since = "forever", Locatable, Tagged, Synthesize)]
 pub struct RefElem {
     /// The target label that should be referenced.
     ///

--- a/crates/typst-library/src/model/strong.rs
+++ b/crates/typst-library/src/model/strong.rs
@@ -18,7 +18,7 @@ use crate::foundations::{Content, elem};
 /// simply enclose it in stars/asterisks (`*`). Note that this only works at
 /// word boundaries. To strongly emphasize part of a word, you have to use the
 /// function.
-#[elem(title = "Strong Emphasis", keywords = ["bold", "weight"], Locatable, Tagged)]
+#[elem(title = "Strong Emphasis", since = "forever", keywords = ["bold", "weight"], Locatable, Tagged)]
 pub struct StrongElem {
     /// The delta to apply on the font weight.
     ///

--- a/crates/typst-library/src/model/table.rs
+++ b/crates/typst-library/src/model/table.rs
@@ -133,7 +133,7 @@ use crate::visualize::{Paint, Stroke};
 /// visually, you should consider making the core information in your table
 /// available as text as well. You can do this by wrapping your table in a
 /// @figure[figure] and using its caption to summarize the table's content.
-#[elem(scope, Locatable, Tagged, Synthesize, LocalName, Figurable)]
+#[elem(scope, since = "forever", Locatable, Tagged, Synthesize, LocalName, Figurable)]
 pub struct TableElem {
     /// The column sizes. See the @grid:track-size[grid documentation] for more
     /// information on track sizing.
@@ -491,7 +491,7 @@ impl TryFrom<Content> for TableItem {
 ///   [7.34], [57],  [2],
 /// )
 /// ```
-#[elem(name = "header", title = "Table Header")]
+#[elem(name = "header", title = "Table Header", since = "0.11.0")]
 pub struct TableHeader {
     /// Whether this header should be repeated across pages.
     #[default(true)]
@@ -521,7 +521,7 @@ pub struct TableHeader {
 /// other information that should be visible on every page.
 ///
 /// No other table cells may be placed after the footer.
-#[elem(name = "footer", title = "Table Footer")]
+#[elem(name = "footer", title = "Table Footer", since = "0.11.0")]
 pub struct TableFooter {
     /// Whether this footer should be repeated across pages.
     #[default(true)]
@@ -564,7 +564,7 @@ pub struct TableFooter {
 ///   [19:00], [Day 1 Attendee Mixer],
 /// )
 /// ```
-#[elem(name = "hline", title = "Table Horizontal Line")]
+#[elem(name = "hline", title = "Table Horizontal Line", since = "0.11.0")]
 pub struct TableHLine {
     /// The row above which the horizontal line is placed (zero-indexed).
     /// Functions identically to the `y` field in @grid.hline.y[`grid.hline`].
@@ -609,7 +609,7 @@ pub struct TableHLine {
 /// @table.stroke[table's `stroke`] field or
 /// @table.cell.stroke[`table.cell`'s `stroke`] field instead if the line you
 /// want to place is part of all your tables' designs.
-#[elem(name = "vline", title = "Table Vertical Line")]
+#[elem(name = "vline", title = "Table Vertical Line", since = "0.11.0")]
 pub struct TableVLine {
     /// The column before which the vertical line is placed (zero-indexed).
     /// Functions identically to the `x` field in @grid.vline.
@@ -729,7 +729,7 @@ pub struct TableVLine {
 ///   [Vikram], [49], [Perseverance],
 /// )
 /// ```
-#[elem(name = "cell", title = "Table Cell")]
+#[elem(name = "cell", title = "Table Cell", since = "0.11.0")]
 pub struct TableCell {
     /// The cell's body.
     #[required]

--- a/crates/typst-library/src/model/terms.rs
+++ b/crates/typst-library/src/model/terms.rs
@@ -21,7 +21,7 @@ use crate::model::{ListItemLike, ListLike};
 /// = Syntax <syntax>
 /// This function also has dedicated syntax: Starting a line with a slash,
 /// followed by a term, a colon and a description creates a term list item.
-#[elem(scope, title = "Term List", Locatable, Tagged)]
+#[elem(scope, title = "Term List", since = "forever", Locatable, Tagged)]
 pub struct TermsElem {
     /// Defines the default @terms.spacing[spacing] of the term list. If it is
     /// `{false}`, the items are spaced apart with
@@ -125,7 +125,7 @@ impl TermsElem {
 }
 
 /// A term list item.
-#[elem(name = "item", title = "Term List Item", Tagged)]
+#[elem(name = "item", title = "Term List Item", since = "0.4.0", Tagged)]
 pub struct TermItem {
     /// The term described by the list item.
     #[required]

--- a/crates/typst-library/src/model/title.rs
+++ b/crates/typst-library/src/model/title.rs
@@ -27,7 +27,7 @@ use crate::text::{FontWeight, TextElem, TextSize};
 /// = Introduction
 /// In recent years, ...
 /// ```
-#[elem(Locatable, Tagged, ShowSet)]
+#[elem(since = "0.14.0", Locatable, Tagged, ShowSet)]
 pub struct TitleElem {
     /// The content of the title.
     ///

--- a/crates/typst-library/src/pdf/accessibility.rs
+++ b/crates/typst-library/src/pdf/accessibility.rs
@@ -33,7 +33,7 @@ use crate::model::{TableCell, TableElem};
 /// In the future, this function may be moved out of the `pdf` module, making it
 /// possible to hide content in HTML export from AT.
 // TODO: maybe generalize this and use it to mark html elements with `aria-hidden="true"`?
-#[elem(Tagged)]
+#[elem(since = "0.14.0", Tagged)]
 pub struct ArtifactElem {
     /// The artifact kind.
     ///
@@ -134,7 +134,7 @@ pub enum ArtifactKind {
 ///   caption: [The Sales org now has a new member],
 /// )
 /// ```
-#[func]
+#[func(since = "0.14.0")]
 pub fn table_summary(
     #[named] summary: Option<EcoString>,
     /// The table.
@@ -200,7 +200,7 @@ pub fn table_summary(
 ///   [30g], [45g],
 /// )
 /// ```
-#[func]
+#[func(since = "0.14.0")]
 pub fn header_cell(
     /// The nesting level of this header cell.
     #[named]
@@ -261,7 +261,7 @@ pub fn header_cell(
 ///   [], [Close 50 enterprise deals], [38],
 /// )
 /// ```
-#[func]
+#[func(since = "0.14.0")]
 pub fn data_cell(
     /// The table cell.
     ///

--- a/crates/typst-library/src/pdf/attach.rs
+++ b/crates/typst-library/src/pdf/attach.rs
@@ -28,7 +28,7 @@ use crate::foundations::{Bytes, Cast, Derived, PathOrStr, elem};
 /// - This element is ignored if exporting to a format other than PDF.
 /// - File attachments are not currently supported for PDF/A-2, even if the
 ///   attached file conforms to PDF/A-1 or PDF/A-2.
-#[elem(keywords = ["embed"], Locatable)]
+#[elem(since = "0.14.0", keywords = ["embed"], Locatable)]
 pub struct AttachElem {
     /// The path of the file to be attached.
     ///

--- a/crates/typst-library/src/text/case.rs
+++ b/crates/typst-library/src/text/case.rs
@@ -9,7 +9,7 @@ use crate::text::TextElem;
 /// #lower[*My Text*] \
 /// #lower[already low]
 /// ```
-#[func(title = "Lowercase")]
+#[func(title = "Lowercase", since = "forever")]
 pub fn lower(
     /// The text to convert to lowercase.
     text: Caseable,
@@ -25,7 +25,7 @@ pub fn lower(
 /// #upper[*my text*] \
 /// #upper[ALREADY HIGH]
 /// ```
-#[func(title = "Uppercase")]
+#[func(title = "Uppercase", since = "forever")]
 pub fn upper(
     /// The text to convert to uppercase.
     text: Caseable,

--- a/crates/typst-library/src/text/deco.rs
+++ b/crates/typst-library/src/text/deco.rs
@@ -9,7 +9,7 @@ use crate::visualize::{Color, FixedStroke, Paint, Stroke};
 /// ```example
 /// This is #underline[important].
 /// ```
-#[elem(Locatable, Tagged)]
+#[elem(since = "forever", Locatable, Tagged)]
 pub struct UnderlineElem {
     /// How to @stroke[stroke] the line.
     ///
@@ -77,7 +77,7 @@ pub struct UnderlineElem {
 /// ```example
 /// #overline[A line over text.]
 /// ```
-#[elem(Locatable, Tagged)]
+#[elem(since = "forever", Locatable, Tagged)]
 pub struct OverlineElem {
     /// How to @stroke[stroke] the line.
     ///
@@ -151,7 +151,7 @@ pub struct OverlineElem {
 /// ```example
 /// This is #strike[not] relevant.
 /// ```
-#[elem(title = "Strikethrough", Locatable, Tagged)]
+#[elem(title = "Strikethrough", since = "forever", Locatable, Tagged)]
 pub struct StrikeElem {
     /// How to @stroke[stroke] the line.
     ///
@@ -210,7 +210,7 @@ pub struct StrikeElem {
 /// ```example
 /// This is #highlight[important].
 /// ```
-#[elem(Locatable, Tagged)]
+#[elem(since = "0.8.0", Locatable, Tagged)]
 pub struct HighlightElem {
     /// The color to highlight the text with.
     ///

--- a/crates/typst-library/src/text/linebreak.rs
+++ b/crates/typst-library/src/text/linebreak.rs
@@ -19,7 +19,7 @@ use crate::foundations::{Content, NativeElement, elem};
 /// This function also has dedicated syntax: To insert a line break, simply
 /// write a backslash followed by whitespace. This always creates an unjustified
 /// break.
-#[elem(title = "Line Break")]
+#[elem(title = "Line Break", since = "forever")]
 pub struct LinebreakElem {
     /// Whether to justify the line before the break.
     ///

--- a/crates/typst-library/src/text/lorem.rs
+++ b/crates/typst-library/src/text/lorem.rs
@@ -20,7 +20,7 @@ use crate::foundations::{Str, func};
 /// = More Blind Text
 /// #lorem(15)
 /// ```
-#[func(keywords = ["Blind Text"])]
+#[func(since = "forever", keywords = ["Blind Text"])]
 pub fn lorem(
     /// The length of the blind text in words.
     words: usize,

--- a/crates/typst-library/src/text/mod.rs
+++ b/crates/typst-library/src/text/mod.rs
@@ -87,7 +87,7 @@ pub(super) fn define(global: &mut Scope) {
 ///   With a function call.
 /// ])
 /// ```
-#[elem(Debug, Construct, PlainText, Repr)]
+#[elem(since = "forever", Debug, Construct, PlainText, Repr)]
 pub struct TextElem {
     /// A font family descriptor or priority list of font family descriptors.
     ///

--- a/crates/typst-library/src/text/raw.rs
+++ b/crates/typst-library/src/text/raw.rs
@@ -250,6 +250,7 @@ use crate::visualize::Color;
 #[elem(
     scope,
     title = "Raw Text / Code",
+    since = "forever",
     Synthesize,
     Locatable,
     Tagged,
@@ -809,7 +810,7 @@ fn format_theme_error(error: syntect::LoadingError) -> LoadError {
 /// It allows you to access various properties of the line, such as the line
 /// number, the raw non-highlighted text, the highlighted text, and whether it
 /// is the first or last line of the raw block.
-#[elem(name = "line", title = "Raw Text / Code Line", Tagged, PlainText)]
+#[elem(name = "line", title = "Raw Text / Code Line", since = "0.9.0", Tagged, PlainText)]
 pub struct RawLine {
     /// The line number of the raw line inside of the raw block, starts at 1.
     #[required]

--- a/crates/typst-library/src/text/shift.rs
+++ b/crates/typst-library/src/text/shift.rs
@@ -12,7 +12,7 @@ use crate::text::{FontMetrics, ScriptMetrics, TextSize};
 /// ```example
 /// Revenue#sub[yearly]
 /// ```
-#[elem(title = "Subscript", Tagged)]
+#[elem(title = "Subscript", since = "forever", Tagged)]
 pub struct SubElem {
     /// Whether to use subscript glyphs from the font if available.
     ///
@@ -71,7 +71,7 @@ pub struct SubElem {
 /// ```example
 /// 1#super[st] try!
 /// ```
-#[elem(title = "Superscript", Tagged)]
+#[elem(title = "Superscript", since = "forever", Tagged)]
 pub struct SuperElem {
     /// Whether to use superscript glyphs from the font if available.
     ///

--- a/crates/typst-library/src/text/smallcaps.rs
+++ b/crates/typst-library/src/text/smallcaps.rs
@@ -40,7 +40,7 @@ use crate::foundations::{Content, elem};
 /// = Introduction
 /// #lorem(40)
 /// ```
-#[elem(title = "Small Capitals")]
+#[elem(title = "Small Capitals", since = "forever")]
 pub struct SmallcapsElem {
     /// Whether to turn uppercase letters into small capitals as well.
     ///

--- a/crates/typst-library/src/text/smartquote.rs
+++ b/crates/typst-library/src/text/smartquote.rs
@@ -29,7 +29,7 @@ use crate::text::{Lang, Region, TextElem};
 /// = Syntax <syntax>
 /// This function also has dedicated syntax: The normal quote characters (`'`
 /// and `"`). Typst automatically makes your quotes smart.
-#[elem(name = "smartquote", PlainText)]
+#[elem(name = "smartquote", since = "forever", PlainText)]
 pub struct SmartQuoteElem {
     /// Whether this should be a double quote.
     #[default(true)]

--- a/crates/typst-library/src/visualize/color.rs
+++ b/crates/typst-library/src/visualize/color.rs
@@ -277,7 +277,7 @@ static TO_SRGB: LazyLock<Arc<moxcms::Transform8BitExecutor>> = LazyLock::new(|| 
 ///   )
 /// }))
 /// ```
-#[ty(scope, cast)]
+#[ty(scope, cast, since = "forever")]
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum Color {
     /// A process color.
@@ -337,7 +337,7 @@ impl Color {
     ///   box(square(fill: luma(x)))
     /// }
     /// ```
-    #[func]
+    #[func(since = "forever")]
     pub fn luma(
         args: &mut Args,
         /// The lightness component.
@@ -390,7 +390,7 @@ impl Color {
     ///   fill: oklab(27%, 20%, -3%, 50%)
     /// )
     /// ```
-    #[func]
+    #[func(since = "0.9.0")]
     pub fn oklab(
         args: &mut Args,
         /// The lightness component.
@@ -449,7 +449,7 @@ impl Color {
     ///   fill: oklch(40%, 0.2, 160deg, 50%)
     /// )
     /// ```
-    #[func]
+    #[func(since = "0.10.0")]
     pub fn oklch(
         args: &mut Args,
         /// The lightness component.
@@ -511,7 +511,7 @@ impl Color {
     ///   30%, 50%, 10%,
     /// ))
     /// ```
-    #[func(title = "Linear RGB")]
+    #[func(title = "Linear RGB", since = "0.9.0")]
     pub fn linear_rgb(
         args: &mut Args,
         /// The red component.
@@ -569,7 +569,7 @@ impl Color {
     /// #square(fill: rgb(87, 127, 230))
     /// #square(fill: rgb(25%, 13%, 65%))
     /// ```
-    #[func(title = "RGB")]
+    #[func(title = "RGB", since = "forever")]
     pub fn rgb(
         args: &mut Args,
         /// The red component.
@@ -645,7 +645,7 @@ impl Color {
     ///   fill: cmyk(27%, 0%, 3%, 5%)
     /// )
     /// ```
-    #[func(title = "CMYK")]
+    #[func(title = "CMYK", since = "forever")]
     pub fn cmyk(
         args: &mut Args,
         /// The cyan component.
@@ -699,7 +699,7 @@ impl Color {
     ///   fill: color.hsl(30deg, 50%, 60%)
     /// )
     /// ```
-    #[func(title = "HSL")]
+    #[func(title = "HSL", since = "0.9.0")]
     pub fn hsl(
         args: &mut Args,
         /// The hue angle.
@@ -756,7 +756,7 @@ impl Color {
     ///   fill: color.hsv(30deg, 50%, 60%)
     /// )
     /// ```
-    #[func(title = "HSV")]
+    #[func(title = "HSV", since = "0.9.0")]
     pub fn hsv(
         args: &mut Args,
         /// The hue angle.
@@ -867,7 +867,7 @@ impl Color {
     /// // note that the alpha component is included by default
     /// #rgb(40%, 60%, 80%).components()
     /// ```
-    #[func]
+    #[func(since = "0.9.0")]
     pub fn components(
         &self,
         /// Whether to include the alpha component.
@@ -897,7 +897,7 @@ impl Color {
     /// #let color = cmyk(1%, 2%, 3%, 4%)
     /// #(color.space() == cmyk)
     /// ```
-    #[func]
+    #[func(since = "0.9.0")]
     pub fn space(&self) -> ColorSpace {
         match self {
             Self::Process(c) => c.space().into(),
@@ -908,7 +908,7 @@ impl Color {
     /// Returns the color's RGB(A) hex representation (such as `#ffaa32` or
     /// `#020304fe`). The alpha component (last two digits in `#020304fe`) is
     /// omitted if it is equal to `ff` (255 / 100%).
-    #[func]
+    #[func(since = "0.9.0")]
     pub fn to_hex(&self) -> EcoString {
         match self {
             Self::Process(c) => c.to_hex(),
@@ -917,7 +917,7 @@ impl Color {
     }
 
     /// Lightens a color by a given factor.
-    #[func]
+    #[func(since = "forever")]
     pub fn lighten(
         &self,
         /// The factor to lighten the color by.
@@ -930,7 +930,7 @@ impl Color {
     }
 
     /// Darkens a color by a given factor.
-    #[func]
+    #[func(since = "forever")]
     pub fn darken(
         &self,
         /// The factor to darken the color by.
@@ -946,7 +946,7 @@ impl Color {
     ///
     /// Only process colors can be saturated. If you want to saturate a spot
     /// color, convert it into a process color first.
-    #[func]
+    #[func(since = "0.9.0")]
     pub fn saturate(
         &self,
         span: Span,
@@ -967,7 +967,7 @@ impl Color {
     ///
     /// Only process colors can be desaturated. If you want to desaturate a spot
     /// color, convert it into a process color first.
-    #[func]
+    #[func(since = "0.9.0")]
     pub fn desaturate(
         &self,
         span: Span,
@@ -992,7 +992,7 @@ impl Color {
     /// #square(fill: yellow.negate())
     /// #square(fill: yellow.negate(space: rgb))
     /// ```
-    #[func]
+    #[func(since = "forever")]
     pub fn negate(
         &self,
         /// The color space used for the transformation. By default, a
@@ -1017,7 +1017,7 @@ impl Color {
     ///
     /// This function only works on color models with a well-defined hue
     /// component, i.e. Oklch, HSL, and HSV.
-    #[func]
+    #[func(since = "0.9.0")]
     pub fn rotate(
         &self,
         span: Span,
@@ -1068,7 +1068,7 @@ impl Color {
     /// #block(fill: color.mix(red, blue, white))
     /// #block(fill: color.mix((red, 70%), (blue, 30%)))
     /// ```
-    #[func]
+    #[func(since = "0.7.0")]
     pub fn mix(
         /// The colors, optionally with weights, specified as a pair (array of
         /// length two) of color and weight (float or ratio).
@@ -1100,7 +1100,7 @@ impl Color {
     /// #block(fill: red.transparentize(50%))[half red]
     /// #block(fill: red.transparentize(75%))[quarter red]
     /// ```
-    #[func]
+    #[func(since = "0.11.0")]
     pub fn transparentize(
         &self,
         /// The factor to change the alpha value by.
@@ -1121,7 +1121,7 @@ impl Color {
     /// #block(fill: half-red.opacify(50%))[three quarters red]
     /// #block(fill: half-red.opacify(-50%))[one quarter red]
     /// ```
-    #[func]
+    #[func(since = "0.11.0")]
     pub fn opacify(
         &self,
         /// The scale to change the alpha value by.
@@ -2300,7 +2300,7 @@ impl Repr for SpotColor {
 /// environment. Once you have created a spot colorant, you can create
 /// colors using its @color.spot.tint[`tint` method].
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-#[ty(scope, name = "spot", title = "Spot Colorant")]
+#[ty(scope, name = "spot", title = "Spot Colorant", since = "0.15.0")]
 pub struct SpotColorant {
     /// Name of the spot colorant to use, if any.
     pub name: Option<SpotColorantName>,
@@ -2317,7 +2317,7 @@ impl Repr for SpotColorant {
 #[scope]
 impl SpotColorant {
     /// Create a new spot colorant.
-    #[func(constructor)]
+    #[func(constructor, since = "0.15.0")]
     pub fn construct(
         /// Name of the spot colorant to use.
         ///
@@ -2371,7 +2371,7 @@ impl SpotColorant {
     /// #square(fill: pantone.tint(70%))
     /// #square(fill: pantone.tint(40%))
     /// ```
-    #[func]
+    #[func(since = "0.15.0")]
     pub fn tint(
         &self,
         /// The tint percentage, between `{0%}` and `{100%}`.

--- a/crates/typst-library/src/visualize/curve.rs
+++ b/crates/typst-library/src/visualize/curve.rs
@@ -39,7 +39,7 @@ use super::FixedStroke;
 ///   curve.close(),
 /// )
 /// ```
-#[elem(scope)]
+#[elem(scope, since = "0.13.0")]
 pub struct CurveElem {
     /// How to fill the curve.
     ///
@@ -170,7 +170,7 @@ impl TryFrom<Content> for CurveComponent {
 ///   curve.close(),
 /// )
 /// ```
-#[elem(name = "move", title = "Curve Move")]
+#[elem(name = "move", title = "Curve Move", since = "0.13.0")]
 pub struct CurveMove {
     /// The starting point for the new component.
     #[required]
@@ -193,7 +193,7 @@ pub struct CurveMove {
 ///   curve.line((150pt, 0pt)),
 /// )
 /// ```
-#[elem(name = "line", title = "Curve Line")]
+#[elem(name = "line", title = "Curve Line", since = "0.13.0")]
 pub struct CurveLine {
     /// The point at which the line shall end.
     #[required]
@@ -233,7 +233,7 @@ pub struct CurveLine {
 ///   curve.quad((20pt, 20pt), (100pt, 0pt)),
 /// )
 /// ```
-#[elem(name = "quad", title = "Curve Quadratic Segment")]
+#[elem(name = "quad", title = "Curve Quadratic Segment", since = "0.13.0")]
 pub struct CurveQuad {
     /// The control point of the quadratic Bézier curve.
     ///
@@ -280,7 +280,7 @@ pub struct CurveQuad {
 ///   curve.cubic((10pt, 20pt), (90pt, 60pt), (100pt, 0pt)),
 /// )
 /// ```
-#[elem(name = "cubic", title = "Curve Cubic Segment")]
+#[elem(name = "cubic", title = "Curve Cubic Segment", since = "0.13.0")]
 pub struct CurveCubic {
     /// The control point going out from the start of the curve segment.
     ///
@@ -362,7 +362,7 @@ pub struct CurveCubic {
 /// #shape(mode: "smooth")
 /// #shape(mode: "straight")
 /// ```
-#[elem(name = "close", title = "Curve Close")]
+#[elem(name = "close", title = "Curve Close", since = "0.13.0")]
 pub struct CurveClose {
     /// How to close the curve.
     pub mode: CloseMode,

--- a/crates/typst-library/src/visualize/gradient.rs
+++ b/crates/typst-library/src/visualize/gradient.rs
@@ -186,7 +186,7 @@ use crate::visualize::{
 /// @color.linear-rgb color spaces. This avoids needing to encode these color
 /// spaces in your PDF file, but it does add extra stops to your gradient, which
 /// can increase the file size.
-#[ty(scope, cast)]
+#[ty(scope, cast, since = "0.9.0")]
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub enum Gradient {
     Linear(Arc<LinearGradient>),
@@ -209,7 +209,7 @@ impl Gradient {
     ///   ),
     /// )
     /// ```
-    #[func(title = "Linear Gradient")]
+    #[func(title = "Linear Gradient", since = "0.9.0")]
     pub fn linear(
         args: &mut Args,
         span: Span,
@@ -299,7 +299,7 @@ impl Gradient {
     ///   )),
     /// )
     /// ```
-    #[func(title = "Radial Gradient")]
+    #[func(title = "Radial Gradient", since = "0.9.0")]
     fn radial(
         span: Span,
         /// The color @gradient:stops[stops] of the gradient.
@@ -416,7 +416,7 @@ impl Gradient {
     ///   )),
     /// )
     /// ```
-    #[func(title = "Conic Gradient")]
+    #[func(title = "Conic Gradient", since = "0.9.0")]
     pub fn conic(
         span: Span,
         /// The color @gradient:stops[stops] of the gradient.
@@ -480,7 +480,7 @@ impl Gradient {
     /// #rect(fill: grad.sharp(5))
     /// #rect(fill: grad.sharp(5, smoothness: 20%))
     /// ```
-    #[func]
+    #[func(since = "0.9.0")]
     pub fn sharp(
         &self,
         /// The number of stops in the gradient.
@@ -575,7 +575,7 @@ impl Gradient {
     ///     .repeat(4),
     /// )
     /// ```
-    #[func]
+    #[func(since = "0.9.0")]
     pub fn repeat(
         &self,
         /// The number of times to repeat the gradient.
@@ -655,7 +655,7 @@ impl Gradient {
     }
 
     /// Returns the kind of this gradient.
-    #[func]
+    #[func(since = "0.9.0")]
     pub fn kind(&self) -> Func {
         match self {
             Self::Linear(_) => Self::linear_data().into(),
@@ -665,7 +665,7 @@ impl Gradient {
     }
 
     /// Returns the stops of this gradient.
-    #[func]
+    #[func(since = "0.9.0")]
     pub fn stops(&self) -> Vec<GradientStop> {
         match self {
             Self::Linear(linear) => linear
@@ -696,7 +696,7 @@ impl Gradient {
     }
 
     /// Returns the mixing space of this gradient.
-    #[func]
+    #[func(since = "0.9.0")]
     pub fn space(&self) -> ColorSpace {
         match self {
             Self::Linear(linear) => linear.space.clone(),
@@ -706,7 +706,7 @@ impl Gradient {
     }
 
     /// Returns the relative placement of this gradient.
-    #[func]
+    #[func(since = "0.9.0")]
     pub fn relative(&self) -> Smart<RelativeTo> {
         match self {
             Self::Linear(linear) => linear.relative,
@@ -718,7 +718,7 @@ impl Gradient {
     /// Returns the angle of this gradient.
     ///
     /// Returns `{none}` if the gradient is neither linear nor conic.
-    #[func]
+    #[func(since = "0.9.0")]
     pub fn angle(&self) -> Option<Angle> {
         match self {
             Self::Linear(linear) => Some(linear.angle),
@@ -730,7 +730,7 @@ impl Gradient {
     /// Returns the center of this gradient.
     ///
     /// Returns `{none}` if the gradient is neither radial nor conic.
-    #[func]
+    #[func(since = "0.13.0")]
     pub fn center(&self) -> Option<Axes<Ratio>> {
         match self {
             Self::Linear(_) => None,
@@ -742,7 +742,7 @@ impl Gradient {
     /// Returns the radius of this gradient.
     ///
     /// Returns `{none}` if the gradient is not radial.
-    #[func]
+    #[func(since = "0.13.0")]
     pub fn radius(&self) -> Option<Ratio> {
         match self {
             Self::Linear(_) => None,
@@ -754,7 +754,7 @@ impl Gradient {
     /// Returns the focal-center of this gradient.
     ///
     /// Returns `{none}` if the gradient is not radial.
-    #[func]
+    #[func(since = "0.13.0")]
     pub fn focal_center(&self) -> Option<Axes<Ratio>> {
         match self {
             Self::Linear(_) => None,
@@ -766,7 +766,7 @@ impl Gradient {
     /// Returns the focal-radius of this gradient.
     ///
     /// Returns `{none}` if the gradient is not radial.
-    #[func]
+    #[func(since = "0.13.0")]
     pub fn focal_radius(&self) -> Option<Ratio> {
         match self {
             Self::Linear(_) => None,
@@ -780,7 +780,7 @@ impl Gradient {
     /// The position is either a position along the gradient (a @ratio[ratio]
     /// between `{0%}` and `{100%}`) or an @angle[angle]. Any value outside of
     /// this range will be clamped.
-    #[func]
+    #[func(since = "0.9.0")]
     pub fn sample(
         &self,
         /// The position at which to sample the gradient.
@@ -801,7 +801,7 @@ impl Gradient {
 
     /// Samples the gradient at multiple positions at once and returns the
     /// results as an array.
-    #[func]
+    #[func(since = "0.9.0")]
     pub fn samples(
         &self,
         /// The positions at which to sample the gradient.

--- a/crates/typst-library/src/visualize/image/mod.rs
+++ b/crates/typst-library/src/visualize/image/mod.rs
@@ -48,7 +48,7 @@ use crate::visualize::image::pdf::PdfDocument;
 ///   ],
 /// )
 /// ```
-#[elem(Locatable, Tagged, Synthesize, LocalName, Figurable)]
+#[elem(since = "forever", Locatable, Tagged, Synthesize, LocalName, Figurable)]
 pub struct ImageElem {
     /// A path to an image file or raw bytes making up an image in one of the
     /// supported @image.format[formats].

--- a/crates/typst-library/src/visualize/line.rs
+++ b/crates/typst-library/src/visualize/line.rs
@@ -15,7 +15,7 @@ use crate::visualize::Stroke;
 ///   stroke: 2pt + maroon,
 /// )
 /// ```
-#[elem]
+#[elem(since = "forever")]
 pub struct LineElem {
     /// The start point of the line.
     ///

--- a/crates/typst-library/src/visualize/polygon.rs
+++ b/crates/typst-library/src/visualize/polygon.rs
@@ -21,7 +21,7 @@ use crate::visualize::{FillRule, Paint, Stroke};
 ///   (0%,  2cm),
 /// )
 /// ```
-#[elem(scope)]
+#[elem(scope, since = "0.1.0")]
 pub struct PolygonElem {
     /// How to fill the polygon.
     ///
@@ -60,7 +60,7 @@ impl PolygonElem {
     ///   vertices: 3,
     /// )
     /// ```
-    #[func(title = "Regular Polygon")]
+    #[func(title = "Regular Polygon", since = "0.8.0")]
     pub fn regular(
         span: Span,
 

--- a/crates/typst-library/src/visualize/shape.rs
+++ b/crates/typst-library/src/visualize/shape.rs
@@ -16,7 +16,7 @@ use kurbo::{PathEl, Shape as _};
 ///   to fit the content.
 /// ]
 /// ```
-#[elem(title = "Rectangle")]
+#[elem(title = "Rectangle", since = "forever")]
 pub struct RectElem {
     /// The rectangle's width, relative to its parent container.
     pub width: Smart<Rel<Length>>,
@@ -140,7 +140,7 @@ pub struct RectElem {
 ///   sized to fit.
 /// ]
 /// ```
-#[elem]
+#[elem(since = "forever")]
 pub struct SquareElem {
     /// The square's side length. This is mutually exclusive with `width` and
     /// `height`.
@@ -218,7 +218,7 @@ pub struct SquareElem {
 ///   to fit the content.
 /// ]
 /// ```
-#[elem]
+#[elem(since = "forever")]
 pub struct EllipseElem {
     /// The ellipse's width, relative to its parent container.
     pub width: Smart<Rel<Length>>,
@@ -268,7 +268,7 @@ pub struct EllipseElem {
 ///   sized to fit.
 /// ]
 /// ```
-#[elem]
+#[elem(since = "forever")]
 pub struct CircleElem {
     /// The circle's radius. This is mutually exclusive with `width` and
     /// `height`.

--- a/crates/typst-library/src/visualize/stroke.rs
+++ b/crates/typst-library/src/visualize/stroke.rs
@@ -49,7 +49,7 @@ use crate::visualize::{Color, Gradient, Paint, Tiling};
 /// constructor function. For example, `{(2pt + blue).thickness}` is `{2pt}`.
 /// Meanwhile, `{stroke(red).cap}` is `{auto}` because it's unspecified. Fields
 /// set to `{auto}` are inherited.
-#[ty(scope, cast)]
+#[ty(scope, cast, since = "forever")]
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
 pub struct Stroke<T: Numeric = Length> {
     /// The stroke's paint.
@@ -96,7 +96,7 @@ impl Stroke {
     /// #my-func(red) \
     /// #my-func(stroke(cap: "round", thickness: 1pt))
     /// ```
-    #[func(constructor)]
+    #[func(constructor, since = "forever")]
     pub fn construct(
         args: &mut Args,
 

--- a/crates/typst-library/src/visualize/tiling.rs
+++ b/crates/typst-library/src/visualize/tiling.rs
@@ -53,7 +53,7 @@ use crate::visualize::RelativeTo;
 /// #set text(fill: pat)
 /// #lorem(10)
 /// ```
-#[ty(scope, cast, keywords = ["pattern"])]
+#[ty(scope, cast, since = "0.13.0", keywords = ["pattern"])]
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Tiling(Arc<TilingInner>);
 
@@ -92,7 +92,7 @@ impl Tiling {
     ///
     /// #rect(width: 100%, height: 60pt, fill: pat)
     /// ```
-    #[func(constructor)]
+    #[func(constructor, since = "0.13.0")]
     pub fn construct(
         engine: &mut Engine,
         span: Span,

--- a/crates/typst-macros/src/elem.rs
+++ b/crates/typst-macros/src/elem.rs
@@ -6,8 +6,9 @@ use syn::punctuated::Punctuated;
 use syn::{Ident, Result, Token};
 
 use crate::util::{
-    BlockWithReturn, determine_name_and_title, documentation, foundations, has_attr, kw,
-    oneliner, parse_attr, parse_flag, parse_string, parse_string_array, validate_attrs,
+    BlockWithReturn, Since, determine_name_and_title, documentation, foundations,
+    has_attr, kw, oneliner, parse_attr, parse_flag, parse_key_value, parse_string,
+    parse_string_array, validate_attrs,
 };
 
 /// Expand the `#[elem]` macro.
@@ -22,6 +23,8 @@ struct Elem {
     name: String,
     /// The element's title case name.
     title: String,
+    /// The version of Typst the element was introduced in.
+    since: Option<Since>,
     /// Whether this element has an associated scope defined by the `#[scope]` macro.
     scope: bool,
     /// A list of alternate search terms for this element.
@@ -128,6 +131,7 @@ struct Meta {
     scope: bool,
     name: Option<String>,
     title: Option<String>,
+    since: Option<Since>,
     keywords: Vec<String>,
     capabilities: Vec<Ident>,
 }
@@ -138,6 +142,7 @@ impl Parse for Meta {
             scope: parse_flag::<kw::scope>(input)?,
             name: parse_string::<kw::name>(input)?,
             title: parse_string::<kw::title>(input)?,
+            since: parse_key_value::<kw::since, Since>(input)?,
             keywords: parse_string_array::<kw::keywords>(input)?,
             capabilities: Punctuated::<Ident, Token![,]>::parse_terminated(input)?
                 .into_iter()
@@ -180,6 +185,7 @@ fn parse(stream: TokenStream, body: &syn::ItemStruct) -> Result<Elem> {
     Ok(Elem {
         name,
         title,
+        since: meta.since,
         scope: meta.scope,
         keywords: meta.keywords,
         docs,
@@ -377,8 +383,16 @@ fn create_with_field_method(field: &Field) -> TokenStream {
 
 /// Creates the element's `NativeElement` implementation.
 fn create_native_elem_impl(element: &Elem) -> Result<TokenStream> {
-    let Elem { name, ident, title, scope, keywords, docs, .. } = element;
+    let Elem {
+        name, ident, title, since, scope, keywords, docs, ..
+    } = element;
     let def_site_key = ident.to_string();
+
+    let since = if let Some(since) = since {
+        quote! { Some(#since) }
+    } else {
+        quote! { None }
+    };
 
     let fields = element.fields.iter().filter(|field| !field.internal).map(|field| {
         let i = field.i;
@@ -431,6 +445,7 @@ fn create_native_elem_impl(element: &Elem) -> Result<TokenStream> {
                     #foundations::ContentVtable::new::<#ident>(
                         #name,
                         #title,
+                        #since,
                         #docs,
                         ::typst_utils::DefSite { path: file!(), key: #def_site_key },
                         &[#(#fields),*],

--- a/crates/typst-macros/src/func.rs
+++ b/crates/typst-macros/src/func.rs
@@ -5,7 +5,7 @@ use syn::parse::{Parse, ParseStream};
 use syn::{Ident, Result, parse_quote};
 
 use crate::util::{
-    determine_name_and_title, documentation, foundations, has_attr, kw, oneliner,
+    Since, determine_name_and_title, documentation, foundations, has_attr, kw, oneliner,
     parse_attr, parse_flag, parse_key_value, parse_string, parse_string_array,
     quote_option, validate_attrs,
 };
@@ -22,11 +22,13 @@ struct Func {
     name: String,
     /// The function's title case name.
     title: String,
+    /// The version of Typst the function was introduced in.
+    since: Option<Since>,
     /// Whether this function has an associated scope defined by the `#[scope]` macro.
     scope: bool,
     /// Whether this function is a constructor.
     constructor: bool,
-    /// A list of alternate search terms for this element.
+    /// A list of alternate search terms for this function.
     keywords: Vec<String>,
     /// The parent type of this function.
     ///
@@ -34,9 +36,9 @@ struct Func {
     parent: Option<syn::Type>,
     /// Whether this function is contextual.
     contextual: bool,
-    /// The documentation for this element as a string.
+    /// The documentation for this function as a string.
     docs: String,
-    /// The element's visibility.
+    /// The function's visibility.
     vis: syn::Visibility,
     /// The name for this function given in Rust.
     ident: Ident,
@@ -106,9 +108,11 @@ pub struct Meta {
     pub name: Option<String>,
     /// The function's title case name.
     pub title: Option<String>,
+    /// The version of Typst the function was introduced in.
+    pub since: Option<Since>,
     /// Whether this function is a constructor.
     pub constructor: bool,
-    /// A list of alternate search terms for this element.
+    /// A list of alternate search terms for this function.
     pub keywords: Vec<String>,
     /// The parent type of this function.
     ///
@@ -124,6 +128,7 @@ impl Parse for Meta {
             name: parse_string::<kw::name>(input)?,
             title: parse_string::<kw::title>(input)?,
             constructor: parse_flag::<kw::constructor>(input)?,
+            since: parse_key_value::<kw::since, Since>(input)?,
             keywords: parse_string_array::<kw::keywords>(input)?,
             parent: parse_key_value::<kw::parent, _>(input)?,
         })
@@ -156,6 +161,7 @@ fn parse(stream: TokenStream, item: &syn::ItemFn) -> Result<Func> {
     Ok(Func {
         name,
         title,
+        since: meta.since,
         scope: meta.scope,
         constructor: meta.constructor,
         keywords: meta.keywords,
@@ -289,6 +295,7 @@ fn create_func_data(func: &Func) -> TokenStream {
         ident,
         name,
         title,
+        since,
         docs,
         keywords,
         returns,
@@ -327,11 +334,18 @@ fn create_func_data(func: &Func) -> TokenStream {
         quote! { #name }
     };
 
+    let since = if let Some(since) = since {
+        quote! { Some(#since) }
+    } else {
+        quote! { None }
+    };
+
     quote! {
         #foundations::NativeFuncData {
             function: #foundations::NativeFuncPtr(&#closure),
             name: #name,
             title: #title,
+            since: #since,
             docs: #docs,
             def_site: Some(::typst_utils::DefSite { path: file!(), key: #def_site_key }),
             keywords: &[#(#keywords),*],

--- a/crates/typst-macros/src/ty.rs
+++ b/crates/typst-macros/src/ty.rs
@@ -4,8 +4,8 @@ use syn::parse::{Parse, ParseStream};
 use syn::{Attribute, Ident, Result};
 
 use crate::util::{
-    BareType, determine_name_and_title, documentation, foundations, kw, oneliner,
-    parse_flag, parse_string, parse_string_array,
+    BareType, Since, determine_name_and_title, documentation, foundations, kw, oneliner,
+    parse_flag, parse_key_value, parse_string, parse_string_array,
 };
 
 /// Expand the `#[ty]` macro.
@@ -49,6 +49,7 @@ struct Meta {
     cast: bool,
     name: Option<String>,
     title: Option<String>,
+    since: Option<Since>,
     keywords: Vec<String>,
 }
 
@@ -59,6 +60,7 @@ impl Parse for Meta {
             cast: parse_flag::<kw::cast>(input)?,
             name: parse_string::<kw::name>(input)?,
             title: parse_string::<kw::title>(input)?,
+            since: parse_key_value::<kw::since, Since>(input)?,
             keywords: parse_string_array::<kw::keywords>(input)?,
         })
     }
@@ -79,6 +81,11 @@ fn create(ty: &Type, item: Option<&syn::Item>) -> TokenStream {
     let Meta { keywords, .. } = meta;
     let def_site_key = ident.to_string();
     let oneliner = oneliner(docs);
+    let since = if let Some(since) = &meta.since {
+        quote! { Some(#since) }
+    } else {
+        quote! { None }
+    };
 
     let constructor = if meta.scope {
         quote! { <#ident as #foundations::NativeScope>::constructor() }
@@ -103,6 +110,7 @@ fn create(ty: &Type, item: Option<&syn::Item>) -> TokenStream {
             name: #name,
             long_name: #long,
             title: #title,
+            since: #since,
             docs: #docs,
             def_site: ::typst_utils::DefSite { path: file!(), key: #def_site_key },
             keywords: &[#(#keywords),*],

--- a/crates/typst-macros/src/util.rs
+++ b/crates/typst-macros/src/util.rs
@@ -1,6 +1,7 @@
 use heck::{ToKebabCase, ToTitleCase};
 use proc_macro2::TokenStream;
 use quote::{ToTokens, quote};
+use std::str::FromStr;
 use syn::parse::{Parse, ParseStream};
 use syn::token::Token;
 use syn::{Attribute, Ident, Result, Token};
@@ -44,11 +45,10 @@ pub fn documentation(attrs: &[syn::Attribute]) -> String {
                 && expr.mac.path.is_ident("stringify")
                 && let Ok(lit) = syn::parse2::<syn::Lit>(expr.mac.tokens.clone())
                 && let Some(value) = match &lit {
-                    syn::Lit::Int(int) => Some(int.base10_digits()),
-                    syn::Lit::Float(float) => Some(float.base10_digits()),
-                    _ => None,
-                }
-            {
+                syn::Lit::Int(int) => Some(int.base10_digits()),
+                syn::Lit::Float(float) => Some(float.base10_digits()),
+                _ => None,
+            } {
                 doc.push_str(value);
                 doc.push('\n');
             }
@@ -271,6 +271,7 @@ pub mod kw {
     syn::custom_keyword!(name);
     syn::custom_keyword!(span);
     syn::custom_keyword!(title);
+    syn::custom_keyword!(since);
     syn::custom_keyword!(scope);
     syn::custom_keyword!(contextual);
     syn::custom_keyword!(cast);
@@ -278,6 +279,69 @@ pub mod kw {
     syn::custom_keyword!(keywords);
     syn::custom_keyword!(parent);
     syn::custom_keyword!(ext);
+}
+
+/// When a feature was introduced.
+pub enum Since {
+    /// The feature was introduced before Typst 0.1.0.
+    Forever,
+    /// The feature was introduced in a version released after Typst 0.1.0.
+    Version([u32; 3]),
+    /// The feature is not present in any official Typst release.
+    Unreleased,
+}
+
+impl Since {
+    const FOREVER: &'static str = "forever";
+    const UNRELEASED: &'static str = "unreleased";
+}
+
+impl FromStr for Since {
+    type Err = ();
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        if s == Self::FOREVER {
+            Ok(Self::Forever)
+        } else if s == Self::UNRELEASED {
+            Ok(Self::Unreleased)
+        } else if let Ok(&[major, minor, patch]) = s
+            .splitn(3, '.')
+            .map(u32::from_str)
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .as_deref()
+        {
+            Ok(Self::Version([major, minor, patch]))
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl Parse for Since {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let value = input.parse::<syn::LitStr>()?;
+        let Ok(since) = value.value().parse() else {
+            bail!(
+                value,
+                "invalid version; use `{:?}` for an unreleased version",
+                Self::UNRELEASED,
+            )
+        };
+        Ok(since)
+    }
+}
+
+impl ToTokens for Since {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            Self::Forever => quote! { #foundations::Since::Forever },
+            Self::Version([major, minor, patch]) => {
+                quote! { #foundations::Since::Version([#major, #minor, #patch]) }
+            }
+            Self::Unreleased => quote! { #foundations::Since::Unreleased },
+        }
+        .to_tokens(tokens);
+    }
 }
 
 /// Extract the first line of documentation.

--- a/docs/components/category.typ
+++ b/docs/components/category.typ
@@ -281,6 +281,11 @@
       Contextual functions can only be used when the context is known.
     ])
   }
+  if info.since != none {
+    set text(0.75em)
+    gap
+    small[Since: #info.since]
+  }
   gap
   deprecation(deprecation-info)
   sources-link(info)
@@ -288,6 +293,12 @@
 
 // Displays additional details about a type.
 #let ty-subtitle(ty-info, deprecation-info) = context {
+  let gap = if target() == "paged" { h(0.5em, weak: true) }
+  if ty-info.since != none {
+    set text(0.75em)
+    gap
+    small[Since: #ty-info.since]
+  }
   deprecation(deprecation-info)
   sources-link(ty-info)
 }
@@ -380,7 +391,7 @@
     with-tooltip[Constructor][
       If a type has a constructor, you can call it like a function to create
       a new value of the type.
-    ],
+    ] + func-subtitle(info, none),
   )
 
   {

--- a/docs/components/category.typ
+++ b/docs/components/category.typ
@@ -285,6 +285,8 @@
     set text(0.75em)
     gap
     small[Since: #info.since]
+  } else {
+    panic("missing `since` for function " + info.def-site.key + " (" + stdx.str-from-path(info.def-site.path) + ")")
   }
   gap
   deprecation(deprecation-info)
@@ -298,6 +300,8 @@
     set text(0.75em)
     gap
     small[Since: #ty-info.since]
+  } else {
+    panic("missing `since` for type " + ty-info.def-site.key + " (" + stdx.str-from-path(ty-info.def-site.path) + ")")
   }
   deprecation(deprecation-info)
   sources-link(ty-info)

--- a/docs/src/reflect.rs
+++ b/docs/src/reflect.rs
@@ -50,6 +50,7 @@ fn describe_func(func: &Func) -> Dict {
     dict! {
         "name" => func.name(),
         "title" => func.title(),
+        "since" => func.since(),
         "docs" => func.docs(),
         "def-site" => func.def_site().map(describe_def_site),
         "element" => func.to_element().is_some(),
@@ -94,6 +95,7 @@ fn describe_ty(ty: Type) -> Dict {
         "short-name" => ty.short_name(),
         "long-name" => ty.long_name(),
         "title" => ty.title(),
+        "since" => ty.since(),
         "docs" => ty.docs(),
         "def-site" => describe_def_site(ty.def_site()),
         "keywords" => ty.keywords(),


### PR DESCRIPTION
This PR adds infrastructure to specify the version of Typst in which elements, functions and types are introduced, and displays the introducing version in the documentation.

Note that function parameters and element fields are not affected by this change. In most cases, parameters are introduced together with the function. But for some elements like `text` or `par`, there are fields that have been introduced in more recent versions, so it may be beneficial to add introducing version for parameters and fields as well.

For bindings introduced on `main` but not present in any previous Typst version, I used `since = "{NEXT_TYPST_VERSION}"`, which should be easy to search and replace when releasing the next version. For information, the Rust Compiler uses `since = "CURRENT_RUSTC_VERSION"`.

The version I consider to be the introducing version is the one where the name becomes available. For example, if a function was introduced in version A and renamed in version B, I consider it introduced in version B. Notable examples of where this is visible:
- `plugin` was introduced in 0.8.0 and changed from a type with a constructor to a function in 0.13.0: `since = "0.8.0"`.
- `arguments` has existed forever, but its constructor was introduced in 0.10.0: `since = "0.10.0"` for the constructor, `since = "forever"` for the type itself.
- `color.kind` was renamed to `color.space` in 0.9.0: `since = "0.9.0"`.

I have assigned a `since` to every documented item. I don't know of a good way to check everything, so I hope i did not make too many mistakes (I would be surprised if I did not make any).

In the last commit, I add a check to the documentation infrastructure that ensures every documented item has a `since`. I am not sure whether we want to keep that, in particular because this might be annoying to people using the documentation generator to generate documentation for their own things, which might not have appropriate values for `since`.

Closes https://github.com/typst/typst/issues/6069.