### PR TITLE
error instead of panic on oversized repeat

### DIFF
--- a/crates/typst-library/src/foundations/array.rs
+++ b/crates/typst-library/src/foundations/array.rs
@@ -141,6 +141,9 @@ impl Array {
         let count = self
             .len()
             .checked_mul(n)
+            .filter(|&count| {
+                count.saturating_mul(std::mem::size_of::<Value>()) < isize::MAX as usize
+            })
             .ok_or_else(|| format!("cannot repeat this array {n} times"))?;
 
         Ok(self.iter().cloned().cycle().take(count).collect())

--- a/crates/typst-library/src/foundations/content/mod.rs
+++ b/crates/typst-library/src/foundations/content/mod.rs
@@ -333,8 +333,11 @@ impl Content {
     }
 
     /// Repeat this content `count` times.
-    pub fn repeat(&self, count: usize) -> Self {
-        Self::sequence(std::iter::repeat_with(|| self.clone()).take(count))
+    pub fn repeat(&self, count: usize) -> StrResult<Self> {
+        if count.saturating_mul(std::mem::size_of::<Content>()) >= isize::MAX as usize {
+            return Err(eco_format!("cannot repeat this content {count} times"));
+        }
+        Ok(Self::sequence(std::iter::repeat_with(|| self.clone()).take(count)))
     }
 
     /// Sets a style property on the content.

--- a/crates/typst-library/src/foundations/ops.rs
+++ b/crates/typst-library/src/foundations/ops.rs
@@ -273,8 +273,8 @@ pub fn mul(lhs: Value, rhs: Value) -> HintedStrResult<Value> {
         (Int(a), Str(b)) => Str(b.repeat(Value::Int(a).cast()?)?),
         (Array(a), Int(b)) => Array(a.repeat(Value::Int(b).cast()?)?),
         (Int(a), Array(b)) => Array(b.repeat(Value::Int(a).cast()?)?),
-        (Content(a), b @ Int(_)) => Content(a.repeat(b.cast()?)),
-        (a @ Int(_), Content(b)) => Content(b.repeat(a.cast()?)),
+        (Content(a), b @ Int(_)) => Content(a.repeat(b.cast()?)?),
+        (a @ Int(_), Content(b)) => Content(b.repeat(a.cast()?)?),
 
         (Int(a), Duration(b)) => Duration(b * (a as f64)),
         (Float(a), Duration(b)) => Duration(b * a),

--- a/crates/typst-library/src/foundations/str.rs
+++ b/crates/typst-library/src/foundations/str.rs
@@ -90,7 +90,12 @@ impl Str {
 
     /// Repeat the string a number of times.
     pub fn repeat(&self, n: usize) -> StrResult<Self> {
-        if self.0.len().checked_mul(n).is_none() {
+        if self
+            .0
+            .len()
+            .checked_mul(n)
+            .is_none_or(|len| len >= isize::MAX as usize)
+        {
             return Err(eco_format!("cannot repeat this string {n} times"));
         }
         Ok(Self(self.0.repeat(n)))

--- a/tests/suite/foundations/array.typ
+++ b/tests/suite/foundations/array.typ
@@ -267,6 +267,10 @@
 // Error: 2-24 array index out of bounds (index: -4, len: 3)
 #(1, 2, 3).slice(0, -4)
 
+--- array-repeat-too-large eval ---
+// Error: 3-29 cannot repeat this array 9223372036854775807 times
+#((1,) * 9223372036854775807)
+
 --- array-position eval ---
 // Test the `position` method.
 #test(("Hi", "❤️", "Love").position(s => s == "❤️"), 1)

--- a/tests/suite/foundations/content.typ
+++ b/tests/suite/foundations/content.typ
@@ -134,3 +134,7 @@
 --- content-try-to-access-internal-field eval ---
 // Error: 9-15 hide does not have field "hidden"
 #hide[].hidden
+
+--- content-repeat-too-large eval ---
+// Error: 3-28 cannot repeat this content 9223372036854775807 times
+#([a] * 9223372036854775807)

--- a/tests/suite/foundations/str.typ
+++ b/tests/suite/foundations/str.typ
@@ -95,6 +95,10 @@
 // Error: 2-28 0x110000 is not a valid codepoint
 #str.from-unicode(0x110000) // 0x10ffff is the highest valid code point
 
+--- str-repeat-too-large eval ---
+// Error: 3-28 cannot repeat this string 9223372036854775807 times
+#("a" * 9223372036854775807)
+
 --- str-normalize eval ---
 // Test the `normalize` method.
 #test("e\u{0301}".normalize(form: "nfc"), "é")


### PR DESCRIPTION
Hit this fuzzing the `*` operator. `"a" * 9223372036854775807` panics with a "capacity overflow" instead of the existing "cannot repeat" error, and the array/content equivalents (e.g. `(1,) * 300000000000000000`) do the same. The guard only catches `usize` overflow of the product, but a product that still exceeds the maximum allocation size aborts in the allocator. Reject when the result would reach `isize::MAX` bytes, accounting for element size in the array and content cases.