### PR TITLE
Implement field access for `arguments` and add IDE completions

### DIFF
--- a/crates/typst-eval/src/access.rs
+++ b/crates/typst-eval/src/access.rs
@@ -84,7 +84,11 @@ pub(crate) fn access_dict<'a>(
             let span = access.target().span();
             if matches!(
                 value, // those types have their own field getters
-                Value::Symbol(_) | Value::Content(_) | Value::Module(_) | Value::Func(_)
+                Value::Symbol(_)
+                    | Value::Content(_)
+                    | Value::Module(_)
+                    | Value::Func(_)
+                    | Value::Args(_)
             ) {
                 bail!(span, "cannot mutate fields on {ty}");
             } else if typst_library::foundations::fields_on(ty).is_empty() {

--- a/crates/typst-eval/src/call.rs
+++ b/crates/typst-eval/src/call.rs
@@ -266,9 +266,9 @@ fn eval_field_callee<'a, 'b>(
         match target.field(field, sink) {
             // The field does exist.
             Ok(callee_value) => {
-                // Aside from Dict and Content, only a few other types have
-                // accessible fields which could produce these errors. As of
-                // March 2026, they are:
+                // Aside from Dict, named Args, and Content, only a few other
+                // types have accessible fields which could produce these
+                // errors. As of June 2026, they are:
                 // - Alignment (.x, .y)
                 // - Length (.abs, .em)
                 // - Relative Length (.ratio, .length)
@@ -277,6 +277,7 @@ fn eval_field_callee<'a, 'b>(
                 // The other types with fields (Symbol, Func, Type, Module) are
                 // handled above.
                 let is_dict = matches!(target, Value::Dict(_));
+                let is_named = matches!(target, Value::Args(_));
                 let mut err = if is_dict {
                     // Dictionaries get a specific error & hint because they're
                     // the easiest to attempt this with, and users need to be
@@ -284,6 +285,12 @@ fn eval_field_callee<'a, 'b>(
                     error!(
                         access.span(),
                         "cannot directly call dictionary keys as functions";
+                    )
+                } else if is_named {
+                    // Also give the custom error & hint for named arguments.
+                    error!(
+                        access.span(),
+                        "cannot directly call named argument fields as functions";
                     )
                 } else {
                     let (kind, name) = element_or_type_with_name(&target);
@@ -305,7 +312,13 @@ fn eval_field_callee<'a, 'b>(
                 } else {
                     err.hint(eco_format!(
                         "to access the `{field}` {}, remove the function arguments: `{}`",
-                        if is_dict { "key" } else { "field" },
+                        if is_dict {
+                            "key"
+                        } else if is_named {
+                            "argument"
+                        } else {
+                            "field"
+                        },
                         access.full_text(),
                     ));
                 }
@@ -313,6 +326,11 @@ fn eval_field_callee<'a, 'b>(
                     err.hint(
                         "dictionary keys cannot be used with method syntax as keys \
                             could conflict with built-in method names",
+                    );
+                } else if is_named {
+                    err.hint(
+                        "named arguments cannot be used with method syntax as argument \
+                            names could conflict with built-in method names",
                     );
                 }
 

--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -223,6 +223,11 @@ fn field_access_completions(
                 ctx.value_completion(name.clone(), value);
             }
         }
+        Value::Args(args) => {
+            for (name, value) in args.to_named().iter() {
+                ctx.value_completion(name.clone(), value);
+            }
+        }
         Value::Func(func) => {
             // Autocomplete get rules.
             if let Some((elem, styles)) = func.to_element().zip(styles.as_ref()) {
@@ -1697,6 +1702,61 @@ mod tests {
         test("$vec(pi)$", -3).must_include(["pi"]).must_exclude(["box"]);
         test("$vec(size:pi)$", -3).must_include(["pi"]).must_exclude(["box"]);
         test("$vec(..pi)$", -3).must_include(["pi"]).must_exclude(["box"]);
+    }
+
+    /// Test dict field autocompletion in code and math.
+    #[test]
+    fn test_autocomplete_dict_fields() {
+        let with = |text| &*format!("#let dict = (a: (c: 1), b: 2); {text}").leak();
+        test(with("#dict."), -1)
+            .must_include(["a", "b", "keys"])
+            .must_exclude(["c"]);
+        test(with("$dict.$"), -2)
+            .must_include(["a", "b", "keys"])
+            .must_exclude(["c"]);
+        test(with("#dict.b."), -1)
+            .must_include(["bit-or"])
+            .must_exclude(["c"]);
+        test(with("$dict.b.$"), -2)
+            .must_include(["bit-or"])
+            .must_exclude(["c"]);
+        test(with("#dict.a."), -1)
+            .must_include(["c", "keys"])
+            .must_exclude(["b"]);
+        test(with("$dict.a.$"), -2)
+            .must_include(["c", "keys"])
+            .must_exclude(["b"]);
+        test(with("#dict.a.c."), -1).must_include(["bit-or"]);
+        test(with("$dict.a.c.$"), -2).must_include(["bit-or"]);
+    }
+
+    /// Test argument field autocompletion in code and math.
+    #[test]
+    fn test_autocomplete_argument_fields() {
+        let with = |text| {
+            &*format!("#let args = arguments(0, a: arguments(c: 1), b: 2); {text}").leak()
+        };
+        test(with("#args."), -1)
+            .must_include(["a", "b", "pos", "named"])
+            .must_exclude(["c"]);
+        test(with("$args.$"), -2)
+            .must_include(["a", "b", "pos", "named"])
+            .must_exclude(["c"]);
+        test(with("#args.b."), -1)
+            .must_include(["bit-or"])
+            .must_exclude(["c"]);
+        test(with("$args.b.$"), -2)
+            .must_include(["bit-or"])
+            .must_exclude(["c"]);
+        test(with("#args.at(0)."), -1).must_include(["bit-or"]);
+        test(with("#args.a."), -1)
+            .must_include(["c", "pos", "named"])
+            .must_exclude(["b"]);
+        test(with("$args.a.$"), -2)
+            .must_include(["c", "pos", "named"])
+            .must_exclude(["b"]);
+        test(with("#args.a.c."), -1).must_include(["bit-or"]);
+        test(with("$args.a.c.$"), -2).must_include(["bit-or"]);
     }
 
     /// Test that the `before_window` doesn't slice into invalid byte

--- a/crates/typst-library/src/foundations/args.rs
+++ b/crates/typst-library/src/foundations/args.rs
@@ -15,9 +15,9 @@ use crate::foundations::{
 
 /// Captured arguments to a function.
 ///
-/// Arguments are either _positional_ or _named_, and can be accessed by the
-/// @arguments.pos[`pos`], @arguments.named[`named`], or @arguments.at[`at`]
-/// methods.
+/// Arguments are either _positional_ or _named,_ and can be accessed through
+/// the @arguments.pos[`pos`], @arguments.named[`named`], and
+/// @arguments.at[`at`] methods.
 ///
 /// Additionally, named arguments can be accessed with @arguments.at[field
 /// syntax] similar to @dictionary[dictionaries].
@@ -347,14 +347,14 @@ impl Args {
     /// Returns the positional argument at the specified index, or the named
     /// argument with the specified name.
     ///
-    /// Named arguments can also be accessed with field syntax
-    /// `{arguments(key: 42).key}` if no default is needed. Unlike
-    /// @dictionary[dictionaries], fields on arguments cannot be modified.
-    ///
     /// If the key is an @int[integer], this is equivalent to first calling
     /// @arguments.pos[`pos`] and then @array.at. If it is a @str[string], this
     /// is equivalent to first calling @arguments.named[`named`] and then
     /// @dictionary.at.
+    ///
+    /// Named arguments can also be accessed with field syntax (e.g.
+    /// `{arguments(key: 42).key}`) if no default is needed. Unlike
+    /// @dictionary[dictionaries], fields on arguments cannot be modified.
     #[func]
     pub fn at(
         &self,

--- a/crates/typst-library/src/foundations/args.rs
+++ b/crates/typst-library/src/foundations/args.rs
@@ -15,6 +15,13 @@ use crate::foundations::{
 
 /// Captured arguments to a function.
 ///
+/// Arguments are either _positional_ or _named_, and can be accessed by the
+/// @arguments.pos[`pos`], @arguments.named[`named`], or @arguments.at[`at`]
+/// methods.
+///
+/// Additionally, named arguments can be accessed with @arguments.at[field
+/// syntax] similar to @dictionary[dictionaries].
+///
 /// = Argument Sinks <argument-sinks>
 /// Like built-in functions, custom functions can also take a variable number of
 /// arguments. You can specify an _argument sink_ which collects all excess
@@ -299,6 +306,15 @@ impl Args {
         };
         item.map(|item| &item.value.v)
     }
+
+    /// Access a named argument as a field.
+    pub fn field(&self, field: &str) -> StrResult<&Value> {
+        self.items
+            .iter()
+            .rfind(|item| item.name.as_ref().map(|name| name.as_str()) == Some(field))
+            .ok_or_else(|| eco_format!("no named argument {}", field.repr()))
+            .map(|item| &item.value.v)
+    }
 }
 
 #[scope]
@@ -330,6 +346,10 @@ impl Args {
 
     /// Returns the positional argument at the specified index, or the named
     /// argument with the specified name.
+    ///
+    /// Named arguments can also be accessed with field syntax
+    /// `{arguments(key: 42).key}` if no default is needed. Unlike
+    /// @dictionary[dictionaries], fields on arguments cannot be modified.
     ///
     /// If the key is an @int[integer], this is equivalent to first calling
     /// @arguments.pos[`pos`] and then @array.at. If it is a @str[string], this
@@ -554,12 +574,13 @@ where
 /// The missing key access error message when no default was given.
 #[cold]
 fn missing_key_no_default(key: ArgumentKey) -> EcoString {
-    eco_format!(
-        "arguments do not contain key {} \
-         and no default value was specified",
-        match key {
-            ArgumentKey::Index(i) => i.repr(),
-            ArgumentKey::Name(name) => name.repr(),
-        }
-    )
+    match key {
+        ArgumentKey::Index(i) => eco_format!(
+            "no positional argument at index {i} and no default value was specified",
+        ),
+        ArgumentKey::Name(name) => eco_format!(
+            "no named argument {} and no default value was specified",
+            name.repr()
+        ),
+    }
 }

--- a/crates/typst-library/src/foundations/dict.rs
+++ b/crates/typst-library/src/foundations/dict.rs
@@ -197,13 +197,13 @@ impl Dict {
 
     /// Returns the value associated with the specified key in the dictionary.
     ///
-    /// Values may also be accessed with field syntax `{(key: 42).key}` if no
-    /// default is needed.
-    ///
     /// May be used on the left-hand side of an assignment if the key is already
     /// present in the dictionary. Returns the default value if the key is not
     /// part of the dictionary or fails with an error if no default value was
     /// specified.
+    ///
+    /// Values may also be accessed with field syntax (e.g. `{(key: 42).key}`)
+    /// if no default is needed.
     #[func]
     pub fn at(
         &self,

--- a/crates/typst-library/src/foundations/dict.rs
+++ b/crates/typst-library/src/foundations/dict.rs
@@ -196,6 +196,10 @@ impl Dict {
     }
 
     /// Returns the value associated with the specified key in the dictionary.
+    ///
+    /// Values may also be accessed with field syntax `{(key: 42).key}` if no
+    /// default is needed.
+    ///
     /// May be used on the left-hand side of an assignment if the key is already
     /// present in the dictionary. Returns the default value if the key is not
     /// part of the dictionary or fails with an error if no default value was

--- a/crates/typst-library/src/foundations/value.rs
+++ b/crates/typst-library/src/foundations/value.rs
@@ -161,6 +161,7 @@ impl Value {
             }
             Self::Version(version) => version.component(field).map(Self::Int),
             Self::Dict(dict) => dict.get(field).cloned(),
+            Self::Args(args) => args.field(field).cloned(),
             Self::Content(content) => content.field_by_name(field),
             Self::Type(ty) => ty.field(field, sink).cloned(),
             Self::Func(func) => func.field(field, sink).cloned(),

--- a/tests/suite/foundations/arguments.typ
+++ b/tests/suite/foundations/arguments.typ
@@ -14,15 +14,85 @@
 #test(args.at(2), 3)
 #test(args.at("a"), 2)
 
---- arguments-at-invalid-index eval ---
+--- arguments-field-access eval ---
+#let args = arguments(0, 1, a: 2, 3, b: arguments(5, c: 4))
+#test(args.a, 2)
+#test(args.b, arguments(5, c: 4))
+#test(args.b.c, 4)
+#test(args.b.at(0), 5)
+#test(args.b.at("c"), 4)
+#test(args.at("b").c, 4)
+
+--- arguments-at-call eval ---
+// Test calling a function in an argument via `.at()`.
+#let args = arguments(x => x + 1, func: x => x + 2)
+#test(args.at(0)(0), 1)
+#test(args.at("func")(0), 2)
+
+--- arguments-at-index-missing eval ---
 #let args = arguments(0, 1, a: 2, 3)
-// Error: 2-12 arguments do not contain key 4 and no default value was specified
+// Error: 2-12 no positional argument at index 4 and no default value was specified
 #args.at(4)
 
---- arguments-at-invalid-name eval ---
+--- arguments-at-name-missing eval ---
 #let args = arguments(0, 1, a: 2, 3)
-// Error: 2-14 arguments do not contain key "b" and no default value was specified
+// Error: 2-14 no named argument "b" and no default value was specified
 #args.at("b")
+
+--- arguments-field-missing eval ---
+#let args = arguments(0, 1, a: 2, 3)
+// Error: 7-8 no named argument "b"
+#args.b
+
+--- arguments-field-invalid-syntax eval ---
+#let args = arguments(0)
+// Error: 11-11 expected comma
+#test(args.0, 0)
+
+--- arguments-field-assign eval ---
+#{
+  let args = arguments(a: 1)
+  // Error: 3-7 cannot mutate fields on arguments
+  args.a = 2
+  test(args.a, 2)
+}
+
+--- arguments-at-assign-named eval ---
+#{
+  let args = arguments(0, a: 1)
+  // Error: 3-15 cannot mutate a temporary value
+  args.at("a") = 2
+  test(args.a, 2)
+}
+
+--- arguments-at-assign-pos eval ---
+#{
+  let args = arguments(0, a: 1)
+  // Error: 3-13 cannot mutate a temporary value
+  args.at(0) = 2
+  test(args.at(0), 2)
+}
+
+--- arguments-field-assign-missing eval ---
+#{
+  let args = arguments(a: 1)
+  // Error: 3-7 cannot mutate fields on arguments
+  args.b = 2
+}
+
+--- arguments-at-assign-missing-name eval ---
+#{
+  let args = arguments(a: 1)
+  // Error: 3-15 cannot mutate a temporary value
+  args.at("b") = 2
+}
+
+--- arguments-at-assign-missing-index eval ---
+#{
+  let args = arguments(0, a: 1)
+  // Error: 3-13 cannot mutate a temporary value
+  args.at(1) = 2
+}
 
 --- arguments-plus-sum-join eval ---
 #let lhs = arguments(0, "1", key: "value", 3)
@@ -53,3 +123,8 @@
 // Test that errors in the function are reported properly.
 // Error: 26-31 cannot subtract integer from string
 #arguments("a").map(x => x - 2)
+
+--- arguments-method-typo eval ---
+#let args = arguments(0)
+// Error: 2-10 type arguments has no method `att`
+#args.att(0)

--- a/tests/suite/foundations/dict.typ
+++ b/tests/suite/foundations/dict.typ
@@ -125,6 +125,11 @@
   test(dict.state.err, false)
 }
 
+--- dict-at-call eval ---
+// Test calling a function in a dictionary via `.at()`.
+#let dict = (func: x => x + 1)
+#test(dict.at("func")(0), 1)
+
 --- dict-at-missing-key eval ---
 // Test rvalue missing key.
 #{

--- a/tests/suite/scripting/methods.typ
+++ b/tests/suite/scripting/methods.typ
@@ -114,6 +114,34 @@ $ pi.alt() $
 // Hint: 3-9 try adding a space before the parentheses
 $ pi.alt() $
 
+--- field-call-args-invalid eval ---
+// Test attempting to call a function from a named argument field.
+// Error: 2-43 cannot directly call named argument fields as functions
+// Hint: 2-43 to call the stored function, wrap the field access in parentheses: `(arguments(call-me: () => "maybe").call-me)(..)`
+// Hint: 2-43 named arguments cannot be used with method syntax as argument names could conflict with built-in method names
+#arguments(call-me: () => "maybe").call-me()
+
+--- math-field-call-args-invalid eval ---
+#let pi = arguments(alt: _ => math.pi.alt)
+// Error: 3-9 cannot directly call named argument fields as functions
+// Hint: 3-9 to call the stored function, use code mode and wrap the field access in parentheses: `#(pi.alt)(..)`
+// Hint: 3-9 named arguments cannot be used with method syntax as argument names could conflict with built-in method names
+$ pi.alt() $
+
+--- field-call-args-non-func eval ---
+// Error: 2-33 cannot directly call named argument fields as functions
+// Hint: 2-33 to access the `non-func` argument, remove the function arguments: `arguments(non-func: 1).non-func`
+// Hint: 2-33 named arguments cannot be used with method syntax as argument names could conflict with built-in method names
+#arguments(non-func: 1).non-func()
+
+--- math-field-call-args-non-func eval ---
+// The hint should differ slightly to account for being in math mode.
+#let pi = arguments(alt: math.pi.alt)
+// Error: 3-9 cannot directly call named argument fields as functions
+// Hint: 3-9 try adding a space before the parentheses
+// Hint: 3-9 named arguments cannot be used with method syntax as argument names could conflict with built-in method names
+$ pi.alt() $
+
 --- field-call-mut-basic eval ---
 // Mutating methods mutate a variable.
 #let numbers = (1, 2, 3)


### PR DESCRIPTION
Laurenz asked me to adjust #7676 to fix the merge conflicts and to add IDE completions for argument fields so that we can get it merged before the release.

I have also updated the docs slightly and added more tests, and I have reworked the error messages when trying to call a named argument field like a method so they mirror the diagnostic messages for dictionaries.

Still unresolved is whether to make argument fields immutable and whether to allow use of the `in` operator.

@Jollywatt I have added you added you as a co-author on the commit.
