### PR TITLE
use checked arithmetic for duration operators

### DIFF
--- a/crates/typst-library/src/foundations/duration.rs
+++ b/crates/typst-library/src/foundations/duration.rs
@@ -17,6 +17,33 @@ impl Duration {
         self.0.is_zero()
     }
 
+    /// Adds two durations, returning `None` on overflow.
+    pub fn checked_add(self, rhs: Self) -> Option<Self> {
+        self.0.checked_add(rhs.0).map(Self)
+    }
+
+    /// Subtracts two durations, returning `None` on overflow.
+    pub fn checked_sub(self, rhs: Self) -> Option<Self> {
+        self.0.checked_sub(rhs.0).map(Self)
+    }
+
+    /// Negates the duration, returning `None` on overflow.
+    pub fn checked_neg(self) -> Option<Self> {
+        self.0.checked_neg().map(Self)
+    }
+
+    /// Scales the duration by a factor, returning `None` if the result
+    /// overflows or the factor is not a number.
+    pub fn checked_mul(self, factor: f64) -> Option<Self> {
+        time::Duration::checked_seconds_f64(self.0.as_seconds_f64() * factor).map(Self)
+    }
+
+    /// Divides the duration by a divisor, returning `None` if the result
+    /// overflows or the divisor is not a number.
+    pub fn checked_div(self, divisor: f64) -> Option<Self> {
+        time::Duration::checked_seconds_f64(self.0.as_seconds_f64() / divisor).map(Self)
+    }
+
     /// Decomposes the time into whole weeks, days, hours, minutes, and seconds.
     pub fn decompose(&self) -> [i64; 5] {
         let mut tmp = self.0;

--- a/crates/typst-library/src/foundations/ops.rs
+++ b/crates/typst-library/src/foundations/ops.rs
@@ -81,7 +81,7 @@ pub fn neg(value: Value) -> HintedStrResult<Value> {
         Ratio(v) => Ratio(-v),
         Relative(v) => Relative(-v),
         Fraction(v) => Fraction(-v),
-        Duration(v) => Duration(-v),
+        Duration(v) => Duration(v.checked_neg().ok_or_else(too_large)?),
         Datetime(_) => mismatch!("cannot apply unary '-' to {}", value),
         v => mismatch!("cannot apply '-' to {}", v),
     })
@@ -152,7 +152,7 @@ pub fn add(lhs: Value, rhs: Value) -> HintedStrResult<Value> {
             Stroke::from_pair(tiling, thickness).into_value()
         }
 
-        (Duration(a), Duration(b)) => Duration(a + b),
+        (Duration(a), Duration(b)) => Duration(a.checked_add(b).ok_or_else(too_large)?),
         (Datetime(a), Duration(b)) => Datetime(a + b),
         (Duration(a), Datetime(b)) => Datetime(b + a),
 
@@ -207,7 +207,7 @@ pub fn sub(lhs: Value, rhs: Value) -> HintedStrResult<Value> {
 
         (Fraction(a), Fraction(b)) => Fraction(a - b),
 
-        (Duration(a), Duration(b)) => Duration(a - b),
+        (Duration(a), Duration(b)) => Duration(a.checked_sub(b).ok_or_else(too_large)?),
         (Datetime(a), Duration(b)) => Datetime(a - b),
         (Datetime(a), Datetime(b)) => Duration((a - b)?),
 
@@ -276,10 +276,10 @@ pub fn mul(lhs: Value, rhs: Value) -> HintedStrResult<Value> {
         (Content(a), b @ Int(_)) => Content(a.repeat(b.cast()?)),
         (a @ Int(_), Content(b)) => Content(b.repeat(a.cast()?)),
 
-        (Int(a), Duration(b)) => Duration(b * (a as f64)),
-        (Float(a), Duration(b)) => Duration(b * a),
-        (Duration(a), Int(b)) => Duration(a * (b as f64)),
-        (Duration(a), Float(b)) => Duration(a * b),
+        (Int(a), Duration(b)) => Duration(b.checked_mul(a as f64).ok_or_else(too_large)?),
+        (Float(a), Duration(b)) => Duration(b.checked_mul(a).ok_or_else(too_large)?),
+        (Duration(a), Int(b)) => Duration(a.checked_mul(b as f64).ok_or_else(too_large)?),
+        (Duration(a), Float(b)) => Duration(a.checked_mul(b).ok_or_else(too_large)?),
 
         (a, b) => mismatch!("cannot multiply {} with {}", a, b),
     })
@@ -333,8 +333,8 @@ pub fn div(lhs: Value, rhs: Value) -> HintedStrResult<Value> {
         (Fraction(a), Float(b)) => Fraction(a / b),
         (Fraction(a), Fraction(b)) => Float(a / b),
 
-        (Duration(a), Int(b)) => Duration(a / (b as f64)),
-        (Duration(a), Float(b)) => Duration(a / b),
+        (Duration(a), Int(b)) => Duration(a.checked_div(b as f64).ok_or_else(too_large)?),
+        (Duration(a), Float(b)) => Duration(a.checked_div(b).ok_or_else(too_large)?),
         (Duration(a), Duration(b)) => Float(a / b),
 
         (a, b) => mismatch!("cannot divide {} by {}", a, b),

--- a/tests/suite/foundations/duration.typ
+++ b/tests/suite/foundations/duration.typ
@@ -116,3 +116,23 @@
 #test(duration(minutes: 20) < duration(minutes: 10), false)
 #test(duration(minutes: 20) <= duration(minutes: 10), false)
 #test(duration(minutes: 20) == duration(minutes: 10), false)
+
+--- duration-negate-too-large eval ---
+// Error: 3-50 value is too large
+#(-duration(seconds: int("-9223372036854775808")))
+
+--- duration-add-too-large eval ---
+// Error: 3-66 value is too large
+#(duration(weeks: 9000000000000) + duration(weeks: 9000000000000))
+
+--- duration-subtract-too-large eval ---
+// Error: 3-67 value is too large
+#(duration(weeks: 9000000000000) - duration(weeks: -9000000000000))
+
+--- duration-multiply-too-large eval ---
+// Error: 3-45 value is too large
+#(duration(weeks: 9000000000000) * 1000000.0)
+
+--- duration-divide-too-large eval ---
+// Error: 3-45 value is too large
+#(duration(weeks: 9000000000000) / 0.0000001)


### PR DESCRIPTION
Found these fuzzing arithmetic on durations built from large unit counts. Every duration operator in `ops.rs` forwards to the time crate's `Add`/`Sub`/`Neg`/`Mul<f64>`/`Div<f64>`, which abort via `expect()` once the i64-second result overflows, so `duration(weeks: 9000000000000) * 1000000.0` (and the +, -, unary -, / forms) take down the compile instead of erroring. Route them through `checked_*` and return the existing `value is too large` error, matching the int and decimal arms.