### PR TITLE
Estimate the size of a `range` to avoid unnecessary allocations

### DIFF
--- a/crates/typst-library/src/foundations/array.rs
+++ b/crates/typst-library/src/foundations/array.rs
@@ -415,9 +415,6 @@ impl Array {
         let step = step.get();
         let step_dir = 0.cmp(&step);
 
-        let mut x = start;
-        let mut array = Self::new();
-
         let in_bounds = |x: i64| {
             if inclusive {
                 // `x` must not exceed `end`.
@@ -427,6 +424,17 @@ impl Array {
                 x.cmp(&end) == step_dir
             }
         };
+
+        let size_estimate = if in_bounds(start) {
+            // The addition and ceil account for `start` being inclusive.
+            let breadth = start.abs_diff(end).saturating_add(inclusive.into());
+            breadth.div_ceil(step.unsigned_abs()).try_into().unwrap_or_default()
+        } else {
+            0
+        };
+
+        let mut x = start;
+        let mut array = Self::with_capacity(size_estimate);
 
         while in_bounds(x) {
             array.push(x.into_value());
@@ -438,6 +446,18 @@ impl Array {
                 break;
             }
         }
+
+        // Failing this check in release is sub-optimal, but not a hard error.
+        // Developers should be aware of the issue though!
+        debug_assert!(
+            size_estimate == array.len(),
+            "Range size estimate was off; \
+            we computed: {size_estimate}, but got: {}.\
+            \n\
+            With start: {start}, end: {end}, step: {step}, \
+            inclusive: {inclusive}.",
+            array.len(),
+        );
 
         Ok(array)
     }

--- a/crates/typst-library/src/foundations/array.rs
+++ b/crates/typst-library/src/foundations/array.rs
@@ -442,16 +442,7 @@ impl Array {
             0
         };
 
-        let mut x = start;
-        Ok(Self::from_iter((0..size_estimate).map(|_| {
-            let current = x.into_value();
-
-            if let Some(next) = x.checked_add(step) {
-                x = next;
-            }
-
-            current
-        })))
+        Ok(Self::from_iter((0..size_estimate).map(|i| (start + step * i).into_value())))
     }
 
     /// Produces a new array with only the items from the original one for which

--- a/crates/typst-library/src/foundations/array.rs
+++ b/crates/typst-library/src/foundations/array.rs
@@ -443,32 +443,15 @@ impl Array {
         };
 
         let mut x = start;
-        let mut array = Self::with_capacity(size_estimate);
-
-        while in_bounds(x) {
-            array.push(x.into_value());
+        Ok(Self::from_iter((0..size_estimate).map(|_| {
+            let current = x.into_value();
 
             if let Some(next) = x.checked_add(step) {
                 x = next;
-            } else {
-                // `end` must have been exceeded this iteration, so we yield.
-                break;
             }
-        }
 
-        // Failing this check in release is sub-optimal, but not a hard error.
-        // Developers should be aware of the issue though!
-        debug_assert!(
-            size_estimate == array.len(),
-            "Range size estimate was off; \
-            we computed: {size_estimate}, but got: {}.\
-            \n\
-            With start: {start}, end: {end}, step: {step}, \
-            inclusive: {inclusive}.",
-            array.len(),
-        );
-
-        Ok(array)
+            current
+        })))
     }
 
     /// Produces a new array with only the items from the original one for which

--- a/crates/typst-library/src/foundations/array.rs
+++ b/crates/typst-library/src/foundations/array.rs
@@ -442,7 +442,18 @@ impl Array {
             0
         };
 
-        Ok(Self::from_iter((0..size_estimate).map(|i| (start + step * i).into_value())))
+        let mut x = start;
+        let mut array = Self::with_capacity(size_estimate);
+
+        for _ in 0..size_estimate {
+            array.push(x.into_value());
+
+            if let Some(next) = x.checked_add(step) {
+                x = next;
+            }
+        }
+
+        Ok(array)
     }
 
     /// Produces a new array with only the items from the original one for which

--- a/crates/typst-library/src/foundations/array.rs
+++ b/crates/typst-library/src/foundations/array.rs
@@ -445,13 +445,28 @@ impl Array {
         let mut x = start;
         let mut array = Self::with_capacity(size_estimate);
 
-        for _ in 0..size_estimate {
+        while in_bounds(x) {
             array.push(x.into_value());
 
             if let Some(next) = x.checked_add(step) {
                 x = next;
+            } else {
+                // `end` must have been exceeded this iteration, so we yield.
+                break;
             }
         }
+
+        // Failing this check in release is sub-optimal, but not a hard error.
+        // Developers should be aware of the issue though!
+        debug_assert!(
+            size_estimate == array.len(),
+            "Range size estimate was off; \
+            we computed: {size_estimate}, but got: {}.\
+            \n\
+            With start: {start}, end: {end}, step: {step}, \
+            inclusive: {inclusive}.",
+            array.len(),
+        );
 
         Ok(array)
     }

--- a/crates/typst-library/src/foundations/array.rs
+++ b/crates/typst-library/src/foundations/array.rs
@@ -427,8 +427,17 @@ impl Array {
 
         let size_estimate = if in_bounds(start) {
             // The addition and ceil account for `start` being inclusive.
-            let breadth = start.abs_diff(end).saturating_add(inclusive.into());
-            breadth.div_ceil(step.unsigned_abs()).try_into().unwrap_or_default()
+            let breadth = start.abs_diff(end).checked_add(inclusive.into());
+            let estimate = breadth.map(|b| b.div_ceil(step.unsigned_abs()));
+
+            if let Some(v) = estimate
+                .filter(|&v| v < i64::MAX as u64)
+                .and_then(|v| v.try_into().ok())
+            {
+                v
+            } else {
+                bail!(args.span, "range is too large")
+            }
         } else {
             0
         };

--- a/tests/suite/foundations/array.typ
+++ b/tests/suite/foundations/array.typ
@@ -168,6 +168,14 @@
 // Error: 18-19 number must not be zero
 #range(10, step: 0)
 
+--- array-range-too-large eval ---
+// Error: 2-19 range is too large
+#range(0, int.max)
+
+--- array-range-breadth-overflow eval ---
+// Error: 2-42 range is too large
+#range(int.min, int.max, inclusive: true)
+
 --- array-bad-method-lvalue eval ---
 // Test bad lvalue.
 #let array = (1, 2, 3)


### PR DESCRIPTION
A shot at the follow-up suggested in https://github.com/typst/typst/pull/8345#pullrequestreview-4379109792 :)

## The logic

Pretty simple in concept; we compute the breadth of the range and divide by the step size to get the number of elements. Off-by-ones and edge-cases are the tricky part :sweat_smile:

The existing logic helps out quite a bit; most things are handled with a single bounds check on `start`, from which the estimator can assume there is output.

With that in mind, I initially had the logic as:
```rs
let range = start.abs_diff(end).saturating_sub((!inclusive).into());
(range / step.unsigned_abs()).saturating_add(1).try_into().unwrap_or_default()
```

Which tracks the actual loop closely: The bounds check for `start` is already checked, so it's included with `.saturating_add(1)`. Then, we check how often `step` fits in the _remaining_ range (`.saturating_sub(1)` unless `inclusive` is given) with a division rounding towards zero (`.div_floor()` isn't stabilized yet, but `/` is equivalent for uints. `step` is a `NonZeroI64` so no issues here). However, imo two (checked) arithmetic operations make this a bit awkward.

Luckily the opposite logically works out exactly the same; including `start` in the range and doing a division that rounds towards infinity is equivalent over the integers! This is what I committed, as it yields much nicer code.

$$ \left\lceil \frac{x}{y} \right\rceil = 1 + \left\lfloor \frac{x-1}{y} \right\rfloor \quad x, y \in \mathbb{N}_0, \  y \gt 0  $$

The proof is left as an exercise to the reader (my assertion is based on running many tests, [playing around in desmos](https://www.desmos.com/calculator/kvfbirihtx), and asking various LLMs).

#### An edge-case
Note that this still incurs one `checked_add` for `inclusive`. Why is best shown in a practical example: `i8::MIN..=i8::MAX` is 256 in length vs `u8::MAX` being 255. But over `i32` we'll then fail allocation anyway; [the docs](https://doc.rust-lang.org/stable/std/vec/struct.Vec.html#method.with_capacity) say `.with_capacity()` panics even on values over `isize::MAX`.

<details>
<summary>Outdated (see discussion below)</summary>

#### Casting & Allocation issues
Since `Vec::with_capacity` requests a usize, we can't simply convert our `u64` with `as` on a 32bit target like WASM. We return `0` as the fallback, leaving us with the same behavior we'd have gotten had we called `Vec::new()`.

For now, I opted not to "detect an over-allocation" and error. Memory allocation is a fragile concept within (stable) rust; I feel this would make quite a few assumptions and end up over-restricting users of the create. There is feedback one way or another soon after anyway.

If preventing users from creating too large ranges is desired, we might instead wish to make our own arbitrary limit as with loops. This would also get rid of the need for the edge case explained via `i8` above and could further be considered for other operations on `array` as well; i.e. joining.

#### Further considerations
This estimate could also be used to avoid bounds-checks in the loop entirely, but that would require _a lot_ of confidence in this computation. From my testing, we would already pass the test suite (without miri complaining) at least.
</details>

## Evaluation
- The existing tests run fine even with miri
- Since the Array is now collected from a range, Vec uses the [`ExactSizeIterator` trait](https://doc.rust-lang.org/stable/std/iter/trait.ExactSizeIterator.html) to allocate once ahead of time :D

#### Performance
It should be noted that `range` initially got much slower with the previous PR due to having to account for correctness. We're now attempting to remedy this a little.

Most initial experiments and exploration into the theoreticals happened out-of-tree. That may be found here: https://github.com/cady-b/range_size-estimation_testing. Unfortunately, this yielded a variety of results and the optimizer is very sensitive to small changes in the hot path, so I'm not comfortable making conclusive statements here. However I **never** measured things getting worse again, which is nice at least!

Integrating that into Typst, each compiled in release on my linux machine and ran during quiet operation, we do see smaller changes overall. However, I'd say this is still an improvement and now also quite nice code wise :) Though I currently don't have ideas for how we could fully catch up again

https://typst.app/project/rmZVTLrn3XkeD7YVdhyjS5
<img width="1889" height="1058" alt="image" src="https://github.com/user-attachments/assets/8a03184d-138a-467c-964b-5b24795d4ccd" />