### PR TITLE
Show full escape sequence in symbol list flyouts

### DIFF
--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -1506,6 +1506,22 @@ p + .symbol-grid {
   gap: 16px;
 }
 
+.symbol-flyout .info .props {
+  min-width: 0;
+}
+
+.symbol-flyout .info .escape {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+}
+
+.symbol-flyout .info .escape > code {
+  margin-inline-start: 0.2em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .symbol-flyout .info .accent > img {
   top: 0.15em;
   position: relative;

--- a/docs/assets/docs.js
+++ b/docs/assets/docs.js
@@ -481,7 +481,7 @@ function setUpSymbolFlyout(symbolGrid) {
   /** @type {HTMLElement | null} */
   const foMathClassSpan = flyout.querySelector(".info .math-class .value");
   /** @type {HTMLElement | null} */
-  const foCodepoint = flyout.querySelector(".info .codepoint .value");
+  const foEscape = flyout.querySelector(".info .escape .value");
   /** @type {HTMLElement | null} */
   const foAccent = flyout.querySelector(".info .accent");
   /** @type {HTMLElement | null} */
@@ -499,7 +499,7 @@ function setUpSymbolFlyout(symbolGrid) {
   /** @type {HTMLElement | null} */
   const foCopyShorthandBtn = flyout.querySelector(".shorthand .copy");
   /** @type {HTMLElement | null} */
-  const foCopyEscapeBtn = flyout.querySelector(".codepoint .copy");
+  const foCopyEscapeBtn = flyout.querySelector(".escape .copy");
 
   const listeners = [];
 
@@ -539,7 +539,7 @@ function setUpSymbolFlyout(symbolGrid) {
     const codexName = item.dataset.codexName;
     const unicName = item.dataset.unicName;
     const latexName = item.dataset.latexName;
-    const codepoint = item.dataset.value?.charCodeAt(0) ?? 0;
+    const value = item.dataset.value;
     const accent = item.dataset.accent != null;
     const alternates = item.dataset.alternates
       ? item.dataset.alternates.split(" ")
@@ -552,10 +552,12 @@ function setUpSymbolFlyout(symbolGrid) {
     const override = item.dataset.override;
     copyText(actualChar);
 
-    let codepointText = codepoint.toString(16).toUpperCase();
-    if (codepointText.length < 4) {
-      codepointText = "0".repeat(4 - codepointText.length) + codepointText;
+    const escapeTextParts = [];
+    for (const c of value) {
+      const codepoint = c.codePointAt(0);
+      escapeTextParts.push(`\\u{${codepoint.toString(16)}}`)
     }
+    const escapeText = escapeTextParts.join("");
 
     flyout.classList.toggle("override", override != null);
     foSymbol.textContent = override ?? actualChar;
@@ -572,7 +574,7 @@ function setUpSymbolFlyout(symbolGrid) {
       foName.style.display = "none";
     }
     foUnicName.textContent = unicName ?? "";
-    foCodepoint.textContent = codepointText;
+    foEscape.textContent = escapeText;
     foAccent.style.display = accent ? null : "none";
     foShorthand.style.display =
       shorthand && shorthand.length > 0 ? "block" : "none";
@@ -617,9 +619,7 @@ function setUpSymbolFlyout(symbolGrid) {
       }
     }
 
-    const codepointListener = () => {
-      copyText("\\u{" + codepointText + "}");
-    };
+    const codepointListener = () => copyText(escapeText);
 
     foCopyEscapeBtn.addEventListener("click", codepointListener);
     listeners.push({ target: foCopyEscapeBtn, listener: codepointListener });

--- a/docs/content/reference/library/symbols.typ
+++ b/docs/content/reference/library/symbols.typ
@@ -90,11 +90,11 @@
           copy-button()
           html.span(class: "remark")
         })
-        html.p(class: "codepoint", {
+        html.p(class: "escape", {
           [Escape: ]
           html.code(
             class: "typ-escape",
-            "\\u{" + html.span(class: "value") + "}",
+            html.span(class: "value"),
           )
           copy-button()
         })

--- a/docs/content/reference/library/symbols.typ
+++ b/docs/content/reference/library/symbols.typ
@@ -73,7 +73,7 @@
   html.template(id: "flyout-template", html.div(class: "symbol-flyout", {
     html.div(class: "info", {
       html.button(class: "main", html.span(class: "sym"))
-      html.div({
+      html.div(class: "props", {
         html.h3(html.span(class: "unic-name"))
         html.p(class: "sym-deprecation", {
           use-icon(16, "warn", "Warning")


### PR DESCRIPTION
Currently, the escape sequence in symbol list flyouts only shows the first character, which is incorrect. This PR fixes that.

The result can get quite long, hence the slightly updated CSS. Example of a result that doesn't look amazing:

<img width="500" height="271" alt="A screenshot of a symbol flyout. The escape sequence is very long and appears on its own line, below the text &quot;Escape:&quot;. It is cut off by an ellipsis. Below it is the copy button." src="https://github.com/user-attachments/assets/c0a7354a-5e7e-4d63-a1a6-d97492d713b1" />

Note that the Unicode name of the symbol (at the top of the flyout) is also very bad. This is tracked in https://github.com/typst/typst/issues/8340.
