### PR TITLE
Update Overview and Reference sections

### DIFF
--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -96,11 +96,18 @@ h4 code {
 }
 
 h1 small,
+h2 small,
+h3 small,
+h4 small,
+.reference-index .mod {
+  color: #565565;
+  font-style: italic;
+}
+
+h1 small,
 h2 small {
   display: inline-flex;
   gap: 8px;
-  color: #565565;
-  font-style: italic;
   font-size: 14px !important;
 }
 
@@ -116,13 +123,16 @@ h3 small,
 h4 small {
   display: inline-flex;
   gap: 4px;
-  color: #565565;
-  font-style: italic;
   font-size: 12px;
 }
 
 h3 small svg {
   margin-bottom: -1px;
+}
+
+.reference-index .mod {
+  font-size: inherit;
+  font-weight: 700;
 }
 
 @media screen and (max-width: 695px) {
@@ -184,6 +194,18 @@ dt,
 dd {
   margin-block-end: 16px;
   margin-inline: 0px;
+}
+
+.reference-index dl {
+  padding-inline-start: 0px;
+}
+
+.reference-index dt {
+  margin-block-end: 8px;
+}
+
+.reference-index dd {
+  padding-inline-start: 16px;
 }
 
 math {

--- a/docs/components/base.typ
+++ b/docs/components/base.typ
@@ -315,8 +315,5 @@
 // Use an insertion from the insertions parameter of the docs function, with a
 // possible fallback.
 #let insertion(name, fallback: none) = context {
-  stdx.config.insertions.at(
-    name,
-    default: fallback,
-  )
+  stdx.config.insertions.at(name, default: fallback)
 }

--- a/docs/components/base.typ
+++ b/docs/components/base.typ
@@ -311,3 +311,12 @@
     body
   }
 }
+
+// Use an insertion from the insertions parameter of the docs function, with a
+// possible fallback.
+#let insertion(name, fallback: none) = context {
+  stdx.config.insertions.at(
+    name,
+    default: fallback,
+  )
+}

--- a/docs/components/category.typ
+++ b/docs/components/category.typ
@@ -78,8 +78,20 @@
   }
 }
 
+#let modifier-list(..modifiers) = {
+  let modifiers = modifiers.pos()
+  context if target() == "paged" {
+    let gap = h(1em)
+    text(style: "italic", modifiers.map(small).join(gap))
+  } else {
+    modifiers.map(modifier => html.small(modifier, class: "mod")).join()
+  }
+}
+
 // Displays the contents of a parameter heading, including the pills, parameter
 // attributes (named / variadic / ...), and default value.
+//
+// When this is changed, `docs/content/reference/index.typ` needs to be updated
 #let param-headline(param, input-types) = {
   let pills = input-types.map(ty-pill)
   let modifiers = ()
@@ -124,7 +136,7 @@
     gap
     pills.join[ #small[or] ]
     gap
-    text(style: "italic", modifiers.map(small).join(gap))
+    modifier-list(..modifiers)
     if default != none {
       // The following four lines ensure that there the default has a minimum
       // distances to the modifiers, while being flush-right even if it is alone
@@ -138,7 +150,7 @@
   } else {
     html.div(class: "additional-info", {
       html.div(pills.join[ #small[or] ])
-      modifiers.map(small).join()
+      modifier-list(..modifiers)
     })
     if default != none {
       html.small(class: "default", default)
@@ -249,6 +261,9 @@
 }
 
 // Displays additional details about a function.
+//
+// When the labels are changed here, `docs/content/reference/index.typ` needs to
+// change, too.
 #let func-subtitle(info, deprecation-info) = context {
   let gap = if target() == "paged" { h(0.5em, weak: true) }
   if info.element {

--- a/docs/components/category.typ
+++ b/docs/components/category.typ
@@ -78,6 +78,7 @@
   }
 }
 
+// Displays parameter modifiers.
 #let modifier-list(..modifiers) = {
   let modifiers = modifiers.pos()
   context if target() == "paged" {

--- a/docs/components/index.typ
+++ b/docs/components/index.typ
@@ -1,6 +1,6 @@
 #import "system.typ": *
 #import "base.typ": *
-#import "category.typ": docs-category
+#import "category.typ": docs-category, modifier-list
 #import "example.typ": example
 #import "figure.typ": docs-figure, side-by-side
 #import "linking.typ": def-dest

--- a/docs/content/overview.typ
+++ b/docs/content/overview.typ
@@ -1,4 +1,4 @@
-#import "../components/index.typ": big-nav-button, def-dest, docs-chapter, icon
+#import "../components/index.typ": big-nav-button, def-dest, docs-chapter, icon, insertion
 
 #show: docs-chapter.with(
   title: "Overview",
@@ -21,8 +21,28 @@
   }),
 )
 
-Welcome to Typst's documentation! Typst is a new markup-based typesetting system for the sciences. It is designed to be an alternative both to advanced tools like LaTeX and simpler tools like Word and Google Docs. Our goal with Typst is to build a typesetting tool that is highly capable _and_ a pleasure to use.
+Welcome to Typst's documentation! Typst is a markup-based typesetting system that combines powerful automation and high-quality typography with speed and ease of use. This makes it suitable for documents of any complexity. Typst is a great alternative to both word processors and LaTeX.
 
-This documentation is split into two parts: A beginner-friendly tutorial that introduces Typst through a practical use case and a comprehensive reference that explains all of Typst's concepts and features.
+This documentation is split into multiple parts, serving different needs:
 
-We also invite you to join the community we're building around Typst. Typst is still a very young project, so your feedback is more than valuable.
+- If you are new to Typst, we highly recommend starting with our @tutorial[beginner-friendly tutorial]. Throughout the tutorial, we will introduce you to Typst through a practical example.
+
+- To answer targeted questions about Typst and familiarize yourself with advanced features, use the @reference[reference]. It describes the fundamental features of the Typst language and contains sections for all the functions, types, and more that come with Typst.
+
+- For tailored, in-depth how-tos on specific features, use cases, and audiences, check out our @guides[guides]. They provide copyable snippets throughout and allow you to build confidence with a specific feature area. If you are coming from LaTeX, the @guides:for-latex-users provides an alternative introduction to Typst, building on concepts you already know.
+
+The term _Typst_ refers to three concepts: The Typst language, the Typst compiler, and the Typst web app. The language is what you write, the compiler translates files in the Typst language into PDFs or HTML pages, and the Typst web app lets you work collaboratively on Typst projects in your browser. The Typst language and the compiler are open-source.
+
+This documentation primarily documents the Typst language, although the tutorial and various pages will refer to the web app and the command line Typst compiler.
+#insertion(
+  "overview-web-app",
+  fallback: [
+    In the copy of the docs hosted on #link("https://typst.app/docs/"), we also include documentation about the web app.
+  ],
+)
+To learn how to install the Typst compiler CLI, visit the #link("https://typst.app/open-source")[Open Source page] on our website. There, you can also learn more about the relationship between the Typst compiler and the web app. Once you have installed the Typst compiler CLI, run `typst help` for more information on how to use it.
+
+Our #link("https://github.com/typst/typst")[GitHub repository] provides additional developer-facing documentation about how to contribute to Typst and how to integrate it into your applications.
+
+The documentation also contains a @changelog[changelog], in which you can track the evolution of Typst and what changes to the markup language mean for your projects. This documentation applies to Typst #sys.version.
+

--- a/docs/content/overview.typ
+++ b/docs/content/overview.typ
@@ -1,4 +1,6 @@
-#import "../components/index.typ": big-nav-button, def-dest, docs-chapter, icon, insertion
+#import "../components/index.typ": (
+  big-nav-button, def-dest, docs-chapter, icon, insertion,
+)
 
 #show: docs-chapter.with(
   title: "Overview",
@@ -31,7 +33,7 @@ This documentation is split into multiple parts, serving different needs:
 
 - For tailored, in-depth how-tos on specific features, use cases, and audiences, check out our @guides[guides]. They provide copyable snippets throughout and allow you to build confidence with a specific feature area. If you are coming from LaTeX, the @guides:for-latex-users provides an alternative introduction to Typst, building on concepts you already know.
 
-The term _Typst_ refers to three concepts: The Typst language, the Typst compiler, and the Typst web app. The language is what you write, the compiler translates files in the Typst language into PDFs or HTML pages, and the Typst web app lets you work collaboratively on Typst projects in your browser. The Typst language and the compiler are open-source.
+The term _Typst_ refers to three concepts: The Typst language, the Typst compiler, and the Typst web app. The language is what you write, the compiler translates files in the Typst language into PDFs, HTML pages, and other formats, and the Typst web app lets you work collaboratively on Typst projects in your browser. The Typst language and the compiler are open-source.
 
 This documentation primarily documents the Typst language, although the tutorial and various pages will refer to the web app and the command line Typst compiler.
 #insertion(
@@ -45,4 +47,3 @@ To learn how to install the Typst compiler CLI, visit the #link("https://typst.a
 Our #link("https://github.com/typst/typst")[GitHub repository] provides additional developer-facing documentation about how to contribute to Typst and how to integrate it into your applications.
 
 The documentation also contains a @changelog[changelog], in which you can track the evolution of Typst and what changes to the markup language mean for your projects. This documentation applies to Typst #sys.version.
-

--- a/docs/content/reference/index.typ
+++ b/docs/content/reference/index.typ
@@ -1,4 +1,6 @@
-#import "../../components/index.typ": docs-chapter, modifier-list, paged-heading-offset, ty-pill
+#import "../../components/index.typ": (
+  docs-chapter, modifier-list, paged-heading-offset, ty-pill,
+)
 
 #docs-chapter(
   title: "Reference",
@@ -7,7 +9,7 @@
   introduction: true,
   class: "reference-index",
 )[
-  This reference documentation is a comprehensive guide to all of Typst's syntax, concepts, functions, and types. Use the reference to answer specific questions about Typst and to broaden your understanding of the available features.
+  This reference documentation is a comprehensive guide to all of Typst's syntax, concepts, functions, types, and other definitions. Use the reference to answer specific questions about Typst and to broaden your understanding of the available features.
 
   If you are completely new to Typst, we recommend starting with the @tutorial[tutorial] and then coming back to the reference to learn more about Typst's features as you need them.
 
@@ -15,27 +17,26 @@
   The reference starts by covering fundamentals of the Typst language. First, we give an overview of @reference:syntax[Typst's syntax.] The following sections cover core concepts central to the Typst language such as @reference:styling[styling documents,] using @reference:scripting[Typst's scripting capabilities,] and @reference:context[reasoning about the contents of your document.]
 
   = Library <library>
-
-  #context if target() == "html" [
-    The second part includes sections
-  ] else [
-    // The PDF outline does not contain the part labels, so we have to tell the reader where each section starts
+  #context if target() == "paged" [
+    // The PDF outline does not contain the part labels, so we have to tell the reader where each section starts.
     Starting with @reference:foundations, the reference includes sections
+  ] else [
+    The second part includes sections
   ] on all functions, types, and other definitions provided by the _standard library_ of the Typst language.
 
   The definition sections are grouped by topic. For example, if you would like to explore all tools Typst provides to adjust where elements land on the page, you should start in the @reference:layout section.
 
   = Export <export>
-
   Some of the features in Typst only apply to certain output file formats.
-  #context if target() != "html" [
-    Starting in the @pdf[PDF] section, you can find chapters for each of the output formats Typst supports.
+  #context if target() == "paged" [
+    Starting in the @pdf[PDF] section, you can find chapters for each of the output formats Typst supports. This is where
+  ] else [
+    In the third part,
   ]
-  This is where you find the available format-specific settings and learn what features are available to customize your document for a given format.
+ you find the available format-specific settings and learn what features are available to customize your document for a given format.
 
   = Reading the reference <reading-the-reference>
-
-  This reference uses a few graphical conventions and labels to allow you to quickly scan its sections.
+  This reference uses a few graphical conventions and labels to let you quickly scan its sections.
 
   / #ty-pill(
       str,
@@ -49,8 +50,6 @@
   / #modifier-list[Required]: Appears on a function parameter if calling the function without that parameter would result in an error.
 
   / #modifier-list[Positional]: Appears on a function parameter that is specified without a parameter name and colon. Instead, Typst will use the parameter order to determine which argument is which. Parameters not marked as positional are _named_ parameters.
-
-  / #modifier-list[Shorthand]: Appears on function parameters that can be specified either as a named or as a positional argument.
 
   / #modifier-list[Variadic]: Appears on function parameters that can be specified multiple times.
 

--- a/docs/content/reference/index.typ
+++ b/docs/content/reference/index.typ
@@ -1,20 +1,60 @@
-#import "../../components/index.typ": docs-chapter, paged-heading-offset
+#import "../../components/index.typ": docs-chapter, modifier-list, paged-heading-offset, ty-pill
 
 #docs-chapter(
   title: "Reference",
   route: "/reference",
   description: "The Typst reference is a systematic and comprehensive guide to the Typst typesetting language.",
   introduction: true,
+  class: "reference-index",
 )[
-  This reference documentation is a comprehensive guide to all of Typst's syntax, concepts, types, and functions. If you are completely new to Typst, we recommend starting with the @tutorial[tutorial] and then coming back to the reference to learn more about Typst's features as you need them.
+  This reference documentation is a comprehensive guide to all of Typst's syntax, concepts, functions, and types. Use the reference to answer specific questions about Typst and to broaden your understanding of the available features.
+
+  If you are completely new to Typst, we recommend starting with the @tutorial[tutorial] and then coming back to the reference to learn more about Typst's features as you need them.
 
   = Language <language>
-  The reference starts with a language part that gives an overview over @reference:syntax[Typst's syntax] and contains information about concepts involved in @reference:styling[styling documents,] using @reference:scripting[Typst's scripting capabilities.]
+  The reference starts by covering fundamentals of the Typst language. First, we give an overview of @reference:syntax[Typst's syntax.] The following sections cover core concepts central to the Typst language such as @reference:styling[styling documents,] using @reference:scripting[Typst's scripting capabilities,] and @reference:context[reasoning about the contents of your document.]
 
-  = Functions <functions>
-  The second part includes chapters on all functions used to insert, style, transform, and layout content in Typst documents. Each function is documented with a description of its purpose, a list of its parameters, and examples of how to use it.
+  = Library <library>
 
-  The final part of the reference explains all functions that are used within Typst's code mode to manipulate and transform data. Just as in the previous part, each function is documented with a description of its purpose, a list of its parameters, and examples of how to use it.
+  #context if target() == "html" [
+    The second part includes sections
+  ] else [
+    // The PDF outline does not contain the part labels, so we have to tell the reader where each section starts
+    Starting with @reference:foundations, the reference includes sections
+  ] on all functions, types, and other definitions provided by the _standard library_ of the Typst language.
+
+  The definition sections are grouped by topic. For example, if you would like to explore all tools Typst provides to adjust where elements land on the page, you should start in the @reference:layout section.
+
+  = Export <export>
+
+  Some of the features in Typst only apply to certain output file formats.
+  #context if target() != "html" [
+    Starting in the @pdf[PDF] section, you can find chapters for each of the output formats Typst supports.
+  ]
+  This is where you find the available format-specific settings and learn what features are available to customize your document for a given format.
+
+  = Reading the reference <reading-the-reference>
+
+  This reference uses a few graphical conventions and labels to allow you to quickly scan its sections.
+
+  / #ty-pill(
+      str,
+      linked: false,
+    ): These pills indicate that a value is of a particular type. Each type's chapter uses the respective pill as its title. Similar types share a color. For example, all numeric types have the same color.
+
+  / #modifier-list[Element]: Some functions are labelled as elements. This means that they can be used with set and show rules. Some elements can be @locate[located] and used with the @query function. Elements generally produce visible output in the document. You may be using elements even if you are not calling functions, as there is dedicated markup for some elements.
+
+  / #modifier-list[Contextual]: These functions can reason about the contents of your document. They can only be used when _context_ is available, for example through a context block. Refer to the @reference:context section for more information.
+
+  / #modifier-list[Required]: Appears on a function parameter if calling the function without that parameter would result in an error.
+
+  / #modifier-list[Positional]: Appears on a function parameter that is specified without a parameter name and colon. Instead, Typst will use the parameter order to determine which argument is which. Parameters not marked as positional are _named_ parameters.
+
+  / #modifier-list[Shorthand]: Appears on function parameters that can be specified either as a named or as a positional argument.
+
+  / #modifier-list[Variadic]: Appears on function parameters that can be specified multiple times.
+
+  / #modifier-list[Settable]: Appears on function parameters of element functions that can be customized with a set rule.
 ]
 
 #show: paged-heading-offset.with(1)

--- a/docs/lib.typ
+++ b/docs/lib.typ
@@ -18,6 +18,9 @@
 
   // Additional content that is appended to the end of the main docs content.
   extra-chapters: none,
+
+  // Dictionary of insertions that the chapters can use if present.
+  insertions: (:),
 ) = {
   assert(content-base.starts-with("/") and content-base.ends-with("/"))
   assert(asset-base.starts-with("/") and asset-base.ends-with("/"))
@@ -27,6 +30,7 @@
   set stdx.config(
     content-base: content-base,
     asset-base: asset-base,
+    insertions: insertions,
   )
 
   show: components.styling

--- a/docs/lib.typ
+++ b/docs/lib.typ
@@ -19,7 +19,7 @@
   // Additional content that is appended to the end of the main docs content.
   extra-chapters: none,
 
-  // Dictionary of insertions that the chapters can use if present.
+  // Dictionary of external insertions that the chapters can use if present.
   insertions: (:),
 ) = {
   assert(content-base.starts-with("/") and content-base.ends-with("/"))

--- a/docs/src/world.rs
+++ b/docs/src/world.rs
@@ -238,6 +238,7 @@ fn stdx_module() -> Module {
 pub struct ConfigElem {
     pub content_base: EcoString,
     pub asset_base: EcoString,
+    pub insertions: Dict,
 }
 
 /// Returns the virtual path part of a path as a string.


### PR DESCRIPTION
Supersedes #8302
Fixes #8140
Closes #738

This commit revamps the overview and documentation pages. It introduces a new section "Reading the reference", explaining the labels in the reference and adapitvely renders guides towards the reference sections in HTML and PDF. The overview section has been rewritten to better allow the reader to navigate the docs and to reflect Typst usage beyond academia. The commit introduces a new insertion mechanism using which the web app build can add additional text.