### PR TITLE
Use CLDR names in emoji list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3153,7 +3153,7 @@ dependencies = [
 [[package]]
 name = "typst-dev-assets"
 version = "0.15.0"
-source = "git+https://github.com/typst/typst-dev-assets?rev=a2e29ed#a2e29ed9393121735ce56d9d06deeab701cf35e0"
+source = "git+https://github.com/typst/typst-dev-assets?rev=f305ed3#f305ed3e236c153be0f6dab23e1d18bf0b5f0bc7"
 
 [[package]]
 name = "typst-docs"
@@ -3705,9 +3705,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode_names2"
-version = "2.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d189085656ca1203291e965444e7f6a2723fbdd1dd9f34f8482e79bafd8338a0"
+checksum = "82c3e18d850bb6ebd57735e5654f0af65e572b05c2397e7b2b1a7c6a792cc29c"
 dependencies = [
  "phf 0.11.3",
  "unicode_names2_generator",
@@ -3715,9 +3715,9 @@ dependencies = [
 
 [[package]]
 name = "unicode_names2_generator"
-version = "2.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1262662dc96937c71115228ce2e1d30f41db71a7a45d3459e98783ef94052214"
+checksum = "849744a58c479122ff24910d7ca57f312b62613ef0412dc327776ae6b235d16a"
 dependencies = [
  "phf_codegen",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ typst-syntax = { path = "crates/typst-syntax", version = "0.15.0" }
 typst-timing = { path = "crates/typst-timing", version = "0.15.0" }
 typst-utils = { path = "crates/typst-utils", version = "0.15.0" }
 typst-assets = { git = "https://github.com/typst/typst-assets", rev = "74217e4" }
-typst-dev-assets = { git = "https://github.com/typst/typst-dev-assets", rev = "a2e29ed" }
+typst-dev-assets = { git = "https://github.com/typst/typst-dev-assets", rev = "f305ed3" }
 arrayvec = "0.7.4"
 az = "1.2"
 base64 = "0.22"
@@ -133,7 +133,7 @@ toml = { version = "0.8", default-features = false, features = ["parse", "displa
 ttf-parser = "0.25.0"
 two-face = { version = "0.4.3", default-features = false, features = ["syntect-fancy"] }
 typed-arena = "2"
-unicode_names2 = "2"
+unicode_names2 = "3.1"
 unicode-bidi = "0.3.18"
 unicode-ident = "1.0"
 unicode-math-class = "0.1"

--- a/docs/src/reflect.rs
+++ b/docs/src/reflect.rs
@@ -158,11 +158,11 @@ fn describe_cast_info(info: &CastInfo) -> Dict {
 
 /// Returns the math class of a character.
 ///
-/// Returns `None` if the provided string has more than one char or if it does
-/// not have a math class.
+/// Returns `None` if the provided string has more than one cluster or if it
+/// does not have a math class.
 #[func]
 pub fn math_class(c: Cluster) -> Option<MathClass> {
-    typst_utils::default_math_class(c.primary)
+    typst_utils::default_math_class(c.primary())
 }
 
 /// Returns whether the given string can be used as an accent with the
@@ -172,10 +172,39 @@ pub fn is_accent(s: Str) -> bool {
     typst::math::Accent::combining(&s).is_some()
 }
 
-/// Returns the full title-cased name of the given character in Unicode.
+/// Returns the name of a symbol in Unicode.
+///
+/// For a single codepoint, that is the full title-cased Unicode name.
+///
+/// For sequences, this is the CLDR short name if it is listed in
+/// [emoji-zwj-sequences.txt](https://www.unicode.org/Public/17.0.0/emoji/emoji-zwj-sequences.txt),
+/// or the Unicode name of the first codepoint otherwise.
 #[func]
-pub fn unicode_name(c: Cluster) -> Option<String> {
-    unicode_names2::name(c.primary).map(|n| n.to_string().to_title_case())
+pub fn unicode_name(c: Cluster) -> Option<EcoString> {
+    static MAP: LazyLock<FxHashMap<EcoString, EcoString>> = LazyLock::new(|| {
+        let data = str::from_utf8(
+            typst_dev_assets::get_by_name("emoji-zwj-sequences.txt").unwrap(),
+        )
+        .unwrap();
+        let mut map = FxHashMap::default();
+        for line in data.lines() {
+            let line = line.split_once('#').map(|(l, _)| l).unwrap_or(line);
+            if line.trim().is_empty() {
+                continue;
+            }
+            let parts = line.split(';').collect::<Vec<_>>();
+            let [code, _, name] = parts[..] else { panic!("malformed data file") };
+            let value = code
+                .split_whitespace()
+                .map(|cp| char::from_u32(u32::from_str_radix(cp, 16).unwrap()).unwrap())
+                .collect();
+            map.insert(value, name.to_title_case().into());
+        }
+        map
+    });
+    MAP.get(&c.value).cloned().or_else(|| {
+        Some(unicode_names2::name(c.primary())?.to_string().to_title_case().into())
+    })
 }
 
 /// Returns the name of a character in LaTeX.
@@ -198,12 +227,22 @@ pub fn latex_name(c: Cluster) -> Option<Str> {
         }
         map
     });
-    NAMES.get(&(c.primary as u32)).copied().map(Into::into)
+    NAMES.get(&(c.primary() as u32)).copied().map(Into::into)
 }
 
 /// A grapheme cluster with an extracted primary char.
 pub struct Cluster {
-    primary: char,
+    value: EcoString,
+}
+
+impl Cluster {
+    /// Returns the primary character for this cluster.
+    fn primary(&self) -> char {
+        // Not every kind of cluster has a well-defined "base", but for our
+        // purposes (getting the math class etc. in presence of a variation
+        // selection) this is good enough.
+        self.value.chars().next().unwrap()
+    }
 }
 
 cast! {
@@ -212,10 +251,7 @@ cast! {
         if s.graphemes(true).count() != 1 {
             bail!("expected exactly one grapheme: `{}`", s.repr());
         }
-        // Not every kind of cluster has a well-defined "base", but for our
-        // purposes (getting the Unicode Name etc. in presence of a variation
-        // selection) this is good enough.
-        Self { primary: s.chars().next().unwrap() }
+        Self { value: s.into() }
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/typst/typst/issues/8340.

Honestly, the status quo is quite bad for the emoji list; even the imperfect solution proposed in this PR is better. Emoji haven't been given much love in Codex either, but I would like to get to it at some point, starting with flags.

Here is how the title of a symbol flyout is determined now:
1. If the symbol value has a CLDR short name listed in [emoji-zwj-sequences.txt](https://www.unicode.org/Public/17.0.0/emoji/emoji-zwj-sequences.txt), use that name.
2. Otherwise, if the first codepoint has a Unicode name in `unicode_names2`, use that name.
3. Else, don't show anything.

~~I would like to get rid of 3., but sadly `unicode_names2` has not been updated to Unicode 17.0. I will make a PR there soon, but I am not convinced a new version will be released in time (the last commit was 9 months ago, and there are open PRs from almost a year ago). This is only an issue for a couple symbols, so it's probably fine.~~

Regarding 1., as explained in https://github.com/typst/typst/issues/8340, ICU4X does not expose CLDR short names for now. I opted for the easiest solution: use the [emoji-zwj-sequences.txt](https://www.unicode.org/Public/17.0.0/emoji/emoji-zwj-sequences.txt) file (added to `typst-dev-assets` in https://github.com/typst/typst-dev-assets/pull/30), which contains most names we care about. This not the most satisfying solution, but it is barely distinguishable from an ideal solution to the end user, which is what matters in the end.