### PR TITLE
Don't compress PDF content streams in pretty mode

### DIFF
--- a/crates/typst-pdf/src/convert.rs
+++ b/crates/typst-pdf/src/convert.rs
@@ -48,7 +48,7 @@ pub fn convert(
     link_resolver: Option<Tracked<LateLinkResolver>>,
 ) -> SourceResult<Vec<u8>> {
     let settings = SerializeSettings {
-        compress_content_streams: true,
+        compress_content_streams: !options.pretty,
         no_device_cs: true,
         ascii_compatible: options.pretty,
         xmp_metadata: true,


### PR DESCRIPTION
The ASCII-compatible setting that is already enabled when using `--pretty` bloats the PDF quite a bit. The `--pretty` mode is thus not really suitable or intended for proper distribution but to produce a human-readable file, e.g. for debugging. In the spirit of this, we should also keep the content streams uncompressed. 