### PR TITLE
Clarify `str.rev` doc

### DIFF
--- a/crates/typst-library/src/foundations/str.rs
+++ b/crates/typst-library/src/foundations/str.rs
@@ -677,7 +677,14 @@ impl Str {
         }
     }
 
-    /// Reverse the string.
+    /// Reverses the string.
+    ///
+    /// More specifically, this returns a string with the same grapheme
+    /// clusters, in reversed order.
+    ///
+    /// ```example
+    /// #"Pirate flag: 🏴‍☠️".rev()
+    /// ```
     #[func(title = "Reverse")]
     pub fn rev(&self) -> Str {
         let mut s = EcoString::with_capacity(self.0.len());


### PR DESCRIPTION
This clarifies that `str.rev` reverses grapheme clusters instead of individual codepoints.

Feel free to suggest a better example. I feel like the flag is a good idea because people who would know about the difference between codepoints and grapheme clusters are likely to know that flags consist of multiple codepoints.