### PR TITLE
Add diagnostics-format environment variable

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -443,7 +443,7 @@ pub struct ProcessArgs {
     pub features: Vec<Feature>,
 
     /// The format to emit diagnostics in.
-    #[clap(long, default_value_t)]
+    #[clap(long, default_value_t, env = "TYPST_DIAGNOSTIC_FORMAT")]
     pub diagnostic_format: DiagnosticFormat,
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in landing a change in Typst! Before opening the PR, please review our contribution guidelines: https://github.com/typst/typst/blob/main/CONTRIBUTING.md

In particular, please keep in mind that we do not accept contributions implemented by an AI model. We would also ask you to refrain from using AI to write your pull request description. Summarizing your work helps to organize your thoughts as much as it helps us with seeing the human thought process behind a particular change.
-->
I often get a lot of warnings when I compile some Typst documents (mostly related to fonts not being available). The default diagnostic format is quite verbose, and mostly I am not interested in all the details of the Diagnostics.  I would therefore be very happy if the Diagnostics format could be configured via an Environment Variable, so that users can see the full diagnostics only when really needed, if they opt in to that.