### PR TITLE
Improve diagnostic printing for `typst eval`

### DIFF
--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -14,6 +14,7 @@ use typst::layout::PageRanges;
 use typst::syntax::Span;
 use typst_bundle::{Bundle, BundleOptions, VirtualFs};
 use typst_html::{HtmlDocument, HtmlOptions};
+use typst_kit::diagnostics::DiagnosticWorld;
 use typst_kit::timer::Timer;
 use typst_layout::{Page, PagedDocument};
 use typst_pdf::{PdfOptions, PdfStandards, Timestamp};
@@ -713,7 +714,7 @@ fn open_path(path: &OsStr, viewer: Option<&str>) -> StrResult<()> {
 
 /// Print diagnostic messages to the terminal.
 pub fn print_diagnostics(
-    world: &SystemWorld,
+    world: &dyn DiagnosticWorld,
     errors: &[SourceDiagnostic],
     warnings: &[SourceDiagnostic],
     format: DiagnosticFormat,

--- a/crates/typst-cli/src/eval.rs
+++ b/crates/typst-cli/src/eval.rs
@@ -1,21 +1,32 @@
+use std::sync::LazyLock;
+
 use comemo::Track;
 use ecow::eco_format;
-use typst::diag::{HintedStrResult, SourceResult, Warned};
-use typst::foundations::{Context, Output, Scope, StyleChain, Value};
+use typst::Library;
+use typst::diag::{FileResult, HintedStrResult, SourceResult, Warned};
+use typst::foundations::{
+    Bytes, Context, Datetime, Duration, Output, Scope, StyleChain, Value,
+};
 use typst::routines::SpanMode;
-use typst::syntax::{Span, SyntaxMode};
+use typst::syntax::{
+    FileId, RangeMapper, RootedPath, Source, Span, SyntaxMode, VirtualPath, VirtualRoot,
+};
+use typst::text::{Font, FontBook};
 use typst::{World, engine::Sink, introspection::Introspector};
 use typst_bundle::Bundle;
 use typst_eval::eval_string;
 use typst_html::HtmlDocument;
+use typst_kit::diagnostics::DiagnosticWorld;
 use typst_layout::PagedDocument;
+use typst_utils::LazyHash;
 
 use crate::args::{EvalCommand, Target};
 use crate::compile::print_diagnostics;
 use crate::set_failed;
 use crate::world::SystemWorld;
 
-/// Execute a query command.
+/// Evaluate an input expression, potentially as a query over an existing
+/// document.
 pub fn eval(command: &'static EvalCommand) -> HintedStrResult<()> {
     let mut world =
         SystemWorld::new(command.r#in.as_ref(), &command.world, &command.process)?;
@@ -35,13 +46,18 @@ pub fn eval(command: &'static EvalCommand) -> HintedStrResult<()> {
     };
 
     match output {
-        // Retrieve and print evaluation results.
+        // The target compiled successfully, continue with evaluating the input
+        // expression.
         Ok(output) => {
+            let expr_world = ExpressionWorld {
+                world,
+                expression: Bytes::from_string(&*command.expression),
+            };
             let mut sink = Sink::new();
             let eval_result = evaluate_expression(
-                command.expression.clone(),
+                &command.expression,
                 &mut sink,
-                &world,
+                &expr_world,
                 output.introspector(),
             );
             let errors = match &eval_result {
@@ -57,7 +73,7 @@ pub fn eval(command: &'static EvalCommand) -> HintedStrResult<()> {
             warnings.extend(sink.warnings());
 
             print_diagnostics(
-                &world,
+                &expr_world,
                 errors,
                 &warnings,
                 command.process.diagnostic_format,
@@ -65,7 +81,7 @@ pub fn eval(command: &'static EvalCommand) -> HintedStrResult<()> {
             .map_err(|err| eco_format!("failed to print diagnostics ({err})"))?;
         }
 
-        // Print diagnostics.
+        // The target failed, print its diagnostics.
         Err(errors) => {
             set_failed();
             print_diagnostics(
@@ -81,13 +97,19 @@ pub fn eval(command: &'static EvalCommand) -> HintedStrResult<()> {
     Ok(())
 }
 
-/// Evaluates the expression with code syntax mode and no scope.
+/// Evaluate the input expression in [`SyntaxMode::Code`] and with no scope.
 fn evaluate_expression(
-    expression: String,
+    expression: &str,
     sink: &mut Sink,
     world: &dyn World,
     introspector: &dyn Introspector,
 ) -> SourceResult<Value> {
+    // Map spans to ranges in the string.
+    let spans = SpanMode::Mapped {
+        id: *EXPRESSION_ID,
+        mapper: &RangeMapper::new(Some(0..expression.len())).unwrap(),
+        mapper_error_span: Span::detached(),
+    };
     let library = world.library();
     eval_string(
         world.track(),
@@ -95,9 +117,70 @@ fn evaluate_expression(
         sink.track_mut(),
         introspector.track(),
         Context::new(None, Some(StyleChain::new(&library.styles))).track(),
-        &expression,
-        SpanMode::Uniform(Span::detached()),
+        expression,
+        spans,
         SyntaxMode::Code,
         Scope::default(),
     )
+}
+
+/// Static [`FileId`] for an input expression. This allows giving accurate
+/// ranges to diagnostics when evaluating the expression.
+static EXPRESSION_ID: LazyLock<FileId> = LazyLock::new(|| {
+    FileId::unique(RootedPath::new(
+        VirtualRoot::Project,
+        VirtualPath::new("<input-expression>").unwrap(),
+    ))
+});
+
+/// A world wrapper that allows us to print accurate diagnostics for an input
+/// expression.
+struct ExpressionWorld {
+    world: SystemWorld,
+    /// We use `Bytes`, not `&'static str` to avoid hashing in `World::file`.
+    expression: Bytes,
+}
+
+impl DiagnosticWorld for ExpressionWorld {
+    fn name(&self, id: FileId) -> String {
+        if id == *EXPRESSION_ID {
+            "<input-expression>".into()
+        } else {
+            self.world.name(id)
+        }
+    }
+}
+
+impl World for ExpressionWorld {
+    fn library(&self) -> &LazyHash<Library> {
+        self.world.library()
+    }
+
+    fn book(&self) -> &LazyHash<FontBook> {
+        self.world.book()
+    }
+
+    fn main(&self) -> FileId {
+        self.world.main()
+    }
+
+    fn source(&self, id: FileId) -> FileResult<Source> {
+        self.world.source(id)
+    }
+
+    fn file(&self, id: FileId) -> FileResult<Bytes> {
+        if id == *EXPRESSION_ID {
+            Ok(self.expression.clone())
+        } else {
+            self.world.file(id)
+        }
+    }
+
+    fn font(&self, index: usize) -> Option<Font> {
+        self.world.font(index)
+    }
+
+    fn today(&self, offset: Option<Duration>) -> Option<Datetime> {
+        self.world.today(offset)
+    }
 }


### PR DESCRIPTION
This PR uses `Rangemapper` in the `eval_string` call for the `eval` command so that we get ranges on diagnostics in the evaluated expression.

Doing so required adding a new `ExpressionWorld` to handle the `EXPRESSION_ID` similarly to how `SystemWorld` handles `STDIN_ID` and `EMPTY_ID` in `world.rs:167`.

This screenshot shows the error output in the terminal before and after this PR:

<img width="444" alt="screenshot of a terminal showing the error from `cargo -q run eval 'test'` before and after this PR" src="https://github.com/user-attachments/assets/51698d1b-66f9-43bd-88cb-62e346824bf6" />

