### PR TITLE
Fix the type pill `font-size` in headers

### DIFF
--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -726,13 +726,13 @@ a.pill {
   );
 }
 
-h1 .pill {
+h1 > .pill {
   font-size: 34px;
   border-radius: 12px;
   padding: 4px 12px;
 }
 
-h3 .pill {
+h3 > .pill {
   font-size: 20px;
   border-radius: 8px;
   padding: 4px 8px;

--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -604,13 +604,32 @@ div[role="tooltip"]:not(.mobile)::after {
   white-space: nowrap;
 }
 
-a.pill {
-  color: inherit !important;
-  text-decoration: none !important;
+h1 > .pill {
+  font-size: 34px;
+  border-radius: 12px;
+  padding: 4px 12px;
+}
+
+h3 > .pill {
+  font-size: 20px;
+  border-radius: 8px;
+  padding: 4px 8px;
 }
 
 .pill + .pill {
   margin-inline-start: 4px;
+}
+
+h3 code + .pill,
+h4 code + .pill {
+  margin-inline-start: 16px;
+}
+
+/* Background styling for unique pills */
+
+a.pill {
+  color: inherit !important;
+  text-decoration: none !important;
 }
 
 .pill-con {
@@ -724,23 +743,6 @@ a.pill {
     rgba(255, 243, 124, 1) 66%,
     rgba(255, 164, 157, 1) 100%
   );
-}
-
-h1 > .pill {
-  font-size: 34px;
-  border-radius: 12px;
-  padding: 4px 12px;
-}
-
-h3 > .pill {
-  font-size: 20px;
-  border-radius: 8px;
-  padding: 4px 8px;
-}
-
-h3 code + .pill,
-h4 code + .pill {
-  margin-inline-start: 16px;
 }
 
 /* Navigation breadcrumbs */


### PR DESCRIPTION
Mentioned at https://github.com/typst/typst/pull/7629#discussion_r3377010978

Resets the type pill `font-size` in headers by changing the CSS selector from `h3 .pill` to `h3 > .pill`. (don't we just love CSS?) I also changed the `h1` selector to `h1 > .pill`.

The `h3 .pill { font-size: 20px; ... }` rule was merged in #7629 for the `spot` color type whose header was in an `h3`, however many type pills are present in `h3`s for parameter docs (but none on the `color` page!) and their sizing looks quite bad at `20px`.

I also reordered some of the other general `.pill` selectors so that they come before the unique pill background stylings.

Here's a screenshot of the `line` parameter docs before this fix:

<img width="500" src="https://github.com/user-attachments/assets/fe8d6498-4f63-4f84-b287-195ede0b6c58" />
