### PR TITLE
Add index range hints for syntax errors/warnings in `eval_string`

### DIFF
--- a/crates/typst-syntax/src/node.rs
+++ b/crates/typst-syntax/src/node.rs
@@ -326,10 +326,22 @@ impl SyntaxNode {
         (errors, warnings)
     }
 
-    /// Set a synthetic span for the node and all its descendants.
+    /// Set a synthetic span for the node and all its descendants, and add hints
+    /// with the original indices to any syntax errors or warnings.
     pub fn synthesize(&mut self, span: Span) {
-        // Sub-ranges are removed since the overall range is not accurate.
-        self.synthesize_with(0, &|_, _| span, &|_, sub_range| *sub_range = None);
+        self.synthesize_with(
+            0,
+            &|_, _| span,
+            // Sub-ranges are removed since the overall range is not accurate.
+            &|_, sub_range| *sub_range = None,
+            &|offset, len| {
+                Some(if len == 0 {
+                    eco_format!("at index `{offset}`")
+                } else {
+                    eco_format!("from index `{offset}` to `{}`", offset + len)
+                })
+            },
+        );
     }
 
     /// Set a raw range span for each node.
@@ -360,6 +372,7 @@ impl SyntaxNode {
                     *sr = mapper.map_sub_range(offset, *sr);
                 }
             },
+            &|_, _| None,
         );
         Ok(())
     }
@@ -373,20 +386,24 @@ impl SyntaxNode {
         mut offset: usize,
         map_span: &impl Fn(usize, usize) -> Span,
         update_sub_range: &impl Fn(usize, &mut Option<SubRange>),
+        add_hint: &impl Fn(usize, usize) -> Option<EcoString>,
     ) {
+        let len = self.len();
+        self.span = map_span(offset, len);
         let mut data = &mut self.data;
         loop {
             match data {
-                Node::Leaf(leaf, _) => {
-                    self.span = map_span(offset, leaf.len());
-                    break;
-                }
+                Node::Leaf(_, _) => break,
                 Node::Inner(inner, _) => {
                     let inner = Arc::make_mut(inner);
-                    self.span = map_span(offset, inner.len);
                     inner.upper = self.span.number();
                     for child in &mut inner.children {
-                        child.synthesize_with(offset, map_span, update_sub_range);
+                        child.synthesize_with(
+                            offset,
+                            map_span,
+                            update_sub_range,
+                            add_hint,
+                        );
                         offset += child.len();
                     }
                     break;
@@ -396,7 +413,9 @@ impl SyntaxNode {
                     for (_hint, sub_range) in err.hints.make_mut() {
                         update_sub_range(offset, sub_range);
                     }
-                    self.span = map_span(offset, err.text.len());
+                    if let Some(hint) = add_hint(offset, len) {
+                        err.hints.push((hint, None));
+                    }
                     break;
                 }
                 Node::Warning(warn, _) => {
@@ -404,6 +423,9 @@ impl SyntaxNode {
                     update_sub_range(offset, &mut warn.sub_range);
                     for (_hint, sub_range) in warn.hints.make_mut() {
                         update_sub_range(offset, sub_range);
+                    }
+                    if let Some(hint) = add_hint(offset, len) {
+                        warn.hints.push((hint, None));
                     }
                     data = &mut warn.child;
                 }

--- a/tests/suite/foundations/eval.typ
+++ b/tests/suite/foundations/eval.typ
@@ -12,6 +12,7 @@
 
 --- eval-syntax-error-1 eval ---
 // Error: 7-12 expected pattern
+// Hint: 7-12 at index `3`
 #eval("let")
 
 --- eval-in-show-rule paged ---
@@ -29,6 +30,7 @@ Blue #move(dy: -0.15em)[🌊]
 
 --- eval-syntax-error-2 eval ---
 // Error: 7-12 expected semicolon or line break
+// Hint: 7-12 at index `1`
 #eval("1 2")
 
 --- eval-path-resolve paged ---
@@ -57,4 +59,5 @@ $f(a) = cases(a + b\, space space x >= 3,a + b\, space space x = 5)$
 // Test that eval shows warnings from the executed code.
 // Warning: 7-11 no text within stars
 // Hint: 7-11 using multiple consecutive stars (e.g. **) has no additional effect
+// Hint: 7-11 from index `0` to `2`
 #eval("**", mode: "markup")

--- a/tests/suite/syntax/depth.typ
+++ b/tests/suite/syntax/depth.typ
@@ -10,12 +10,15 @@
 
   s = pat.replace("{}", s)
   // Error: 8-9 maximum parsing depth exceeded
+  // Hint: 8-9 from index `256` to `258`
   eval(s)
 }
 
 --- parser-depth-exceeded-unbalanced eval ---
 // Error: 7-17 unclosed delimiter
+// Hint: 7-17 from index `0` to `1`
 // Error: 7-17 maximum parsing depth exceeded
+// Hint: 7-17 from index `256` to `1024`
 #eval(1024 * "(")
 
 --- parser-depth-exceeded-unbalanced-arrow eval ---
@@ -23,13 +26,19 @@
 // Error: 7-20 the character `#` is not valid in code
 // Hint: 7-20 you are already in code mode
 // Hint: 7-20 try removing the `#`
+// Hint: 7-20 from index `0` to `1`
 // Error: 7-20 unclosed delimiter
+// Hint: 7-20 from index `1` to `2`
 // Error: 7-20 unexpected arrow
+// Hint: 7-20 from index `3` to `5`
 // Error: 7-20 maximum parsing depth exceeded
+// Hint: 7-20 from index `641` to `2560`
 #eval(512 * "#((=>")
 
 --- parser-depth-exceeded-unop eval ---
 // https://issues.oss-fuzz.com/issues/415163163
 // Error: 7-17 maximum parsing depth exceeded
+// Hint: 7-17 from index `512` to `513`
 // Error: 7-17 expected expression
+// Hint: 7-17 at index `1023`
 #eval(512 * "- ")


### PR DESCRIPTION
When using the `eval` function, we set a synthetic span on the evaluated string, but this overrides the spans for error and warning diagnostics and leads to a pessimistic range on diagnostics. Improving these ranges would require a lot of effort, and is not even feasible at all in the general case, but there are some simpler improvements we can make.

This PR takes the step of adding a hint to syntax errors and warnings containing the original index range of the diagnostic. This does not apply to evaluation errors like undefined variables, but is a step in the right direction.

This is an improvement for #7799, but is not a complete fix.

CC @JeppeKlitgaard
