### PR TITLE
Correct the link to Hayagriva changelog in Typst 0.15 changelog

### DIFF
--- a/docs/content/changelog/0.15.0.typ
+++ b/docs/content/changelog/0.15.0.typ
@@ -79,7 +79,7 @@
   - Added support for BibLaTeX name options in `.bib` files #pr(90, repo: "typst/biblatex")
   - Added support for propagating non-numeric `volume` fields in `.bib` files to bibliographies #pr(478, repo: "typst/hayagriva")
   - Improved sorting in bibliographies to take into account language conventions #pr(314, repo: "typst/hayagriva")
-  - Improved interoperability with CSL styles; for a full listing of changes, review #link("https://github.com/typst/codex/blob/v0.3.0/CHANGELOG.md#version-030-june-4-2026")[the Hayagriva 0.10.0 changelog]
+  - Improved interoperability with CSL styles; for a full listing of changes, review #link("https://github.com/typst/hayagriva/blob/v0.10.0/CHANGELOG.md#0100")[the Hayagriva 0.10.0 changelog]
   - Added support for setting directors on videos without a parent in Hayagriva YAML files #pr(450, repo: "typst/hayagriva")
   - Improved handling of `Anthos` entries in Hayagriva YAML files by treating them as `chapter`s in CSL #pr(427, repo: "typst/hayagriva")
 - Footnotes


### PR DESCRIPTION
It was linked to codex.

<!--
Thanks for your interest in landing a change in Typst! Before opening the PR, please review our contribution guidelines: https://github.com/typst/typst/blob/main/CONTRIBUTING.md

In particular, please keep in mind that we do not accept contributions implemented by an AI model. We would also ask you to refrain from using AI to write your pull request description. Summarizing your work helps organizing your thoughts as much as it helps us with seeing the human thought process behind a particular change.
-->


(By the way, [Changelog - Typst Extra Docs](https://typst-community.github.io/extra-docs/hayagriva/changelog.html) might be more friendly to readers, because issue numbers there are clickable.)
