### PR TITLE
Additional trait implementations for typst-kit

### DIFF
--- a/crates/typst-kit/src/files.rs
+++ b/crates/typst-kit/src/files.rs
@@ -286,6 +286,7 @@ impl<F: FileLoader> FileLoader for Arc<F> {
 /// - package files are loaded from configured directories and/or the official
 ///   Typst Universe package registry via [`SystemPackages`].
 #[cfg(feature = "system-files")]
+#[derive(Debug)]
 pub struct SystemFiles {
     project: FsRoot,
     packages: SystemPackages,

--- a/crates/typst-kit/src/files.rs
+++ b/crates/typst-kit/src/files.rs
@@ -5,6 +5,7 @@ use std::mem;
 use std::path::{Path, PathBuf};
 use std::str;
 use std::str::Utf8Error;
+use std::sync::Arc;
 
 use parking_lot::Mutex;
 use rustc_hash::FxHashMap;
@@ -262,6 +263,18 @@ pub trait FileLoader {
     /// [`id.vpath()`](typst_syntax::RootedPath::vpath) in the project /
     /// package.
     fn load(&self, id: FileId) -> FileResult<Bytes>;
+}
+
+impl<F: FileLoader> FileLoader for Box<F> {
+    fn load(&self, id: FileId) -> FileResult<Bytes> {
+        (**self).load(id)
+    }
+}
+
+impl<F: FileLoader> FileLoader for Arc<F> {
+    fn load(&self, id: FileId) -> FileResult<Bytes> {
+        (**self).load(id)
+    }
 }
 
 /// Serves project files from a directory and package files from standard

--- a/crates/typst-kit/src/files.rs
+++ b/crates/typst-kit/src/files.rs
@@ -28,7 +28,7 @@ use {crate::packages::SystemPackages, typst_syntax::VirtualRoot};
 /// If you need more control, you can skip this and implement custom logic that
 /// directly handles the [`World::source`](typst_library::World::source) and
 /// [`World::file`](typst_library::World::file) requests. A language server is
-/// an example of an integration that might want to go even deeper,  to create,
+/// an example of an integration that might want to go even deeper, to create,
 /// manage, and edit source files by itself. If you go the manual route, ensure
 /// that those methods are cheap on repeated calls (either through caching or by
 /// virtue of always being cheap).

--- a/crates/typst-kit/src/packages.rs
+++ b/crates/typst-kit/src/packages.rs
@@ -148,7 +148,7 @@ impl SystemPackages {
 /// - Top-level directories denote namespaces
 /// - Second-level directories denote packages
 /// - Third-level directories denote package versions
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FsPackages(PathBuf);
 
 impl FsPackages {


### PR DESCRIPTION
I went ahead and implemented `FileLoader` for the smart pointer types. Since it's not required to be `Send + Sync + 'static` we could even add the `&[mut] F where F: FileLoader` implementations too. But I left that out since I'm unsure how useful that is in practice.

The other commits fix a typo and add `Clone` to two more types which could benefit from it, loaders are cheap so cloning them is also an option for me, but I'll need either `Clone`, `Arc<dyn FileLoader>: FileLoader` or implement a warpper type around `Arc` myself.

Feel free to drop the clone commit if that doesn't feel right.