### PR TITLE
Fix numbering offset for `bibliography` with `full: true` and no citations

### DIFF
--- a/crates/typst-library/src/model/bibliography.rs
+++ b/crates/typst-library/src/model/bibliography.rs
@@ -1093,18 +1093,39 @@ fn render<'a>(
 
     if let Some(offset) = offset
         && let Some(bib) = &rendered.bibliography
-        // Check whether the style uses numbering.
-        && rendered.citations.iter().any(|rendered| {
-            rendered
-                .citation
-                .find_meta(&hayagriva::ElemMeta::CitationNumber)
-                .is_some()
-        })
+        // Check whether the bibliography or any citation displays citation
+        // numbers. Only then does the bibliography occupy a numbering range
+        // that subsequent bibliographies in the same group must skip.
+        && (bib.items.iter().any(displays_citation_number)
+            || rendered.citations.iter().any(|rendered| {
+                rendered
+                    .citation
+                    .find_meta(&hayagriva::ElemMeta::CitationNumber)
+                    .is_some()
+            }))
     {
         *offset += bib.items.len();
     }
 
     rendered
+}
+
+/// Whether a rendered bibliography item displays a citation number.
+///
+/// For styles with `second-field-align` (like IEEE), the number resides in
+/// the item's first field rather than in its content.
+fn displays_citation_number(item: &hayagriva::BibliographyItem) -> bool {
+    item.content.find_meta(&hayagriva::ElemMeta::CitationNumber).is_some()
+        || item.first_field.as_ref().is_some_and(|child| match child {
+            hayagriva::ElemChild::Elem(elem) => {
+                elem.meta == Some(hayagriva::ElemMeta::CitationNumber)
+                    || elem
+                        .children
+                        .find_meta(&hayagriva::ElemMeta::CitationNumber)
+                        .is_some()
+            }
+            _ => false,
+        })
 }
 
 /// Creates a hayagriva citation item for a citation element.

--- a/tests/ref/html/hashes.txt
+++ b/tests/ref/html/hashes.txt
@@ -8,7 +8,7 @@ b7db257520089ca4fabc7de0ce145d4f bibliography-group-auto
 f6e1a9094c1ed21bef299f26aad195a2 bibliography-group-form-year
 8997aa88a2a9c92d8e39674942922140 bibliography-group-full
 12ec2dcc83fe5ee77a921565164d048e bibliography-group-full-custom-style
-c00f97bdc174e68526d4a94d7b7f0b6f bibliography-group-mixed-full
+dfb3c710d089677eec69861ae5785a31 bibliography-group-mixed-full
 c456aecc3b410f0b4f8705fc87e6d499 bibliography-group-mixed-styles
 0b7c6366e0660d06550c9081512d5bb9 bibliography-group-none
 5fab6af8d6370f60818ea4e1eec8095a bibliography-group-out-of-order

--- a/tests/ref/html/hashes.txt
+++ b/tests/ref/html/hashes.txt
@@ -4,9 +4,11 @@ a845db3f6f6d466d683136b703f44cf6 basic-table
 3f625e61698549ccccf65b72a66b72e7 bibliography-csl-display
 74b33b507da27e15d265f3217c858ac6 bibliography-custom-title
 b7db257520089ca4fabc7de0ce145d4f bibliography-group-auto
+02368f0b0c101c641df858196b440872 bibliography-group-citation-numbers-only
 f6e1a9094c1ed21bef299f26aad195a2 bibliography-group-form-year
 8997aa88a2a9c92d8e39674942922140 bibliography-group-full
 12ec2dcc83fe5ee77a921565164d048e bibliography-group-full-custom-style
+c00f97bdc174e68526d4a94d7b7f0b6f bibliography-group-mixed-full
 0b7c6366e0660d06550c9081512d5bb9 bibliography-group-none
 5fab6af8d6370f60818ea4e1eec8095a bibliography-group-out-of-order
 17da3cafc27f03d422dd8863d4bf9707 bibliography-group-str

--- a/tests/ref/html/hashes.txt
+++ b/tests/ref/html/hashes.txt
@@ -9,6 +9,7 @@ f6e1a9094c1ed21bef299f26aad195a2 bibliography-group-form-year
 8997aa88a2a9c92d8e39674942922140 bibliography-group-full
 12ec2dcc83fe5ee77a921565164d048e bibliography-group-full-custom-style
 c00f97bdc174e68526d4a94d7b7f0b6f bibliography-group-mixed-full
+c456aecc3b410f0b4f8705fc87e6d499 bibliography-group-mixed-styles
 0b7c6366e0660d06550c9081512d5bb9 bibliography-group-none
 5fab6af8d6370f60818ea4e1eec8095a bibliography-group-out-of-order
 17da3cafc27f03d422dd8863d4bf9707 bibliography-group-str

--- a/tests/ref/html/hashes.txt
+++ b/tests/ref/html/hashes.txt
@@ -4,6 +4,9 @@ a845db3f6f6d466d683136b703f44cf6 basic-table
 3f625e61698549ccccf65b72a66b72e7 bibliography-csl-display
 74b33b507da27e15d265f3217c858ac6 bibliography-custom-title
 b7db257520089ca4fabc7de0ce145d4f bibliography-group-auto
+f6e1a9094c1ed21bef299f26aad195a2 bibliography-group-form-year
+8997aa88a2a9c92d8e39674942922140 bibliography-group-full
+12ec2dcc83fe5ee77a921565164d048e bibliography-group-full-custom-style
 0b7c6366e0660d06550c9081512d5bb9 bibliography-group-none
 5fab6af8d6370f60818ea4e1eec8095a bibliography-group-out-of-order
 17da3cafc27f03d422dd8863d4bf9707 bibliography-group-str

--- a/tests/suite/model/bibliography.typ
+++ b/tests/suite/model/bibliography.typ
@@ -202,6 +202,49 @@ hi:
 #bibliography("/assets/bib/works.bib", group: "a")
 #bibliography("/assets/bib/works_too.bib", group: "b", style: "nlm-citation-sequence")
 
+--- bibliography-group-full html ---
+// Test that a numbered bibliography that is printed in full without any
+// citations still advances the shared numbering.
+#bibliography("/assets/bib/works_too.bib", full: true)
+#bibliography("/assets/bib/works.bib", full: true)
+
+--- bibliography-group-form-year html ---
+// Test that a bibliography whose citations all use a form that displays no
+// citation number still advances the shared numbering.
+#cite(<Zee04>, form: "year")
+#bibliography("/assets/bib/works_too.bib")
+
+@netwok
+#bibliography("/assets/bib/works.bib")
+
+--- bibliography-group-full-custom-style html ---
+// Test that the shared numbering also advances for a numbered custom style
+// that does not declare its citation format.
+#let style = ```csl
+  <?xml version="1.0" encoding="utf-8"?>
+  <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0">
+    <info>
+      <title>Test</title>
+      <id>test</id>
+    </info>
+    <citation>
+      <layout prefix="[" suffix="]" delimiter=", ">
+        <text variable="citation-number"/>
+      </layout>
+    </citation>
+    <bibliography second-field-align="flush">
+      <layout>
+        <text variable="citation-number" prefix="[" suffix="]"/>
+        <text variable="title"/>
+      </layout>
+    </bibliography>
+  </style>
+```
+
+#set bibliography(style: bytes(style.text), full: true)
+#bibliography("/assets/bib/works_too.bib")
+#bibliography("/assets/bib/works.bib")
+
 --- bibliography-group-out-of-order html ---
 // The numbers are ordered in the order of the bibliographies, so in the prose
 // they can be out of order if using shared numbering.

--- a/tests/suite/model/bibliography.typ
+++ b/tests/suite/model/bibliography.typ
@@ -208,6 +208,45 @@ hi:
 #bibliography("/assets/bib/works_too.bib", full: true)
 #bibliography("/assets/bib/works.bib", full: true)
 
+--- bibliography-group-mixed-full html ---
+// Test that the shared numbering continues from a bibliography with
+// `full: true` into one that only contains cited entries.
+#bibliography("/assets/bib/works_too.bib", full: true)
+
+@netwok
+#bibliography("/assets/bib/works.bib")
+
+--- bibliography-group-citation-numbers-only html ---
+// Test that a bibliography whose style displays citation numbers in
+// citations, but not in the bibliography itself, still advances the
+// shared numbering.
+#let style = ```csl
+  <?xml version="1.0" encoding="utf-8"?>
+  <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0">
+    <info>
+      <title>Test</title>
+      <id>test</id>
+    </info>
+    <citation>
+      <layout prefix="[" suffix="]" delimiter=", ">
+        <text variable="citation-number"/>
+      </layout>
+    </citation>
+    <bibliography>
+      <layout>
+        <text variable="title"/>
+      </layout>
+    </bibliography>
+  </style>
+```
+#set bibliography(style: bytes(style.text))
+
+@Zee04
+#bibliography("/assets/bib/works_too.bib")
+
+@netwok
+#bibliography("/assets/bib/works.bib")
+
 --- bibliography-group-form-year html ---
 // Test that a bibliography whose citations all use a form that displays no
 // citation number still advances the shared numbering.

--- a/tests/suite/model/bibliography.typ
+++ b/tests/suite/model/bibliography.typ
@@ -210,11 +210,15 @@ hi:
 
 --- bibliography-group-mixed-full html ---
 // Test that the shared numbering continues from a bibliography with
-// `full: true` into one that only contains cited entries.
+// `full: true` into one that only contains cited entries, and that the
+// latter advances the numbering by its rendered items rather than by the
+// entries in its source file.
 #bibliography("/assets/bib/works_too.bib", full: true)
 
 @netwok
 #bibliography("/assets/bib/works.bib")
+
+#bibliography("/assets/bib/works_too.bib", full: true)
 
 --- bibliography-group-mixed-styles html ---
 // Test that a bibliography with a non-numeric style does not consume

--- a/tests/suite/model/bibliography.typ
+++ b/tests/suite/model/bibliography.typ
@@ -216,6 +216,15 @@ hi:
 @netwok
 #bibliography("/assets/bib/works.bib")
 
+--- bibliography-group-mixed-styles html ---
+// Test that a bibliography with a non-numeric style does not consume
+// numbers from the shared numbering.
+@Zee04
+#bibliography("/assets/bib/works_too.bib", style: "apa")
+
+@netwok
+#bibliography("/assets/bib/works.bib")
+
 --- bibliography-group-citation-numbers-only html ---
 // Test that a bibliography whose style displays citation numbers in
 // citations, but not in the bibliography itself, still advances the


### PR DESCRIPTION
Fixes https://github.com/typst/typst/issues/8476

A `bibliography` with `full: true` and no citations pointing at it doesn't
advance its group's shared numbering offset, so the next bibliography starts
over at [1]:

| Before | After |
|--------|-------|
| <img width="350"  alt="before" src="https://github.com/user-attachments/assets/e4e5bec4-13eb-43c3-89d7-4079c6899c82" /> | <img width="350" alt="after" src="https://github.com/user-attachments/assets/ac4cb7cc-bc28-46cc-ae69-e78b2c06fe0c" /> |

<details>
<summary>Reproduction</summary>

```typ
#bibliography("a.bib", full: true, title: [Bibliography A])
#bibliography("b.bib", full: true, title: [Bibliography B])
```

with two `.bib` files of two entries each, default IEEE style, default
(automatic) grouping.

</details>

## Why it happens

The offset code in `render()` decides whether a bibliography participates in
numbering by sampling the rendered citations for a `CitationNumber` element.
With `full: true` and no explicit citations, the driver only ever sees hidden
citations, which render to nothing — so the sample is empty, the check comes
back false, and the offset never moves.

Once you see it that way, there's a second hole the issue doesn't mention: if
every citation uses a form that displays no number (say,
`#cite(<key>, form: "year")`), the sample is just as empty and the offset is
lost the same way.

As the issue already points out, just deleting the check isn't an option
either: a non-numeric bibliography in the same group must not consume numbers,
or a later numeric one would skip ahead for no visible reason.

## The fix

The root problem is answering a yes/no question from a sample that can be
empty. So instead of only looking at citations, the check now also looks at
the rendered bibliography items themselves: the bibliography occupies a
numbering range iff any of its items, or any citation, actually displays a
citation number. The items can't be missing — the check only runs inside the
branch where `rendered.bibliography` exists.

One wrinkle worth knowing about for review: the number can live in two places.
For styles with `second-field-align` (IEEE among them), hayagriva moves the
number out of the item's content into `first_field`; styles without that
property keep it in the content. So the predicate checks both. It also matches
the `CitationNumber` meta specifically rather than treating any `first_field`
as a number — `second-field-align` isn't exclusive to numeric styles.

I also considered reading the style's `<category citation-format="numeric"/>`
metadata instead. citationberg parses it (the archived styles retain it too,
and hayagriva already consults it when rendering prose citations), but the
field is optional, so a custom numeric style that omits it would silently lose
the offset, with no graceful fallback — the rendered-output check would still
be needed as a backstop. And when a declaration disagrees with what the style
actually renders, trusting the declaration produces visible glitches in both
directions; trusting the output produces none. Longer-term this question
probably belongs in hayagriva, which already tracks identifier usage
internally and could just expose it. Happy to do that as a follow-up if
preferred.

## Tests

Three new HTML tests, one per way of reaching the failure, placed with the
other `bibliography-group-*` tests:

- `bibliography-group-full`: the scenario from the issue — two `full: true`
  bibliographies with no citations; numbering must continue across them
  (the screenshots above show this document).
- `bibliography-group-form-year`: the second hole described above — a
  bibliography whose only citation uses `form: "year"` and thus displays no
  number; the offset must still advance (caught via the rendered items, since
  the citations are no help here).
- `bibliography-group-full-custom-style`: a custom numeric style with no
  `citation-format` metadata and with `second-field-align`, so the
  `first_field` path is actually exercised — and so that a future switch to
  metadata-based detection would fail loudly here.