### PR TITLE
Nicer font variant printing

### DIFF
--- a/crates/typst-cli/src/fonts.rs
+++ b/crates/typst-cli/src/fonts.rs
@@ -99,7 +99,6 @@ fn write_variant(
 /// Formats a variation axis.
 fn write_axis(f: &mut Formatter, axis: &FontAxis) -> fmt::Result {
     use std::convert::identity;
-
     match axis.tag {
         StandardAxes::ITAL => write_axis_with(f, axis, "Italic", identity),
         StandardAxes::SLNT => write_axis_with(f, axis, "Slant", identity),

--- a/crates/typst-cli/src/fonts.rs
+++ b/crates/typst-cli/src/fonts.rs
@@ -98,15 +98,17 @@ fn write_variant(
 
 /// Formats a variation axis.
 fn write_axis(f: &mut Formatter, axis: &FontAxis) -> fmt::Result {
+    use std::convert::identity;
+
     match axis.tag {
-        StandardAxes::ITAL => write_axis_with(f, axis, "Italic", |v| v.0),
-        StandardAxes::SLNT => write_axis_with(f, axis, "Slant", |v| v.0),
+        StandardAxes::ITAL => write_axis_with(f, axis, "Italic", identity),
+        StandardAxes::SLNT => write_axis_with(f, axis, "Slant", identity),
         StandardAxes::WGHT => write_axis_with(f, axis, "Weight", FontWeight::from_wght),
         StandardAxes::WDTH => write_axis_with(f, axis, "Stretch", FontStretch::from_wdth),
         StandardAxes::OPSZ => write_axis_with(f, axis, "Optical Size", |v| {
-            typst_utils::display(move |f| write!(f, "{}pt", v.0))
+            typst_utils::display(move |f| write!(f, "{v}pt"))
         }),
-        _ => write_axis_with(f, axis, &axis.tag.to_str_lossy(), |v| v.0),
+        _ => write_axis_with(f, axis, &axis.tag.to_str_lossy(), identity),
     }
 }
 

--- a/crates/typst-library/src/text/font/variant.rs
+++ b/crates/typst-library/src/text/font/variant.rs
@@ -299,13 +299,12 @@ impl Repr for FontStretch {
 
 impl Display for FontStretch {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let integer_component = self.0 / 10;
-        let decimal_component = self.0 % 10;
-
-        if decimal_component == 0 {
-            write!(f, "{integer_component}%")
+        let int_part = self.0 / 10;
+        let dec_part = self.0 % 10;
+        if dec_part == 0 {
+            write!(f, "{int_part}%")
         } else {
-            write!(f, "{integer_component}.{decimal_component}%")
+            write!(f, "{int_part}.{dec_part}%")
         }
     }
 }
@@ -356,10 +355,9 @@ mod tests {
         assert_eq!(format!("{}", FontStretch(1)), "0.1%");
         assert_eq!(format!("{}", FontStretch(10)), "1%");
         assert_eq!(format!("{}", FontStretch(100)), "10%");
-        assert_eq!(format!("{}", FontStretch(1000)), "100%");
-        assert_eq!(format!("{}", FontStretch(u16::MAX)), "6553.5%");
-
-        assert_eq!(format!("{}", FontStretch(1120)), "112%");
         assert_eq!(format!("{}", FontStretch(666)), "66.6%");
+        assert_eq!(format!("{}", FontStretch(1000)), "100%");
+        assert_eq!(format!("{}", FontStretch(1120)), "112%");
+        assert_eq!(format!("{}", FontStretch(u16::MAX)), "6553.5%");
     }
 }

--- a/crates/typst-library/src/text/font/variant.rs
+++ b/crates/typst-library/src/text/font/variant.rs
@@ -299,7 +299,14 @@ impl Repr for FontStretch {
 
 impl Display for FontStretch {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{}%", self.to_ratio().get() * 100.0)
+        let integer_component = self.0 / 10;
+        let decimal_component = self.0 % 10;
+
+        if decimal_component == 0 {
+            write!(f, "{integer_component}%")
+        } else {
+            write!(f, "{integer_component}.{decimal_component}%")
+        }
     }
 }
 
@@ -341,5 +348,18 @@ mod tests {
     #[test]
     fn test_font_stretch_debug() {
         assert_eq!(FontStretch::EXPANDED.repr(), "125%")
+    }
+
+    #[test]
+    fn text_font_stretch_fmt() {
+        assert_eq!(format!("{}", FontStretch(0)), "0%");
+        assert_eq!(format!("{}", FontStretch(1)), "0.1%");
+        assert_eq!(format!("{}", FontStretch(10)), "1%");
+        assert_eq!(format!("{}", FontStretch(100)), "10%");
+        assert_eq!(format!("{}", FontStretch(1000)), "100%");
+        assert_eq!(format!("{}", FontStretch(u16::MAX)), "6553.5%");
+
+        assert_eq!(format!("{}", FontStretch(1120)), "112%");
+        assert_eq!(format!("{}", FontStretch(666)), "66.6%");
     }
 }

--- a/crates/typst-library/src/text/font/variations.rs
+++ b/crates/typst-library/src/text/font/variations.rs
@@ -68,20 +68,8 @@ impl Hash for AxisValue {
 }
 
 impl Display for AxisValue {
-    // Per Google Fonts Axis Registry, generally no more than two decimal digits
-    // of precision are expected; we replicate std::fmt's rounding to compute
-    // the appropriate amount, avoiding visual noise of trailing zeros.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let rounded_hundredths = (self.0 * 100.0).round_ties_even();
-        let decimal_digits = rounded_hundredths.rem_euclid(100.) as u8;
-
-        let precision = match decimal_digits {
-            0 => 0,
-            v if v % 10 == 0 => 1,
-            _ => 2,
-        };
-
-        write!(f, "{:.precision$}", self.0)
+        write!(f, "{}", typst_utils::round_with_precision(self.0.into(), 2))
     }
 }
 
@@ -252,10 +240,13 @@ mod tests {
 
     #[test]
     fn text_axis_value_fmt() {
+        // Assure we're printing with appropriate precision.
         assert_eq!(format!("{}", AxisValue(100.)), "100");
         assert_eq!(format!("{}", AxisValue(-2.5)), "-2.5");
-        assert_eq!(format!("{}", AxisValue(8.250023)), "8.25");
-        assert_eq!(format!("{}", AxisValue(25_000.248)), "25000.25");
+        assert_eq!(format!("{}", AxisValue(4.2)), "4.2");
+        assert_eq!(format!("{}", AxisValue(i16::MAX as f32 + 0.75)), "32767.75");
+
+        // These should be impossible to represent, but still work in fmt.
         assert_eq!(format!("{}", AxisValue(f32::NAN)), "NaN");
         assert_eq!(format!("{}", AxisValue(f32::INFINITY)), "inf");
     }

--- a/crates/typst-library/src/text/font/variations.rs
+++ b/crates/typst-library/src/text/font/variations.rs
@@ -1,6 +1,7 @@
 use ecow::{EcoString, eco_format};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
+use std::fmt::{self, Display, Formatter};
 use std::hash::{Hash, Hasher};
 use typst_utils::Rdedup;
 
@@ -63,6 +64,24 @@ impl AxisValue {
 impl Hash for AxisValue {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.0.to_bits().hash(state);
+    }
+}
+
+impl Display for AxisValue {
+    // Per Google Fonts Axis Registry, generally no more than two decimal digits
+    // of precision are expected; we replicate std::fmt's rounding to compute
+    // the appropriate amount, avoiding visual noise of trailing zeros.
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let rounded_hundredths = (self.0 * 100.0).round_ties_even();
+        let decimal_digits = rounded_hundredths.rem_euclid(100.) as u8;
+
+        let precision = match decimal_digits {
+            0 => 0,
+            v if v % 10 == 0 => 1,
+            _ => 2,
+        };
+
+        write!(f, "{:.precision$}", self.0)
     }
 }
 
@@ -225,4 +244,19 @@ cast! {
 
 fn tag_hint_helper(index: usize, key: &impl Repr) -> EcoString {
     eco_format!("occurred in tag at index {index} (`{}`)", key.repr())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn text_axis_value_fmt() {
+        assert_eq!(format!("{}", AxisValue(100.)), "100");
+        assert_eq!(format!("{}", AxisValue(-2.5)), "-2.5");
+        assert_eq!(format!("{}", AxisValue(8.250023)), "8.25");
+        assert_eq!(format!("{}", AxisValue(25_000.248)), "25000.25");
+        assert_eq!(format!("{}", AxisValue(f32::NAN)), "NaN");
+        assert_eq!(format!("{}", AxisValue(f32::INFINITY)), "inf");
+    }
 }

--- a/crates/typst-library/src/text/font/variations.rs
+++ b/crates/typst-library/src/text/font/variations.rs
@@ -1,8 +1,9 @@
+use std::fmt::{self, Display, Formatter};
+use std::hash::{Hash, Hasher};
+
 use ecow::{EcoString, eco_format};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
-use std::fmt::{self, Display, Formatter};
-use std::hash::{Hash, Hasher};
 use typst_utils::Rdedup;
 
 use crate::diag::{Hint, HintedStrResult};
@@ -61,15 +62,15 @@ impl AxisValue {
     }
 }
 
-impl Hash for AxisValue {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0.to_bits().hash(state);
-    }
-}
-
 impl Display for AxisValue {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{}", typst_utils::round_with_precision(self.0.into(), 2))
+    }
+}
+
+impl Hash for AxisValue {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.to_bits().hash(state);
     }
 }
 


### PR DESCRIPTION
Resolves #8481. The property is stored as a fixed-point value, so we format that directly now :sparkles:

```diff
 Adwaita Mono
   └ /usr/share/fonts/Adwaita/AdwaitaMono-Regular.ttf
       Style: Normal, Weight: 400, Stretch: 100%

 Merriweather 7pt
   └ ./Merriweather[opsz,wdth,wght].ttf (Variable)
       Style: Normal
       Weight: 300-900 (Default: 300)
-      Stretch: 87%-112.00000000000001% (Default: 100%)
+      Stretch: 87%-112% (Default: 100%)
       Optical Size: 7pt-144pt (Default: 7pt

 LMMonoLtCond10
   └ /usr/share/fonts/OTF/lmmonoltcond10-regular.otf
-      Style: Normal, Weight: 300, Stretch: 66.60000000000001%
+      Style: Normal, Weight: 300, Stretch: 66.6%
```

---

The values of other features are read directly as floats, so should be much better behaved. Though if a font stores them as such, in principle they could give weird output as well.

The [Google Fonts Axis Registry](https://github.com/google/fonts/tree/main/axisregistry) says in practice no more than two decimal digits of precision are expected. Typst will of course use the exact value later, but it might still make sense to put that general limit in place for the display?

I've patched myself such a file with fonttools ttx for demonstration purposes:
```diff
 Brokenweather 7pt
   └ ./Brokenweather.ttf (Variable)
       Style: Normal
       Weight: 300-900 (Default: 300)
       Stretch: 87%-100% (Default: 100%)
-      Optical Size: 7pt-144pt (Default: 8.2500305pt)
+      Optical Size: 7pt-144pt (Default: 8.25pt)
```

Feel free to drop that commit if you think its too much though; it just nicely followed from my initial attempts before I figured out the fixed-point thing :sweat_smile: