### PR TITLE
Fix shared numbering for bibliography styles that use sorting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -959,9 +959,9 @@ dependencies = [
 
 [[package]]
 name = "hayagriva"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5f9b181c35b7aa0ca4837c7b26a940d2502ec940fabfc520b61eb0f2e47acf"
+checksum = "7b6c185c5c72546d50b25b70187f01ab9a1a2fa21c4db8691e2426fa5fce805c"
 dependencies = [
  "biblatex",
  "ciborium",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ flate2 = { version = "1", features = ["zlib-rs"] }
 fontdb = { version = "0.23", default-features = false }
 fs_extra = "1.3"
 glidesort = "0.1.2"
-hayagriva = "0.10.0"
+hayagriva = "0.10.1"
 hayro = { version = "0.7.1", default-features = false }
 hayro-svg = { version = "0.7.0", default-features = false }
 hayro-syntax = "0.7.2"

--- a/tests/ref/html/hashes.txt
+++ b/tests/ref/html/hashes.txt
@@ -12,6 +12,7 @@ dfb3c710d089677eec69861ae5785a31 bibliography-group-mixed-full
 c456aecc3b410f0b4f8705fc87e6d499 bibliography-group-mixed-styles
 0b7c6366e0660d06550c9081512d5bb9 bibliography-group-none
 5fab6af8d6370f60818ea4e1eec8095a bibliography-group-out-of-order
+26e950c54e970fbac890d45eee54e320 bibliography-group-sorted-style
 17da3cafc27f03d422dd8863d4bf9707 bibliography-group-str
 376934db510f9e65eee13bd8a679ddc3 bibliography-multiple-files
 1e0f40cc69e2d5efa0590d9c17fec0a6 bibliography-no-title

--- a/tests/suite/model/bibliography.typ
+++ b/tests/suite/model/bibliography.typ
@@ -303,3 +303,10 @@ hi:
 @keshav2007read @netwok @arrgh
 #bibliography("/assets/bib/works.bib")
 #bibliography("/assets/bib/works_too.bib")
+
+--- bibliography-group-sorted-style html ---
+// Test that the shared numbering also advances for a style that uses sorting.
+#set bibliography(style: "association-for-computing-machinery")
+@netwok @keshav2007read
+#bibliography("/assets/bib/works.bib")
+#bibliography("/assets/bib/works_too.bib")


### PR DESCRIPTION
Fixes https://github.com/typst/typst/issues/8497#issuecomment-4692154342.

~~Requires https://github.com/typst/hayagriva/pull/487 to be merged and a hayagriva patch release to be cut before being merged.~~