### PR TITLE
Docs: Implement the ARIA Combobox Pattern / keyboard navigation for search

### DIFF
--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -516,6 +516,10 @@ a.chain img {
   box-shadow: inset 0 0 0 2px #007aff;
 }
 
+.search-results .active-result {
+  outline: auto;
+}
+
 /* Shadow component */
 
 figure {

--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -544,6 +544,10 @@ a.chain img {
   box-shadow: inset 0 0 0 2px #007aff;
 }
 
+.search-results .active-result {
+  box-shadow: inset 0 0 0 2px #007aff;
+}
+
 /* Shadow component */
 
 figure {

--- a/docs/assets/docs.js
+++ b/docs/assets/docs.js
@@ -775,6 +775,11 @@ async function setUpGlobalSearch() {
         switchActive(items[items.length - 1]);
         break;
     }
+
+    // Send other events back to the search box for type-ahead like behavior.
+    if ([...event.key].length == 1 || event.key == "Backspace") {
+      textBox.focus();
+    }
   });
   resultList.addEventListener("click", (event) => {
     const target = event.target.closest(".search-results [role=option]");

--- a/docs/assets/docs.js
+++ b/docs/assets/docs.js
@@ -743,6 +743,49 @@ async function setUpGlobalSearch() {
   const resultList = document.getElementById("search-results");
   if (!textBox || !resultList) return;
 
+  // Handle ARIA listbox keyboard navigation.
+  const getAriaActiveDescendant = (elem) => elem.querySelector("#" + elem.getAttribute("aria-activedescendant"));
+  resultList.addEventListener("keydown", (event) => {
+    const items = Array.from(resultList.children);
+    const currentElem = getAriaActiveDescendant(resultList);
+    const currentIndex = items.indexOf(currentElem);
+    const switchActive = (target) => {
+      event.preventDefault();
+      currentElem?.classList.remove("active-result");
+      target.classList.add("active-result");
+      resultList.setAttribute("aria-activedescendant", target.id);
+    };
+
+    if (currentIndex == -1) return;
+
+    switch (event.key) {
+      case "Enter":
+        currentElem?.querySelector("a")?.click();
+        break;
+      case "ArrowUp":
+        switchActive(items[currentIndex - 1] || items[items.length - 1]);
+        break;
+      case "ArrowDown":
+        switchActive(items[currentIndex + 1] || items[0]);
+        break;
+      case "Home":
+        switchActive(items[0]);
+        break;
+      case "End":
+        switchActive(items[items.length - 1]);
+        break;
+    }
+  });
+  resultList.addEventListener("click", (event) => {
+    const target = event.target.closest(".search-results [role=option]");
+    if (target?.id) {
+      const currentElem = getAriaActiveDescendant(resultList);
+      currentElem?.classList.remove("active-result");
+      target.classList.add("active-result");
+      resultList.setAttribute("aria-activedescendant", target.id)
+    }
+  });
+
   const index = await fetchSearchIndex();
   if (!index) return;
 
@@ -751,7 +794,7 @@ async function setUpGlobalSearch() {
     const matches = searchGlobally(index, query);
 
     // Generate a `li > a` for each match.
-    const items = matches.map((hit) => {
+    const items = matches.map((hit, i) => {
       const item = index.items[hit];
       let url = item.route;
       if (
@@ -766,6 +809,12 @@ async function setUpGlobalSearch() {
       const li = document.createElement("li");
       const a = document.createElement("a");
       const span = document.createElement("span");
+      li.id = "search-result-" + i;
+      li.role = "option";
+      if (i == 0) {
+        li.classList.add("active-result");
+        resultList.setAttribute("aria-activedescendant", li.id);
+      }
       a.href = url;
       a.textContent = item.title;
       span.classList.add("type");
@@ -779,7 +828,16 @@ async function setUpGlobalSearch() {
     resultList.classList.toggle("hidden", matches.length === 0);
   };
 
-  textBox.addEventListener("keyup", search);
+  textBox.addEventListener("keyup", (event) => {
+    if (event.key == "ArrowDown") {
+      resultList.focus();
+    } else if (event.key == "Enter") {
+      const active = getAriaActiveDescendant(resultList);
+      active?.querySelector("a")?.click();
+    } else {
+      search();
+    }
+  });
   document.addEventListener("keyup", (event) => {
     if (event.key && event.key.toLowerCase() == "s") {
       event.stopPropagation();

--- a/docs/assets/docs.js
+++ b/docs/assets/docs.js
@@ -746,6 +746,18 @@ async function setUpGlobalSearch() {
   const index = await fetchSearchIndex();
   if (!index) return;
 
+  const switchActiveResult = (target) => {
+    const prev = getAriaActiveDescendant(textBox);
+    prev?.classList.remove("active-result");
+
+    if (!target || !target.id) {
+      textBox.removeAttribute("aria-activedescendant");
+    } else {
+      target.classList.add("active-result");
+      textBox.setAttribute("aria-activedescendant", target.id);
+    }
+  };
+
   const search = () => {
     const query = textBox.value;
     const matches = searchGlobally(index, query);
@@ -766,8 +778,16 @@ async function setUpGlobalSearch() {
       const li = document.createElement("li");
       const a = document.createElement("a");
       const span = document.createElement("span");
+      // Using the unique searchindex as an id helps accessibility APIs detect
+      // when changes are relevant (esp. for the automatically selected result).
+      li.id = "search-result-" + hit;
+      li.role = "option";
+      li.dataset.route = url;
       a.href = url;
       a.textContent = item.title;
+      // Links are in the default tab sequence of some UAs (e.g. Chromium),
+      // while popup descendants generally shall not.
+      a.tabIndex = -1;
       span.classList.add("type");
       span.textContent = item.kind;
       a.appendChild(span);
@@ -776,10 +796,50 @@ async function setUpGlobalSearch() {
     });
 
     resultList.replaceChildren(...items);
-    resultList.classList.toggle("hidden", matches.length === 0);
+    switchActiveResult(items[0]);
+
+    const empty = matches.length === 0;
+    resultList.classList.toggle("hidden", empty);
+    textBox.setAttribute("aria-expanded", !empty);
   };
 
-  textBox.addEventListener("keyup", search);
+  textBox.addEventListener("input", search);
+
+  const navigationKeys = new Set(["ArrowDown", "ArrowUp", "Home", "End", "Enter"]);
+  textBox.addEventListener("keydown", (event) => {
+    if (!navigationKeys.has(event.key) || resultList.children.length === 0) return;
+    event.preventDefault();
+
+    const items = Array.from(resultList.children);
+    const currentIndex = items.indexOf(getAriaActiveDescendant(textBox));
+
+    switch (event.key) {
+      case "ArrowDown":
+        switchActiveResult(items[currentIndex + 1] ?? items[0]);
+        break;
+      case "ArrowUp":
+        switchActiveResult(items[currentIndex - 1] ?? items[items.length - 1]);
+        break;
+      case "Home":
+        switchActiveResult(items[0]);
+        break;
+      case "End":
+        switchActiveResult(items[items.length - 1]);
+        break;
+      case "Enter":
+        const active = getAriaActiveDescendant(textBox) ?? items[0];
+        if (active?.dataset.route) window.location.href = active.dataset.route;
+        break;
+    }
+  });
+
+  // Assure pointer interactions play nicely with keyboard controls.
+  resultList.addEventListener("click", (event) => {
+    const target = event.target.closest(".search-results [role=option]");
+    if (target) switchActiveResult(target);
+  });
+
+  // Global search hotkey.
   document.addEventListener("keyup", (event) => {
     if (event.key && event.key.toLowerCase() == "s") {
       event.stopPropagation();
@@ -1242,6 +1302,12 @@ function isElementInViewport(el) {
       (window.innerHeight || document.documentElement.clientHeight) &&
     rect.right <= (window.innerWidth || document.documentElement.clientWidth)
   );
+}
+
+/** Basic polyfill for `ariaActiveDescendantElement`. */
+function getAriaActiveDescendant(container) {
+  const id = container.getAttribute("aria-activedescendant");
+  return id ? document.getElementById(id) : null;
 }
 
 main();

--- a/docs/components/nav.typ
+++ b/docs/components/nav.typ
@@ -72,7 +72,7 @@
 #let nav-folding(current) = html.nav(class: "folding", context {
   html.button(class: "close", icon(16, "close", "Close"))
   search-box(id: "docs-search", placeholder: "Search (S)")
-  html.ul(id: "search-results", class: "search-results hidden")
+  html.ul(id: "search-results", class: "search-results hidden", role: "listbox", tabindex: 0)
   let items = query(selector.or(
     <metadata-page>,
     <metadata-nav-separation>,

--- a/docs/components/nav.typ
+++ b/docs/components/nav.typ
@@ -71,8 +71,8 @@
 // The folding navigation on the left of the docs.
 #let nav-folding(current) = html.nav(class: "folding", context {
   html.button(class: "close", icon(16, "close", "Close"))
-  search-box(id: "docs-search", placeholder: "Search (S)")
-  html.ul(id: "search-results", class: "search-results hidden")
+  search-box(id: "docs-search", placeholder: "Search (S)", role: "combobox", aria-controls: "search-results", aria-autocomplete: "list", aria-expanded: false)
+  html.ul(id: "search-results", class: "search-results hidden", role: "listbox")
   let items = query(selector.or(
     <metadata-page>,
     <metadata-nav-separation>,


### PR DESCRIPTION
Closes #8272, which bothered me again today. Looking into what would have to be done to actually resolve this, I saw that W3C WAI lays out pretty clear tracks with their [keyboard navigation guide](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/), from which ~~I~~ we determined the ~~Listbox~~ [Combobox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/) to be relevant.

### Summary of the new behavior

<details>
<summary>Outdated: initial version</summary>

- From the search box, arrow-down (or tab, still implicitly but now consistent) moves focus to the results and makes the first item active
- Arrow-keys may be used to navigate the list
- Enter leads to the page of the selected result (also from the search box, in which case it'll be the first).
- Pressing a printing character (we use the string-representation's length in codepoints as a metric; [control characters have longer ones](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key#value)) while focus is on results snaps it back to the search box, enabling type-ahead like behavior

Still available https://github.com/cady-b/typst/tree/search-v1 for now.
</details>

- While Typing in the search box, visual indicator (and ARIA attributes) track the focus state. As requested in the linked issue, initially the first result is automatically selected.
- <kbd>Enter</kbd> navigates to the focused item just as clicking it would.
- The focus may be moved with: <kbd>↑</kbd>, <kbd>↓</kbd>, <kbd>Home</kbd>, <kbd>End</kbd> (with wrap-around behavior). During that, focus remains on the search box so other input is handled as normal and will update the results accordingly. (Including composing sequences; IME should work as well, but I don't have any set up to test.)

### A tradeoff

Something to note is that WAI prescribes focus either not be set before the user navigates the list, or to appear as an inline completion suggestion (such that after typing only the suggested ending is spoken). This is currently not implemented, because the main thing I wanted to solve was keyboard navigation. The results are too noisy for inline autocomplete, and waiting for list navigation would either slow users down quite a bit and decrease discoverability of the feature (no focus and enter not doing anything at first) or lead to behavior that is difficult to understand (i.e. enter navigating to the first item even if it doesn't have visual focus, it then taking two down arrow presses to get to the second).

If I slow down with typing, it's still a lot more usable with a screen-reader than before, so I've left it at that for now. Technically its not the nicest for users that rely on one though. My firefox search bar seems to employ some sort of hybrid solution; a basic non-selected listbox until the score gets good enough that prefilling makes sense. That could be something to look into, but would require reworking the search function (currently its purely for ranking and doesn't really scale with certainty) and pre-filling may still annoy some users. Not sure that's worth it for this much simpler search box.

### Quick Demo in Firefox with Orca

Unmute to hear lots of espeak chatter

https://github.com/user-attachments/assets/892ed7c6-591b-42dd-9873-4d3b6e35a7ef

I've verified everything I touched behaves as I'd expect and that no console errors are generated with a recent Firefox & Chromium on Linux; the keyboard navigation also works in Luakit (WebKit based), but idk how to read logs there. Sadly I have no other OSes or older versions of browsers available for testing.