### PR TITLE
Fix project/package root escape via drive letter on Windows

### DIFF
--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -421,7 +421,9 @@ fn write_virtual_fs(root: &Path, fs: &VirtualFs) -> StrResult<Vec<Output>> {
 
     fs.par_iter()
         .map(|(path, data)| {
-            let realized = path.realize(root);
+            let realized = path
+                .realize(root)
+                .map_err(|err| eco_format!("failed to realize path ({err})"))?;
 
             if let Some(parent) = realized.parent() {
                 std::fs::create_dir_all(parent)

--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -150,8 +150,10 @@ impl DiagnosticWorld for SystemWorld {
         match id.root() {
             VirtualRoot::Project => {
                 // Try to express the path relative to the working directory.
-                let rooted = vpath.realize(self.root());
-                pathdiff::diff_paths(rooted, self.workdir())
+                vpath
+                    .realize(self.root())
+                    .ok()
+                    .and_then(|rooted| pathdiff::diff_paths(rooted, self.workdir()))
                     .map(|path| path.to_string_lossy().into_owned())
                     .unwrap_or_else(|| vpath.get_without_slash().into())
             }
@@ -243,7 +245,7 @@ impl SystemFiles {
 
     /// Resolves the file system path for the given `id`.
     pub fn resolve(&self, id: FileId) -> FileResult<PathBuf> {
-        Ok(self.root(id)?.resolve(id.vpath()))
+        self.root(id)?.resolve(id.vpath())
     }
 
     /// Resolves the root in which the given file ID resides.

--- a/crates/typst-kit/src/files.rs
+++ b/crates/typst-kit/src/files.rs
@@ -302,7 +302,7 @@ impl SystemFiles {
 
     /// Resolves the path of the given file `id` in the file system.
     pub fn resolve(&self, id: FileId) -> FileResult<PathBuf> {
-        Ok(self.root(id)?.resolve(id.vpath()))
+        self.root(id)?.resolve(id.vpath())
     }
 
     /// Resolves the root in which the given file ID resides.
@@ -341,15 +341,15 @@ impl FsRoot {
 
     /// Resolves the real file system path for the given virtual path in this
     /// root.
-    pub fn resolve(&self, path: &VirtualPath) -> PathBuf {
-        path.realize(&self.0)
+    pub fn resolve(&self, path: &VirtualPath) -> FileResult<PathBuf> {
+        path.realize(&self.0).map_err(Into::into)
     }
 
     /// Loads file data from the given virtual path in this root.
     pub fn load(&self, path: &VirtualPath) -> FileResult<Bytes> {
         // Join the path to the root. If it tries to escape, deny access. Note:
         // It can still escape via symlinks.
-        let path = self.resolve(path);
+        let path = self.resolve(path)?;
         let f = |e| FileError::from_io(e, &path);
         if fs::metadata(&path).map_err(f)?.is_dir() {
             Err(FileError::IsDirectory)

--- a/crates/typst-library/src/diag.rs
+++ b/crates/typst-library/src/diag.rs
@@ -17,7 +17,9 @@ use std::string::FromUtf8Error;
 use az::SaturatingAs;
 use comemo::Tracked;
 use typst_syntax::package::{PackageSpec, PackageVersion};
-use typst_syntax::{DiagSpan, Lines, Span, Spanned, SyntaxDiagnostic, VirtualRoot};
+use typst_syntax::{
+    DiagSpan, Lines, RealizeError, Span, Spanned, SyntaxDiagnostic, VirtualRoot,
+};
 use utf8_iter::ErrorReportingUtf8Chars;
 
 use crate::engine::Engine;
@@ -612,6 +614,9 @@ pub enum FileError {
     NotSource,
     /// The file was not valid UTF-8, but should have been.
     InvalidUtf8,
+    /// A virtual Typst path could not be realized into a real path on the
+    /// current platform.
+    Realize(RealizeError),
     /// The package the file is part of could not be loaded.
     Package(PackageError),
     /// Another error.
@@ -648,7 +653,8 @@ impl Display for FileError {
             Self::IsDirectory => f.pad("failed to load file (is a directory)"),
             Self::NotSource => f.pad("not a Typst source file"),
             Self::InvalidUtf8 => f.pad("file is not valid UTF-8"),
-            Self::Package(error) => error.fmt(f),
+            Self::Realize(err) => write!(f, "failed to load file ({err})"),
+            Self::Package(err) => err.fmt(f),
             Self::Other(Some(err)) => write!(f, "failed to load file ({err})"),
             Self::Other(None) => f.pad("failed to load file"),
         }
@@ -664,6 +670,12 @@ impl From<Utf8Error> for FileError {
 impl From<FromUtf8Error> for FileError {
     fn from(_: FromUtf8Error) -> Self {
         Self::InvalidUtf8
+    }
+}
+
+impl From<RealizeError> for FileError {
+    fn from(err: RealizeError) -> Self {
+        Self::Realize(err)
     }
 }
 

--- a/crates/typst-syntax/src/lib.rs
+++ b/crates/typst-syntax/src/lib.rs
@@ -27,7 +27,8 @@ pub use self::node::{
 };
 pub use self::parser::{parse, parse_code, parse_math};
 pub use self::path::{
-    FileId, PathError, RootedPath, VirtualPath, VirtualRoot, VirtualizeError,
+    FileId, PathError, RealizeError, RootedPath, VirtualPath, VirtualRoot,
+    VirtualizeError,
 };
 pub use self::source::Source;
 pub use self::span::{

--- a/crates/typst-syntax/src/path.rs
+++ b/crates/typst-syntax/src/path.rs
@@ -591,8 +591,6 @@ pub enum VirtualizeError {
 
 impl fmt::Display for VirtualizeError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "could not virtualize path, ")?;
-
         match self {
             Self::Path(inner) => fmt::Display::fmt(inner, f),
             Self::Invalid(component) => {

--- a/crates/typst-syntax/src/path.rs
+++ b/crates/typst-syntax/src/path.rs
@@ -475,7 +475,15 @@ impl<'a> Segment<'a> {
         let mut iter = Path::new(self.get()).components();
         match (iter.next(), iter.next()) {
             // Exactly one normal component.
-            (Some(path::Component::Normal(s)), None) => Ok(s),
+            (Some(path::Component::Normal(s)), None) => {
+                // Forbid access to reserved files on Windows as they are
+                // conceptually not part of any root.
+                #[cfg(windows)]
+                if is_windows_reserved(self.get()) {
+                    return Err(RealizeError::Invalid(self.get().into()));
+                }
+                Ok(s)
+            }
             // No or multiple components, starting with normal.
             (None | Some(path::Component::Normal(_)), _) => {
                 Err(RealizeError::Invalid(self.get().into()))
@@ -486,6 +494,31 @@ impl<'a> Segment<'a> {
             }
         }
     }
+}
+
+/// Whether the give file name is reserved on Windows.
+///
+/// Follows <https://cs.opensource.google/go/go/+/refs/tags/go1.26.4:src/internal/filepathlite/path_windows.go;l=98>.
+/// See also: <https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file>
+#[cfg(windows)]
+fn is_windows_reserved(name: &str) -> bool {
+    #[rustfmt::skip]
+    fn is_reserved_base(basename: &str) -> bool {
+        matches!(
+            basename,
+            "CON" | "PRN" | "AUX" | "NUL"
+                | "COM0" | "COM1" | "COM2" | "COM3" | "COM4" | "COM5" | "COM6"
+                | "COM7" | "COM8" | "COM9" | "COM¹" | "COM²" | "COM³"
+                | "LPT0" | "LPT1" | "LPT2" | "LPT3" | "LPT4" | "LPT5" | "LPT6"
+                | "LPT7" | "LPT8" | "LPT9" | "LPT¹" | "LPT²" | "LPT³"
+                | "CONIN$" | "CONOUT$"
+        )
+    }
+
+    // Some Windows versions also allow arbitrary characters after a dot or
+    // colon in device names (and trailing spaces before that suffix).
+    let base = name.split(['.', ':']).next().unwrap_or(name).trim_end_matches(' ');
+    base.len() <= 7 && is_reserved_base(&EcoString::from(base).to_ascii_uppercase())
 }
 
 /// Stores a sequence of path segments as a string.
@@ -773,6 +806,10 @@ mod tests {
         assert_eq!(path("Foo/E:System").realize(root), Err(invalid("E:")));
         assert_eq!(path("Foo/E:/System").realize(root), Err(invalid("E:")));
         assert_eq!(path("F:").realize(root), Err(invalid("F:")));
+        assert_eq!(path("CON").realize(root), Err(invalid("CON")));
+        assert_eq!(path("A/CON .txt").realize(root), Err(invalid("CON .txt")));
+        assert_eq!(path("A/CON:foo/bar").realize(root), Err(invalid("CON:foo")));
+        assert_eq!(path("a/LPT\u{00b2} .baz/b").realize(root), Err(invalid("LPT² .baz")));
     }
 
     #[test]

--- a/crates/typst-syntax/src/path.rs
+++ b/crates/typst-syntax/src/path.rs
@@ -1,6 +1,7 @@
 //! Virtual, cross-platform reproducible path handling.
 
 use std::error;
+use std::ffi::OsStr;
 use std::fmt::{self, Debug, Formatter};
 use std::num::NonZeroU16;
 use std::ops::Deref;
@@ -229,17 +230,22 @@ impl VirtualPath {
     /// project or package resides). You need to provide the appropriate `root`
     /// path, relative to which this path will be resolved.
     ///
-    /// This can be used in the implementations of `World::source` and
-    /// `World::file`.
-    ///
     /// This is the single function that translates from a virtual path to a
     /// real path. Its counterpart is [`VirtualPath::virtualize`].
-    pub fn realize(&self, root: &Path) -> PathBuf {
+    ///
+    /// This function has platform-specific output and returns an error if the
+    /// path contains platform-specific syntax that could lexically escape the
+    /// `root`. Currently, no file system operations are performed, though this
+    /// may change in the future.
+    ///
+    /// This can be used in the implementations of `World::source` and
+    /// `World::file`.
+    pub fn realize(&self, root: &Path) -> Result<PathBuf, RealizeError> {
         let mut out = root.to_path_buf();
         for s in self.0.iter() {
-            out.push(s.get());
+            out.push(s.realize()?);
         }
-        out
+        Ok(out)
     }
 
     /// Extracts the path with a leading slash.
@@ -361,7 +367,7 @@ impl VirtualPath {
     /// (where the project or package resides).
     #[deprecated = "use `realize` instead"]
     pub fn resolve(&self, root: &Path) -> Option<PathBuf> {
-        Some(self.realize(root))
+        self.realize(root).ok()
     }
 
     /// Get the underlying path without a leading `/` or `\`.
@@ -456,6 +462,29 @@ impl<'a> Segment<'a> {
         let after = iter.next();
         let before = iter.next();
         if before == Some("") { (Some(self.0), None) } else { (before, after) }
+    }
+
+    /// Ensures that this segment can be joined to an existing platform-specific
+    /// path without lexically escaping the root formed by that path.
+    ///
+    /// Sanity-checked against <https://pkg.go.dev/path/filepath#IsLocal>.
+    fn realize(self) -> Result<&'a OsStr, RealizeError> {
+        // We ensure that this segment corresponds to exactly one platform-level
+        // path component. Drive letters on Windows are rejected since they are
+        // `Prefix` components.
+        let mut iter = Path::new(self.get()).components();
+        match (iter.next(), iter.next()) {
+            // Exactly one normal component.
+            (Some(path::Component::Normal(s)), None) => Ok(s),
+            // No or multiple components, starting with normal.
+            (None | Some(path::Component::Normal(_)), _) => {
+                Err(RealizeError::Invalid(self.get().into()))
+            }
+            // Non-normal component.
+            (Some(other), _) => {
+                Err(RealizeError::Invalid(other.as_os_str().to_string_lossy().into()))
+            }
+        }
     }
 }
 
@@ -552,7 +581,7 @@ impl Segments {
 
 /// An error that can occur on construction or modification of a
 /// [`VirtualPath`].
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum PathError {
     /// The constructed or modified path would escape the root. This would
     /// for instance, when trying to join `..` to the path `/`.
@@ -577,7 +606,7 @@ impl fmt::Display for PathError {
 impl error::Error for PathError {}
 
 /// An error that can occur in [`VirtualPath::virtualize`].
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum VirtualizeError {
     /// A normal path error.
     Path(PathError),
@@ -611,6 +640,33 @@ impl From<PathError> for VirtualizeError {
         Self::Path(err)
     }
 }
+
+/// An error that can occur in [`VirtualPath::realize`].
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub enum RealizeError {
+    /// A virtual path component was of a form that would be specially
+    /// interpreted on the current platform as opposed to designating just a
+    /// file or directory.
+    ///
+    /// For example, this occurs when a path segments contains a drive letter
+    /// prefix on Windows (i.e. the virtual path `/C:/System32/..`) as Windows
+    /// interprets interior drive letters as resetting the path to the cwd (if
+    /// the cwd is on the current drive) or resetting the path to root (if the
+    /// cwd is on another drive).
+    Invalid(EcoString),
+}
+
+impl fmt::Display for RealizeError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Invalid(component) => {
+                write!(f, "path contains invalid component `{component:?}`")
+            }
+        }
+    }
+}
+
+impl error::Error for RealizeError {}
 
 #[cfg(test)]
 mod tests {
@@ -702,8 +758,21 @@ mod tests {
         let p = path("src/text/main.typ");
         assert_eq!(
             p.realize(Path::new("/home/users/typst")),
-            Path::new("/home/users/typst/src/text/main.typ")
+            Ok(PathBuf::from("/home/users/typst/src/text/main.typ")),
         );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_realize_windows() {
+        let root = Path::new("C:\\Users\\typst");
+        let invalid = |s: &str| RealizeError::Invalid(s.into());
+        assert_eq!(path("C:System32").realize(root), Err(invalid("C:")));
+        assert_eq!(path("D:Stuff").realize(root), Err(invalid("D:")));
+        assert_eq!(path("C:/System32").realize(root), Err(invalid("C:")));
+        assert_eq!(path("Foo/E:System").realize(root), Err(invalid("E:")));
+        assert_eq!(path("Foo/E:/System").realize(root), Err(invalid("E:")));
+        assert_eq!(path("F:").realize(root), Err(invalid("F:")));
     }
 
     #[test]

--- a/docs/src/main.rs
+++ b/docs/src/main.rs
@@ -200,7 +200,7 @@ fn export_website(mut bundle: Bundle, config: &Config) -> SourceResult<()> {
 fn write_virtual_fs(root: &Path, fs: &VirtualFs) {
     std::fs::create_dir_all(root).unwrap();
     fs.par_iter().for_each(|(path, data)| {
-        let realized = path.realize(root);
+        let realized = path.realize(root).unwrap();
         if let Some(parent) = realized.parent() {
             std::fs::create_dir_all(parent).unwrap();
         }

--- a/docs/src/world.rs
+++ b/docs/src/world.rs
@@ -160,7 +160,7 @@ impl DocsFiles {
     }
 
     fn resolve(&self, id: FileId) -> FileResult<PathBuf> {
-        Ok(self.root(id)?.resolve(id.vpath()))
+        self.root(id)?.resolve(id.vpath())
     }
 
     fn root(&self, id: FileId) -> FileResult<FsRoot> {

--- a/tests/src/notes.rs
+++ b/tests/src/notes.rs
@@ -354,7 +354,7 @@ impl Display for NoteRange {
             Self::Some { external_file, positions: Range { start, end }, .. } => {
                 let mut buffer = String::new();
                 if let Some(file) = external_file {
-                    let path = TestFiles.resolve(*file);
+                    let path = TestFiles.resolve(*file).unwrap();
                     write!(buffer, "\"{}\" ", path.display())?;
                 }
                 let must_print_lines = f.alternate() || external_file.is_some();

--- a/tests/src/world.rs
+++ b/tests/src/world.rs
@@ -114,7 +114,7 @@ pub struct TestFiles;
 
 impl TestFiles {
     /// Resolves the file system path for a file ID.
-    pub fn resolve(&self, id: FileId) -> PathBuf {
+    pub fn resolve(&self, id: FileId) -> FileResult<PathBuf> {
         let root = match id.root() {
             VirtualRoot::Project => PathBuf::new(),
             VirtualRoot::Package(spec) => {
@@ -122,7 +122,7 @@ impl TestFiles {
                 format!("tests/packages/{}-{}", spec.name, spec.version).into()
             }
         };
-        id.vpath().realize(&root)
+        id.vpath().realize(&root).map_err(Into::into)
     }
 
     /// Get the rooted path for a loaded file.
@@ -148,7 +148,7 @@ impl TestFiles {
 
 impl FileLoader for TestFiles {
     fn load(&self, id: FileId) -> FileResult<Bytes> {
-        let path = self.resolve(id);
+        let path = self.resolve(id)?;
 
         // Resolve asset.
         if let Ok(suffix) = path.strip_prefix("assets/") {


### PR DESCRIPTION
In https://github.com/typst/typst/pull/7688, the path handling was rewritten to use a Typst-specific `VirtualPath` implementation instead of the platform-specific `PathBuf` for all Typst path operations. This type always holds a sandboxed absolute path and cannot contain `.`, `..`, or backslashes. Due to this, I had deemed it secure to directly join its individual segments onto a platform path. This is, however, decidedly _not_ the case, as Typst paths such as `D:/folder/secret.txt` would piece-by-piece be joined to a project root such as `C:\Users\typst\mydoc` and become `D:folder\secret.txt` (as Rust replaces the full path when encountering a `Prefix` component).

This could be used for **arbitrary reads on other drives and cwd-scoped reads on the current drive on Windows**[^1]. The new, experimental bundle export uses the same code paths and as such, with it, arbitrary writes on other drives and cwd-scoped ones on the current one would be possible in the same manner.

This PR fixes the issue by validating that a Typst path segment corresponds to exactly one `std::path::Component::Normal` and rejecting to realize the path otherwise. **Typst 0.14.2 and below are not affected by this vulnerability** as they generally used Rust's [platform-specific component iterator instead the new Typst-native one](https://github.com/typst/typst/blob/v0.14.2/crates/typst-syntax/src/path.rs#L60-L77).

Additionally, this PR adds further security hardening by also rejecting [reserved filenames](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file) such as `CON` on Windows. These reserved filenames represent devices and similar things and reading from them could, depending on the user's setup, reveal information. In practice, reading from them does not work on either Typst 0.14.2 or Typst 0.15 because (a) we first call `fs::metadata` (which will fail for these devices), and (b) accessing these devices as part of a larger path such as `C:\Users\typst\CON` only works on Windows 10 and below[^2]. Still, they are conceptually not part of the project sandbox and Go's [`IsLocal`](https://pkg.go.dev/path/filepath#IsLocal), which is conceptually very close to our current security model, also rejects them, so this provides some defense-in-depth. Moreover, with bundle export, the potential attack surface increases from read-only to writing to such reserved devices, which is more problematic.

[^1]: Windows interprets a path with a drive letter but no slash following it as cwd-relative if on the current drive and as rooted if on another one.
[^2]: This does not apply to `NUL`: On Windows 11, a special `NUL` file is still present in every directory. However, to access it, the user must not specify any file extensions, unlike Windows 10 and below.