### PR TITLE
docs: improve gradient stops documentation

### DIFF
--- a/crates/typst-library/src/visualize/gradient.rs
+++ b/crates/typst-library/src/visualize/gradient.rs
@@ -71,6 +71,33 @@ use crate::visualize::{
 /// the offsets when defining a gradient. In this case, Typst will space all
 /// stops evenly.
 ///
+/// There are two ways to specify stops:
+/// - **Without offset:** Just pass colors. Typst will space them evenly.
+/// - **With offset:** Pass an array of `(color, offset)` pairs for precise control.
+///
+/// ```example
+/// #set square(size: 50pt)
+/// #stack(
+///   dir: ltr,
+///   spacing: 1fr,
+///   // Without offsets - evenly spaced
+///   square(fill: gradient.linear(red, blue)),
+///   // With offsets - precise control
+///   square(fill: gradient.linear(
+///     (red, 0%),
+///     (blue, 50%),
+///     (red, 100%),
+///   )),
+/// )
+/// ```
+///
+/// You can also use a spread operator to pass a predefined color map as stops:
+///
+/// ```example
+/// #set square(size: 50pt)
+/// #square(fill: gradient.linear(..color.map.rainbow))
+/// ```
+///
 /// Typst predefines color maps that you can use as stops. See the
 /// @color:predefined-color-maps[`color`] documentation for more details.
 ///


### PR DESCRIPTION
## Summary

Fixes #3109

Improves the gradient stops documentation to clarify the two ways to specify stops and provide more examples.

## Changes

- Added explanation of two stop formats: without offset (evenly spaced) and with offset (array of pairs)
- Added code example showing both approaches side by side
- Added example using spread operator with predefined color maps

## Before

The stops section only described stops conceptually without showing the array format.

## After

The stops section now clearly shows:
1. Colors without offsets (auto-spaced)
2. `(color, offset)` pairs for precise control
3. Using `..color.map.rainbow` spread syntax

## Testing

This is a documentation-only change. No code changes, no build required.