### PR TITLE
docs: list all elements usable with counter constructor

### DIFF
--- a/crates/typst-library/src/introspection/counter.rs
+++ b/crates/typst-library/src/introspection/counter.rs
@@ -27,9 +27,16 @@ use crate::{Library, World};
 
 /// Counts through pages, elements, and more.
 ///
-/// With the counter function, you can access and modify counters for pages,
-/// headings, figures, and more. Moreover, you can define custom counters for
-/// other things you want to count.
+/// With the counter function, you can access and modify counters for the
+/// following built-in elements:
+/// - @page[`page`] — counts pages
+/// - @heading[`heading`] — counts headings (supports multi-level numbering)
+/// - @figure[`figure`] — counts figures
+/// - @math.equation[`equation`] — counts equations
+/// - @footnote[`footnote`] — counts footnotes
+///
+/// Moreover, you can define custom counters for other things you want to
+/// count by passing a string key to the `counter` function.
 ///
 /// Since counters change throughout the course of the document, their current
 /// value is _contextual._ It is recommended to read the chapter on


### PR DESCRIPTION
## Summary

Lists all built-in elements that can be used with the `counter` constructor in the documentation.

Closes #2728

## What this PR does

The previous documentation said "pages, headings, figures, and more" which was vague. This PR explicitly lists all 5 built-in elements:

- `page` — counts pages
- `heading` — counts headings (supports multi-level numbering)
- `figure` — counts figures
- `equation` — counts equations
- `footnote` — counts footnotes

Plus mentions custom counters with string keys.

## Testing

Documentation-only change, no code changes required.