### PR TITLE
Cleanup existing lints in `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,12 +168,13 @@ strip = true
 
 [workspace.lints.clippy]
 blocks_in_conditions = "allow"
-iter_over_hash_type = "warn"
+# See https://github.com/typst/typst/pull/6560#issuecomment-3045393640
+derived_hash_with_manual_eq = "allow"
 manual_is_multiple_of = "allow"
 manual_range_contains = "allow"
 mutable_key_type = "allow"
-uninlined_format_args = "warn"
 wildcard_in_or_patterns = "allow"
-# See https://github.com/typst/typst/pull/6560#issuecomment-3045393640
-derived_hash_with_manual_eq = "allow"
+
 disallowed_methods = "warn"
+iter_over_hash_type = "warn"
+uninlined_format_args = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,6 @@ strip = true
 
 [workspace.lints.clippy]
 blocks_in_conditions = "allow"
-comparison_chain = "allow"
 iter_over_hash_type = "warn"
 manual_is_multiple_of = "allow"
 manual_range_contains = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,6 @@ codegen-units = 1
 strip = true
 
 [workspace.lints.clippy]
-blocks_in_conditions = "allow"
 # See https://github.com/typst/typst/pull/6560#issuecomment-3045393640
 derived_hash_with_manual_eq = "allow"
 manual_is_multiple_of = "allow"

--- a/tests/fuzz/Cargo.toml
+++ b/tests/fuzz/Cargo.toml
@@ -19,6 +19,9 @@ typst-syntax = { workspace = true }
 comemo = { workspace = true }
 libfuzzer-sys = { workspace = true }
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "parse"
 path = "src/bin/parse.rs"

--- a/tests/wrapper/Cargo.toml
+++ b/tests/wrapper/Cargo.toml
@@ -5,3 +5,6 @@ rust-version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
 publish = false
+
+[lints]
+workspace = true


### PR DESCRIPTION
This is the first of a few stacked PRs inspired by the blog posts [Your Clippy Config Should Be Stricter](https://emschwartz.me/your-clippy-config-should-be-stricter/) and [Your Clippy Config Should Be Stricter-er](https://billylevin.dev/posts/clippy-config/), although I mainly prefer the latter.

The thrust of the blog posts is that Clippy has a bunch of great lints that are allow-by-default but can make code cleaner and more consistent. We already enable a few, but I've taken time to go over the available _pedantic_ and _restriction_ lints based on the method in the second post, and I'll be adding the ones I think are most helpful to our workspace `Cargo.toml` in upcoming PRs.

---

This first PR is just meant to clean up our existing Clippy configuration:

The first commit ensures all our crates in this repo are inheriting the lints. I checked this with the lovely [`cargo-workspace-lints`](https://github.com/jarredallen/cargo-workspace-lints) tool.

One of the lints we already explicitly allow ([`comparison-chain`](https://rust-lang.github.io/rust-clippy/master/index.html#comparison_chain)) actually converted from warn-by-default to allow-by-default in [Rust 1.87](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-187), so I removed it from `Cargo.toml`.

And since the upcoming PRs add a bunch of "warn" lints, I alphabetized and separated the "allow" lints above the "warn" lints so they're easier to parse.

However, not all of the "allow" lints in `Cargo.toml` currently trigger, and I would appreciate feedback on whether we should remove `blocks_in_conditions` or keep it.
- [`blocks_in_conditions`](https://rust-lang.github.io/rust-clippy/master/index.html#blocks_in_conditions) _does not trigger_
- [`derived_hash_with_manual_eq`](https://rust-lang.github.io/rust-clippy/master/index.html#derived_hash_with_manual_eq) triggers 12 times
- [`manual_is_multiple_of`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_multiple_of) triggers 6 times
- [`manual_range_contains`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_range_contains) triggers 4 times
- [`mutable_key_type`](https://rust-lang.github.io/rust-clippy/master/index.html#mutable_key_type) triggers 1 time
- [`wildcard_in_or_patterns`](https://rust-lang.github.io/rust-clippy/master/index.html#wildcard_in_or_patterns) triggers 1 time
