### PR TITLE
Convert most lint `allow` attributes to `expect`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,12 +168,13 @@ strip = true
 
 [workspace.lints.clippy]
 blocks_in_conditions = "allow"
-iter_over_hash_type = "warn"
+# See https://github.com/typst/typst/pull/6560#issuecomment-3045393640
+derived_hash_with_manual_eq = "allow"
 manual_is_multiple_of = "allow"
 manual_range_contains = "allow"
 mutable_key_type = "allow"
-uninlined_format_args = "warn"
 wildcard_in_or_patterns = "allow"
-# See https://github.com/typst/typst/pull/6560#issuecomment-3045393640
-derived_hash_with_manual_eq = "allow"
+
 disallowed_methods = "warn"
+iter_over_hash_type = "warn"
+uninlined_format_args = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,6 @@ strip = true
 
 [workspace.lints.clippy]
 blocks_in_conditions = "allow"
-comparison_chain = "allow"
 iter_over_hash_type = "warn"
 manual_is_multiple_of = "allow"
 manual_range_contains = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,6 @@ codegen-units = 1
 strip = true
 
 [workspace.lints.clippy]
-blocks_in_conditions = "allow"
 # See https://github.com/typst/typst/pull/6560#issuecomment-3045393640
 derived_hash_with_manual_eq = "allow"
 manual_is_multiple_of = "allow"

--- a/crates/typst-bundle/src/lib.rs
+++ b/crates/typst-bundle/src/lib.rs
@@ -137,7 +137,7 @@ pub fn bundle(
 
 /// The internal implementation of `bundle`.
 #[comemo::memoize]
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn bundle_impl(
     world: Tracked<dyn World + '_>,
     library: &LazyHash<Library>,

--- a/crates/typst-cli/build.rs
+++ b/crates/typst-cli/build.rs
@@ -7,7 +7,7 @@ use clap_complete::{Shell, generate_to};
 use clap_mangen::Man;
 
 #[path = "src/args.rs"]
-#[allow(dead_code)]
+#[expect(dead_code)]
 mod args;
 
 fn main() {

--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -655,7 +655,7 @@ display_possible_values!(Feature);
 
 /// A PDF standard that Typst can enforce conformance with.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, ValueEnum)]
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub enum PdfStandard {
     /// PDF 1.4.
     #[value(name = "1.4")]

--- a/crates/typst-cli/src/greet.rs
+++ b/crates/typst-cli/src/greet.rs
@@ -59,7 +59,7 @@ fn print_and_exit(message: &'static str) -> ! {
 }
 
 /// Waits for the user.
-#[allow(clippy::unused_io_amount)]
+#[expect(clippy::unused_io_amount)]
 fn pause() {
     eprintln!();
     eprintln!("Press enter to continue...");

--- a/crates/typst-eval/src/call.rs
+++ b/crates/typst-eval/src/call.rs
@@ -632,7 +632,7 @@ impl Eval for ast::Closure<'_> {
 
 /// Call the function in the context with the arguments.
 #[comemo::memoize]
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn eval_closure(
     func: &Func,
     closure: &LazyHash<Closure>,

--- a/crates/typst-eval/src/flow.rs
+++ b/crates/typst-eval/src/flow.rs
@@ -123,7 +123,6 @@ impl Eval for ast::ForLoop<'_> {
             (for $pat:ident in $iterable:expr) => {{
                 vm.scopes.enter();
 
-                #[allow(unused_parens)]
                 for value in $iterable {
                     destructure(vm, $pat, value.into_value())?;
 

--- a/crates/typst-eval/src/lib.rs
+++ b/crates/typst-eval/src/lib.rs
@@ -99,7 +99,7 @@ pub fn eval(
 /// Evaluates a string in the given syntax `mode` and returns the resulting
 /// value.
 #[comemo::memoize]
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn eval_string(
     world: Tracked<dyn World + '_>,
     library: &LazyHash<Library>,

--- a/crates/typst-html/src/document.rs
+++ b/crates/typst-html/src/document.rs
@@ -41,7 +41,7 @@ pub fn html_document(
 
 /// The internal implementation of `html_document`.
 #[comemo::memoize]
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn html_document_impl(
     world: Tracked<dyn World + '_>,
     library: &LazyHash<Library>,
@@ -96,7 +96,7 @@ pub fn html_document_for_bundle(
 
 /// The internal implementation of `html_document_for_bundle`.
 #[comemo::memoize]
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn html_document_for_bundle_impl(
     world: Tracked<dyn World + '_>,
     library: &LazyHash<Library>,
@@ -124,7 +124,7 @@ fn html_document_for_bundle_impl(
 
 /// The shared, unmemoized implementation of `html_document` and
 /// `html_document_for_bundle`.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn html_document_common(
     world: Tracked<dyn World + '_>,
     library: &LazyHash<Library>,

--- a/crates/typst-html/src/fragment.rs
+++ b/crates/typst-html/src/fragment.rs
@@ -38,7 +38,7 @@ pub fn html_block_fragment(
 
 /// The cached, internal implementation of [`html_block_fragment`].
 #[comemo::memoize]
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn html_block_fragment_impl(
     world: Tracked<dyn World + '_>,
     library: &LazyHash<Library>,

--- a/crates/typst-html/src/mathml.rs
+++ b/crates/typst-html/src/mathml.rs
@@ -1082,7 +1082,7 @@ fn handle_mathml(
 }
 
 /// Creates an `mo` element.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn make_mo(
     text: &str,
     span: Span,

--- a/crates/typst-kit/src/files.rs
+++ b/crates/typst-kit/src/files.rs
@@ -109,7 +109,7 @@ where
     /// in place with updated data, leading to improved incremental compilation
     /// performance.
     pub fn reset(&mut self) {
-        #[allow(clippy::iter_over_hash_type, reason = "order does not matter")]
+        #[expect(clippy::iter_over_hash_type, reason = "order does not matter")]
         for slot in self.slots.get_mut().values_mut() {
             slot.reset();
         }

--- a/crates/typst-kit/src/watcher.rs
+++ b/crates/typst-kit/src/watcher.rs
@@ -76,7 +76,7 @@ impl Watcher {
     pub fn update(&mut self, iter: impl IntoIterator<Item = PathBuf>) -> StrResult<()> {
         // Mark all files as not "seen" so that we may unwatch them if they
         // aren't in the dependency list.
-        #[allow(clippy::iter_over_hash_type, reason = "order does not matter")]
+        #[expect(clippy::iter_over_hash_type, reason = "order does not matter")]
         for seen in self.watched.values_mut() {
             *seen = false;
         }

--- a/crates/typst-layout/src/flow/collect.rs
+++ b/crates/typst-layout/src/flow/collect.rs
@@ -29,7 +29,6 @@ use crate::modifiers::layout_and_modify;
 /// Collects all elements of the flow into prepared children. These are much
 /// simpler to handle than the raw elements.
 #[typst_macros::time]
-#[allow(clippy::too_many_arguments)]
 pub fn collect<'a>(
     engine: &mut Engine,
     bump: &'a Bump,

--- a/crates/typst-layout/src/flow/collect.rs
+++ b/crates/typst-layout/src/flow/collect.rs
@@ -410,7 +410,7 @@ impl SingleChild<'_> {
 
 /// The cached, internal implementation of [`SingleChild::layout`].
 #[comemo::memoize]
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn layout_single_impl(
     world: Tracked<dyn World + '_>,
     library: &LazyHash<Library>,
@@ -510,7 +510,7 @@ impl<'a> MultiChild<'a> {
 
 /// The cached, internal implementation of [`MultiChild::layout_full`].
 #[comemo::memoize]
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn layout_multi_impl(
     world: Tracked<dyn World + '_>,
     library: &LazyHash<Library>,

--- a/crates/typst-layout/src/flow/mod.rs
+++ b/crates/typst-layout/src/flow/mod.rs
@@ -106,7 +106,7 @@ pub fn layout_columns(
 
 /// The cached, internal implementation of [`layout_fragment`].
 #[comemo::memoize]
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn layout_fragment_impl(
     world: Tracked<dyn World + '_>,
     library: &LazyHash<Library>,
@@ -187,7 +187,7 @@ impl From<FragmentKind> for FlowMode {
 }
 
 /// Lays out realized content into regions, potentially with columns.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn layout_flow<'a>(
     engine: &mut Engine,
     children: &[Pair<'a>],

--- a/crates/typst-layout/src/grid/lines.rs
+++ b/crates/typst-layout/src/grid/lines.rs
@@ -391,7 +391,7 @@ pub fn vline_stroke_at_row(
 ///
 /// This function assumes columns are sorted by increasing `x`, and rows are
 /// sorted by increasing `y`.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn hline_stroke_at_column(
     grid: &CellGrid,
     rows: &[RowPiece],

--- a/crates/typst-layout/src/grid/rowspans.rs
+++ b/crates/typst-layout/src/grid/rowspans.rs
@@ -608,7 +608,7 @@ impl GridLayouter<'_> {
     /// Returns `true` if we'll need to run a simulation to more accurately
     /// expand the auto row based on the rowspan's demanded size, or `false`
     /// otherwise.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn prepare_rowspan_sizes(
         &self,
         auto_row_y: usize,
@@ -698,7 +698,7 @@ impl GridLayouter<'_> {
     /// auto row will have to expand, given the current sizes of the auto row
     /// in each region and the pending rowspans' data (parent Y, rowspan amount
     /// and vector of requested sizes).
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn simulate_and_measure_rowspans_in_auto_row(
         &self,
         y: usize,
@@ -875,7 +875,7 @@ impl GridLayouter<'_> {
     ///
     /// If the simulations don't stabilize (they return 5 different and
     /// successively larger values), aborts and returns `false`.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn run_rowspan_simulation(
         &self,
         y: usize,
@@ -1055,7 +1055,7 @@ impl<'a> RowspanSimulator<'a> {
     /// `total_spanned_height + amount_to_grow` becomes larger than
     /// `requested_rowspan_height`, as the results are not going to become any
     /// more useful after that point.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn simulate_rowspan_layout(
         mut self,
         y: usize,

--- a/crates/typst-layout/src/inline/line.rs
+++ b/crates/typst-layout/src/inline/line.rs
@@ -483,7 +483,6 @@ pub fn apply_shift<'a>(
 }
 
 /// Commit to a line and build its frame.
-#[allow(clippy::too_many_arguments)]
 pub fn commit(
     engine: &mut Engine,
     p: &Preparation,

--- a/crates/typst-layout/src/inline/linebreak.rs
+++ b/crates/typst-layout/src/inline/linebreak.rs
@@ -530,7 +530,6 @@ fn linebreak_optimized_approximate(
 }
 
 /// Compute the stretch ratio and cost of a line.
-#[allow(clippy::too_many_arguments)]
 fn ratio_and_cost(
     p: &Preparation,
     metrics: &CostMetrics,

--- a/crates/typst-layout/src/inline/mod.rs
+++ b/crates/typst-layout/src/inline/mod.rs
@@ -68,7 +68,7 @@ pub fn layout_par(
 
 /// The internal, memoized implementation of `layout_par`.
 #[comemo::memoize]
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn layout_par_impl(
     elem: &Packed<ParElem>,
     world: Tracked<dyn World + '_>,
@@ -149,7 +149,7 @@ pub fn layout_inline<'a>(
 }
 
 /// The internal implementation of [`layout_inline`].
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn layout_inline_impl<'a>(
     engine: &mut Engine,
     children: &[Pair<'a>],

--- a/crates/typst-layout/src/inline/shaping.rs
+++ b/crates/typst-layout/src/inline/shaping.rs
@@ -782,7 +782,6 @@ fn is_compatible(a: Script, b: Script) -> bool {
 }
 
 /// Shape text into [`ShapedText`].
-#[allow(clippy::too_many_arguments)]
 fn shape<'a>(
     engine: &Engine,
     base: usize,

--- a/crates/typst-layout/src/math/cancel.rs
+++ b/crates/typst-layout/src/math/cancel.rs
@@ -70,7 +70,7 @@ pub fn layout_cancel(
 }
 
 /// Draws a cancel line.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn draw_cancel_line(
     engine: &mut Engine,
     length_scale: Rel<Abs>,

--- a/crates/typst-layout/src/pages/mod.rs
+++ b/crates/typst-layout/src/pages/mod.rs
@@ -49,7 +49,7 @@ pub fn layout_document(
 
 /// The internal implementation of `layout_document`.
 #[comemo::memoize]
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn layout_document_impl(
     world: Tracked<dyn World + '_>,
     library: &LazyHash<Library>,
@@ -96,7 +96,7 @@ pub fn layout_document_for_bundle(
 
 /// The internal implementation of `layout_document_for_bundle`.
 #[comemo::memoize]
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn layout_document_for_bundle_impl(
     world: Tracked<dyn World + '_>,
     library: &LazyHash<Library>,
@@ -124,7 +124,7 @@ fn layout_document_for_bundle_impl(
 
 /// The shared, unmemoized implementation of `layout_document` and
 /// `layout_document_for_bundle`.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn layout_document_common(
     library: &LazyHash<Library>,
     world: Tracked<dyn World + '_>,

--- a/crates/typst-layout/src/pages/run.rs
+++ b/crates/typst-layout/src/pages/run.rs
@@ -75,7 +75,7 @@ pub fn layout_page_run(
 
 /// The internal implementation of `layout_page_run`.
 #[comemo::memoize]
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn layout_page_run_impl(
     world: Tracked<dyn World + '_>,
     library: &LazyHash<Library>,

--- a/crates/typst-layout/src/shapes.rs
+++ b/crates/typst-layout/src/shapes.rs
@@ -483,7 +483,7 @@ impl ShapeKind {
 }
 
 /// Layout a shape.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn layout_shape(
     engine: &mut Engine,
     locator: Locator,

--- a/crates/typst-layout/src/stack.rs
+++ b/crates/typst-layout/src/stack.rs
@@ -64,7 +64,7 @@ where
 /// more deeply, such as for lists, which need a custom layout function that
 /// might borrow data from the environment for each list item (a stack child).
 /// Each child receives relevant layout data from the stack as well.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn layout_stack_internal<'a, F>(
     children: impl IntoIterator<Item = StackLayoutChild<'a, F>>,
     span: Span,

--- a/crates/typst-layout/src/transforms.rs
+++ b/crates/typst-layout/src/transforms.rs
@@ -185,7 +185,7 @@ pub fn layout_skew(
 }
 
 /// Applies a transformation to a frame, reflowing the layout if necessary.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn measure_and_layout(
     engine: &mut Engine,
     locator: Locator,

--- a/crates/typst-library/src/diag.rs
+++ b/crates/typst-library/src/diag.rs
@@ -1027,7 +1027,6 @@ impl LineCol {
     pub fn try_from_byte_pos(pos: usize, bytes: &[u8]) -> Option<Self> {
         let bytes = &bytes[..pos];
         let mut line = 0;
-        #[allow(clippy::double_ended_iterator_last)]
         let line_start = memchr::memchr_iter(b'\n', bytes)
             .inspect(|_| line += 1)
             .last()

--- a/crates/typst-library/src/foundations/auto.rs
+++ b/crates/typst-library/src/foundations/auto.rs
@@ -204,8 +204,6 @@ impl<T> Smart<T> {
     where
         T: Default,
     {
-        // we want to do this; the Clippy lint is not type-aware
-        #[allow(clippy::unwrap_or_default)]
         self.unwrap_or_else(T::default)
     }
 }

--- a/crates/typst-library/src/foundations/content/mod.rs
+++ b/crates/typst-library/src/foundations/content/mod.rs
@@ -734,7 +734,7 @@ impl Debug for SequenceElem {
 }
 
 // Derive is currently incompatible with `elem` macro.
-#[allow(clippy::derivable_impls)]
+#[expect(clippy::derivable_impls)]
 impl Default for SequenceElem {
     fn default() -> Self {
         Self { children: Default::default() }

--- a/crates/typst-library/src/foundations/content/vtable.rs
+++ b/crates/typst-library/src/foundations/content/vtable.rs
@@ -140,7 +140,7 @@ pub struct ContentVtable<T: 'static = RawContent> {
 
 impl ContentVtable {
     /// Creates the vtable for an element.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub const fn new<E: NativeElement>(
         name: &'static str,
         title: &'static str,

--- a/crates/typst-library/src/foundations/styles.rs
+++ b/crates/typst-library/src/foundations/styles.rs
@@ -1112,7 +1112,7 @@ mod rule {
                 // `&Content`. `Packed<T>` is a transparent wrapper around
                 // `Content`. The resulting function is unsafe to call because
                 // content of the correct type must be passed to it.
-                #[allow(clippy::missing_transmute_annotations)]
+                #[expect(clippy::missing_transmute_annotations)]
                 f: unsafe { std::mem::transmute(f) },
             }
         }

--- a/crates/typst-library/src/introspection/convergence.rs
+++ b/crates/typst-library/src/introspection/convergence.rs
@@ -142,7 +142,7 @@ pub trait Introspect: Debug + PartialEq + Hash + Send + Sync + Sized + 'static {
 /// A type-erased representation of an [introspection](Introspect) that was
 /// recorded during compilation.
 #[derive(Debug, Clone, Hash)]
-#[allow(clippy::derived_hash_with_manual_eq)]
+#[expect(clippy::derived_hash_with_manual_eq)]
 pub struct Introspection(Arc<dyn Bounds>);
 
 impl Introspection {

--- a/crates/typst-library/src/introspection/counter.rs
+++ b/crates/typst-library/src/introspection/counter.rs
@@ -906,7 +906,7 @@ fn sequence(
 
 /// Memoized implementation of `sequence`.
 #[comemo::memoize]
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn sequence_impl(
     counter: &Counter,
     selector: &Selector,

--- a/crates/typst-library/src/layout/container.rs
+++ b/crates/typst-library/src/layout/container.rs
@@ -175,7 +175,7 @@ impl Construct for InlineElem {
 
 impl InlineElem {
     /// Create an inline-level item with a custom layouter.
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     pub fn layouter<T: NativeElement>(
         captured: Packed<T>,
         callback: fn(
@@ -632,7 +632,7 @@ mod callbacks {
                         //   private field and `Content`'s `Clone` impl is
                         //   guaranteed to retain the type (if it didn't,
                         //   literally everything would break).
-                        #[allow(clippy::missing_transmute_annotations)]
+                        #[expect(clippy::missing_transmute_annotations)]
                         f: unsafe { std::mem::transmute(f) },
                     }
                 }

--- a/crates/typst-library/src/layout/grid/mod.rs
+++ b/crates/typst-library/src/layout/grid/mod.rs
@@ -881,7 +881,6 @@ impl Default for Packed<GridCell> {
 
 impl From<Content> for GridCell {
     fn from(value: Content) -> Self {
-        #[allow(clippy::unwrap_or_default)]
         value.unpack::<Self>().unwrap_or_else(Self::new)
     }
 }

--- a/crates/typst-library/src/layout/grid/resolve.rs
+++ b/crates/typst-library/src/layout/grid/resolve.rs
@@ -504,7 +504,7 @@ pub trait ResolvableCell {
     /// fill, align, inset and stroke properties, plus the expected value of
     /// the `breakable` field.
     /// Returns a final Cell.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn resolve_cell(
         self,
         x: usize,
@@ -904,7 +904,7 @@ impl CellGrid {
 /// Cells must implement Clone as they will be owned. Additionally, they
 /// must implement Default in order to fill positions in the grid which
 /// weren't explicitly specified by the user with empty cells.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn resolve_cellgrid<'a, T, C, I>(
     tracks: Axes<&'a [Sizing]>,
     gutter: Axes<&'a [Sizing]>,
@@ -1137,7 +1137,7 @@ impl CellGridResolver<'_, '_> {
     /// appropriate positions in the resolved grid. This is mostly relevant for
     /// items without fixed positions, such that they must be placed after the
     /// previous one, perhaps skipping existing cells along the way.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn resolve_grid_child<T, I>(
         &mut self,
         columns: usize,
@@ -1710,7 +1710,7 @@ impl CellGridResolver<'_, '_> {
     /// For example, an hline above the second row (y = 1) is inside the inner
     /// vector at position 1 of the first vector (hlines) returned by this
     /// function.
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     fn collect_lines(
         &self,
         pending_hlines: Vec<(Span, Line, bool)>,
@@ -2156,7 +2156,7 @@ fn check_for_conflicting_cell_row(
 /// indicate the first empty row available. Any rows before those should
 /// not be picked by cells with `auto` row positioning, since headers and
 /// footers occupy entire rows, and may not conflict with cells outside them.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn resolve_cell_position(
     cell_x: Smart<usize>,
     cell_y: Smart<usize>,

--- a/crates/typst-library/src/layout/grid/resolve.rs
+++ b/crates/typst-library/src/layout/grid/resolve.rs
@@ -1812,7 +1812,6 @@ impl CellGridResolver<'_, '_> {
     ///    an adjacent gutter row to be repeated alongside that header or
     ///    footer, if there is gutter;
     /// 3. Wrap headers and footers in the correct [`Repeatable`] variant.
-    #[allow(clippy::type_complexity)]
     fn finalize_headers_and_footers(
         &self,
         has_gutter: bool,

--- a/crates/typst-library/src/math/ir/item.rs
+++ b/crates/typst-library/src/math/ir/item.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::too_many_arguments)]
+#![expect(clippy::too_many_arguments)]
 use std::cell::Cell;
 use std::ops::{Deref, MulAssign};
 use std::rc::Rc;

--- a/crates/typst-library/src/math/ir/resolve.rs
+++ b/crates/typst-library/src/math/ir/resolve.rs
@@ -1109,7 +1109,7 @@ fn resolve_cases<'a, 'v, 'e>(
 /// Resolves the inner contents of a matrix, vector, or cases.
 ///
 /// The contents of the cells are resolved in denominator style.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn resolve_cells<'a, 'v, 'e>(
     ctx: &mut MathResolver<'a, 'v, 'e>,
     styles: StyleChain<'a>,

--- a/crates/typst-library/src/model/table.rs
+++ b/crates/typst-library/src/model/table.rs
@@ -798,7 +798,6 @@ impl Default for Packed<TableCell> {
 
 impl From<Content> for TableCell {
     fn from(value: Content) -> Self {
-        #[allow(clippy::unwrap_or_default)]
         value.unpack::<Self>().unwrap_or_else(Self::new)
     }
 }

--- a/crates/typst-library/src/pdf/accessibility.rs
+++ b/crates/typst-library/src/pdf/accessibility.rs
@@ -342,7 +342,7 @@ macro_rules! pdf_marker_tag {
         impl PdfMarkerTag {
             $(
                 #[doc = $doc]
-                #[allow(non_snake_case)]
+                #[expect(non_snake_case)]
                 pub fn $variant($($($name: $ty,)+)? body: Content) -> Content {
                     let span = body.span();
                     Self {

--- a/crates/typst-library/src/text/deco.rs
+++ b/crates/typst-library/src/text/deco.rs
@@ -293,7 +293,7 @@ pub struct Decoration {
 
 /// A kind of decorative line.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 pub enum DecoLine {
     Underline {
         stroke: Stroke<Abs>,

--- a/crates/typst-library/src/text/font/exceptions.rs
+++ b/crates/typst-library/src/text/font/exceptions.rs
@@ -36,7 +36,6 @@ impl Exception {
         Self { weight: Some(FontWeight(weight)), ..self }
     }
 
-    #[allow(unused)] // left for future use
     const fn stretch(self, stretch: u16) -> Self {
         Self { stretch: Some(FontStretch(stretch)), ..self }
     }

--- a/crates/typst-library/src/visualize/gradient.rs
+++ b/crates/typst-library/src/visualize/gradient.rs
@@ -195,7 +195,7 @@ pub enum Gradient {
 }
 
 #[scope]
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 impl Gradient {
     /// Creates a new linear gradient, in which colors transition along a
     /// straight line.

--- a/crates/typst-library/src/visualize/stroke.rs
+++ b/crates/typst-library/src/visualize/stroke.rs
@@ -299,8 +299,6 @@ impl Stroke<Abs> {
 
     /// Unpack the stroke, filling missing fields with the default values.
     pub fn unwrap_or_default(self) -> FixedStroke {
-        // we want to do this; the Clippy lint is not type-aware
-        #[allow(clippy::unwrap_or_default)]
         self.unwrap_or(FixedStroke::default())
     }
 }

--- a/crates/typst-macros/src/cast.rs
+++ b/crates/typst-macros/src/cast.rs
@@ -185,7 +185,7 @@ struct Cast {
 }
 
 /// A pattern in a cast, e.g.`"ascender"` or `v: i64`.
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 enum Pattern {
     Str(syn::LitStr),
     Ty(syn::Pat, syn::Type),

--- a/crates/typst-macros/src/elem.rs
+++ b/crates/typst-macros/src/elem.rs
@@ -281,7 +281,7 @@ fn create_struct(element: &Elem) -> TokenStream {
     quote! {
         #[doc = #oneliner]
         #[derive(Hash, #debug Clone)]
-        #[allow(rustdoc::broken_intra_doc_links)]
+        #[expect(rustdoc::broken_intra_doc_links)]
         #vis struct #ident {
             #(#fields,)*
         }
@@ -320,7 +320,7 @@ fn create_inherent_impl(element: &Elem) -> TokenStream {
             #new_func
             #(#with_field_methods)*
         }
-        #[allow(non_upper_case_globals)]
+        #[expect(non_upper_case_globals)]
         impl #ident {
             #(#style_consts)*
         }

--- a/crates/typst-macros/src/func.rs
+++ b/crates/typst-macros/src/func.rs
@@ -263,7 +263,7 @@ fn create(func: &Func, item: &syn::ItemFn) -> TokenStream {
         let ident_data = quote::format_ident!("{ident}_data");
         quote! {
             #[doc(hidden)]
-            #[allow(non_snake_case)]
+            #[expect(non_snake_case)]
             #vis fn #ident_data() -> &'static #foundations::NativeFuncData {
                 static DATA: #foundations::NativeFuncData = #data;
                 &DATA
@@ -273,8 +273,8 @@ fn create(func: &Func, item: &syn::ItemFn) -> TokenStream {
 
     quote! {
         #[doc = #oneliner]
-        #[allow(dead_code)]
-        #[allow(rustdoc::broken_intra_doc_links)]
+        #[expect(dead_code)]
+        #[expect(rustdoc::broken_intra_doc_links)]
         #item
 
         #[doc(hidden)]
@@ -352,7 +352,7 @@ fn create_func_ty(func: &Func) -> Option<TokenStream> {
     let Func { vis, ident, .. } = func;
     Some(quote! {
         #[doc(hidden)]
-        #[allow(non_camel_case_types)]
+        #[expect(non_camel_case_types)]
         #vis enum #ident {}
     })
 }

--- a/crates/typst-macros/src/scope.rs
+++ b/crates/typst-macros/src/scope.rs
@@ -105,7 +105,7 @@ pub fn scope(stream: TokenStream, item: syn::Item) -> Result<TokenStream> {
                 #constructor
             }
 
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             fn scope() -> #foundations::Scope {
                 let mut scope = #foundations::Scope::deduplicating();
                 #(#definitions;)*
@@ -215,7 +215,7 @@ fn rewrite_primitive_base(item: &syn::ItemImpl, ident_ext: &syn::Ident) -> Token
 
     let self_ty = &item.self_ty;
     quote! {
-        #[allow(non_camel_case_types)]
+        #[expect(non_camel_case_types)]
         trait #ident_ext {
             #(#sigs)*
         }

--- a/crates/typst-macros/src/util.rs
+++ b/crates/typst-macros/src/util.rs
@@ -215,7 +215,7 @@ impl<T: Parse> Parse for Array<T> {
 }
 
 /// Shorthand for `::typst_library::foundations`.
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub struct foundations;
 
 impl quote::ToTokens for foundations {
@@ -246,7 +246,7 @@ impl Parse for BlockWithReturn {
 }
 
 /// Parse a bare `type Name;` item.
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub struct BareType {
     pub attrs: Vec<Attribute>,
     pub type_token: Token![type],

--- a/crates/typst-pdf/src/lib.rs
+++ b/crates/typst-pdf/src/lib.rs
@@ -274,7 +274,7 @@ impl Hash for PdfStandards {
 ///
 /// Support for more standards is planned.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 #[non_exhaustive]
 pub enum PdfStandard {
     /// PDF 1.4.

--- a/crates/typst-pdf/src/tags/context/grid.rs
+++ b/crates/typst-pdf/src/tags/context/grid.rs
@@ -14,7 +14,7 @@ pub(super) trait GridExt {
     /// Convert from "effective" positions inside the cell grid, which may
     /// include gutter tracks in addition to the cells, to conventional
     /// positions.
-    #[allow(clippy::wrong_self_convention)]
+    #[expect(clippy::wrong_self_convention)]
     fn from_effective(&self, i: usize) -> u32;
 
     /// Convert from conventional positions to "effective" positions inside the

--- a/crates/typst-pdf/src/tags/tree/build.rs
+++ b/crates/typst-pdf/src/tags/tree/build.rs
@@ -196,7 +196,7 @@ pub fn build(document: &PagedDocument, options: &PdfOptions) -> SourceResult<Tre
     .at(Span::detached())?;
 
     // Insert logical children into the tree.
-    #[allow(clippy::iter_over_hash_type)]
+    #[expect(clippy::iter_over_hash_type)]
     for (loc, children) in tree.logical_children.iter() {
         let located = (tree.groups.by_loc(loc))
             .expect_internal("parent group")
@@ -336,7 +336,7 @@ fn visit_end_tag(tree: &mut TreeBuilder, loc: Location) -> SourceResult<()> {
 
 fn progress_tree_start(tree: &mut TreeBuilder, elem: &Content) -> GroupId {
     // Artifacts
-    #[allow(clippy::redundant_pattern_matching)]
+    #[expect(clippy::redundant_pattern_matching)]
     if let Some(_) = elem.to_packed::<HideElem>() {
         push_artifact(tree, elem, ArtifactType::Other)
     } else if let Some(artifact) = elem.to_packed::<ArtifactElem>() {

--- a/crates/typst-pdf/src/tags/util/idvec.rs
+++ b/crates/typst-pdf/src/tags/util/idvec.rs
@@ -30,7 +30,6 @@ impl<T> IdVec<T> {
         &mut self.inner[id.idx()]
     }
 
-    #[allow(unused)]
     pub fn iter(&self) -> std::slice::Iter<'_, T> {
         self.inner.iter()
     }

--- a/crates/typst-svg/src/text.rs
+++ b/crates/typst-svg/src/text.rs
@@ -111,7 +111,7 @@ impl SVGRenderer<'_> {
     }
 
     /// Render a pre-scaled path glyph defined by an outline.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn render_path_glyph(
         &mut self,
         svg: &mut SvgElem,

--- a/crates/typst-syntax/src/parser.rs
+++ b/crates/typst-syntax/src/parser.rs
@@ -1573,10 +1573,10 @@ enum AtNewline {
 impl AtNewline {
     /// Whether to stop at a newline or continue based on the current context.
     fn stop_at(self, Newline { column, parbreak }: Newline, kind: SyntaxKind) -> bool {
-        #[allow(clippy::match_like_matches_macro)]
         match self {
             AtNewline::Continue => false,
             AtNewline::Stop => true,
+            #[expect(clippy::match_like_matches_macro)]
             AtNewline::ContextualContinue => match kind {
                 SyntaxKind::Else | SyntaxKind::Dot => false,
                 _ => true,

--- a/docs/src/live.rs
+++ b/docs/src/live.rs
@@ -155,7 +155,7 @@ fn has_attr(attrs: &[syn::Attribute], ident: &str) -> bool {
 }
 
 /// Parse a bare `type Name;` item.
-#[allow(dead_code)]
+#[expect(dead_code)]
 struct BareType {
     attrs: Vec<syn::Attribute>,
     type_token: syn::Token![type],

--- a/tests/fuzz/Cargo.toml
+++ b/tests/fuzz/Cargo.toml
@@ -19,6 +19,9 @@ typst-syntax = { workspace = true }
 comemo = { workspace = true }
 libfuzzer-sys = { workspace = true }
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "parse"
 path = "src/bin/parse.rs"

--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -204,7 +204,7 @@ fn undangle() {
             }
 
             // Remove dangling hashes from file.
-            #[allow(clippy::iter_over_hash_type)]
+            #[expect(clippy::iter_over_hash_type)]
             for (path, names) in dangling_hashes {
                 let text = std::fs::read_to_string(path).unwrap();
                 let mut hashed_refs = HashedRefs::from_str(&text).unwrap();

--- a/tests/wrapper/Cargo.toml
+++ b/tests/wrapper/Cargo.toml
@@ -5,3 +5,6 @@ rust-version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
 publish = false
+
+[lints]
+workspace = true


### PR DESCRIPTION
This is the second of a few stacked PRs inspired by the blog posts [Your Clippy Config Should Be Stricter](https://emschwartz.me/your-clippy-config-should-be-stricter/) and [Your Clippy Config Should Be Stricter-er](https://billylevin.dev/posts/clippy-config/).

Prior PR: #8521
New commits: **Remove unneeded `allow` attributes** and **Convert most lint `allow` attributes to `expect`**.
[Full diff from the previous PR](https://github.com/isuffix/typst/compare/lint-cleanup...allow-to-expect)

---

Using  `expect` attributes causes clippy to warn if a lint _doesn't_ trigger, which is a much nicer behavior than just allowing the lint since it can notify us to remove attributes that no longer apply. Indeed, the first commit removes 13 unneeded attributes!

And with the help of `rg '#\[allow'`, I audited and converted all of our still necessary `allow` attributes to `expect`.

Only 10 instances of `allow` still remain, each for one of the following reasons:

The uses of `OptionExt::map_or_default` require `allow(unstable_name_collisions)` and `allow(unused_imports)` so they work on the nightly compiler. But it looks like the standard library method [should stabilize](https://github.com/rust-lang/rust/issues/138099) in Rust 1.97!

The uses of `allow(clippy::needless_lifetimes)` are due to `comemo::track`, and could be removed since the false-positive for that behavior is fixed, however I'm replacing them with `expect(clippy::elidable_lifetime_names)` due to another false-positive in a later PR, so I'm simply not touching them here.

The rest are due to conditional macro expansions:
- `unused_mut` in macros that conditionally mutate a value
- `unused_variables` due to some conditional `cfg` attributes
- `irrefutable_let_patterns` for a `.try_from()` call with `Err(Infallible)` on only some of the used types
