### PR TITLE
text/raw: merge adjacent same-style tokens to enable OpenType ligatures

### DIFF
--- a/crates/typst-library/src/text/raw.rs
+++ b/crates/typst-library/src/text/raw.rs
@@ -589,17 +589,27 @@ impl Packed<RawElem> {
             for (i, (line, line_span)) in lines.into_iter().enumerate() {
                 let mut line_content = vec![];
                 let mut span_offset = 0;
-                for (style, piece) in highlighter
+                // Merge adjacent tokens with identical styles so that
+                // OpenType ligatures can form across token boundaries
+                // (e.g. `|>` in R with Fira Code / Cascadia Code).
+                let tokens = highlighter
                     .highlight_line(line.as_str(), syntax_set)
                     .into_iter()
                     .flatten()
-                {
+                    .fold(Vec::<(synt::Style, String)>::new(), |mut acc, (style, piece)| {
+                        match acc.last_mut() {
+                            Some(last) if last.0 == style => last.1.push_str(piece),
+                            _ => acc.push((style, piece.to_owned())),
+                        }
+                        acc
+                    });
+                for (style, piece) in &tokens {
                     line_content.push(styled(
                         routines,
                         target,
                         piece,
                         foreground,
-                        style,
+                        *style,
                         line_span,
                         span_offset,
                     ));


### PR DESCRIPTION
## Problem

When a syntax-highlighted raw block is rendered, syntect tokenizes the text and each token becomes a separate `Content` element. OpenType ligatures cannot form across element boundaries because each element is shaped as its own independent text run.

This means multi-character operators that get split into separate same-style tokens — such as `|>` in R with fonts like Fira Code or Cascadia Code — never render as ligatures.

## Fix

In `crates/typst-library/src/text/raw.rs`, merge adjacent tokens that share an identical `synt::Style` before calling `styled()`. Since the merged tokens have exactly the same style, the visual output is identical. The only difference is that they now form a single text run, allowing OpenType ligatures to work.

```rust
// Before: each token → separate Content element
for (style, piece) in highlighter.highlight_line(...) {
    line_content.push(styled(..., piece, style, ...));
}

// After: adjacent same-style tokens → single Content element
let tokens = highlighter
    .highlight_line(...)
    .fold(vec![], |mut acc, (style, piece)| {
        match acc.last_mut() {
            Some(last) if last.0 == style => last.1.push_str(piece),
            _ => acc.push((style, piece.to_owned())),
        }
        acc
    });
for (style, piece) in &tokens {
    line_content.push(styled(..., piece, *style, ...));
}
```