### PR TITLE
[FEAT] Reload system fonts before complaining font not found in watch mode

### DIFF
--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -264,7 +264,16 @@ pub fn compile_once(
         Status::Compiling.print(config).unwrap();
     }
 
-    let Warned { output, mut warnings } = compile_and_export(world, config);
+    let mut warned = compile_and_export(world, config);
+
+    // In watch mode, a font referenced by the document may have been installed after the session started, so it isn't in the cached system font list.
+    // Before reporting it as unknown, re-scan the fonts and recompile once to pick up any newly installed fonts.
+    if config.watching && has_unknown_font_warning(&warned.warnings) {
+        world.reload_fonts();
+        warned = compile_and_export(world, config);
+    }
+
+    let Warned { output, mut warnings } = warned;
 
     // Add static warnings (for deprecated CLI flags and such).
     for warning in config.warnings.iter() {
@@ -311,6 +320,13 @@ pub fn compile_once(
     }
 
     Ok(())
+}
+
+/// Whether any of the given warnings reports an unknown font family.
+fn has_unknown_font_warning(warnings: &[SourceDiagnostic]) -> bool {
+    warnings
+        .iter()
+        .any(|warning| warning.message.starts_with("unknown font family"))
 }
 
 /// Compile and then export the document.

--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -19,7 +19,7 @@ use typst_kit::files::{FileLoader, FileStore, FsRoot};
 use typst_kit::fonts::FontStore;
 use typst_kit::packages::SystemPackages;
 
-use crate::args::{Feature, Input, ProcessArgs, WorldArgs};
+use crate::args::{Feature, FontArgs, Input, ProcessArgs, WorldArgs};
 
 /// A world that provides access to the operating system.
 pub struct SystemWorld {
@@ -29,6 +29,8 @@ pub struct SystemWorld {
     library: LazyHash<Library>,
     /// Metadata about discovered fonts and lazily loaded fonts.
     fonts: LazyLock<FontStore, Box<dyn Fn() -> FontStore + Send + Sync>>,
+    /// The font arguments, kept so that fonts can be re-scanned in watch mode.
+    font_args: &'static FontArgs,
     /// Maps file ids to source files and buffers.
     files: FileStore<SystemFiles>,
     /// The current datetime if requested. This is stored here to ensure it is
@@ -79,6 +81,7 @@ impl SystemWorld {
             fonts: LazyLock::new(Box::new(|| {
                 crate::fonts::discover_fonts(&world_args.font)
             })),
+            font_args: &world_args.font,
             files: FileStore::new(SystemFiles::new(input, world_args)?),
             now,
         })
@@ -110,6 +113,17 @@ impl SystemWorld {
     ///
     /// Does nothing if the fonts were already scanned.
     pub fn scan_fonts(&mut self) {
+        LazyLock::force(&self.fonts);
+    }
+
+    /// Discards the cached fonts and re-scans all configured font sources.
+    ///
+    /// This is used in watch mode to pick up fonts that were installed after the session started.
+    pub fn reload_fonts(&mut self) {
+        let font_args = self.font_args;
+        self.fonts =
+            LazyLock::new(Box::new(move || crate::fonts::discover_fonts(font_args)));
+
         LazyLock::force(&self.fonts);
     }
 }


### PR DESCRIPTION
Closes #8318.

When a font is installed after `typst watch` has started, it never showed up in the cached system font list, so it kept being reported as "unknown font family" until the watcher was restarted.

This re-scans the fonts on recompilation: if a compilation produces an unknown-font warning while watching, the font sources are reloaded and the document is compiled once more before the warning is reported. Plain `typst compile` is unaffected.

Tested manually: started a watch on a document referencing a missing font, dropped the font into the `--font-path` directory, then edited the source to trigger a recompile. The warning disappears and it compiles successfully without restarting the watcher.
