### PR TITLE
Use `abs` in a docs code example

### DIFF
--- a/crates/typst-library/src/math/lr.rs
+++ b/crates/typst-library/src/math/lr.rs
@@ -40,7 +40,7 @@ pub struct LrElem {
 /// Scales delimiters vertically to the nearest surrounding `{lr()}` group.
 ///
 /// ```example
-/// $ { x mid(|) sum_(i=1)^n w_i|f_i (x)| < 1 } $
+/// $ { x mid(|) sum_(i=1)^n w_i abs(f_i (x)) < 1 } $
 /// ```
 #[elem(Mathy)]
 pub struct MidElem {


### PR DESCRIPTION
I noticed that this example in the docs was using `| ... |` (which won't match properly) instead of `math.abs`.