### PR TITLE
Compare file modules by file id

### DIFF
--- a/crates/typst-library/src/foundations/module.rs
+++ b/crates/typst-library/src/foundations/module.rs
@@ -1,4 +1,5 @@
 use std::fmt::{self, Debug, Formatter};
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use ecow::{EcoString, eco_format};
@@ -45,7 +46,7 @@ use crate::foundations::{Content, Repr, Scope, Value, ty};
 /// therefore access its contents dynamically, using the
 /// @dictionary.constructor[dictionary constructor].
 #[ty(cast)]
-#[derive(Clone, Hash)]
+#[derive(Clone)]
 pub struct Module {
     /// The module's name.
     name: Option<EcoString>,
@@ -176,6 +177,27 @@ impl Repr for Module {
 
 impl PartialEq for Module {
     fn eq(&self, other: &Self) -> bool {
-        self.name == other.name && Arc::ptr_eq(&self.inner, &other.inner)
+        if self.name != other.name {
+            return false;
+        }
+
+        if Arc::ptr_eq(&self.inner, &other.inner) {
+            return true;
+        }
+
+        matches!(
+            (self.inner.file_id, other.inner.file_id),
+            (Some(self_id), Some(other_id)) if self_id == other_id
+        )
+    }
+}
+
+impl Hash for Module {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+        match self.inner.file_id {
+            Some(file_id) => file_id.hash(state),
+            None => self.inner.hash(state),
+        }
     }
 }


### PR DESCRIPTION
`Module` equality previously required matching names and `Arc` pointer identity. That is too strict for file-backed modules. In `import-nested-item`, `orig-chap2` imports `modules/chap2.typ` directly, while `chap2` is re-exported through `module.typ`. Both paths resolve to the same `FileId`, but the nested import evaluates `chap2` with `module.typ` already on the import `Route`. Since `Route` is part of the memoized eval input, comemo may materialize a distinct `Module` value with a distinct `Arc` even though it represents the same file module.

Keep the existing fast path for shared `Arc`s, but allow same-named file-backed modules to compare equal when their `FileId` matches. Implement `Hash` manually so file-backed modules hash by `FileId` while anonymous and other non-file modules keep the existing inner-value hash behavior.

This fixes test failure on riscv64:

    Running src/tests.rs (target/debug/deps/tests-eb14e3db602ad826)
    import-nested-item (tests/suite/scripting/import.typ:49)
      not annotated
        Error: 5:2-5:25 Assertion failed: <module chap2> != <module chap2>

Validation in riscv64:

- `cargo test -p typst-tests --test tests -- --exact import-nested-item --no-report --verbose`

- `cargo test --workspace`

<!--
Thanks for your interest in landing a change in Typst! Before opening the PR, please review our contribution guidelines: https://github.com/typst/typst/blob/main/CONTRIBUTING.md

In particular, please keep in mind that we do not accept contributions implemented by an AI model. We would also ask you to refrain from using AI to write your pull request description. Summarizing your work helps organizing your thoughts as much as it helps us with seeing the human thought process behind a particular change.
-->
