### PR TITLE
Forward pretty format option to nested SVG frames

### DIFF
--- a/crates/typst-html/src/encode.rs
+++ b/crates/typst-html/src/encode.rs
@@ -398,5 +398,17 @@ fn write_frame(w: &mut Writer, frame: &HtmlFrame) {
         &frame.anchors,
         w.link_resolver,
     );
-    w.buf.push_str(&svg);
+
+    if w.pretty {
+        // Indent the SVG after generation. This ensures the frame is cached no
+        // matter the current indentation of the outer HTML.
+        for (i, line) in svg.lines().enumerate() {
+            if i != 0 {
+                write_indent(w);
+            }
+            w.buf.push_str(line);
+        }
+    } else {
+        w.buf.push_str(&svg);
+    }
 }

--- a/crates/typst-svg/src/lib.rs
+++ b/crates/typst-svg/src/lib.rs
@@ -89,10 +89,7 @@ pub fn svg_in_html(
     link_resolver: Tracked<LateLinkResolver>,
 ) -> String {
     let mut renderer = SVGRenderer::with_options(Some(link_resolver));
-    let mut xml = XmlWriter::new(xmlwriter::Options {
-        indent: xmlwriter::Indent::None,
-        ..xml_options(pretty)
-    });
+    let mut xml = XmlWriter::new(xml_options(pretty));
     let mut svg = svg_header_with_custom_attrs(&mut xml, frame.size(), |svg| {
         if let Some(id) = id {
             svg.attr("id", id);

--- a/tests/ref/bundle/link-bundle-html-frame.txt
+++ b/tests/ref/bundle/link-bundle-html-frame.txt
@@ -1,2 +1,2 @@
 5caa14f2425347763746e46baed2a725 index.html
-7719c156941e5d000349af0abf2337de folder/a.html
+1fe4c62d11dc09f78c89e735f7ce9f0c folder/a.html

--- a/tests/ref/html/hashes.txt
+++ b/tests/ref/html/hashes.txt
@@ -20,13 +20,13 @@ c456aecc3b410f0b4f8705fc87e6d499 bibliography-group-mixed-styles
 805860e9a2d6bc7f9e466517c058eeec block-box-html
 2771d670b32a96e330e3db46aebd5f5b block-display-html
 ffa25d90e2baac1e02b03a60cae89720 block-html-block
-3c77f2f38c8f3fa6c90b1beb10c5d722 block-html-frame
+408fa53d2d35abe39c279f182a7c5df3 block-html-frame
 56e9ac9cf5876bc5ebbdd43b1a640a99 block-html-inline
 083d9124f7249ddd06de82bab51e932d block-html-multiple
 0b57400a2448caf6d434728014f5f047 block-html-text
 2b2857e0703e2211a74a25da543ec421 block-invalid-html
 33daaa5982a84b668f506461b070bf11 box-block-html
-800ffd92f70fed0affed4b5731aab0d1 box-html-frame
+627d1c6c247afedf8cba16543c7889bf box-html-frame
 33daaa5982a84b668f506461b070bf11 box-html-inline
 8aeeb8c8a69284b88f9c1464ecab9795 box-html-multiple
 9c97626487e554505316c09c201e2672 box-html-text
@@ -58,7 +58,7 @@ e34ea44e32ada9e0685b72d6e82ecfd5 html-elem-attrs-fold
 2ea76ccf8bdc8f8a39f586aab6ed80c9 html-elem-custom
 52de31c777d4b7b8d356b54138b5fe14 html-elem-metadata
 0a1d1443e72ef554d74d15ae49cd076c html-escapable-raw-text-contains-closing-tag
-30c425a860c27388ccda71cdd5d49e5f html-frame
+41d47680056dc0777c4060cf3ecc8c6a html-frame
 1e1005b4ac5db07bd074e5d12aa2162e html-pre-starting-with-newline
 9ddbaca4b63c936215a967cb76b0327a html-script
 de4b0b9e9a41128ffdb982bae7550178 html-space-collapsing
@@ -95,8 +95,8 @@ b1b17f3b81e381628200be8eee0a7e27 issue-7437-math-accent-text-presentation
 51719643a3ad5c5a58e9a93141653d28 issue-8261-string-as-non-numeric
 08eef154f592feabbe8e2ef7915d1f73 issue-math-realize-scripting
 44fbc75996ca7154896d82a2cc32da32 link-basic
-64f6d891e22ff529a703605d80ac4ab7 link-html-frame
-3ba326b82bb0c42ddea6c3266fda9c87 link-html-frame-ref
+a401e6e8dbbfb91c6fcd9f50b0812f00 link-html-frame
+aecca822229f41f10fdcfae3954413f1 link-html-frame-ref
 49c235cf678e473ea05818dfa2846180 link-html-here
 85145829d953d451be76af5b4f9369cb link-html-id-attach
 5ffe20ca590c5e8ce14f77537aae6b31 link-html-id-existing


### PR DESCRIPTION
This passes the `pretty` parameter of `HTML` to nested SVG elements, which seems expected.
Before the nested SVGs were always minimized, which was an oversight in #8371.