### PR TITLE
Improve `spot.name` documentation

### DIFF
--- a/crates/typst-library/src/visualize/color.rs
+++ b/crates/typst-library/src/visualize/color.rs
@@ -2336,9 +2336,9 @@ impl SpotColorant {
         /// #link("https://en.wikipedia.org/wiki/Offset_printing#Plates")[color plates],
         /// use of this colorant will result in the specified tint being applied
         /// equally to all plates. If you choose `{none}`, no colorant will be
-        /// applied when using this color. Instead, you can use a spot color
-        /// with the name `{"none"}` to indicate cuts or varnishes. Be sure to
-        /// discuss this with your production printer!
+        /// applied when using this color. This special value is often used to
+        /// indicate cuts or varnishes. Be sure to discuss this with your
+        /// production printer!
         ///
         /// We do not recommend using the names `{"Cyan"}`, `{"Magenta"}`,
         /// `{"Yellow"}`, `{"Key"}`, `{"Black"}`, or their translations to your

--- a/crates/typst-library/src/visualize/color.rs
+++ b/crates/typst-library/src/visualize/color.rs
@@ -2337,7 +2337,7 @@ impl SpotColorant {
         /// use of this colorant will result in the specified tint being applied
         /// equally to all plates. If you choose `{none}`, no colorant will be
         /// applied when using this color. Instead, you can use a spot color
-        /// with the name `{none}` to indicate cuts or varnishes. Be sure to
+        /// with the name `{"none"}` to indicate cuts or varnishes. Be sure to
         /// discuss this with your production printer!
         ///
         /// We do not recommend using the names `{"Cyan"}`, `{"Magenta"}`,


### PR DESCRIPTION
Seems to refer to a custom named color "none", not the Typst `none`.
At least that is my understanding, because:
- the previous sentence already mentioned the behavior for `none`
- the edited sentence starts with "Instead ...", suggesting that it describes something other than behavior for `none`

(Please let me know if I misunderstood it.)