### PR TITLE
Document how to avoid link syntax

### DIFF
--- a/crates/typst-library/src/model/link.rs
+++ b/crates/typst-library/src/model/link.rs
@@ -44,9 +44,9 @@ use crate::text::{LocalName, TextElem};
 /// `https://` is automatically turned into a link.
 ///
 /// To avoid turning into a link, you can put the text in a @str[string] like
-/// `[#"https://*.com"]`, or a @raw[`raw` element] like #raw("[`https://*.com`]").
-/// Note that the text may still be clickable in PDF, because some PDF readers
-/// auto-detect links.
+/// `[#"https://example.com"]`. If the text is a computer code, you may also put
+/// it in a @raw[`raw` element] like #raw("[`https://*.com`]"). Note that the text
+/// may still be clickable in PDF, because some PDF readers auto-detect links.
 ///
 /// = Hyphenation <hyphenation>
 /// If you enable hyphenation or justification, by default, it will not apply to

--- a/crates/typst-library/src/model/link.rs
+++ b/crates/typst-library/src/model/link.rs
@@ -43,6 +43,11 @@ use crate::text::{LocalName, TextElem};
 /// This function also has dedicated syntax: Text that starts with `http://` or
 /// `https://` is automatically turned into a link.
 ///
+/// To avoid turning into a link, you can put the text in a @str[string] like
+/// `[#"https://*.com"]`, or a @raw[`raw` element] like #raw("[`https://*.com`]").
+/// Note that the text may still be clickable in PDF, because some PDF readers
+/// add additional links.
+///
 /// = Hyphenation <hyphenation>
 /// If you enable hyphenation or justification, by default, it will not apply to
 /// links to prevent unwanted hyphenation in URLs. You can opt out of this

--- a/crates/typst-library/src/model/link.rs
+++ b/crates/typst-library/src/model/link.rs
@@ -46,7 +46,7 @@ use crate::text::{LocalName, TextElem};
 /// To avoid turning into a link, you can put the text in a @str[string] like
 /// `[#"https://*.com"]`, or a @raw[`raw` element] like #raw("[`https://*.com`]").
 /// Note that the text may still be clickable in PDF, because some PDF readers
-/// add additional links.
+/// auto-detect links.
 ///
 /// = Hyphenation <hyphenation>
 /// If you enable hyphenation or justification, by default, it will not apply to

--- a/crates/typst-library/src/model/link.rs
+++ b/crates/typst-library/src/model/link.rs
@@ -43,10 +43,24 @@ use crate::text::{LocalName, TextElem};
 /// This function also has dedicated syntax: Text that starts with `http://` or
 /// `https://` is automatically turned into a link.
 ///
-/// To avoid turning into a link, you can put the text in a @str[string] like
-/// `[#"https://example.com"]`. If the text is a computer code, you may also put
-/// it in a @raw[`raw` element] like #raw("[`https://*.com`]"). Note that the text
-/// may still be clickable in PDF, because some PDF readers auto-detect links.
+/// To avoid automatic creation of a link, you can put the text in a
+/// @str[string]. To embed the string in markup, prefix it with a hash.
+/// Alternatively, if the link-like text is computer code, you may also put it
+/// in a @raw[`raw` element]. Note that, in both cases, the text may remain
+/// clickable in PDF because some PDF readers auto-detect links.
+///
+/// ```example
+/// #show link: set text(blue)
+///
+/// // Automatic link
+/// https://example.com
+///
+/// // String, not a link
+/// #"https://example.com"
+///
+/// // Raw, not a link
+/// `https://*.com`
+/// ```
 ///
 /// = Hyphenation <hyphenation>
 /// If you enable hyphenation or justification, by default, it will not apply to


### PR DESCRIPTION
<!--
Thanks for your interest in landing a change in Typst! Before opening the PR, please review our contribution guidelines: https://github.com/typst/typst/blob/main/CONTRIBUTING.md

In particular, please keep in mind that we do not accept contributions implemented by an AI model. We would also ask you to refrain from using AI to write your pull request description. Summarizing your work helps organizing your thoughts as much as it helps us with seeing the human thought process behind a particular change.
-->

Several days ago, a poor friend found SumatraPDF keeps turning `mAP@0.5` in a `table` into `mailto:mAP@0.5`.
It would be helpful if typst's doc on `link` mentions the quirk.
