### PR TITLE
Use `https://` URL in documentation

### DIFF
--- a/docs/content/guides/page-setup.typ
+++ b/docs/content/guides/page-setup.typ
@@ -53,7 +53,7 @@ This page is a square.
 ```
 
 == #short-or-long[Change Margins][Change the page's margins] <change-margins>
-Margins are a vital ingredient for good typography: #link("http://webtypography.net/2.1.2")[Typographers consider lines that fit between 45 and 75 characters best length for legibility] and your margins and @guides:page-setup:columns[columns] help define line widths. By default, Typst will create margins proportional to the page size of your document. To set custom margins, you will use the @page.margin[`margin`] argument in the @page[`{page}`] set rule.
+Margins are a vital ingredient for good typography: #link("https://webtypography.net/2.1.2")[Typographers consider lines that fit between 45 and 75 characters best length for legibility] and your margins and @guides:page-setup:columns[columns] help define line widths. By default, Typst will create margins proportional to the page size of your document. To set custom margins, you will use the @page.margin[`margin`] argument in the @page[`{page}`] set rule.
 
 The `margin` argument will accept a length if you want to set all margins to the same width. However, you often want to set different margins on each side. To do this, you can pass a dictionary:
 


### PR DESCRIPTION
The target website seems to support HTTPS, so using an `https://` URL might be better.

Looks like this was the only occurrence of a `http://` URL in the documentation.