### PR TITLE
Support columns in HTML output

### DIFF
--- a/crates/typst-html/src/convert.rs
+++ b/crates/typst-html/src/convert.rs
@@ -4,7 +4,7 @@ use typst_library::engine::Engine;
 use typst_library::foundations::{Content, Packed, StyleChain, Target, TargetElem};
 use typst_library::introspection::{SplitLocator, TagElem};
 use typst_library::layout::{
-    Abs, Axes, BlockBody, BlockElem, BoxElem, HElem, Region, Size,
+    Abs, Axes, BlockBody, BlockElem, BoxElem, ColumnsElem, HElem, Region, Size,
 };
 use typst_library::routines::Pair;
 use typst_library::text::{
@@ -152,6 +152,8 @@ fn handle(
         // be wrapped in a `box` to omit the `display` annotation.
         make_block_level(&mut node).unwrap();
         converter.push(node);
+    } else if let Some(elem) = child.to_packed::<ColumnsElem>() {
+        handle_columns(converter, elem, styles)?
     } else {
         converter.engine.sink.warn(warning!(
             child.span(),
@@ -434,6 +436,29 @@ fn handle_block(
             .spanned(elem.span()),
     );
 
+    Ok(())
+}
+
+/// Processes a columns element
+fn handle_columns(
+    converter: &mut Converter,
+    elem: &Packed<ColumnsElem>,
+    styles: StyleChain,
+) -> SourceResult<()> {
+    let children = html_block_fragment(
+        converter.engine,
+        &elem.body,
+        converter.locator.next(&elem.span()),
+        styles,
+        converter.whitespace,
+    )?;
+    let count = elem.count.get(styles);
+    converter.push(
+        HtmlElement::new(tag::div)
+            .with_css(css::Properties::new().with("column-count", count.to_string()))
+            .with_children(children)
+            .spanned(elem.span()),
+    );
     Ok(())
 }
 

--- a/crates/typst-html/src/convert.rs
+++ b/crates/typst-html/src/convert.rs
@@ -14,6 +14,7 @@ use typst_library::text::{
 use typst_syntax::Span;
 use typst_utils::SliceExt;
 
+use crate::css::ToCss;
 use crate::fragment::{html_block_fragment, html_inline_fragment, html_math_fragment};
 use crate::{
     FrameElem, HtmlElem, HtmlElement, HtmlFrame, HtmlNode, attr, css, property, tag,
@@ -453,9 +454,14 @@ fn handle_columns(
         converter.whitespace,
     )?;
     let count = elem.count.get(styles);
+    let gutter = elem.gutter.get(styles);
     converter.push(
         HtmlElement::new(tag::div)
-            .with_css(css::Properties::new().with("column-count", count.to_string()))
+            .with_css(
+                css::Properties::new()
+                    .with("column-count", count.to_string())
+                    .with("column-gap", gutter.to_css(())),
+            )
             .with_children(children)
             .spanned(elem.span()),
     );

--- a/tests/ref/html/hashes.txt
+++ b/tests/ref/html/hashes.txt
@@ -40,6 +40,8 @@ ffa25d90e2baac1e02b03a60cae89720 block-html-block
 252cb984e3a921ac9d717570371f4fa6 cite-group
 e87734ba4dba7fed32967be69484478c col-gutter-table
 e87734ba4dba7fed32967be69484478c col-row-gutter-table
+1e292a6038b63797587212b27b70acd3 columns-gutter-html
+6168dc54a377492697a44d35d9d0a905 columns-html
 c3adb00220cf56685a91e1bd4d93f3b4 divider-html
 4131a1789df95f853768971f54e850a9 enum-par
 013e6642f1140f60b83d7ca64ca77c87 enum-start

--- a/tests/suite/layout/container.typ
+++ b/tests/suite/layout/container.typ
@@ -370,6 +370,12 @@ Paragraph B
 // attempt to set a `display` property.
 A #box(html.div()) B
 
+--- columns-html html ---
+#columns(3)[Text]
+
+--- columns-gutter-html html ---
+#columns(3, gutter: 1em)[Text]
+
 --- container-layoutable-child paged ---
 // Test box/block sizing with directly layoutable child.
 //


### PR DESCRIPTION
With the HTML backend, render this:

```typst
#columns(3, gutter: 1em)[Blah blah]
```

as this:

```html
<div style="column-count: 3; column-gap: 1em">Blah blah</div>
```

(Currently it just emits a warning.)