### PR TITLE
Add more CJK brackets to punctuation width adjustment

### DIFF
--- a/crates/typst-layout/src/inline/shaping.rs
+++ b/crates/typst-layout/src/inline/shaping.rs
@@ -1384,11 +1384,13 @@ fn assert_glyph_ranges_in_order(glyphs: &[ShapedGlyph], dir: Dir) {
 }
 
 // The CJK punctuation that can appear at the beginning or end of a line.
-pub const BEGIN_PUNCT_PAT: &[char] =
-    &['“', '‘', '《', '〈', '（', '『', '「', '【', '〖', '〔', '［', '｛'];
+pub const BEGIN_PUNCT_PAT: &[char] = &[
+    '“', '‘', '《', '〈', '（', '『', '「', '【', '〖', '〔', '［', '｛', '｟', '〘',
+    '〝',
+];
 pub const END_PUNCT_PAT: &[char] = &[
     '”', '’', '，', '．', '。', '、', '：', '；', '》', '〉', '）', '』', '」', '】',
-    '〗', '〕', '］', '｝', '？', '！',
+    '〗', '〕', '］', '｝', '｠', '〙', '〟', '？', '！',
 ];
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -1456,8 +1458,23 @@ fn is_cjk_left_aligned_punctuation(
         return true;
     }
 
-    // See appendix A.3 https://www.w3.org/TR/clreq/#tables_of_chinese_punctuation_marks
-    matches!(c, '》' | '）' | '』' | '」' | '】' | '〗' | '〕' | '〉' | '］' | '｝')
+    // See CLReq appendix A.3 https://www.w3.org/TR/clreq/#table_of_bracket_indication_punctuation_marks
+    // and JLReq appendix A.2 https://www.w3.org/TR/jlreq/?lang=ja#cl-02
+    matches!(
+        c,
+        '》' | '）'
+            | '』'
+            | '」'
+            | '】'
+            | '〗'
+            | '〕'
+            | '〉'
+            | '］'
+            | '｝'
+            | '｠'
+            | '〙'
+            | '〟'
+    )
 }
 
 /// See <https://www.w3.org/TR/clreq/#punctuation_width_adjustment>
@@ -1471,8 +1488,23 @@ fn is_cjk_right_aligned_punctuation(
     if matches!(c, '“' | '‘') && x_advance + stretchability.0 == Em::one() {
         return true;
     }
-    // See appendix A.3 https://www.w3.org/TR/clreq/#tables_of_chinese_punctuation_marks
-    matches!(c, '《' | '（' | '『' | '「' | '【' | '〖' | '〔' | '〈' | '［' | '｛')
+    // See CLReq appendix A.3 https://www.w3.org/TR/clreq/#table_of_bracket_indication_punctuation_marks
+    // and JLReq appendix A.1 https://www.w3.org/TR/jlreq/?lang=ja#cl-01
+    matches!(
+        c,
+        '《' | '（'
+            | '『'
+            | '「'
+            | '【'
+            | '〖'
+            | '〔'
+            | '〈'
+            | '［'
+            | '｛'
+            | '｟'
+            | '〘'
+            | '〝'
+    )
 }
 
 /// See <https://www.w3.org/TR/clreq/#punctuation_width_adjustment>


### PR DESCRIPTION
This PR fixes the brackets mentioned in JLReq that don't yet support adjustment in Typst.
1. Fixes for `｟`, `｠`, `〘`,` 〙`, `〝`, `〟`
2. Add JLReq URLs to comments (and fix CLReq URLs to the correct ones)

Fixes #8555 