### PR TITLE
Replace introspection capability traits with bools in the element vtable

### DIFF
--- a/crates/typst-library/src/foundations/content/element.rs
+++ b/crates/typst-library/src/foundations/content/element.rs
@@ -81,6 +81,21 @@ impl Element {
         self.can_type_id(TypeId::of::<C>())
     }
 
+    /// Whether the element is locatable.
+    pub fn is_locatable(self) -> bool {
+        self.vtable().introspection.locatable
+    }
+
+    /// Whether the element is unqueriable.
+    pub fn is_unqueriable(self) -> bool {
+        self.vtable().introspection.unqueriable
+    }
+
+    /// Whether the element is tagged in PDF files.
+    pub fn is_tagged(self) -> bool {
+        self.vtable().introspection.tagged
+    }
+
     /// Whether the element has the given capability where the capability is
     /// given by a `TypeId`.
     pub fn can_type_id(self, type_id: TypeId) -> bool {

--- a/crates/typst-library/src/foundations/content/mod.rs
+++ b/crates/typst-library/src/foundations/content/mod.rs
@@ -7,7 +7,7 @@ mod vtable;
 pub use self::element::*;
 pub use self::field::*;
 pub use self::packed::Packed;
-pub use self::vtable::{ContentVtable, FieldVtable};
+pub use self::vtable::{ContentVtable, FieldVtable, IntrospectionCapabilities};
 #[doc(inline)]
 pub use typst_macros::elem;
 
@@ -278,6 +278,21 @@ impl Content {
         C: ?Sized + 'static,
     {
         self.elem().can::<C>()
+    }
+
+    /// Whether the contained element is locatable.
+    pub fn is_locatable(&self) -> bool {
+        self.elem().is_locatable()
+    }
+
+    /// Whether the contained element is unqueriable.
+    pub fn is_unqueriable(&self) -> bool {
+        self.elem().is_unqueriable()
+    }
+
+    /// Whether the contained element is tagged in PDF files.
+    pub fn is_tagged(&self) -> bool {
+        self.elem().is_tagged()
     }
 
     /// Cast to a trait object if the contained element has the given

--- a/crates/typst-library/src/foundations/content/vtable.rs
+++ b/crates/typst-library/src/foundations/content/vtable.rs
@@ -109,6 +109,8 @@ pub struct ContentVtable<T: 'static = RawContent> {
     /// pointer to a native Rust vtable of `Packed<Self>` w.r.t to the trait `C`
     /// where `capability` is `TypeId::of::<dyn C>()`.
     pub(super) capability: fn(capability: TypeId) -> Option<NonNull<()>>,
+    /// Introspection capabilities of the type.
+    pub(super) introspection: IntrospectionCapabilities,
 
     /// The `Drop` impl (for the whole raw content). The content must have a
     /// reference count of zero and may not be used anymore after `drop` was
@@ -147,6 +149,7 @@ impl ContentVtable {
         fields: &'static [FieldVtable<Packed<E>>],
         field_id: fn(name: &str) -> Option<u8>,
         capability: fn(TypeId) -> Option<NonNull<()>>,
+        introspection: IntrospectionCapabilities,
         store: fn() -> &'static LazyElementStore,
     ) -> ContentVtable<Packed<E>> {
         ContentVtable {
@@ -162,6 +165,7 @@ impl ContentVtable {
             local_name: None,
             scope: || Scope::new(),
             capability,
+            introspection,
             drop: RawContent::drop_impl::<E>,
             clone: RawContent::clone_impl::<E>,
             hash: |elem| typst_utils::hash128(elem.as_ref()),
@@ -305,6 +309,16 @@ impl ContentHandle<(&RawContent, &RawContent)> {
         let (a, b) = self.0;
         unsafe { self.1.eq.map(|f| f(a, b)) }
     }
+}
+
+/// A set of introspection capabilties available for the element.
+pub struct IntrospectionCapabilities {
+    /// Makes an element available in the introspector.
+    pub locatable: bool,
+    /// Marks an element as not queriable for the user.
+    pub unqueriable: bool,
+    /// Marks an element as tagged in PDF files.
+    pub tagged: bool,
 }
 
 /// A vtable for performing field-specific actions on type-erased

--- a/crates/typst-library/src/foundations/context.rs
+++ b/crates/typst-library/src/foundations/context.rs
@@ -5,7 +5,7 @@ use crate::engine::Engine;
 use crate::foundations::{
     Args, Construct, Content, Func, ShowFn, StyleChain, Value, elem,
 };
-use crate::introspection::{Locatable, Location};
+use crate::introspection::Location;
 
 /// Data that is contextually made available to code.
 ///

--- a/crates/typst-library/src/foundations/selector.rs
+++ b/crates/typst-library/src/foundations/selector.rs
@@ -12,7 +12,7 @@ use crate::foundations::{
     CastInfo, Content, Context, Dict, Element, FromValue, Func, Label, Reflect, Regex,
     Repr, Str, StyleChain, Symbol, Type, Value, cast, func, repr, scope, ty,
 };
-use crate::introspection::{Locatable, Location, QueryUniqueIntrospection, Unqueriable};
+use crate::introspection::{Location, QueryUniqueIntrospection};
 
 /// A helper macro to create a field selector used in [`Selector::Elem`]
 #[macro_export]
@@ -423,7 +423,7 @@ impl FromValue for LocatableSelector {
         fn validate(selector: &Selector) -> StrResult<()> {
             match selector {
                 Selector::Elem(elem, _) => {
-                    if !elem.can::<dyn Locatable>() || elem.can::<dyn Unqueriable>() {
+                    if !elem.is_locatable() || elem.is_unqueriable() {
                         Err(eco_format!("{} is not locatable", elem.name()))?
                     }
                 }

--- a/crates/typst-library/src/introspection/counter.rs
+++ b/crates/typst-library/src/introspection/counter.rs
@@ -17,8 +17,7 @@ use crate::foundations::{
     StyleChain, Value, cast, elem, func, scope, select_where, ty,
 };
 use crate::introspection::{
-    History, Introspect, Introspector, Locatable, Location, QueryFirstIntrospection, Tag,
-    Unqueriable,
+    History, Introspect, Introspector, Location, QueryFirstIntrospection, Tag,
 };
 use crate::layout::{Frame, FrameItem, PageElem};
 use crate::math::EquationElem;

--- a/crates/typst-library/src/introspection/location.rs
+++ b/crates/typst-library/src/introspection/location.rs
@@ -15,15 +15,6 @@ use crate::introspection::{
 use crate::layout::Abs;
 use crate::model::Numbering;
 
-/// Makes an element available in the introspector.
-pub trait Locatable {}
-
-/// Marks an element as not queriable for the user.
-pub trait Unqueriable: Locatable {}
-
-/// Marks an element as tagged in PDF files.
-pub trait Tagged {}
-
 /// Identifies an element in the document.
 ///
 /// A location uniquely identifies an element in the document and lets you

--- a/crates/typst-library/src/introspection/metadata.rs
+++ b/crates/typst-library/src/introspection/metadata.rs
@@ -1,5 +1,4 @@
 use crate::foundations::{Value, elem};
-use crate::introspection::Locatable;
 
 /// Exposes a value to the query system without producing visible content.
 ///

--- a/crates/typst-library/src/introspection/state.rs
+++ b/crates/typst-library/src/introspection/state.rs
@@ -9,7 +9,7 @@ use crate::foundations::{
     Args, Construct, Content, Context, Func, LocatableSelector, NativeElement, Repr,
     Selector, Str, Value, cast, elem, func, scope, select_where, ty,
 };
-use crate::introspection::{History, Introspect, Introspector, Locatable, Location};
+use crate::introspection::{History, Introspect, Introspector, Location};
 use crate::{Library, World};
 
 /// Manages stateful parts of your document.

--- a/crates/typst-library/src/introspection/tag.rs
+++ b/crates/typst-library/src/introspection/tag.rs
@@ -47,10 +47,10 @@ impl Debug for Tag {
 pub struct TagFlags {
     /// Whether the element will be inserted into the
     /// [`Introspector`](super::Introspector).
-    /// Either because it is [`Locatable`](super::Locatable), has been labelled,
-    /// or a location has been manually set.
+    /// Either because it is `Locatable`, has been labelled, or a location has
+    /// been manually set.
     pub introspectable: bool,
-    /// Whether the element is [`Tagged`](super::Tagged).
+    /// Whether the element is `Tagged`.
     pub tagged: bool,
 }
 

--- a/crates/typst-library/src/layout/grid/mod.rs
+++ b/crates/typst-library/src/layout/grid/mod.rs
@@ -13,7 +13,6 @@ use crate::foundations::{
     Array, CastInfo, Content, Context, Fold, FromValue, Func, IntoValue, Packed, Reflect,
     Resolve, Smart, StyleChain, Synthesize, Value, cast, elem, scope,
 };
-use crate::introspection::Tagged;
 use crate::layout::resolve::{CellGrid, grid_to_cellgrid};
 use crate::layout::{
     Alignment, Length, OuterHAlignment, OuterVAlignment, Rel, Sides, Sizing,

--- a/crates/typst-library/src/layout/hide.rs
+++ b/crates/typst-library/src/layout/hide.rs
@@ -1,5 +1,4 @@
 use crate::foundations::{Content, elem};
-use crate::introspection::Tagged;
 
 /// Hides content without affecting layout.
 ///

--- a/crates/typst-library/src/layout/layout.rs
+++ b/crates/typst-library/src/layout/layout.rs
@@ -1,7 +1,6 @@
 use typst_syntax::Span;
 
 use crate::foundations::{Content, Func, NativeElement, elem, func};
-use crate::introspection::Locatable;
 
 /// Provides access to the current outer container's (or page's, if none)
 /// dimensions (width and height).

--- a/crates/typst-library/src/layout/place.rs
+++ b/crates/typst-library/src/layout/place.rs
@@ -1,5 +1,4 @@
 use crate::foundations::{Cast, Content, Smart, elem, scope};
-use crate::introspection::{Locatable, Tagged, Unqueriable};
 use crate::layout::{Alignment, Em, Length, Rel};
 
 /// Places content relatively to its parent container.

--- a/crates/typst-library/src/layout/repeat.rs
+++ b/crates/typst-library/src/layout/repeat.rs
@@ -1,5 +1,4 @@
 use crate::foundations::{Content, elem};
-use crate::introspection::Tagged;
 use crate::layout::Length;
 
 /// Repeats content to the available space.

--- a/crates/typst-library/src/math/equation.rs
+++ b/crates/typst-library/src/math/equation.rs
@@ -9,7 +9,7 @@ use crate::engine::Engine;
 use crate::foundations::{
     Content, NativeElement, Packed, ShowSet, Smart, StyleChain, Styles, Synthesize, elem,
 };
-use crate::introspection::{Count, Counter, CounterUpdate, Locatable, Tagged};
+use crate::introspection::{Count, Counter, CounterUpdate};
 use crate::layout::{
     AlignElem, Alignment, BlockElem, OuterHAlignment, SpecificAlignment, VAlignment,
 };

--- a/crates/typst-library/src/model/asset.rs
+++ b/crates/typst-library/src/model/asset.rs
@@ -2,7 +2,6 @@ use typst_macros::elem;
 
 use crate::diag::bail;
 use crate::foundations::{BundlePath, Bytes, ShowFn, Str, cast};
-use crate::introspection::Locatable;
 
 /// Adds a custom file to a bundle.
 ///

--- a/crates/typst-library/src/model/bibliography.rs
+++ b/crates/typst-library/src/model/bibliography.rs
@@ -32,8 +32,7 @@ use crate::foundations::{
     Selector, ShowSet, Smart, StyleChain, Styles, Synthesize, Value, elem,
 };
 use crate::introspection::{
-    EmptyIntrospector, History, Introspect, Introspector, Locatable, Location,
-    QueryIntrospection,
+    EmptyIntrospector, History, Introspect, Introspector, Location, QueryIntrospection,
 };
 use crate::layout::{BlockElem, Em, HElem, PadElem};
 use crate::loading::{DataSource, Load, LoadSource, Loaded, format_yaml_error};

--- a/crates/typst-library/src/model/cite.rs
+++ b/crates/typst-library/src/model/cite.rs
@@ -5,7 +5,6 @@ use crate::engine::Engine;
 use crate::foundations::{
     Cast, Content, Derived, Label, Packed, Smart, StyleChain, Synthesize, cast, elem,
 };
-use crate::introspection::Locatable;
 use crate::model::bibliography::Works;
 use crate::model::{CslSource, CslStyle};
 use crate::text::{Lang, Region, TextElem};

--- a/crates/typst-library/src/model/document.rs
+++ b/crates/typst-library/src/model/document.rs
@@ -6,7 +6,6 @@ use crate::foundations::{
     Array, BundlePath, Cast, Content, Datetime, OneOrMultiple, Packed, ShowFn, ShowSet,
     Smart, StyleChain, Styles, Target, Value, cast, elem,
 };
-use crate::introspection::Locatable;
 use crate::text::{Locale, TextElem};
 
 /// Manages metadata and is used to add a document file to a bundle.

--- a/crates/typst-library/src/model/emph.rs
+++ b/crates/typst-library/src/model/emph.rs
@@ -1,5 +1,4 @@
 use crate::foundations::{Content, elem};
-use crate::introspection::{Locatable, Tagged};
 
 /// Emphasizes content by toggling italics.
 ///

--- a/crates/typst-library/src/model/enum.rs
+++ b/crates/typst-library/src/model/enum.rs
@@ -6,7 +6,6 @@ use crate::diag::{bail, warning};
 use crate::foundations::{
     Array, Content, Packed, Reflect, Smart, Styles, cast, elem, scope,
 };
-use crate::introspection::{Locatable, Tagged};
 use crate::layout::{Alignment, Em, HAlignment, Length};
 use crate::model::{ListItemLike, ListLike, Numbering, NumberingPattern};
 

--- a/crates/typst-library/src/model/figure.rs
+++ b/crates/typst-library/src/model/figure.rs
@@ -11,9 +11,7 @@ use crate::foundations::{
     Content, Element, NativeElement, Packed, Selector, ShowSet, Smart, StyleChain,
     Styles, Synthesize, cast, elem, scope, select_where,
 };
-use crate::introspection::{
-    Count, Counter, CounterKey, CounterUpdate, Locatable, Location, Tagged,
-};
+use crate::introspection::{Count, Counter, CounterKey, CounterUpdate, Location};
 use crate::layout::{
     AlignElem, Alignment, BlockElem, Em, Length, OuterVAlignment, PlacementScope,
     VAlignment,

--- a/crates/typst-library/src/model/footnote.rs
+++ b/crates/typst-library/src/model/footnote.rs
@@ -11,7 +11,7 @@ use crate::foundations::{
     elem, scope,
 };
 use crate::introspection::{
-    Count, Counter, CounterUpdate, Locatable, Location, QueryLabelIntrospection, Tagged,
+    Count, Counter, CounterUpdate, Location, QueryLabelIntrospection,
 };
 use crate::layout::{Em, Length, Ratio};
 use crate::model::{DirectLinkElem, Numbering, NumberingPattern, ParElem};

--- a/crates/typst-library/src/model/heading.rs
+++ b/crates/typst-library/src/model/heading.rs
@@ -8,7 +8,7 @@ use crate::engine::Engine;
 use crate::foundations::{
     Content, NativeElement, Packed, ShowSet, Smart, StyleChain, Styles, Synthesize, elem,
 };
-use crate::introspection::{Count, Counter, CounterUpdate, Locatable, Tagged};
+use crate::introspection::{Count, Counter, CounterUpdate};
 use crate::layout::{BlockElem, Em, Length};
 use crate::model::{Numbering, Outlinable, Refable, Supplement};
 use crate::text::{FontWeight, LocalName, TextElem, TextSize};

--- a/crates/typst-library/src/model/link.rs
+++ b/crates/typst-library/src/model/link.rs
@@ -14,9 +14,8 @@ use crate::foundations::{
     Smart, StyleChain, Styles, cast, elem,
 };
 use crate::introspection::{
-    Counter, CounterKey, History, Introspect, Introspector, Locatable, Location,
-    PagedPosition, PathIntrospection, QueryFirstIntrospection, QueryLabelIntrospection,
-    Tagged,
+    Counter, CounterKey, History, Introspect, Introspector, Location, PagedPosition,
+    PathIntrospection, QueryFirstIntrospection, QueryLabelIntrospection,
 };
 use crate::layout::PageElem;
 use crate::model::{NumberingPattern, Refable};

--- a/crates/typst-library/src/model/list.rs
+++ b/crates/typst-library/src/model/list.rs
@@ -6,7 +6,6 @@ use crate::foundations::{
     Array, Content, Context, Depth, Func, NativeElement, Packed, Smart, StyleChain,
     Styles, Value, cast, elem, scope,
 };
-use crate::introspection::{Locatable, Tagged};
 use crate::layout::{Alignment, Em, HAlignment, Length};
 use crate::text::TextElem;
 

--- a/crates/typst-library/src/model/outline.rs
+++ b/crates/typst-library/src/model/outline.rs
@@ -13,8 +13,8 @@ use crate::foundations::{
     Resolve, ShowSet, Smart, StyleChain, Styles, cast, elem, func, scope, select_where,
 };
 use crate::introspection::{
-    Counter, CounterKey, Locatable, Location, Locator, LocatorLink,
-    PageNumberingIntrospection, QueryIntrospection, Tagged, Unqueriable,
+    Counter, CounterKey, Location, Locator, LocatorLink, PageNumberingIntrospection,
+    QueryIntrospection,
 };
 use crate::layout::{
     Abs, Axes, BlockBody, BlockElem, BoxElem, Dir, Em, Fr, HElem, Length, Region, Rel,

--- a/crates/typst-library/src/model/par.rs
+++ b/crates/typst-library/src/model/par.rs
@@ -8,7 +8,7 @@ use crate::foundations::{
     IntoValue, NativeElement, Packed, Reflect, Smart, Unlabellable, Value, cast, dict,
     elem, scope,
 };
-use crate::introspection::{Count, CounterUpdate, Locatable, Tagged, Unqueriable};
+use crate::introspection::{Count, CounterUpdate};
 use crate::layout::{Abs, Em, HAlignment, Length, OuterHAlignment, Ratio, Rel};
 use crate::model::Numbering;
 

--- a/crates/typst-library/src/model/quote.rs
+++ b/crates/typst-library/src/model/quote.rs
@@ -4,7 +4,6 @@ use crate::foundations::{
     Content, Depth, Label, NativeElement, Packed, ShowSet, Smart, StyleChain, Styles,
     cast, elem,
 };
-use crate::introspection::{Locatable, Tagged};
 use crate::layout::{BlockElem, Em, PadElem};
 use crate::model::{CitationForm, CiteElem};
 use crate::text::{SmartQuotes, SpaceElem, TextElem};

--- a/crates/typst-library/src/model/reference.rs
+++ b/crates/typst-library/src/model/reference.rs
@@ -8,8 +8,8 @@ use crate::foundations::{
     StyleChain, Synthesize, cast, elem,
 };
 use crate::introspection::{
-    Counter, CounterKey, Locatable, PageNumberingIntrospection,
-    PageSupplementIntrospection, QueryLabelIntrospection, Tagged,
+    Counter, CounterKey, PageNumberingIntrospection, PageSupplementIntrospection,
+    QueryLabelIntrospection,
 };
 use crate::math::EquationElem;
 use crate::model::{

--- a/crates/typst-library/src/model/strong.rs
+++ b/crates/typst-library/src/model/strong.rs
@@ -1,5 +1,4 @@
 use crate::foundations::{Content, elem};
-use crate::introspection::{Locatable, Tagged};
 
 /// Strongly emphasizes content by increasing the font weight.
 ///

--- a/crates/typst-library/src/model/table.rs
+++ b/crates/typst-library/src/model/table.rs
@@ -9,7 +9,6 @@ use crate::engine::Engine;
 use crate::foundations::{
     Content, Packed, Smart, StyleChain, Synthesize, cast, elem, scope,
 };
-use crate::introspection::{Locatable, Tagged};
 use crate::layout::resolve::{CellGrid, table_to_cellgrid};
 use crate::layout::{
     Abs, Alignment, Celled, GridCell, GridFooter, GridHLine, GridHeader, GridVLine,

--- a/crates/typst-library/src/model/terms.rs
+++ b/crates/typst-library/src/model/terms.rs
@@ -2,7 +2,6 @@ use crate::diag::{bail, warning};
 use crate::foundations::{
     Array, Content, NativeElement, Packed, Reflect, Smart, Styles, cast, elem, scope,
 };
-use crate::introspection::{Locatable, Tagged};
 use crate::layout::{Em, HElem, Length};
 use crate::model::{ListItemLike, ListLike};
 

--- a/crates/typst-library/src/model/title.rs
+++ b/crates/typst-library/src/model/title.rs
@@ -1,6 +1,5 @@
 use crate::diag::{Hint, HintedStrResult};
 use crate::foundations::{Content, Packed, ShowSet, Smart, StyleChain, Styles, elem};
-use crate::introspection::{Locatable, Tagged};
 use crate::layout::{BlockElem, Em};
 use crate::model::DocumentElem;
 use crate::text::{FontWeight, TextElem, TextSize};

--- a/crates/typst-library/src/pdf/accessibility.rs
+++ b/crates/typst-library/src/pdf/accessibility.rs
@@ -8,7 +8,6 @@ use crate::diag::SourceResult;
 use crate::diag::bail;
 use crate::engine::Engine;
 use crate::foundations::{Args, Construct, Content, NativeElement, Smart};
-use crate::introspection::Tagged;
 use crate::model::{TableCell, TableElem};
 
 /// Marks content as a PDF artifact.

--- a/crates/typst-library/src/pdf/attach.rs
+++ b/crates/typst-library/src/pdf/attach.rs
@@ -4,7 +4,6 @@ use typst_syntax::Spanned;
 use crate::World;
 use crate::diag::At;
 use crate::foundations::{Bytes, Cast, Derived, PathOrStr, elem};
-use crate::introspection::Locatable;
 
 /// A file that will be attached to the output PDF.
 ///

--- a/crates/typst-library/src/text/deco.rs
+++ b/crates/typst-library/src/text/deco.rs
@@ -1,5 +1,4 @@
 use crate::foundations::{Content, Smart, elem};
-use crate::introspection::{Locatable, Tagged};
 use crate::layout::{Abs, Corners, Length, Rel, Sides};
 use crate::text::{BottomEdge, BottomEdgeMetric, TopEdge, TopEdgeMetric};
 use crate::visualize::{Color, FixedStroke, Paint, Stroke};

--- a/crates/typst-library/src/text/raw.rs
+++ b/crates/typst-library/src/text/raw.rs
@@ -20,7 +20,6 @@ use crate::foundations::{
     Bytes, Content, Derived, OneOrMultiple, Packed, PlainText, ShowSet, Smart,
     StyleChain, Styles, Synthesize, Target, TargetElem, cast, elem, scope,
 };
-use crate::introspection::{Locatable, Tagged};
 use crate::layout::{Em, HAlignment};
 use crate::loading::{DataSource, Load};
 use crate::model::{Figurable, ParElem};

--- a/crates/typst-library/src/text/shift.rs
+++ b/crates/typst-library/src/text/shift.rs
@@ -1,4 +1,3 @@
-use crate::introspection::Tagged;
 use ttf_parser::Tag;
 
 use crate::foundations::{Content, Smart, elem};

--- a/crates/typst-library/src/visualize/image/mod.rs
+++ b/crates/typst-library/src/visualize/image/mod.rs
@@ -24,7 +24,6 @@ use crate::engine::Engine;
 use crate::foundations::{
     Bytes, Cast, Derived, Packed, Smart, StyleChain, Synthesize, cast, elem,
 };
-use crate::introspection::{Locatable, Tagged};
 use crate::layout::{Length, Rel, Sizing};
 use crate::loading::{DataSource, Load, Loaded};
 use crate::model::Figurable;

--- a/crates/typst-macros/src/elem.rs
+++ b/crates/typst-macros/src/elem.rs
@@ -49,11 +49,6 @@ impl Elem {
     fn cannot(&self, name: &str) -> bool {
         !self.can(name)
     }
-
-    /// Whether the element has the given trait listed as a capability.
-    fn with(&self, name: &str) -> Option<&Ident> {
-        self.capabilities.iter().find(|capability| *capability == name)
-    }
 }
 
 impl Elem {
@@ -251,21 +246,12 @@ fn create(element: &Elem) -> Result<TokenStream> {
 
     // Implementations.
     let inherent_impl = create_inherent_impl(element);
-    let native_element_impl = create_native_elem_impl(element);
+    let native_element_impl = create_native_elem_impl(element)?;
     let field_impls =
         element.fields.iter().map(|field| create_field_impl(element, field));
     let construct_impl =
         element.cannot("Construct").then(|| create_construct_impl(element));
     let set_impl = element.cannot("Set").then(|| create_set_impl(element));
-    let unqueriable_impl = element
-        .with("Unqueriable")
-        .map(|cap| create_introspection_impl(element, cap));
-    let locatable_impl = element
-        .with("Locatable")
-        .map(|cap| create_introspection_impl(element, cap));
-    let tagged_impl = element
-        .with("Tagged")
-        .map(|cap| create_introspection_impl(element, cap));
     let mathy_impl = element.can("Mathy").then(|| create_mathy_impl(element));
 
     // We use a const block to create an anonymous scope, as to not leak any
@@ -279,9 +265,6 @@ fn create(element: &Elem) -> Result<TokenStream> {
             #(#field_impls)*
             #construct_impl
             #set_impl
-            #unqueriable_impl
-            #locatable_impl
-            #tagged_impl
             #mathy_impl
         };
     })
@@ -393,7 +376,7 @@ fn create_with_field_method(field: &Field) -> TokenStream {
 }
 
 /// Creates the element's `NativeElement` implementation.
-fn create_native_elem_impl(element: &Elem) -> TokenStream {
+fn create_native_elem_impl(element: &Elem) -> Result<TokenStream> {
     let Elem { name, ident, title, scope, keywords, docs, .. } = element;
     let def_site_key = ident.to_string();
 
@@ -430,6 +413,7 @@ fn create_native_elem_impl(element: &Elem) -> TokenStream {
     };
 
     let capable_func = create_capable_func(element);
+    let introspection = create_introspection_capabilities(element)?;
 
     let with_keywords =
         (!keywords.is_empty()).then(|| quote! { .with_keywords(&[#(#keywords),*]) });
@@ -438,7 +422,7 @@ fn create_native_elem_impl(element: &Elem) -> TokenStream {
     let with_local_name = element.can("LocalName").then(|| quote! { .with_local_name() });
     let with_scope = scope.then(|| quote! { .with_scope() });
 
-    quote! {
+    Ok(quote! {
         unsafe impl #foundations::NativeElement for #ident {
             const ELEM: #foundations::Element = #foundations::Element::from_vtable({
                 static STORE: #foundations::LazyElementStore
@@ -452,6 +436,7 @@ fn create_native_elem_impl(element: &Elem) -> TokenStream {
                         &[#(#fields),*],
                         #field_id,
                         #capable_func,
+                        #introspection,
                         || &STORE,
                     ) #with_keywords
                     #with_repr
@@ -462,7 +447,7 @@ fn create_native_elem_impl(element: &Elem) -> TokenStream {
                 &VTABLE
             });
         }
-    }
+    })
 }
 
 /// Creates the appropriate trait implementation for a field.
@@ -657,9 +642,22 @@ fn create_field_parser(field: &Field) -> (TokenStream, TokenStream) {
 
 /// Creates the element's casting vtable.
 fn create_capable_func(element: &Elem) -> TokenStream {
-    // Forbidden capabilities (i.e capabilities that are not object safe).
-    const FORBIDDEN: &[&str] =
-        &["Debug", "PartialEq", "Hash", "Construct", "Set", "Repr", "LocalName"];
+    // Forbidden capabilities, i.e capabilities that are not object safe or
+    // introspection capabilities that are handled otherwise.
+    const FORBIDDEN: &[&str] = &[
+        // Not object safe.
+        "Debug",
+        "PartialEq",
+        "Hash",
+        "Construct",
+        "Set",
+        "Repr",
+        "LocalName",
+        // Introspection capabilities.
+        "Locatable",
+        "Unqueriable",
+        "Tagged",
+    ];
 
     let ident = &element.ident;
     let relevant = element
@@ -688,10 +686,29 @@ fn create_capable_func(element: &Elem) -> TokenStream {
     }
 }
 
-/// Creates the element's introspection capability implementation.
-fn create_introspection_impl(element: &Elem, capability: &Ident) -> TokenStream {
-    let ident = &element.ident;
-    quote! { impl ::typst_library::introspection::#capability for #foundations::Packed<#ident> {} }
+/// Creates the element's casting vtable.
+fn create_introspection_capabilities(element: &Elem) -> Result<TokenStream> {
+    let find_cap = |name| element.capabilities.iter().find(|ident| *ident == name);
+    let locatable = find_cap("Locatable");
+    let unqueriable = find_cap("Unqueriable");
+    let tagged = find_cap("Tagged");
+
+    if let Some(unqueriable) = unqueriable
+        && locatable.is_none()
+    {
+        bail!(unqueriable, "only `Locatable` element can be marked `Unqueriable`");
+    }
+
+    let locatable = locatable.is_some();
+    let unqueriable = unqueriable.is_some();
+    let tagged = tagged.is_some();
+    Ok(quote! {
+        #foundations::IntrospectionCapabilities {
+            locatable: #locatable,
+            unqueriable: #unqueriable,
+            tagged: #tagged,
+        }
+    })
 }
 
 /// Creates the element's `Mathy` implementation.

--- a/crates/typst-realize/src/lib.rs
+++ b/crates/typst-realize/src/lib.rs
@@ -21,9 +21,7 @@ use typst_library::foundations::{
     Recipe, RecipeIndex, Selector, SequenceElem, ShowSet, Style, StyleChain, StyledElem,
     Styles, SymbolElem, Synthesize, Target, TargetElem, Transformation,
 };
-use typst_library::introspection::{
-    Locatable, LocationKey, SplitLocator, Tag, TagElem, TagFlags, Tagged,
-};
+use typst_library::introspection::{LocationKey, SplitLocator, Tag, TagElem, TagFlags};
 use typst_library::layout::{
     AlignElem, BoxElem, HElem, InlineElem, PageElem, PagebreakElem, VElem,
 };
@@ -520,8 +518,8 @@ fn verdict<'a>(
             elem.label().is_none()
                 && elem.location().is_none()
                 && !elem.can::<dyn ShowSet>()
-                && !elem.can::<dyn Locatable>()
-                && !elem.can::<dyn Tagged>()
+                && !elem.is_locatable()
+                && !elem.is_tagged()
                 && !elem.can::<dyn Synthesize>()
         })
     {
@@ -547,10 +545,10 @@ fn prepare(
     // when it stems from a query.
     let key = typst_utils::hash128(&elem);
     let flags = TagFlags {
-        introspectable: elem.can::<dyn Locatable>()
+        introspectable: elem.is_locatable()
             || elem.label().is_some()
             || elem.location().is_some(),
-        tagged: elem.can::<dyn Tagged>(),
+        tagged: elem.is_tagged(),
     };
     if elem.location().is_none() && flags.any() {
         let loc = locator.next_location(engine, key, elem.span());


### PR DESCRIPTION
Based on #8535

This allows defining `Locatable`, `Unqueriable`, and `Tagged` elements outside of `typst_library`.
Required for #8496.

See #5664 "Packed Trouble"