### PR TITLE
Eval: Add `--output` to output to a file

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -7,7 +7,7 @@ use std::fmt::{self, Display, Formatter};
 use std::io::Write;
 use std::num::NonZeroUsize;
 use std::ops::RangeInclusive;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use clap::builder::styling::{AnsiColor, Effects};
@@ -207,9 +207,18 @@ pub struct EvalCommand {
     #[clap(long, default_value_t)]
     pub target: Target,
 
+    /// Path to output file. Use `-` to write output to stdout.
+    #[clap(
+         long, short,
+         default_value = "-",
+         value_parser = output_value_parser(),
+         value_hint = ValueHint::FilePath,
+     )]
+    pub output: Output,
+
     /// The format to serialize in.
-    #[clap(long = "format", default_value_t)]
-    pub format: SerializationFormat,
+    #[clap(long = "format")]
+    pub format: Option<SerializationFormat>,
 
     /// Whether to pretty-print the serialized output.
     ///
@@ -550,6 +559,14 @@ impl Output {
         match self {
             Self::Stdout => Ok(OpenOutput::Stdout(std::io::stdout().lock())),
             Self::Path(path) => std::fs::File::create(path).map(OpenOutput::File),
+        }
+    }
+
+    /// Get the path if the output if a path was specified.
+    pub fn as_path(&self) -> Option<&Path> {
+        match self {
+            Self::Stdout => None,
+            Self::Path(path) => Some(path),
         }
     }
 }

--- a/crates/typst-cli/src/eval.rs
+++ b/crates/typst-cli/src/eval.rs
@@ -1,9 +1,10 @@
+use std::path::Path;
 use std::sync::LazyLock;
 
 use comemo::Track;
 use ecow::eco_format;
 use typst::Library;
-use typst::diag::{FileResult, HintedStrResult, SourceResult, Warned};
+use typst::diag::{At, FileResult, HintedStrResult, SourceResult, Warned};
 use typst::foundations::{
     Bytes, Context, Datetime, Duration, Output, Scope, StyleChain, Value,
 };
@@ -20,7 +21,7 @@ use typst_kit::diagnostics::DiagnosticWorld;
 use typst_layout::PagedDocument;
 use typst_utils::LazyHash;
 
-use crate::args::{EvalCommand, Target};
+use crate::args::{EvalCommand, SerializationFormat, Target};
 use crate::compile::print_diagnostics;
 use crate::set_failed;
 use crate::world::SystemWorld;
@@ -45,6 +46,21 @@ pub fn eval(command: &'static EvalCommand) -> HintedStrResult<()> {
             .map(|result| result.map(|output| Box::new(output) as Box<dyn Output>)),
     };
 
+    let output_format = if let Some(specified) = command.format {
+        specified
+    } else {
+        match command.output.as_path().and_then(Path::extension) {
+            Some(ext) if ext.eq_ignore_ascii_case("json") => SerializationFormat::Json,
+            Some(ext)
+                if ext.eq_ignore_ascii_case("yaml")
+                    || ext.eq_ignore_ascii_case("yml") =>
+            {
+                SerializationFormat::Yaml
+            }
+            _ => SerializationFormat::default(),
+        }
+    };
+
     match output {
         // The target compiled successfully, continue with evaluating the input
         // expression.
@@ -60,13 +76,21 @@ pub fn eval(command: &'static EvalCommand) -> HintedStrResult<()> {
                 &expr_world,
                 output.introspector(),
             );
-            let errors = match &eval_result {
-                Err(errors) => errors.as_slice(),
+            let errors = match eval_result {
+                Err(errors) => errors,
                 Ok(value) => {
-                    let serialized =
-                        crate::serialize(value, command.format, command.pretty)?;
-                    println!("{serialized}");
-                    &[]
+                    let mut serialized =
+                        crate::serialize(&value, output_format, command.pretty)?;
+                    if !serialized.ends_with('\n') {
+                        serialized.push('\n');
+                    }
+                    command
+                        .output
+                        .write(serialized.as_bytes())
+                        .map_err(|err| eco_format!("failed to write output file ({err})"))
+                        .at(Span::detached())
+                        .err()
+                        .unwrap_or_default()
                 }
             };
             // Collect additional warnings from evaluating the expression.
@@ -74,7 +98,7 @@ pub fn eval(command: &'static EvalCommand) -> HintedStrResult<()> {
 
             print_diagnostics(
                 &expr_world,
-                errors,
+                &errors,
                 &warnings,
                 command.process.diagnostic_format,
             )

--- a/crates/typst-cli/tests/smoke.rs
+++ b/crates/typst-cli/tests/smoke.rs
@@ -48,6 +48,106 @@ fn test_eval() {
 }
 
 #[test]
+fn test_eval_format() {
+    // Default format (JSON).
+    let output = exec().arg("eval").arg("(1, 2, 3, 4)").must_succeed();
+    output.stdout.must_match_lines(["[1,2,3,4]"]);
+
+    // JSON manually specified.
+    let output = exec()
+        .arg("eval")
+        .args(["(1, 2, 3, 4)", "--format", "json"])
+        .must_succeed();
+    output.stdout.must_match_lines(["[1,2,3,4]"]);
+
+    // YAML manually specified.
+    let output = exec()
+        .arg("eval")
+        .args(["(1, 2, 3, 4)", "--format", "yaml"])
+        .must_succeed();
+    output.stdout.must_match_lines(["- 1", "- 2", "- 3", "- 4"]);
+}
+
+#[test]
+fn test_eval_output() {
+    let project = tempfs();
+
+    // Named path.
+    let output = exec()
+        .args(["eval", "(1, 2, 3, 4)", "-o"])
+        .arg(project.resolve("foo"))
+        .must_succeed();
+    output.stdout.must_be_empty();
+    output.stderr.must_be_empty();
+    project.read("foo").must_match_lines(["[1,2,3,4]"]);
+
+    // Output to stdout.
+    let output = exec().args(["eval", "(1, 2, 3, 4)", "-o", "-"]).must_succeed();
+    output.stdout.must_match_lines(["[1,2,3,4]"]);
+    output.stderr.must_be_empty();
+}
+
+#[test]
+fn test_eval_infer_format() {
+    let project = tempfs();
+
+    // Unknown extension (default format).
+    exec()
+        .args(["eval", "(1, 2, 3, 4)", "-o"])
+        .arg(project.resolve("foo.extension"))
+        .must_succeed();
+    project.read("foo.extension").must_match_lines(["[1,2,3,4]"]);
+
+    // Unknown extension, default format overwritten.
+    exec()
+        .args(["eval", "(1, 2, 3, 4)", "--format", "yaml", "-o"])
+        .arg(project.resolve("foo.extension"))
+        .must_succeed();
+    project
+        .read("foo.extension")
+        .must_match_lines(["- 1", "- 2", "- 3", "- 4"]);
+
+    // JSON inferred.
+    exec()
+        .args(["eval", "(1, 2, 3, 4)", "-o"])
+        .arg(project.resolve("foo.json"))
+        .must_succeed();
+    project.read("foo.json").must_match_lines(["[1,2,3,4]"]);
+
+    // YAML inferred (1).
+    exec()
+        .args(["eval", "(1, 2, 3, 4)", "-o"])
+        .arg(project.resolve("foo.yaml"))
+        .must_succeed();
+    project
+        .read("foo.yaml")
+        .must_match_lines(["- 1", "- 2", "- 3", "- 4"]);
+
+    // YAML inferred (2).
+    exec()
+        .args(["eval", "(1, 2, 3, 4)", "-o"])
+        .arg(project.resolve("foo.yml"))
+        .must_succeed();
+    project.read("foo.yml").must_match_lines(["- 1", "- 2", "- 3", "- 4"]);
+
+    // YAML overwritten.
+    exec()
+        .args(["eval", "(1, 2, 3, 4)", "--format", "yaml", "-o"])
+        .arg(project.resolve("foo.json"))
+        .must_succeed();
+    project
+        .read("foo.json")
+        .must_match_lines(["- 1", "- 2", "- 3", "- 4"]);
+
+    // JSON overwritten.
+    exec()
+        .args(["eval", "(1, 2, 3, 4)", "--format=json", "-o"])
+        .arg(project.resolve("foo.yml"))
+        .must_succeed();
+    project.read("foo.yml").must_match_lines(["[1,2,3,4]"]);
+}
+
+#[test]
 fn test_fonts_embedded() {
     let output = exec().arg("fonts").arg("--ignore-system-fonts").must_succeed();
     output.stdout.must_match_lines([
@@ -356,6 +456,12 @@ impl<T: AsRef<[u8]>> Stream<T> {
             self.lines().collect::<Vec<_>>(),
             lines.into_iter().collect::<Vec<_>>(),
         );
+        self
+    }
+
+    #[track_caller]
+    fn must_be_empty(&self) -> &Self {
+        assert!(self.0.as_ref().is_empty(), "{self:?} is not empty");
         self
     }
 


### PR DESCRIPTION
Some use-cases for `typst eval` (or previously `typst query`) include generating additional files. For example, with the touying package for presentations allows exporting speaker notes to a JSON file ([docs](https://touying-typ.github.io/docs/external/pdfpc#exporting-pdfpc-file)). Users evaluate `query(<pdfpc-file>).first().value` to get the contents.

While it's easy to use file redirection when running the command to output to a file, the main motivation for this is the output of dependencies when used in a Makefile (#8577).

This PR adds the `--output/-o` argument. This is `-` (stdout) by default. If a file is specified, the output format will be inferred from the extension (similar to `typst compile`).

One semi-related change to the output of the command is that it no longer outputs two final newlines when the output format is YAML.