### PR TITLE
Eval: Add support for printing dependencies

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -226,6 +226,10 @@ pub struct EvalCommand {
     #[clap(long)]
     pub pretty: bool,
 
+    /// Dependency arguments.
+    #[clap(flatten)]
+    pub deps: DependencyArgs,
+
     /// The world arguments.
     #[clap(flatten)]
     pub world: WorldArgs,
@@ -365,24 +369,9 @@ pub struct CompileArgs {
     #[arg(long = "ppi", default_value_t = 144.0)]
     pub ppi: f64,
 
-    /// File path to which a Makefile with the current compilation's
-    /// dependencies will be written.
-    #[clap(long = "make-deps", value_name = "PATH", hide = true)]
-    pub make_deps: Option<PathBuf>,
-
-    /// File path to which a list of current compilation's dependencies will be
-    /// written. Use `-` to write to stdout.
-    #[clap(
-        long,
-        value_name = "PATH",
-        value_parser = output_value_parser(),
-        value_hint = ValueHint::FilePath,
-    )]
-    pub deps: Option<Output>,
-
-    /// File format to use for dependencies.
-    #[clap(long, default_value_t)]
-    pub deps_format: DepsFormat,
+    /// Dependency arguments.
+    #[clap(flatten)]
+    pub deps: DependencyArgs,
 
     /// Processing arguments.
     #[clap(flatten)]
@@ -518,6 +507,29 @@ pub struct ServerArgs {
     pub port: Option<u16>,
 }
 
+/// Arguments for dependencies.
+#[derive(Debug, Clone, Parser)]
+pub struct DependencyArgs {
+    /// File path to which a Makefile with the current compilation's
+    /// dependencies will be written.
+    #[clap(long = "make-deps", value_name = "PATH", hide = true)]
+    pub make_deps: Option<PathBuf>,
+
+    /// File path to which a list of current compilation's dependencies will be
+    /// written. Use `-` to write to stdout.
+    #[clap(
+        long,
+        value_name = "PATH",
+        value_parser = output_value_parser(),
+        value_hint = ValueHint::FilePath,
+    )]
+    pub deps: Option<Output>,
+
+    /// File format to use for dependencies.
+    #[clap(long, default_value_t)]
+    pub deps_format: DepsFormat,
+}
+
 /// An input that is either stdin or a real path.
 #[derive(Debug, Clone)]
 pub enum Input {
@@ -568,6 +580,10 @@ impl Output {
             Self::Stdout => None,
             Self::Path(path) => Some(path),
         }
+    }
+
+    pub fn is_stdout(&self) -> bool {
+        matches!(self, Output::Stdout)
     }
 }
 

--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -7,7 +7,7 @@ use std::fmt::{self, Display, Formatter};
 use std::io::Write;
 use std::num::NonZeroUsize;
 use std::ops::RangeInclusive;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use clap::builder::styling::{AnsiColor, Effects};
@@ -207,9 +207,18 @@ pub struct EvalCommand {
     #[clap(long, default_value_t)]
     pub target: Target,
 
+    /// Path to output file. Use `-` to write output to stdout.
+    #[clap(
+         long, short,
+         default_value = "-",
+         value_parser = output_value_parser(),
+         value_hint = ValueHint::FilePath,
+     )]
+    pub output: Output,
+
     /// The format to serialize in.
-    #[clap(long = "format", default_value_t)]
-    pub format: SerializationFormat,
+    #[clap(long = "format")]
+    pub format: Option<SerializationFormat>,
 
     /// Whether to pretty-print the serialized output.
     ///
@@ -550,6 +559,14 @@ impl Output {
         match self {
             Self::Stdout => Ok(OpenOutput::Stdout(std::io::stdout().lock())),
             Self::Path(path) => std::fs::File::create(path).map(OpenOutput::File),
+        }
+    }
+
+    /// Get the path if the output if a path was specified.
+    pub fn as_path(&self) -> Option<&Path> {
+        match self {
+            Self::Stdout => None,
+            Self::Path(path) => Some(path),
         }
     }
 }

--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -195,10 +195,10 @@ impl CompileConfig {
             None
         };
 
-        let mut deps = args.deps.clone();
-        let mut deps_format = args.deps_format;
+        let mut deps = args.deps.deps.clone();
+        let mut deps_format = args.deps.deps_format;
 
-        if let Some(path) = &args.make_deps
+        if let Some(path) = &args.deps.make_deps
             && deps.is_none()
         {
             deps = Some(Output::Path(path.clone()));

--- a/crates/typst-cli/src/eval.rs
+++ b/crates/typst-cli/src/eval.rs
@@ -4,7 +4,7 @@ use std::sync::LazyLock;
 use comemo::Track;
 use ecow::eco_format;
 use typst::Library;
-use typst::diag::{At, FileResult, HintedStrResult, SourceResult, Warned};
+use typst::diag::{At, FileResult, HintedStrResult, SourceResult, Warned, bail};
 use typst::foundations::{
     Bytes, Context, Datetime, Duration, Output, Scope, StyleChain, Value,
 };
@@ -21,8 +21,9 @@ use typst_kit::diagnostics::DiagnosticWorld;
 use typst_layout::PagedDocument;
 use typst_utils::LazyHash;
 
-use crate::args::{EvalCommand, SerializationFormat, Target};
+use crate::args::{self, EvalCommand, SerializationFormat, Target};
 use crate::compile::print_diagnostics;
+use crate::deps::write_deps;
 use crate::set_failed;
 use crate::world::SystemWorld;
 
@@ -35,6 +36,14 @@ pub fn eval(command: &'static EvalCommand) -> HintedStrResult<()> {
     // Reset everything and ensure that the main file is present.
     world.reset();
     world.source(world.main()).map_err(|err| err.to_string())?;
+
+    if command.output.is_stdout()
+        && command.deps.deps.as_ref().is_some_and(args::Output::is_stdout)
+    {
+        bail!(
+            "can't write both the eval result and depdendencies to stdout.\neither specify a file output with `-o/--output` or a file output for dependencies with `--deps`."
+        );
+    }
 
     // Compile the main file and get the introspector.
     let Warned { output, mut warnings } = match command.target {
@@ -61,7 +70,7 @@ pub fn eval(command: &'static EvalCommand) -> HintedStrResult<()> {
         }
     };
 
-    match output {
+    match output.as_deref() {
         // The target compiled successfully, continue with evaluating the input
         // expression.
         Ok(output) => {
@@ -103,6 +112,8 @@ pub fn eval(command: &'static EvalCommand) -> HintedStrResult<()> {
                 command.process.diagnostic_format,
             )
             .map_err(|err| eco_format!("failed to print diagnostics ({err})"))?;
+
+            world = expr_world.world;
         }
 
         // The target failed, print its diagnostics.
@@ -110,12 +121,22 @@ pub fn eval(command: &'static EvalCommand) -> HintedStrResult<()> {
             set_failed();
             print_diagnostics(
                 &world,
-                &errors,
+                errors,
                 &warnings,
                 command.process.diagnostic_format,
             )
             .map_err(|err| eco_format!("failed to print diagnostics ({err})"))?;
         }
+    }
+
+    if let Some(dest) = &command.deps.deps {
+        write_deps(
+            &mut world,
+            dest,
+            command.deps.deps_format,
+            Some(std::slice::from_ref(&command.output)),
+        )
+        .map_err(|err| eco_format!("failed to create dependency file ({err})"))?;
     }
 
     Ok(())

--- a/crates/typst-cli/src/eval.rs
+++ b/crates/typst-cli/src/eval.rs
@@ -1,9 +1,10 @@
+use std::path::Path;
 use std::sync::LazyLock;
 
 use comemo::Track;
 use ecow::eco_format;
 use typst::Library;
-use typst::diag::{FileResult, HintedStrResult, SourceResult, Warned};
+use typst::diag::{At, FileResult, HintedStrResult, SourceResult, Warned};
 use typst::foundations::{
     Bytes, Context, Datetime, Duration, Output, Scope, StyleChain, Value,
 };
@@ -20,7 +21,7 @@ use typst_kit::diagnostics::DiagnosticWorld;
 use typst_layout::PagedDocument;
 use typst_utils::LazyHash;
 
-use crate::args::{EvalCommand, Target};
+use crate::args::{EvalCommand, SerializationFormat, Target};
 use crate::compile::print_diagnostics;
 use crate::set_failed;
 use crate::world::SystemWorld;
@@ -45,6 +46,21 @@ pub fn eval(command: &'static EvalCommand) -> HintedStrResult<()> {
             .map(|result| result.map(|output| Box::new(output) as Box<dyn Output>)),
     };
 
+    let output_format = if let Some(specified) = command.format {
+        specified
+    } else {
+        match command.output.as_path().and_then(Path::extension) {
+            Some(ext) if ext.eq_ignore_ascii_case("json") => SerializationFormat::Json,
+            Some(ext)
+                if ext.eq_ignore_ascii_case("yaml")
+                    || ext.eq_ignore_ascii_case("yml") =>
+            {
+                SerializationFormat::Yaml
+            }
+            _ => SerializationFormat::default(),
+        }
+    };
+
     match output {
         // The target compiled successfully, continue with evaluating the input
         // expression.
@@ -60,13 +76,21 @@ pub fn eval(command: &'static EvalCommand) -> HintedStrResult<()> {
                 &expr_world,
                 output.introspector(),
             );
-            let errors = match &eval_result {
-                Err(errors) => errors.as_slice(),
+            let errors = match eval_result {
+                Err(errors) => errors,
                 Ok(value) => {
-                    let serialized =
-                        crate::serialize(value, command.format, command.pretty)?;
-                    println!("{serialized}");
-                    &[]
+                    let mut serialized =
+                        crate::serialize(&value, output_format, command.pretty)?;
+                    if !serialized.ends_with('\n') {
+                        serialized.push('\n');
+                    }
+                    command
+                        .output
+                        .write(serialized.as_bytes())
+                        .map_err(|err| eco_format!("failed to write output file ({err})"))
+                        .at(Span::detached())
+                        .err()
+                        .unwrap_or_default()
                 }
             };
             // Collect additional warnings from evaluating the expression.
@@ -74,7 +98,7 @@ pub fn eval(command: &'static EvalCommand) -> HintedStrResult<()> {
 
             print_diagnostics(
                 &expr_world,
-                errors,
+                &errors,
                 &warnings,
                 command.process.diagnostic_format,
             )

--- a/crates/typst-cli/tests/smoke.rs
+++ b/crates/typst-cli/tests/smoke.rs
@@ -148,6 +148,96 @@ fn test_eval_infer_format() {
 }
 
 #[test]
+fn test_eval_deps() {
+    let project = tempfs();
+
+    let main = project.write("main.typ", "#image(\"tiger.jpg\")");
+    project.write("tiger.jpg", typst_dev_assets::get_by_name("tiger.jpg").unwrap());
+
+    // Output result to file and deps to stdout.
+    let output = exec()
+        .args(["eval", "(1, 2, 3, 4)", "--deps-format=make", "--in"])
+        .arg(&main)
+        .arg("-o")
+        .arg(project.resolve("foo.json"))
+        .arg("--deps=-")
+        .must_succeed();
+    output
+        .stdout
+        .must_contain("foo.json:") // Input
+        .must_contain("main.typ")
+        .must_contain("tiger.jpg");
+    output.stderr.must_be_empty();
+    project.read("foo.json").must_match_lines(["[1,2,3,4]"]);
+
+    // Output result to stdout and deps to file.
+    let output = exec()
+        .args(["eval", "(1, 2, 3, 4)", "--in"])
+        .arg(&main)
+        .arg("--deps")
+        .arg(project.resolve("main.d"))
+        .must_succeed();
+    output.stdout.must_match_lines(["[1,2,3,4]"]);
+    output.stderr.must_be_empty();
+    project
+        .read("main.d")
+        .must_not_contain("\"-\"")
+        .must_contain("main.typ\"")
+        .must_contain("tiger.jpg\"");
+
+    // Output both result and deps to file.
+    let output = exec()
+        .args(["eval", "(1, 2, 3, 4)", "--deps-format=make", "--in"])
+        .arg(&main)
+        .arg("-o")
+        .arg(project.resolve("foo.json"))
+        .arg("--deps")
+        .arg(project.resolve("main.d"))
+        .must_succeed();
+    output.stdout.must_be_empty();
+    output.stderr.must_be_empty();
+    project.read("foo.json").must_match_lines(["[1,2,3,4]"]);
+    project
+        .read("main.d")
+        .must_contain("foo.json:")
+        .must_contain("main.typ")
+        .must_contain("tiger.jpg");
+
+    // Output both result and deps to stdout (should fail).
+    let output = exec()
+        .args(["eval", "(1, 2, 3, 4)", "--deps=-", "--in"])
+        .arg(&main)
+        .must_fail();
+    output
+        .stderr
+        .must_contain("can't write both the eval result and depdendencies to stdout");
+    output.stdout.must_be_empty();
+}
+
+#[test]
+fn test_eval_deps_incomplete() {
+    let project = tempfs();
+
+    let main = project.write("main.typ", "#image(\"tiger.jpg\") #thisisinvalid");
+    project.write("tiger.jpg", typst_dev_assets::get_by_name("tiger.jpg").unwrap());
+
+    // Output result to stdout and deps to file.
+    let output = exec()
+        .args(["eval", "(1, 2, 3, 4)", "--in"])
+        .arg(&main)
+        .arg("--deps")
+        .arg(project.resolve("main.d"))
+        .must_fail();
+    output.stdout.must_match_lines([]);
+    output.stderr.must_contain("error: unknown variable");
+    project
+        .read("main.d")
+        .must_not_contain("\"-\"")
+        .must_contain("main.typ\"")
+        .must_contain("tiger.jpg\"");
+}
+
+#[test]
 fn test_fonts_embedded() {
     let output = exec().arg("fonts").arg("--ignore-system-fonts").must_succeed();
     output.stdout.must_match_lines([
@@ -438,6 +528,12 @@ impl<T: AsRef<[u8]>> Stream<T> {
     #[track_caller]
     fn must_contain(&self, data: impl Debug + AsRef<[u8]>) -> &Self {
         assert!(self.contains(data.as_ref()), "{self:?} did not contain {data:?}",);
+        self
+    }
+
+    #[track_caller]
+    fn must_not_contain(&self, data: impl Debug + AsRef<[u8]>) -> &Self {
+        assert!(!self.contains(data.as_ref()), "{self:?} contained {data:?}",);
         self
     }
 

--- a/crates/typst-cli/tests/smoke.rs
+++ b/crates/typst-cli/tests/smoke.rs
@@ -48,6 +48,106 @@ fn test_eval() {
 }
 
 #[test]
+fn test_eval_format() {
+    // Default format (JSON).
+    let output = exec().arg("eval").arg("(1, 2, 3, 4)").must_succeed();
+    output.stdout.must_match_lines(["[1,2,3,4]"]);
+
+    // JSON manually specified.
+    let output = exec()
+        .arg("eval")
+        .args(["(1, 2, 3, 4)", "--format", "json"])
+        .must_succeed();
+    output.stdout.must_match_lines(["[1,2,3,4]"]);
+
+    // YAML manually specified.
+    let output = exec()
+        .arg("eval")
+        .args(["(1, 2, 3, 4)", "--format", "yaml"])
+        .must_succeed();
+    output.stdout.must_match_lines(["- 1", "- 2", "- 3", "- 4"]);
+}
+
+#[test]
+fn test_eval_output() {
+    let project = tempfs();
+
+    // Named path.
+    let output = exec()
+        .args(["eval", "(1, 2, 3, 4)", "-o"])
+        .arg(project.resolve("foo"))
+        .must_succeed();
+    output.stdout.must_be_empty();
+    output.stderr.must_be_empty();
+    project.read("foo").must_match_lines(["[1,2,3,4]"]);
+
+    // Output to stdout.
+    let output = exec().args(["eval", "(1, 2, 3, 4)", "-o", "-"]).must_succeed();
+    output.stdout.must_match_lines(["[1,2,3,4]"]);
+    output.stderr.must_be_empty();
+}
+
+#[test]
+fn test_eval_infer_format() {
+    let project = tempfs();
+
+    // Unknown extension (default format).
+    exec()
+        .args(["eval", "(1, 2, 3, 4)", "-o"])
+        .arg(project.resolve("foo.extension"))
+        .must_succeed();
+    project.read("foo.extension").must_match_lines(["[1,2,3,4]"]);
+
+    // Unknown extension, default format overwritten.
+    exec()
+        .args(["eval", "(1, 2, 3, 4)", "--format", "yaml", "-o"])
+        .arg(project.resolve("foo.extension"))
+        .must_succeed();
+    project
+        .read("foo.extension")
+        .must_match_lines(["- 1", "- 2", "- 3", "- 4"]);
+
+    // JSON inferred.
+    exec()
+        .args(["eval", "(1, 2, 3, 4)", "-o"])
+        .arg(project.resolve("foo.json"))
+        .must_succeed();
+    project.read("foo.json").must_match_lines(["[1,2,3,4]"]);
+
+    // YAML inferred (1).
+    exec()
+        .args(["eval", "(1, 2, 3, 4)", "-o"])
+        .arg(project.resolve("foo.yaml"))
+        .must_succeed();
+    project
+        .read("foo.yaml")
+        .must_match_lines(["- 1", "- 2", "- 3", "- 4"]);
+
+    // YAML inferred (2).
+    exec()
+        .args(["eval", "(1, 2, 3, 4)", "-o"])
+        .arg(project.resolve("foo.yml"))
+        .must_succeed();
+    project.read("foo.yml").must_match_lines(["- 1", "- 2", "- 3", "- 4"]);
+
+    // YAML overwritten.
+    exec()
+        .args(["eval", "(1, 2, 3, 4)", "--format", "yaml", "-o"])
+        .arg(project.resolve("foo.json"))
+        .must_succeed();
+    project
+        .read("foo.json")
+        .must_match_lines(["- 1", "- 2", "- 3", "- 4"]);
+
+    // JSON overwritten.
+    exec()
+        .args(["eval", "(1, 2, 3, 4)", "--format=json", "-o"])
+        .arg(project.resolve("foo.yml"))
+        .must_succeed();
+    project.read("foo.yml").must_match_lines(["[1,2,3,4]"]);
+}
+
+#[test]
 fn test_fonts_embedded() {
     let output = exec().arg("fonts").arg("--ignore-system-fonts").must_succeed();
     output.stdout.must_match_lines([
@@ -356,6 +456,12 @@ impl<T: AsRef<[u8]>> Stream<T> {
             self.lines().collect::<Vec<_>>(),
             lines.into_iter().collect::<Vec<_>>(),
         );
+        self
+    }
+
+    #[track_caller]
+    fn must_be_empty(&self) -> &Self {
+        assert!(self.0.as_ref().is_empty(), "{self:?} is not empty");
         self
     }
 


### PR DESCRIPTION
This adds support for printing file dependencies when using `typst eval`. The motivation for this is similar to #8576 - better support for the command in Makefiles (or similar).

The arguments are the same as in the other commands. Dependencies can be printed to stdout or a file. The eval output must be a file when printing to stdout.

Depends on #8576.