### PR TITLE
Improve error for field-access calls on settable element fields

### DIFF
--- a/crates/typst-eval/src/call.rs
+++ b/crates/typst-eval/src/call.rs
@@ -1,7 +1,8 @@
 use comemo::{Tracked, TrackedMut};
 use ecow::{EcoString, EcoVec, eco_format};
 use typst_library::diag::{
-    At, HintedStrResult, HintedString, SourceResult, Trace, Tracepoint, bail, error,
+    At, HintedStrResult, HintedString, SourceDiagnostic, SourceResult, Trace, Tracepoint,
+    bail, error,
 };
 use typst_library::engine::{Engine, Sink, Traced};
 use typst_library::foundations::{
@@ -255,92 +256,50 @@ fn eval_field_callee<'a, 'b>(
     {
         is_method_call = true;
         method.read_checked(sink).clone()
-    } else if matches!(
-        target,
-        Value::Symbol(_) | Value::Func(_) | Value::Type(_) | Value::Module(_)
-    ) {
-        // Only these types are allowed to use field call syntax on non-methods.
+    } else if matches!(target, Value::Symbol(_) | Value::Type(_) | Value::Module(_)) {
+        // These types are allowed to use field call syntax on non-methods.
         target.field(field, sink).at(field_span)?
+    } else if let Value::Func(func) = &target {
+        // Functions can also use field call syntax on non-methods, but not for
+        // settable fields accessed from context.
+        match target.field(field, sink).at(field_span) {
+            Ok(callee_value) => callee_value,
+            Err(err) => {
+                if let Some(element) = func.to_element()
+                    && let Some(field_accessor) = element.settable_field_accessor(field)
+                {
+                    let styles = vm.context.styles().at(field_span)?;
+                    let callee_value = field_accessor(styles);
+                    bail!(disallowed_field_call_error(
+                        callee_value,
+                        access,
+                        field,
+                        target,
+                        in_math
+                    ));
+                } else {
+                    return Err(err);
+                }
+            }
+        }
     } else {
-        // Otherwise we cannot call this field and produce an error.
+        // Otherwise we are not allowed to call the field and produce an error.
         match target.field(field, sink) {
             // The field does exist.
             Ok(callee_value) => {
-                // Aside from Dict, named Args, and Content, only a few other
-                // types have accessible fields which could produce these
-                // errors. As of June 2026, they are:
-                // - Alignment (.x, .y)
-                // - Length (.abs, .em)
-                // - Relative Length (.ratio, .length)
-                // - Stroke (.cap, .dash, .join, .miter-limit, .paint, .thickness)
-                // - Version (.major, .minor, .patch)
-                // The other types with fields (Symbol, Func, Type, Module) are
-                // handled above.
-                let is_dict = matches!(target, Value::Dict(_));
-                let is_named = matches!(target, Value::Args(_));
-                let mut err = if is_dict {
-                    // Dictionaries get a specific error & hint because they're
-                    // the easiest to attempt this with, and users need to be
-                    // told directly why it's not allowed.
-                    error!(
-                        access.span(),
-                        "cannot directly call dictionary keys as functions";
-                    )
-                } else if is_named {
-                    // Also give the custom error & hint for named arguments.
-                    error!(
-                        access.span(),
-                        "cannot directly call named argument fields as functions";
-                    )
-                } else {
-                    let (kind, name) = element_or_type_with_name(&target);
-                    error!(
-                        access.span(),
-                        "`{field}` is not a valid method for {kind} `{name}`";
-                    )
-                };
-                if callee_value.clone().cast::<Func>().is_ok() {
-                    err.hint(eco_format!(
-                        "to call the stored function, {}wrap the field access \
-                            in parentheses: `{}({})(..)`",
-                        if in_math { "use code mode and " } else { "" },
-                        if in_math { "#" } else { "" },
-                        access.full_text(),
-                    ));
-                } else if in_math {
-                    err.hint("try adding a space before the parentheses");
-                } else {
-                    err.hint(eco_format!(
-                        "to access the `{field}` {}, remove the function arguments: `{}`",
-                        if is_dict {
-                            "key"
-                        } else if is_named {
-                            "argument"
-                        } else {
-                            "field"
-                        },
-                        access.full_text(),
-                    ));
-                }
-                if is_dict {
-                    err.hint(
-                        "dictionary keys cannot be used with method syntax as keys \
-                            could conflict with built-in method names",
-                    );
-                } else if is_named {
-                    err.hint(
-                        "named arguments cannot be used with method syntax as argument \
-                            names could conflict with built-in method names",
-                    );
-                }
-
-                bail!(err)
+                bail!(disallowed_field_call_error(
+                    callee_value,
+                    access,
+                    field,
+                    target,
+                    in_math
+                ));
             }
             // The field does not exist. We don't try as hard on the error here
             // to avoid assuming the user's intent.
             Err(_) => {
                 let (kind, name) = element_or_type_with_name(&target);
-                bail!(access.span(), "{kind} {name} has no method `{field}`")
+                bail!(access.span(), "{kind} {name} has no method `{field}`");
             }
         }
     };
@@ -352,6 +311,83 @@ fn eval_field_callee<'a, 'b>(
         Ok(func) => Ok(FieldCallee::Func(func)),
         Err(err) => Ok(FieldCallee::NonFunc(callee_value, err)),
     }
+}
+
+/// Produce an error for calls to fields that do exist, but are not allowed to
+/// be called with field-access syntax.
+///
+/// The types that do allow direct field-access calling are `Symbol`, `Type`,
+/// `Module`, and `Func`. Although functions don't allow settable fields
+/// accessed from context (like `heading.numbering`) to be called directly.
+///
+/// The main types that allow field-access but disallow calling are `Dict`,
+/// named `Args`, and `Content`.
+///
+/// And the remaining types/fields that could produce this error are:
+/// - `Alignment`: `.x`, `.y`
+/// - `Length`: `.abs`, `.em`
+/// - `Rel`: `.ratio`, `.length`
+/// - `Stroke`: `.cap`, `.dash`, `.join`, `.miter-limit`, `.paint`, `.thickness`
+/// - `Version`: `.major`, `.minor`, `.patch`
+fn disallowed_field_call_error(
+    callee_value: Value,
+    access: &SyntaxNode,
+    field: &str,
+    target: Value,
+    in_math: bool,
+) -> SourceDiagnostic {
+    let is_dict = matches!(target, Value::Dict(_));
+    let is_named = matches!(target, Value::Args(_));
+    let mut err = if is_dict {
+        // Dictionaries get a specific error & hint because they're the easiest
+        // to attempt this with, and users need to be told directly why it's not
+        // allowed.
+        error!(access.span(), "cannot directly call dictionary keys as functions")
+    } else if is_named {
+        // Also give the custom error & hint for named arguments.
+        error!(access.span(), "cannot directly call named argument fields as functions")
+    } else {
+        let (kind, name) = element_or_type_with_name(&target);
+        error!(access.span(), "`{field}` is not a valid method for {kind} `{name}`")
+    };
+
+    if callee_value.clone().cast::<Func>().is_ok() {
+        err.hint(eco_format!(
+            "to call the stored function, {}wrap the field access \
+                in parentheses: `{}({})(..)`",
+            if in_math { "use code mode and " } else { "" },
+            if in_math { "#" } else { "" },
+            access.full_text(),
+        ));
+    } else if in_math {
+        err.hint("try adding a space before the parentheses");
+    } else {
+        err.hint(eco_format!(
+            "to access the `{field}` {}, remove the function arguments: `{}`",
+            if is_dict {
+                "key"
+            } else if is_named {
+                "argument"
+            } else {
+                "field"
+            },
+            access.full_text(),
+        ));
+    }
+
+    if is_dict {
+        err.hint(
+            "dictionary keys cannot be used with method syntax as keys could conflict \
+                with built-in method names",
+        );
+    } else if is_named {
+        err.hint(
+            "named arguments cannot be used with method syntax as argument names could \
+                conflict with built-in method names",
+        );
+    }
+
+    err
 }
 
 /// If the value is content, the string "element" and the name of its element

--- a/crates/typst-eval/src/code.rs
+++ b/crates/typst-eval/src/code.rs
@@ -371,18 +371,14 @@ pub(crate) fn access_field(
         Err(err) => err,
     };
 
-    // Check whether this is a get rule field access.
+    // Missing fields may actually be present if they are settable parameters
+    // on elements accessed with context, e.g. `block.stroke`.
     if let Value::Func(func) = &target
         && let Some(element) = func.to_element()
-        && let Some(id) = element.field_id(field)
-        && let styles = vm.context.styles().at(field_span)
-        && let Ok(value) =
-            element.field_from_styles(id, styles.as_ref().map(|&s| s).unwrap_or_default())
+        && let Some(field_accessor) = element.settable_field_accessor(field)
     {
-        // Only validate the contextual styles once we know that this is indeed
-        // a field from the style chain.
-        let _ = styles?;
-        return Ok(value);
+        let styles = vm.context.styles().at(field_span)?;
+        return Ok(field_accessor(styles));
     }
 
     Err(err)

--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -231,10 +231,10 @@ fn field_access_completions(
         Value::Func(func) => {
             // Autocomplete get rules.
             if let Some((elem, styles)) = func.to_element().zip(styles.as_ref()) {
-                for param in elem.params().iter().filter(|param| !param.required) {
-                    if let Some(value) = elem.field_id(param.name).and_then(|id| {
-                        elem.field_from_styles(id, StyleChain::new(styles)).ok()
-                    }) {
+                for param in elem.params() {
+                    if let Some(field_accessor) = elem.settable_field_accessor(param.name)
+                    {
+                        let value = field_accessor(StyleChain::new(styles));
                         ctx.value_completion(param.name, &value);
                     }
                 }

--- a/crates/typst-library/src/foundations/content/element.rs
+++ b/crates/typst-library/src/foundations/content/element.rs
@@ -11,8 +11,8 @@ use typst_utils::{DefSite, Static};
 use crate::diag::SourceResult;
 use crate::engine::Engine;
 use crate::foundations::{
-    Args, Content, ContentVtable, FieldAccessError, Func, NativeParamInfo, Repr, Scope,
-    Selector, StyleChain, Styles, Value, cast,
+    Args, Content, ContentVtable, Func, NativeParamInfo, Repr, Scope, Selector,
+    StyleChain, Styles, Value, cast,
 };
 use crate::text::{Lang, Region};
 
@@ -157,16 +157,14 @@ impl Element {
         self.vtable().field(id).map(|data| data.name)
     }
 
-    /// Extract the value of the field for the given field ID and style chain.
-    pub fn field_from_styles(
-        &self,
-        id: u8,
-        styles: StyleChain,
-    ) -> Result<Value, FieldAccessError> {
-        self.vtable()
-            .field(id)
-            .and_then(|field| (field.get_from_styles)(styles))
-            .ok_or(FieldAccessError::Unknown)
+    /// The style chain accessor for a settable field of the element. Returns
+    /// `None` if the field is unknown or is not settable.
+    ///
+    /// Note that this will return `None` for `#[ghost]` fields since `field_id`
+    /// returns `None`.
+    pub fn settable_field_accessor(self, name: &str) -> Option<fn(StyleChain) -> Value> {
+        let id = (self.vtable().field_id)(name)?;
+        self.vtable().fields[usize::from(id)].get_from_styles
     }
 
     /// The element's local name, if any.

--- a/crates/typst-library/src/foundations/content/field.rs
+++ b/crates/typst-library/src/foundations/content/field.rs
@@ -95,7 +95,7 @@ impl<E: RequiredField<I>, const I: u8> RequiredFieldData<E, I> {
             has: |_| true,
             get: |elem| Some((E::FIELD.get)(elem).clone().into_value()),
             get_with_styles: |elem, _| Some((E::FIELD.get)(elem).clone().into_value()),
-            get_from_styles: |_| None,
+            get_from_styles: None,
             materialize: |_, _| {},
             eq: |a, b| (E::FIELD.get)(a) == (E::FIELD.get)(b),
         }
@@ -122,7 +122,7 @@ impl<E: RequiredField<I>, const I: u8> RequiredFieldData<E, I> {
             has: |_| true,
             get: |elem| Some((E::FIELD.get)(elem).clone().into_value()),
             get_with_styles: |elem, _| Some((E::FIELD.get)(elem).clone().into_value()),
-            get_from_styles: |_| None,
+            get_from_styles: None,
             materialize: |_, _| {},
             eq: |a, b| (E::FIELD.get)(a) == (E::FIELD.get)(b),
         }
@@ -178,7 +178,7 @@ impl<E: SynthesizedField<I>, const I: u8> SynthesizedFieldData<E, I> {
             get_with_styles: |elem, _| {
                 (E::FIELD.get)(elem).clone().map(|v| v.into_value())
             },
-            get_from_styles: |_| None,
+            get_from_styles: None,
             materialize: |_, _| {},
             // Synthesized fields don't affect equality.
             eq: |_, _| true,
@@ -232,7 +232,7 @@ impl<E: ExternalField<I>, const I: u8> ExternalFieldData<E, I> {
             has: |_| false,
             get: |_| None,
             get_with_styles: |_, _| None,
-            get_from_styles: |_| None,
+            get_from_styles: None,
             materialize: |_, _| {},
             eq: |_, _| true,
         }
@@ -308,9 +308,9 @@ impl<E: SettableField<I>, const I: u8> SettableFieldData<E, I> {
             get_with_styles: |elem, styles| {
                 Some((E::FIELD.get)(elem).get_cloned(styles).into_value())
             },
-            get_from_styles: |styles| {
-                Some(styles.get_cloned::<E, I>(Field::new()).into_value())
-            },
+            get_from_styles: Some(|styles| {
+                styles.get_cloned::<E, I>(Field::new()).into_value()
+            }),
             materialize: |elem, styles| {
                 if !(E::FIELD.get)(elem).is_set() {
                     (E::FIELD.get_mut)(elem).set(styles.get_cloned::<E, I>(Field::new()));
@@ -423,9 +423,9 @@ impl<E: SettableProperty<I>, const I: u8> SettablePropertyData<E, I> {
             get_with_styles: |_, styles| {
                 Some(styles.get_cloned::<E, I>(Field::new()).into_value())
             },
-            get_from_styles: |styles| {
-                Some(styles.get_cloned::<E, I>(Field::new()).into_value())
-            },
+            get_from_styles: Some(|styles| {
+                styles.get_cloned::<E, I>(Field::new()).into_value()
+            }),
             materialize: |_, _| {},
             eq: |_, _| true,
         }

--- a/crates/typst-library/src/foundations/content/vtable.rs
+++ b/crates/typst-library/src/foundations/content/vtable.rs
@@ -358,8 +358,12 @@ pub struct FieldVtable<T: 'static = RawContent> {
     /// element, the style chain, or a mix (if it's a
     /// [`Fold`](crate::foundations::Fold) field).
     pub(super) get_with_styles: unsafe fn(elem: &T, StyleChain) -> Option<Value>,
-    /// Retrieves the field just from the styles.
-    pub(super) get_from_styles: fn(StyleChain) -> Option<Value>,
+    /// Retrieves the field just from the styles, falling back to the default
+    /// value if not manually set.
+    ///
+    /// Note that this is currently `Some` when the field is settable and `None`
+    /// otherwise.
+    pub(super) get_from_styles: Option<fn(StyleChain) -> Value>,
     /// Sets the field from the styles if it is currently unset. (Or merges
     /// with the style data in case of a `Fold` field).
     pub(super) materialize: unsafe fn(elem: &mut T, styles: StyleChain),

--- a/tests/suite/scripting/get-rule.typ
+++ b/tests/suite/scripting/get-rule.typ
@@ -11,6 +11,12 @@
 #set text(lang: "de")
 #context test(translate(de: "Inhalt", en: "Contents"), "Inhalt")
 
+--- get-rule-call paged empty ---
+// Test calling a contextual field as a function. Note that we need to wrap the
+// field-access in parens to avoid an error for a disallowed field call.
+#set heading(numbering: (..n) => n)
+#context test((heading.numbering)(1, 2), arguments(1, 2))
+
 --- get-rule-in-array-callback paged empty ---
 // Test whether context is retained in built-in callback.
 #set text(lang: "de")

--- a/tests/suite/scripting/methods.typ
+++ b/tests/suite/scripting/methods.typ
@@ -142,6 +142,37 @@ $ pi.alt() $
 // Hint: 3-9 named arguments cannot be used with method syntax as argument names could conflict with built-in method names
 $ pi.alt() $
 
+--- field-call-no-context eval ---
+#set heading(numbering: (..n) => none)
+// Error: 10-19 function `heading` does not contain field `numbering`
+#heading.numbering(1)
+
+--- math-field-call-no-context eval ---
+#set heading(numbering: (..n) => none)
+// Error: 14-23 function `heading` does not contain field `numbering`
+$std.heading.numbering(#1)$
+
+--- field-call-contextual-invalid paged empty ---
+// Test calling a contextual field as a function.
+#set heading(numbering: (..n) => none)
+// Error: 18-27 function `heading` does not contain field `numbering`
+#context heading.numbering(1)
+
+--- math-field-call-contextual-invalid paged empty ---
+#set heading(numbering: (..n) => none)
+// Error: 23-32 function `heading` does not contain field `numbering`
+#context $std.heading.numbering(#1)$
+
+--- field-call-contextual-non-func paged empty ---
+#set heading(numbering: "1.")
+// Error: 18-27 function `heading` does not contain field `numbering`
+#context heading.numbering(1)
+
+--- math-field-call-contextual-non-func paged empty ---
+#set heading(numbering: "1.")
+// Error: 23-32 function `heading` does not contain field `numbering`
+#context $std.heading.numbering(#1)$
+
 --- field-call-mut-basic eval ---
 // Mutating methods mutate a variable.
 #let numbers = (1, 2, 3)

--- a/tests/suite/scripting/methods.typ
+++ b/tests/suite/scripting/methods.typ
@@ -144,33 +144,41 @@ $ pi.alt() $
 
 --- field-call-no-context eval ---
 #set heading(numbering: (..n) => none)
-// Error: 10-19 function `heading` does not contain field `numbering`
+// Error: 10-19 can only be used when context is known
+// Hint: 10-19 try wrapping this in a `context` expression
+// Hint: 10-19 the `context` expression should wrap everything that depends on this function
 #heading.numbering(1)
 
 --- math-field-call-no-context eval ---
 #set heading(numbering: (..n) => none)
-// Error: 14-23 function `heading` does not contain field `numbering`
+// Error: 14-23 can only be used when context is known
+// Hint: 14-23 try wrapping this in a `context` expression
+// Hint: 14-23 the `context` expression should wrap everything that depends on this function
 $std.heading.numbering(#1)$
 
 --- field-call-contextual-invalid paged empty ---
 // Test calling a contextual field as a function.
 #set heading(numbering: (..n) => none)
-// Error: 18-27 function `heading` does not contain field `numbering`
+// Error: 10-27 `numbering` is not a valid method for type `function`
+// Hint: 10-27 to call the stored function, wrap the field access in parentheses: `(heading.numbering)(..)`
 #context heading.numbering(1)
 
 --- math-field-call-contextual-invalid paged empty ---
 #set heading(numbering: (..n) => none)
-// Error: 23-32 function `heading` does not contain field `numbering`
+// Error: 11-32 `numbering` is not a valid method for type `function`
+// Hint: 11-32 to call the stored function, use code mode and wrap the field access in parentheses: `#(std.heading.numbering)(..)`
 #context $std.heading.numbering(#1)$
 
 --- field-call-contextual-non-func paged empty ---
 #set heading(numbering: "1.")
-// Error: 18-27 function `heading` does not contain field `numbering`
+// Error: 10-27 `numbering` is not a valid method for type `function`
+// Hint: 10-27 to access the `numbering` field, remove the function arguments: `heading.numbering`
 #context heading.numbering(1)
 
 --- math-field-call-contextual-non-func paged empty ---
 #set heading(numbering: "1.")
-// Error: 23-32 function `heading` does not contain field `numbering`
+// Error: 11-32 `numbering` is not a valid method for type `function`
+// Hint: 11-32 try adding a space before the parentheses
 #context $std.heading.numbering(#1)$
 
 --- field-call-mut-basic eval ---


### PR DESCRIPTION
Fixes #8578

We previously didn't handle this case because the logic for accessing settable fields in `access_field` wasn't copied to `eval_field_callee`. The final commit adds that logic and factors out the `disallowed_field_call_error` function so we get the same error message as for non-settable field-access calls.

However, I wasn't satisfied with the shape of that logic, and dug into the vtable internals to realize that we can refactor `Element::field_from_styles` to return the accessor function itself so we don't have to do the whole song-and-dance of `styles.as_ref().map(|&s| s).unwrap_or_default()` and `let _ = styles?;`. I added this change as the first commit.

I will also note that the first commit makes it so that `FieldVtable::get_from_styles` and `FieldVtable::settable` are correlated such that `settable == get_from_styles.is_some()`, but I didn't want to replace `settable` since I don't know if that is intended to always be true.

Finally, instead of erroring, we could just choose to allow field-access calls for settable fields, but this would be similar to allowing `#heading([], supplement: x => x + 1).supplement(2)`, which I've previously noted as "would be pretty cursed" (in `field-call-invalid-content-field-func`).