### PR TITLE
fix: use container full for place() in empty flows closes #6822

### DIFF
--- a/crates/typst-layout/src/flow/compose.rs
+++ b/crates/typst-layout/src/flow/compose.rs
@@ -168,6 +168,13 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
 
             output.push_frame(Point::with_x(x), frame);
             inner.next();
+
+            if !regions.expand.y
+                && regions.size.y.is_finite()
+                && !output.size().y.is_zero()
+            {
+                inner.full = output.size().y;
+            }
         }
 
         // Column balancing with re-layout

--- a/crates/typst-layout/src/flow/compose.rs
+++ b/crates/typst-layout/src/flow/compose.rs
@@ -165,6 +165,13 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
 
             output.push_frame(Point::with_x(x), frame);
             inner.next();
+
+            if !regions.expand.y
+                && regions.size.y.is_finite()
+                && !output.size().y.is_zero()
+            {
+                inner.full = output.size().y;
+            }
         }
 
         Ok(output)

--- a/crates/typst-layout/src/flow/distribute.rs
+++ b/crates/typst-layout/src/flow/distribute.rs
@@ -606,14 +606,30 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
                     output.push_frame(pos, frame);
                 }
                 Item::Placed(frame, placed) => {
-                    let x = placed.align_x.position(size.x - frame.width());
+                    let container_x = if region.expand.x || used.x.is_zero() {
+                        region.size.x
+                    } else {
+                        size.x
+                    };
+                    let x = placed.align_x.position(container_x - frame.width());
+                    let container_y = if used.y.is_zero() && !region.expand.y {
+                        self.regions.full
+                    } else {
+                        size.y
+                    };
                     let y = match placed.align_y.unwrap_or_default() {
-                        Some(align) => align.position(size.y - frame.height()),
+                        Some(align) => align.position(container_y - frame.height()),
                         _ => offset + ruler.position(free),
                     };
 
                     let pos = Point::new(x, y)
-                        + placed.delta.zip_map(size, Rel::relative_to).to_point();
+                        + placed
+                            .delta
+                            .zip_map(
+                                Size::new(container_x, container_y),
+                                Rel::relative_to,
+                            )
+                            .to_point();
 
                     output.push_frame(pos, frame);
                 }

--- a/crates/typst-layout/src/flow/distribute.rs
+++ b/crates/typst-layout/src/flow/distribute.rs
@@ -80,8 +80,8 @@ enum Item<'a, 'b> {
     Fr(Fr, u8, Option<&'b SingleChild<'a>>),
     /// A frame for a laid out line or block.
     Frame(Frame, Axes<FixedAlignment>),
-    /// A frame for an absolutely (not floatingly) placed child.
-    Placed(Frame, &'b PlacedChild<'a>),
+    /// An absolutely (not floatingly) placed child.
+    Placed(&'b PlacedChild<'a>),
 }
 
 impl Item<'_, '_> {
@@ -96,7 +96,7 @@ impl Item<'_, '_> {
                         matches!(item, FrameItem::Link(_, _) | FrameItem::Tag(_))
                     })
             }
-            Self::Placed(_, placed) => !placed.float,
+            Self::Placed(placed) => !placed.float,
             _ => false,
         }
     }
@@ -454,7 +454,7 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
             self.composer
                 .footnotes(&self.regions, &frame, Abs::zero(), true, true)?;
             self.flush_tags();
-            self.items.push(Item::Placed(frame, placed));
+            self.items.push(Item::Placed(placed));
         }
         Ok(())
     }
@@ -605,18 +605,29 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
 
                     output.push_frame(pos, frame);
                 }
-                Item::Placed(frame, placed) => {
+                Item::Placed(placed) => {
                     let container_x = if region.expand.x || used.x.is_zero() {
                         region.size.x
                     } else {
                         size.x
                     };
-                    let x = placed.align_x.position(container_x - frame.width());
                     let container_y = if used.y.is_zero() && !region.expand.y {
                         self.regions.full
                     } else {
                         size.y
                     };
+
+                    let base = Size::new(
+                        region.size.x,
+                        if used.y.is_zero() && !region.expand.y {
+                            self.regions.full
+                        } else {
+                            size.y
+                        },
+                    );
+                    let frame = placed.layout(self.composer.engine, base)?;
+
+                    let x = placed.align_x.position(container_x - frame.width());
                     let y = match placed.align_y.unwrap_or_default() {
                         Some(align) => align.position(container_y - frame.height()),
                         _ => offset + ruler.position(free),

--- a/crates/typst-layout/src/flow/distribute.rs
+++ b/crates/typst-layout/src/flow/distribute.rs
@@ -650,12 +650,12 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
                     output.push_frame(pos, frame);
                 }
                 Item::Placed(placed) => {
-                    let container_x = if region.expand.x || used.x.is_zero() {
+                    let container_x = if region.expand.x || self.used.x.is_zero() {
                         region.size.x
                     } else {
                         size.x
                     };
-                    let container_y = if used.y.is_zero() && !region.expand.y {
+                    let container_y = if self.used.y.is_zero() && !region.expand.y {
                         self.regions.full
                     } else {
                         size.y
@@ -663,7 +663,7 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
 
                     let base = Size::new(
                         region.size.x,
-                        if used.y.is_zero() && !region.expand.y {
+                        if self.used.y.is_zero() && !region.expand.y {
                             self.regions.full
                         } else {
                             size.y

--- a/crates/typst-layout/src/flow/distribute.rs
+++ b/crates/typst-layout/src/flow/distribute.rs
@@ -92,8 +92,8 @@ enum Item<'a, 'b> {
     Fr(Fr, u8, Option<&'b SingleChild<'a>>),
     /// A frame for a laid out line or block.
     Frame(Frame, Axes<FixedAlignment>),
-    /// A frame for an absolutely (not floatingly) placed child.
-    Placed(Frame, &'b PlacedChild<'a>),
+    /// An absolutely (not floatingly) placed child.
+    Placed(&'b PlacedChild<'a>),
 }
 
 impl Item<'_, '_> {
@@ -108,7 +108,7 @@ impl Item<'_, '_> {
                         matches!(item, FrameItem::Link(_, _) | FrameItem::Tag(_))
                     })
             }
-            Self::Placed(_, placed) => !placed.float,
+            Self::Placed(placed) => !placed.float,
             _ => false,
         }
     }
@@ -506,7 +506,7 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
             self.composer
                 .footnotes(&self.regions, &frame, Abs::zero(), true, true)?;
             self.flush_tags();
-            self.items.push(Item::Placed(frame, placed));
+            self.items.push(Item::Placed(placed));
         }
         Ok(())
     }
@@ -649,18 +649,29 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
 
                     output.push_frame(pos, frame);
                 }
-                Item::Placed(frame, placed) => {
+                Item::Placed(placed) => {
                     let container_x = if region.expand.x || used.x.is_zero() {
                         region.size.x
                     } else {
                         size.x
                     };
-                    let x = placed.align_x.position(container_x - frame.width());
                     let container_y = if used.y.is_zero() && !region.expand.y {
                         self.regions.full
                     } else {
                         size.y
                     };
+
+                    let base = Size::new(
+                        region.size.x,
+                        if used.y.is_zero() && !region.expand.y {
+                            self.regions.full
+                        } else {
+                            size.y
+                        },
+                    );
+                    let frame = placed.layout(self.composer.engine, base)?;
+
+                    let x = placed.align_x.position(container_x - frame.width());
                     let y = match placed.align_y.unwrap_or_default() {
                         Some(align) => align.position(container_y - frame.height()),
                         _ => offset + ruler.position(free),

--- a/crates/typst-layout/src/flow/distribute.rs
+++ b/crates/typst-layout/src/flow/distribute.rs
@@ -650,14 +650,30 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
                     output.push_frame(pos, frame);
                 }
                 Item::Placed(frame, placed) => {
-                    let x = placed.align_x.position(size.x - frame.width());
+                    let container_x = if region.expand.x || used.x.is_zero() {
+                        region.size.x
+                    } else {
+                        size.x
+                    };
+                    let x = placed.align_x.position(container_x - frame.width());
+                    let container_y = if used.y.is_zero() && !region.expand.y {
+                        self.regions.full
+                    } else {
+                        size.y
+                    };
                     let y = match placed.align_y.unwrap_or_default() {
-                        Some(align) => align.position(size.y - frame.height()),
+                        Some(align) => align.position(container_y - frame.height()),
                         _ => offset + ruler.position(free),
                     };
 
                     let pos = Point::new(x, y)
-                        + placed.delta.zip_map(size, Rel::relative_to).to_point();
+                        + placed
+                            .delta
+                            .zip_map(
+                                Size::new(container_x, container_y),
+                                Rel::relative_to,
+                            )
+                            .to_point();
 
                     output.push_frame(pos, frame);
                 }

--- a/crates/typst-layout/src/grid/layouter.rs
+++ b/crates/typst-layout/src/grid/layouter.rs
@@ -1620,11 +1620,10 @@ impl<'a> GridLayouter<'a> {
         if self
             .current
             .lrows
-            .last()
-            .is_some_and(|row| self.grid.is_gutter_track(row.index()))
+            .pop_if(|row| self.grid.is_gutter_track(row.index()))
+            .is_some()
         {
             // Remove the last row in the region if it is a gutter row.
-            self.current.lrows.pop().unwrap();
             self.current.repeated_header_rows =
                 self.current.repeated_header_rows.min(self.current.lrows.len());
         }

--- a/crates/typst-library/src/foundations/styles.rs
+++ b/crates/typst-library/src/foundations/styles.rs
@@ -837,10 +837,8 @@ impl<'a> Iterator for Entries<'a> {
                 return Some(entry);
             }
 
-            match self.links.next() {
-                Some(next) => self.inner = next.iter(),
-                None => return None,
-            }
+            let next = self.links.next()?;
+            self.inner = next.iter();
         }
     }
 }

--- a/tests/ref/pdf/hashes.txt
+++ b/tests/ref/pdf/hashes.txt
@@ -677,7 +677,7 @@ db778f6d68fcdba7e75a44585bd161ad issue-2128-block-width-box
 0fcd0e7eaf2052d47ca72693e9395f7d issue-2134-pagebreak-bibliography
 e8d3e33e8d893bdaccdd7240f0d2518e issue-2162-pagebreak-set-style
 953f63d30f27170b98bfeba55506020a issue-2199-place-spacing-bottom
-150b64d99790b0d203a2a208fbe420f4 issue-2199-place-spacing-default
+a3f206fdc8da8905c12acd590c433fe8 issue-2199-place-spacing-default
 0fbb81dc6b16e8d5dce7d294787d8d7a issue-2213-align-fr
 681f9da07a7b077ef683d6ef0ef20fdb issue-2214-baseline-math
 a90ccee256ce36426b07ae7ee6042f5b issue-2259-raw-color-overwrite

--- a/tests/ref/pdf/hashes.txt
+++ b/tests/ref/pdf/hashes.txt
@@ -693,7 +693,7 @@ db778f6d68fcdba7e75a44585bd161ad issue-2128-block-width-box
 0fcd0e7eaf2052d47ca72693e9395f7d issue-2134-pagebreak-bibliography
 e8d3e33e8d893bdaccdd7240f0d2518e issue-2162-pagebreak-set-style
 953f63d30f27170b98bfeba55506020a issue-2199-place-spacing-bottom
-150b64d99790b0d203a2a208fbe420f4 issue-2199-place-spacing-default
+a3f206fdc8da8905c12acd590c433fe8 issue-2199-place-spacing-default
 0fbb81dc6b16e8d5dce7d294787d8d7a issue-2213-align-fr
 681f9da07a7b077ef683d6ef0ef20fdb issue-2214-baseline-math
 a90ccee256ce36426b07ae7ee6042f5b issue-2259-raw-color-overwrite

--- a/tests/ref/svg/hashes.txt
+++ b/tests/ref/svg/hashes.txt
@@ -675,7 +675,7 @@ df7389f1ef0245aee8178dd1cfb6b9dc issue-2128-block-width-box
 3735451693e5357af5743ab44c346fdb issue-2134-pagebreak-bibliography
 3fd3758d8ecefb25e81909dd13ea35e0 issue-2162-pagebreak-set-style
 62f8304a63bf4ecab5e77c9224759a4a issue-2199-place-spacing-bottom
-3a214027c3487f9e6eb18d0b5d256a21 issue-2199-place-spacing-default
+ca16f09f86ba1714084ee7e85d4c5e3c issue-2199-place-spacing-default
 2a14a1963c36e8b8bd9c5a132874f0b2 issue-2213-align-fr
 9e980932779246b7188d81d1729fe37a issue-2214-baseline-math
 c41d51f569dcf27f881bd7d3d3648396 issue-2259-raw-color-overwrite

--- a/tests/ref/svg/hashes.txt
+++ b/tests/ref/svg/hashes.txt
@@ -691,7 +691,7 @@ df7389f1ef0245aee8178dd1cfb6b9dc issue-2128-block-width-box
 3735451693e5357af5743ab44c346fdb issue-2134-pagebreak-bibliography
 3fd3758d8ecefb25e81909dd13ea35e0 issue-2162-pagebreak-set-style
 62f8304a63bf4ecab5e77c9224759a4a issue-2199-place-spacing-bottom
-3a214027c3487f9e6eb18d0b5d256a21 issue-2199-place-spacing-default
+ca16f09f86ba1714084ee7e85d4c5e3c issue-2199-place-spacing-default
 2a14a1963c36e8b8bd9c5a132874f0b2 issue-2213-align-fr
 e3cf07b2d0add6f46fb349c411ffdaf8 issue-2214-baseline-math
 c41d51f569dcf27f881bd7d3d3648396 issue-2259-raw-color-overwrite


### PR DESCRIPTION
fix the broken alignment examples in alignment #6822

<img width="1157" height="1037" alt="image" src="https://github.com/user-attachments/assets/3a7f7571-6751-4b99-95db-91c597c8f5eb" />

another example

```typ
#lorem(80)
#columns()[
  #lorem(80) #colbreak() #place(center + horizon)[#square(fill: red)]]
#lorem(80)
#lorem(80)
```

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/640b8390-3251-4b86-b47d-ac9210476825" />


closes #6822