### PR TITLE
Document countable elements

### DIFF
--- a/crates/typst-library/src/introspection/counter.rs
+++ b/crates/typst-library/src/introspection/counter.rs
@@ -107,6 +107,15 @@ use crate::{Library, World};
 /// }
 /// ```
 ///
+/// = Element counters <element-counters>
+/// Above, there are various examples of using the @heading counter. Headings
+/// are just one kind of element that can be counted. In general, counters can
+/// count through any kind of @location:locatable[_locatable_ element].
+///
+/// Additionally, a counter can also count just those elements that match a
+/// specific @selector. For example, `{counter(figure.where(kind: image))}`
+/// counts figures containing images, but ignores other kinds of figures.
+///
 /// = Page counter <page-counter>
 /// The page counter is special. It is automatically stepped at each pagebreak.
 /// But like other counters, you can also step it manually. For example, you
@@ -133,16 +142,6 @@ use crate::{Library, World};
 /// page and total number of pages in
 /// Arabic numbers.
 /// ```
-///
-/// = Element counters <element-counters>
-/// In addition to the @counter:page-counter[page counter] and custom counters
-/// based on strings, counters can count through
-/// @location:locatable[locatable] elements in the document.
-///
-/// You can also count through selectors that match locatable elements. For
-/// example, `{counter(figure.where(kind: image))}` counts image figures.
-/// See @location:locatable[locatable elements] for the list of built-in
-/// locatable elements.
 ///
 /// = Custom counters <custom-counters>
 /// To define your own counter, call the `counter` function with a string as a
@@ -352,14 +351,14 @@ impl Counter {
         ///   by manual updates,
         /// - If it is the @page function, counts through pages,
         /// - If it is a @selector[selector], counts through elements that match
-        ///   the selector. For example,
-        ///   - provide an element function: counts elements of that type,
-        ///   - provide a @function.where[`where`] selector: counts a type of
+        ///   the selector. For example, you can
+        ///   - provide an element function to count elements of that type,
+        ///   - provide a @function.where[`where`] selector to count a type of
         ///     element with specific fields,
-        ///   - provide a @label[`{<label>}`]: counts elements with that label.
+        ///   - provide a @label[`{<label>}`] to count elements with that label.
         ///
-        ///   Element functions and @function.where[`where`] selectors must
-        ///   match locatable elements.
+        ///   Element and @function.where[`where`] selector counter keys are
+        ///   only supported for @location:locatable[locatable elements].
         key: CounterKey,
     ) -> Counter {
         Self::new(key)

--- a/crates/typst-library/src/introspection/counter.rs
+++ b/crates/typst-library/src/introspection/counter.rs
@@ -34,27 +34,6 @@ use crate::{Library, World};
 /// value is _contextual._ It is recommended to read the chapter on
 /// @reference:context[context] before continuing here.
 ///
-/// = Countable elements <countable-elements>
-/// In addition to the @counter:page-counter[page counter] and custom counters
-/// based on strings, counters can count through
-/// @location:locatable[locatable] elements in the document. The built-in
-/// locatable elements are:
-///
-/// - @reference:model[Model]: @document, @par, @par.line, @strong, @emph,
-///   @list, @enum, @terms, @link, @title, @heading, @figure, @figure.caption,
-///   @quote, @footnote, @footnote.entry, @outline, @outline.entry, @ref,
-///   @cite, @bibliography, @table, and @asset.
-/// - @reference:text[Text]: @raw, @underline, @overline, @strike, and
-///   @highlight.
-/// - Layout: @layout.
-/// - Math: @math.equation.
-/// - @reference:introspection[Introspection]: @metadata.
-/// - Visualize: @image.
-/// - PDF: @pdf.attach.
-///
-/// You can also count through selectors that match locatable elements. For
-/// example, `{counter(figure.where(kind: image))}` counts image figures.
-///
 /// = #short-or-long[Accessing][Accessing a counter] <accessing>
 /// To access the raw value of a counter, we can use the @counter.get[`get`]
 /// function. This function returns an @array[array]: Counters can have multiple
@@ -154,6 +133,16 @@ use crate::{Library, World};
 /// page and total number of pages in
 /// Arabic numbers.
 /// ```
+///
+/// = Element counters <element-counters>
+/// In addition to the @counter:page-counter[page counter] and custom counters
+/// based on strings, counters can count through
+/// @location:locatable[locatable] elements in the document.
+///
+/// You can also count through selectors that match locatable elements. For
+/// example, `{counter(figure.where(kind: image))}` counts image figures.
+/// See @location:locatable[locatable elements] for the list of built-in
+/// locatable elements.
 ///
 /// = Custom counters <custom-counters>
 /// To define your own counter, call the `counter` function with a string as a

--- a/crates/typst-library/src/introspection/counter.rs
+++ b/crates/typst-library/src/introspection/counter.rs
@@ -34,6 +34,27 @@ use crate::{Library, World};
 /// value is _contextual._ It is recommended to read the chapter on
 /// @reference:context[context] before continuing here.
 ///
+/// = Countable elements <countable-elements>
+/// In addition to the @counter:page-counter[page counter] and custom counters
+/// based on strings, counters can count through
+/// @location:locatable[locatable] elements in the document. The built-in
+/// locatable elements are:
+///
+/// - @reference:model[Model]: @document, @par, @par.line, @strong, @emph,
+///   @list, @enum, @terms, @link, @title, @heading, @figure, @figure.caption,
+///   @quote, @footnote, @footnote.entry, @outline, @outline.entry, @ref,
+///   @cite, @bibliography, @table, and @asset.
+/// - @reference:text[Text]: @raw, @underline, @overline, @strike, and
+///   @highlight.
+/// - Layout: @layout.
+/// - Math: @math.equation.
+/// - @reference:introspection[Introspection]: @metadata.
+/// - Visualize: @image.
+/// - PDF: @pdf.attach.
+///
+/// You can also count through selectors that match locatable elements. For
+/// example, `{counter(figure.where(kind: image))}` counts image figures.
+///
 /// = #short-or-long[Accessing][Accessing a counter] <accessing>
 /// To access the raw value of a counter, we can use the @counter.get[`get`]
 /// function. This function returns an @array[array]: Counters can have multiple
@@ -342,7 +363,8 @@ impl Counter {
         ///   by manual updates,
         /// - If it is the @page function, counts through pages,
         /// - If it is a @selector[selector], counts through elements that match
-        ///   the selector. For example,
+        ///   the selector. Element functions and @function.where[`where`]
+        ///   selectors must match locatable elements. For example,
         ///   - provide an element function: counts elements of that type,
         ///   - provide a @function.where[`where`] selector: counts a type of
         ///     element with specific fields,

--- a/crates/typst-library/src/introspection/counter.rs
+++ b/crates/typst-library/src/introspection/counter.rs
@@ -352,12 +352,14 @@ impl Counter {
         ///   by manual updates,
         /// - If it is the @page function, counts through pages,
         /// - If it is a @selector[selector], counts through elements that match
-        ///   the selector. Element functions and @function.where[`where`]
-        ///   selectors must match locatable elements. For example,
+        ///   the selector. For example,
         ///   - provide an element function: counts elements of that type,
         ///   - provide a @function.where[`where`] selector: counts a type of
         ///     element with specific fields,
         ///   - provide a @label[`{<label>}`]: counts elements with that label.
+        ///
+        ///   Element functions and @function.where[`where`] selectors must
+        ///   match locatable elements.
         key: CounterKey,
     ) -> Counter {
         Self::new(key)

--- a/crates/typst-library/src/introspection/location.rs
+++ b/crates/typst-library/src/introspection/location.rs
@@ -38,7 +38,7 @@ use crate::model::Numbering;
 ///   element is locatable as being queried for is its primary purpose.
 ///
 /// - In the other categories, most elements are not locatable. Exceptions are
-///   @math.equation and @image.
+///   @layout, @math.equation, @image, and @pdf.attach.
 ///
 /// To find out whether a specific element is locatable, you can try to @query
 /// for it.

--- a/crates/typst-library/src/introspection/location.rs
+++ b/crates/typst-library/src/introspection/location.rs
@@ -26,9 +26,12 @@ use crate::model::Numbering;
 /// Elements that are automatically assigned a location are called _locatable._
 /// For efficiency reasons, not all elements are locatable.
 ///
-/// - In the @reference:model[Model category], most elements are locatable. This
-///   is because semantic elements like @heading[headings] and @figure[figures]
-///   are often used with introspection.
+/// - In the @reference:model[Model category], the following elements are
+///   locatable: @document, @par, @strong, @emph, @list, @enum, @terms, @link,
+///   @title, @heading, @figure, @figure.caption, @quote, @footnote,
+///   @footnote.entry, @outline, @outline.entry, @ref, @cite, @bibliography,
+///   @table, and @asset. This is because semantic elements like
+///   @heading[headings] and @figure[figures] are often used with introspection.
 ///
 /// - In the @reference:text[Text category], the @raw element, and the
 ///   decoration elements @underline, @overline, @strike, and @highlight are
@@ -38,7 +41,7 @@ use crate::model::Numbering;
 ///   element is locatable as being queried for is its primary purpose.
 ///
 /// - In the other categories, most elements are not locatable. Exceptions are
-///   @layout, @math.equation, @image, and @pdf.attach.
+///   @math.equation, @image, and @pdf.attach.
 ///
 /// To find out whether a specific element is locatable, you can try to @query
 /// for it.

--- a/crates/typst-library/src/introspection/location.rs
+++ b/crates/typst-library/src/introspection/location.rs
@@ -23,17 +23,18 @@ use crate::model::Numbering;
 /// element with the @content.location[`location()`] method on content.
 ///
 /// = #short-or-long[Locatable][Locatable elements] <locatable>
-/// Elements that are automatically assigned a location are called _locatable._
-/// For efficiency reasons, not all elements are locatable.
+/// Elements that are automatically assigned a location are called _locatable_
+/// and can be found with @query[queries]:
 ///
 /// - In the @reference:model[Model category], the following elements are
-///   locatable: @document, @par, @strong, @emph, @list, @enum, @terms, @link,
-///   @title, @heading, @figure, @figure.caption, @quote, @footnote,
-///   @footnote.entry, @outline, @outline.entry, @ref, @cite, @bibliography,
-///   @table, and @asset. This is because semantic elements like
-///   @heading[headings] and @figure[figures] are often used with introspection.
+///   locatable: @asset, @bibliography, @cite, @document, @emph, @enum, @figure,
+///   @figure.caption, @footnote, @footnote.entry, @heading, @link, @list,
+///   @outline, @outline.entry, @par, @quote, @ref, @strong, @table, @terms, and
+///   @title. Most of the elements in the _Model_ category are locatable because
+///   semantic elements like headings and figures are often
+///   used with introspection.
 ///
-/// - In the @reference:text[Text category], the @raw element, and the
+/// - In the @reference:text[Text category], the @raw element and the
 ///   decoration elements @underline, @overline, @strike, and @highlight are
 ///   locatable as these are also quite semantic in nature.
 ///


### PR DESCRIPTION
Good day! I tried to close #2728.

In this PR, I added a documentation section for counters that lists the exposed locatable elements that can be used with counter(...). I also made it clear that selector-based counters require locatable elements, and synced the list of exceptions in the location docs with the current list of locatable elements.

User-facing benefit: it is now easier to understand which elements can be used with counter(...) and avoid mistakes when using selector-based counters.

Checks:
```bash
cargo fmt –check –all
cargo docit compile –format website –deny-warnings
cargo docit compile –format pdf –deny-warnings
cargo test –workspace –no-fail-fast
cargo clippy –workspace –all-targets –all-features
cargo clippy –workspace –all-targets –no-default-features
cargo doc –workspace –no-deps –document-private-items
```

Done. 🌹🌹🌹