### PR TITLE
Add keyword aliases for docs

### DIFF
--- a/docs/content/reference/language/scripting.typ
+++ b/docs/content/reference/language/scripting.typ
@@ -1,4 +1,5 @@
 #import "../../../components/index.typ": docs-chapter, docs-table, short-or-long
+#import "../../../components/search.typ": register-index-item
 
 #show: docs-chapter.with(
   title: "Scripting",
@@ -107,7 +108,7 @@ Destructuring also works in argument lists of functions ...
 }
 ```
 
-= Conditionals <conditionals>
+= Conditionals #context register-index-item(kind: "Language", title: "Conditionals", dest: locate(<conditionals>), keywords: ("If", "Else")) <conditionals>
 With a conditional, you can display or compute different things depending on whether some condition is fulfilled. Typst supports `{if}`, `{else if}` and `{else}` expressions. When the condition evaluates to `{true}`, the conditional yields the value resulting from the if's body. Otherwise, it yields the value resulting from the else's body.
 
 ```example
@@ -125,7 +126,7 @@ Each branch can have a code or content block as its body.
 - `{if condition [..] else {..}}`
 - `{if condition [..] else if condition {..} else [..]}`
 
-= Loops <loops>
+= Loops #context register-index-item(kind: "Language", title: "Loops", dest: locate(<loops>), keywords: ("For", "While")) <loops>
 With loops, you can repeat content or compute something iteratively. Typst supports two types of loops: `{for}` and `{while}` loops. The former iterate over a specified collection whereas the latter iterate as long as a condition stays fulfilled. Just like blocks, loops _join_ the results from each iteration into one value.
 
 In the example below, the three sentences created by the for loop join together into a single content value and the length-1 arrays in the while loop join together into one larger array.
@@ -221,7 +222,7 @@ The structure of a method call is `{value.method(..args)}` and its equivalent fu
 
 There are a few special functions that modify the value they are called on (e.g. @array.push). These functions _must_ be called in method form. In some cases, when the method is only called for its side effect, its return value should be ignored (and not participate in joining). The canonical way to discard a value is with a let binding: `{let _ = array.remove(1)}`.
 
-= Modules <modules>
+= Modules #context register-index-item(kind: "Language", title: "Modules", dest: locate(<modules>), keywords: ("Include", "Import")) <modules>
 You can split up your Typst projects into multiple files called _modules._ A module can refer to the content and definitions of another module in multiple ways:
 
 - *Including:* `{include "bar.typ"}` \

--- a/docs/content/reference/language/scripting.typ
+++ b/docs/content/reference/language/scripting.typ
@@ -40,7 +40,12 @@ Content and code blocks can be nested arbitrarily. In the example below, `{[hell
 }
 ```
 
-= #short-or-long[Bindings][Bindings and Destructuring] <bindings>
+= #short-or-long[Bindings][Bindings and Destructuring] <bindings> #context register-index-item(
+  kind: "Language",
+  title: "Bindings",
+  dest: locate(<bindings>),
+  keywords: ("Let",),
+)
 As already demonstrated above, variables can be defined with `{let}` bindings. The variable is assigned the value of the expression that follows the `=` sign. A @reference:syntax:identifiers[valid variable name] may contain `-`, but cannot start with `-`. The assignment of a value is optional, if no value is assigned, the variable will be initialized as `{none}`. The `{let}` keyword can also be used to create a @function:defining-functions[custom named function]. Variables can be accessed for the rest of the containing block (or the rest of the file if there is no containing block).
 
 ```example

--- a/docs/content/reference/language/scripting.typ
+++ b/docs/content/reference/language/scripting.typ
@@ -108,7 +108,12 @@ Destructuring also works in argument lists of functions ...
 }
 ```
 
-= Conditionals #context register-index-item(kind: "Language", title: "Conditionals", dest: locate(<conditionals>), keywords: ("If", "Else")) <conditionals>
+= Conditionals <conditionals> #context register-index-item(
+  kind: "Language",
+  title: "Conditionals",
+  dest: locate(<conditionals>),
+  keywords: ("If", "Else"),
+)
 With a conditional, you can display or compute different things depending on whether some condition is fulfilled. Typst supports `{if}`, `{else if}` and `{else}` expressions. When the condition evaluates to `{true}`, the conditional yields the value resulting from the if's body. Otherwise, it yields the value resulting from the else's body.
 
 ```example
@@ -126,7 +131,10 @@ Each branch can have a code or content block as its body.
 - `{if condition [..] else {..}}`
 - `{if condition [..] else if condition {..} else [..]}`
 
-= Loops #context register-index-item(kind: "Language", title: "Loops", dest: locate(<loops>), keywords: ("For", "While")) <loops>
+= Loops <loops> #context register-index-item(kind: "Language", title: "Loops", dest: locate(<loops>), keywords: (
+  "For",
+  "While",
+))
 With loops, you can repeat content or compute something iteratively. Typst supports two types of loops: `{for}` and `{while}` loops. The former iterate over a specified collection whereas the latter iterate as long as a condition stays fulfilled. Just like blocks, loops _join_ the results from each iteration into one value.
 
 In the example below, the three sentences created by the for loop join together into a single content value and the length-1 arrays in the while loop join together into one larger array.
@@ -222,7 +230,12 @@ The structure of a method call is `{value.method(..args)}` and its equivalent fu
 
 There are a few special functions that modify the value they are called on (e.g. @array.push). These functions _must_ be called in method form. In some cases, when the method is only called for its side effect, its return value should be ignored (and not participate in joining). The canonical way to discard a value is with a let binding: `{let _ = array.remove(1)}`.
 
-= Modules #context register-index-item(kind: "Language", title: "Modules", dest: locate(<modules>), keywords: ("Include", "Import")) <modules>
+= Modules <modules> #context register-index-item(
+  kind: "Language",
+  title: "Modules",
+  dest: locate(<modules>),
+  keywords: ("Include", "Import"),
+)
 You can split up your Typst projects into multiple files called _modules._ A module can refer to the content and definitions of another module in multiple ways:
 
 - *Including:* `{include "bar.typ"}` \

--- a/docs/content/reference/language/styling.typ
+++ b/docs/content/reference/language/styling.typ
@@ -1,4 +1,5 @@
 #import "../../../components/index.typ": docs-chapter
+#import "../../../components/search.typ": register-index-item
 
 #show: docs-chapter.with(
   title: "Styling",
@@ -8,7 +9,12 @@
 
 Typst includes a flexible styling system that automatically applies styling of your choice to your document. With _set rules,_ you can configure basic properties of elements. This way, you create most common styles. However, there might not be a built-in property for everything you wish to do. For this reason, Typst further supports _show rules_ that can completely redefine the appearance of elements.
 
-= Set rules <set-rules>
+= Set rules <set-rules> #context register-index-item(
+  kind: "Language",
+  title: "Set rules",
+  dest: locate(selector(<set-rules>).after(<reference:styling>)),
+  keywords: ("Set",),
+)
 With set rules, you can customize the appearance of elements. They are written as a @function[function call] to an @function:element-functions[element function] preceded by the `{set}` keyword (or `[#set]` in markup). Only optional parameters of that function can be provided to the set rule. Refer to each function's documentation to see which parameters are optional. In the example below, we use two set rules to change the @text.font[font family] and @heading.numbering[heading numbering].
 
 ```example
@@ -46,7 +52,12 @@ Sometimes, you'll want to apply a set rule conditionally. For this, you can use 
 #task(critical: false)[Work deadline]
 ```
 
-= Show rules <show-rules>
+= Show rules <show-rules> #context register-index-item(
+  kind: "Language",
+  title: "Show rules",
+  dest: locate(selector(<show-rules>).after(<reference:styling>)),
+  keywords: ("Show",),
+)
 With show rules, you can deeply customize the look of a type of element. The most basic form of show rule is a _show-set rule._ Such a rule is written as the `{show}` keyword followed by a @selector[selector], a colon and then a set rule. The most basic form of selector is an @function:element-functions[element function]. This lets the set rule only apply to the selected element. In the example below, headings become dark blue while all other text stays black.
 
 ```example


### PR DESCRIPTION
Currently covers `let`, `if`, `else`, `for`, `while`, `include`, and `import`.

Unresolved problems: 

* ~~these all appear twice in the index, while the entry for the whole “Scripting” chapter correctly appears only once.~~
* ~~Trying to add similar `register-index-item` calls in the styling section gives the following errors:~~
  ```
  error: label `<set-rules>` occurs multiple times in the document
     ┌─ @typst/docs:0.0.0/content/reference/language/styling.typ:15:8
     │
  15 │   dest: locate(<set-rules>),
     │         ^^^^^^^^^^^^^^^^^^^
  
  error: label `<show-rules>` occurs multiple times in the document
     ┌─ @typst/docs:0.0.0/content/reference/language/styling.typ:58:8
     │
  58 │   dest: locate(<show-rules>),
     │         ^^^^^^^^^^^^^^^^^^^^
  
  ```