### PR TITLE
Fix unused warning in release builds

### DIFF
--- a/crates/typst-pdf/src/tags/util/idvec.rs
+++ b/crates/typst-pdf/src/tags/util/idvec.rs
@@ -30,6 +30,7 @@ impl<T> IdVec<T> {
         &mut self.inner[id.idx()]
     }
 
+    #[allow(unused)]
     pub fn iter(&self) -> std::slice::Iter<'_, T> {
         self.inner.iter()
     }


### PR DESCRIPTION
The `iter` method is only used for a debug assertion.