### PR TITLE
Fix bundle export errors for single-page documents not being delayed

### DIFF
--- a/crates/typst-bundle/src/lib.rs
+++ b/crates/typst-bundle/src/lib.rs
@@ -305,12 +305,12 @@ fn compile_document<'a>(
 
             let num_pages = doc.pages().len();
             if num_pages != 1 && matches!(format, PagedFormat::Png | PagedFormat::Svg) {
-                bail!(
+                engine.sink.delayed_error(error!(
                     document.span(),
                     "expected document to have a single page";
                     hint: "the document resulted in {num_pages} pages";
                     hint: "documents exported to an image format only support a single page";
-                );
+                ));
             }
 
             BundleDocument::Paged(

--- a/tests/ref/bundle/issue-8616-document-delayed-pages.txt
+++ b/tests/ref/bundle/issue-8616-document-delayed-pages.txt
@@ -1,0 +1,2 @@
+dc5f3ead99ba15ab3ce189ab3c1a5456 doc.png
+e9810b5dd33e63d639870f432f3ddec7 doc.svg

--- a/tests/suite/model/document.typ
+++ b/tests/suite/model/document.typ
@@ -299,3 +299,11 @@ world
 
 #counted-document[A]
 #counted-document[B]
+
+--- issue-8616-document-delayed-pages bundle ---
+// Test that bundle documents which are expected to have exactly one page
+// perform this assertion only on the final iteration.
+#import "../introspection/switch.typ": switch
+#for ext in ("png", "svg") {
+  document("doc." + ext, switch(n => if n == 1 { pagebreak() }))
+}


### PR DESCRIPTION
Closes #8616 by pushing a delayed error instead of bailing immediately.

A corresponding test case that errors before the change in `lib.rs` and now passes has also been added.