### PR TITLE
Make typst eval exit with code 1 when expression evaluation fails

### DIFF
--- a/crates/typst-cli/src/eval.rs
+++ b/crates/typst-cli/src/eval.rs
@@ -61,7 +61,10 @@ pub fn eval(command: &'static EvalCommand) -> HintedStrResult<()> {
                 output.introspector(),
             );
             let errors = match &eval_result {
-                Err(errors) => errors.as_slice(),
+                Err(errors) => {
+                    set_failed();
+                    errors.as_slice()
+                }
                 Ok(value) => {
                     let serialized =
                         crate::serialize(value, command.format, command.pretty)?;


### PR DESCRIPTION
Fixes #8593

Previously `typst eval` returned 1 when evaluation of the context/document/introspection failed, but not when the expression provided in the CLI failed.