### PR TITLE
Fix duplicate HTML attributes when overriding spread arguments

### DIFF
--- a/crates/typst-html/src/typed.rs
+++ b/crates/typst-html/src/typed.rs
@@ -126,8 +126,20 @@ fn construct(element: &'static data::ElemInfo, args: &mut Args) -> SourceResult<
         let value = std::mem::take(&mut item.value.v);
         let ty = AttrType::convert(attr.ty);
         match ty.cast(value).at(span) {
-            Ok(Some(string)) => attrs.push(HtmlAttr::constant(attr.name), string),
-            Ok(None) => {}
+            // A later argument with the same name overrides an earlier one
+            // (e.g. from a spread), matching the behaviour of regular
+            // functions and avoiding duplicate HTML attributes.
+            Ok(Some(string)) => {
+                let key = HtmlAttr::constant(attr.name);
+                match attrs.get_mut(key) {
+                    Some(slot) => *slot = string,
+                    None => attrs.push(key, string),
+                }
+            }
+            // A later argument that resolves to no attribute (e.g. a presence
+            // attribute set to `false`) removes an earlier one with the same
+            // name.
+            Ok(None) => attrs.0.retain(|(k, _)| *k != HtmlAttr::constant(attr.name)),
             Err(diags) => errors.extend(diags),
         }
 

--- a/tests/ref/html/hashes.txt
+++ b/tests/ref/html/hashes.txt
@@ -68,7 +68,7 @@ dbe6c87ce3f9f79373ddff2a67f20c23 html-space-protection-br
 c3be983a199a95106caffe0572463a58 html-style
 568cbc99dba4312ba440431d779ec70a html-style-str
 f9671e4e56820cd2f5fbd767d04eabc0 html-textarea-starting-with-newline
-9a0437e6bfcead63fe7f55125d1df400 html-typed
+ae85c58499762e873dde2524d73d52fe html-typed
 58895c458693621c61d4d498ab0f8b64 html-untyped-style-content
 f7eaf53ac8ae30b69426912e83ff1b43 image-blocky-html
 59e349bb0bd41fb1a37a6d575c12b41e image-jpg-html-base64

--- a/tests/suite/html/typed.typ
+++ b/tests/suite/html/typed.typ
@@ -106,6 +106,15 @@
 // Icon size.
 #html.link(rel: "icon", sizes: ((32, 24), (64, 48)))
 
+// A later argument overrides an earlier one (e.g. from a spread) instead of
+// emitting a duplicate attribute.
+#html.a(..(href: "A"), href: "B")[link]
+#html.a(href: "B", ..(href: "A"))[link]
+#html.div(..(id: "a", class: "x"), id: "b")
+
+// A later argument that resolves to no attribute removes the earlier one.
+#html.div(..(hidden: true), hidden: false)
+
 --- html-typed-dir-str eval ---
 // Error: 16-21 expected direction or auto, found string
 #html.div(dir: "ltr")


### PR DESCRIPTION
## Summary

Fixes #8507.

Typed HTML element constructors (e.g. `html.a`, `html.div`) collected every matching named argument into an ordered attribute list. When the same attribute was supplied both through a spread and explicitly, both ended up in the list:

```typ
#let attrs = (href: "A")
#html.a(..attrs, href: "B")[Document link]
```

produced

```html
<a href="A" href="B">Document link</a>
```

This is invalid HTML (duplicate `href`) and contradicts the usual Typst convention where a later argument overrides an earlier one.

## Change

In the shared `construct` function, when an argument resolves to an attribute value that is already present, its value is now overwritten instead of appended. Additionally, an argument that resolves to *no* attribute (e.g. a presence attribute set to `false`) removes an earlier one with the same name, so the override semantics are consistent in both directions.

With this change:
- `html.a(..(href: "A"), href: "B")` → `<a href="B">`
- `html.a(href: "B", ..(href: "A"))` → `<a href="A">`
- `html.div(..(id: "a", class: "x"), id: "b")` → `<div id="b" class="x">`
- `html.div(..(hidden: true), hidden: false)` → `<div>`

## Tests

Added cases to `tests/suite/html/typed.typ` covering override via spread (in both orders), preservation of other attributes, and removal via a resolved-to-none argument. The `html-typed` reference hash was updated accordingly. The full `--stages html` suite passes.