### PR TITLE
Clarify string escape wording

### DIFF
--- a/crates/typst-library/src/foundations/str.rs
+++ b/crates/typst-library/src/foundations/str.rs
@@ -64,7 +64,7 @@ pub use crate::__format_str as format_str;
 /// ```
 ///
 /// = #short-or-long[Escapes][Escape sequences] <escapes>
-/// Just like in markup, you can escape a few symbols in strings:
+/// Strings support the following escape sequences:
 /// - `[\\]` for a backslash
 /// - `[\"]` for a quote
 /// - `[\n]` for a newline


### PR DESCRIPTION
Closes #7339.

The previous sentence implied that string escape syntax matched markup. This replaces it with a direct introduction to the actual string escape list.

Validation:
- `cargo fmt --all -- --check`
- `cargo check -p typst-library`