### PR TITLE
Expose `MathClass::Diacritic` variant to users

### DIFF
--- a/crates/typst-library/src/foundations/cast.rs
+++ b/crates/typst-library/src/foundations/cast.rs
@@ -522,6 +522,8 @@ cast! {
     "binary" => MathClass::Binary,
     /// An operator that can be both unary or binary like `+`.
     "vary" => MathClass::Vary,
+    /// An accent character.
+    "diacritic" => MathClass::Diacritic,
 }
 
 /// A type that contains a user-visible source portion and something that is

--- a/tests/ref/html/hashes.txt
+++ b/tests/ref/html/hashes.txt
@@ -408,6 +408,7 @@ a1415a1210cce6969daa96308df55723 mathml-multiline-alignment-3
 2678cd89ff2cacd73cb048c4d42a2495 mathml-primes
 5106a875b624d5d22d173f3b5eff78f5 mathml-primes-factorial-explicit-class
 aa70e6e6dec9074fd30b6fe0002c7acf mathml-show-rule
+9f2126bdba0246ce57364b0e73af515d mathml-show-rule-accent
 ae1ec94243b16393e712c63a2e51afca mathml-show-rule-math-in-non-math-in-math
 6ca02b4c8a157bdf99fa3e1e9fe8aaaf mathml-show-rule-non-math-in-math
 431573e9e1c3b08713d89f7310479aff mathml-show-rule-non-math-in-math-in-math

--- a/tests/suite/html/mathml.typ
+++ b/tests/suite/html/mathml.typ
@@ -159,3 +159,12 @@ $ a/sqrt(b) $
     Hello $x$
   ]
 })
+
+--- mathml-show-rule-accent html ---
+#show math.overline: it => {
+  html.elem("mover", attrs: (accent: "true"), {
+    html.elem("mrow", it.body)
+    $class("diacritic", stretch(\u{203E}))$
+  })
+}
+$ overline(A B C) $


### PR DESCRIPTION
From a discussion on the Discord I realised that there are a number of math class variants that aren't exposed to users: alphabetic, diacritic, glyph-part, space, special. This PR makes it so that diacritic is exposed. I've opted to only add this one for now since it is the only one that can have an effect on the output (in MathML export the diacritic class gets the postfix form).

Some of the remaining ones could make sense along with changes to some behaviour (so that they actually have a point in being used). But I leave this to the future.

For the doc comment I tried adding an example like `◌̀`, mimicking what Wikipedia does having the dotted circle as a placeholder, but it looks terrible in the docs font.