### PR TITLE
Test report improvements

### DIFF
--- a/tests/src/report/diff.rs
+++ b/tests/src/report/diff.rs
@@ -57,11 +57,40 @@ impl Diff {
         }
     }
 
+    pub fn kind(&self) -> DiffKind {
+        match self {
+            Self::Text(_) => DiffKind::Text,
+            Self::Image(_) => DiffKind::Image,
+            Self::Html(_) => DiffKind::Html,
+        }
+    }
+
     pub fn mode(&self) -> DiffMode {
         match self {
             Diff::Text(_) => DiffMode::Text,
             Diff::Image(_) | Diff::Html(_) => DiffMode::Visual,
         }
+    }
+
+    pub fn is_image(&self) -> bool {
+        matches!(self, Self::Image(..))
+    }
+}
+
+#[derive(Copy, Clone)]
+pub enum DiffKind {
+    Text,
+    Image,
+    Html,
+}
+
+impl Display for DiffKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            DiffKind::Text => "text",
+            DiffKind::Image => "image",
+            DiffKind::Html => "html",
+        })
     }
 }
 

--- a/tests/src/report/html.rs
+++ b/tests/src/report/html.rs
@@ -491,9 +491,13 @@ fn test_reports(body: &mut HtmlElem, reports: &[TestReport]) {
                             test_report_header(div, test_report, test_idx, close);
                         });
 
+                        let image_kind = match &test_report.files[0].diffs[0] {
+                            Diff::Image(_) => " image",
+                            Diff::Text(_) | Diff::Html(_) => "",
+                        };
                         div.div()
                             .id(display!("test-report-body-{test_idx}"))
-                            .class("test-report-body")
+                            .class(display!("test-report-body{image_kind}"))
                             .hidden(close)
                             .with(|div| {
                                 test_report_source(div, test_report, test_idx);
@@ -508,6 +512,15 @@ fn test_reports(body: &mut HtmlElem, reports: &[TestReport]) {
                                         test_idx,
                                         file_idx,
                                     );
+                                }
+
+                                // There is one set of image controls for the
+                                // image diffs of all outputs of a test report.
+                                let has_image_diff = (test_report.files.iter())
+                                    .flat_map(|f| f.diffs.iter())
+                                    .any(Diff::is_image);
+                                if has_image_diff {
+                                    image_diff_controls(div, test_idx);
                                 }
                             });
                     });
@@ -778,7 +791,7 @@ fn test_report_source(parent: &mut HtmlElem, test_report: &TestReport, test_idx:
         .hidden(true)
         .id(display!("test-report-source-{test_idx}"))
         .with(|div| {
-            div.table().class("text-diff").with(|table| {
+            div.table().class("file-diff html").with(|table| {
                 table.colgroup().with(|colgroup| {
                     colgroup.col().attr("span", 1).class("col-line-gutter");
                     colgroup.col().attr("span", 1).class("col-source-line-body");
@@ -983,11 +996,12 @@ fn file_diff_tabpanel(
         .role("tabpanel")
         .aria_labelledby(display!("file-diff-tab-{n}-{}", diff.mode()))
         .hidden(diff_idx != 0)
-        .class("file-diff")
+        .class(display!("file-diff {}", diff.kind()))
+        .data_attr("kind", diff.kind())
         .with(|div| match diff {
             Diff::Text(diff) => text_diff(div, diff),
             Diff::Image(diff) => {
-                image_diff(div, &test_report.name, report_file.output, diff, n);
+                image_diff(div, &test_report.name, report_file.output, diff);
             }
             Diff::Html(diff) => html_diff(div, diff),
         });
@@ -1072,8 +1086,34 @@ fn image_diff(
     name: &str,
     output: TestOutput,
     diff: &FileDiff<Image>,
-    n: usize,
 ) {
+    let image = |parent: &mut HtmlElem<'_>, data_url: &str| {
+        parent
+            .img()
+            .src(data_url)
+            .alt(display!("The {output} image of `{name}` test"));
+    };
+
+    parent
+        .canvas()
+        .class("image-canvas")
+        .data_attr("output", output)
+        .with(|canvas| {
+            let data_url = (diff.left())
+                .and_then(|old| old.data())
+                .map(|img| img.data_url.as_str())
+                .unwrap_or("");
+            image(canvas, data_url);
+
+            let data_url = (diff.right())
+                .and_then(|res| res.as_ref().ok())
+                .map(|img| img.data_url.as_str())
+                .unwrap_or("");
+            image(canvas, data_url);
+        });
+}
+
+fn image_diff_controls(parent: &mut HtmlElem, n: usize) {
     let radio_icon_button = |parent: &mut HtmlElem, name, value, title, icon, checked| {
         parent.label().class("icon-toggle-button").with(|label| {
             label
@@ -1148,165 +1188,136 @@ fn image_diff(
         });
     };
 
-    parent.div().class("image-diff").with(|div| {
-        div.div().class("image-controls").with(|div| {
-            div.fieldset().class("control-group").with(|fieldset| {
+    parent.div().class("image-controls top").with(|div| {
+        div.fieldset().class("control-group").with(|fieldset| {
+            radio_icon_button(
+                fieldset,
+                "image-view-mode",
+                "side-by-side",
+                "View Mode side by side",
+                icons::VIEW_SIDE_BY_SIDE,
+                true,
+            );
+            radio_icon_button(
+                fieldset,
+                "image-view-mode",
+                "swipe",
+                "View Mode swipe",
+                icons::VIEW_SWIPE,
+                false,
+            );
+            radio_icon_button(
+                fieldset,
+                "image-view-mode",
+                "blend",
+                "View Mode blend",
+                icons::VIEW_BLEND,
+                false,
+            );
+            radio_icon_button(
+                fieldset,
+                "image-view-mode",
+                "difference",
+                "View Mode difference",
+                icons::VIEW_DIFFERENCE,
+                false,
+            );
+        });
+
+        div.fieldset().class("control-group").with(|fieldset| {
+            checkbox_icon_button(
+                fieldset,
+                "image-antialiasing",
+                "Antialiasing",
+                icons::ANTIALIASING,
+                true,
+            );
+        });
+
+        div.fieldset().class("control-group").with(|fieldset| {
+            icon_button(fieldset, "image-zoom-minus", "Zoom out", icons::MINUS);
+            icon_button(fieldset, "image-zoom-plus", "Zoom in", icons::PLUS);
+
+            slider(
+                fieldset,
+                "image-zoom",
+                "Zoom",
+                None,
+                SliderOpts { min: 0.5, max: 8.0, value: 2.0, step: 0.05 },
+            );
+        });
+    });
+
+    parent.div().class("image-controls bottom").with(|div| {
+        div.fieldset()
+            .class("control-group image-align-y-control")
+            .with(|fieldset| {
                 radio_icon_button(
                     fieldset,
-                    "image-view-mode",
-                    "side-by-side",
-                    "View Mode side by side",
-                    icons::VIEW_SIDE_BY_SIDE,
+                    "image-align-y",
+                    "top",
+                    "Vertical-align top",
+                    icons::ALIGN_TOP,
                     true,
                 );
                 radio_icon_button(
                     fieldset,
-                    "image-view-mode",
-                    "swipe",
-                    "View Mode swipe",
-                    icons::VIEW_SWIPE,
+                    "image-align-y",
+                    "center",
+                    "Vertical-align center",
+                    icons::ALIGN_HORIZON,
                     false,
                 );
                 radio_icon_button(
                     fieldset,
-                    "image-view-mode",
-                    "blend",
-                    "View Mode blend",
-                    icons::VIEW_BLEND,
-                    false,
-                );
-                radio_icon_button(
-                    fieldset,
-                    "image-view-mode",
-                    "difference",
-                    "View Mode difference",
-                    icons::VIEW_DIFFERENCE,
+                    "image-align-y",
+                    "bottom",
+                    "Vertical-align bottom",
+                    icons::ALIGN_BOTTOM,
                     false,
                 );
             });
 
-            div.fieldset().class("control-group").with(|fieldset| {
-                checkbox_icon_button(
+        div.fieldset()
+            .class("control-group image-align-x-control")
+            .with(|fieldset| {
+                radio_icon_button(
                     fieldset,
-                    "image-antialiasing",
-                    "Antialiasing",
-                    icons::ANTIALIASING,
+                    "image-align-x",
+                    "left",
+                    "Horizontal-align left",
+                    icons::ALIGN_LEFT,
                     true,
                 );
+                radio_icon_button(
+                    fieldset,
+                    "image-align-x",
+                    "center",
+                    "Horizontal-align center",
+                    icons::ALIGN_CENTER,
+                    false,
+                );
+                radio_icon_button(
+                    fieldset,
+                    "image-align-x",
+                    "right",
+                    "Horizontal-align right",
+                    icons::ALIGN_RIGHT,
+                    false,
+                );
             });
 
-            div.fieldset().class("control-group").with(|fieldset| {
-                icon_button(fieldset, "image-zoom-minus", "Zoom out", icons::MINUS);
-                icon_button(fieldset, "image-zoom-plus", "Zoom in", icons::PLUS);
-
-                // HACK: Scale factor of HTML pt (`1/72 inch`) to px (`1/96 inch`).
-                // Since PNG images are rendered with 1 px/pt and PDFs converted
-                // to SVGs don't currently specify a unit thus default to px.
-                let factor = if output == TestOutput::Svg { 72.0 / 96.0 } else { 1.0 };
+        div.fieldset()
+            .class("control-group image-blend-control")
+            .with(|fieldset| {
                 slider(
                     fieldset,
-                    "image-zoom",
-                    "Zoom",
-                    None,
-                    factor * SliderOpts { min: 0.5, max: 8.0, value: 2.0, step: 0.05 },
+                    "image-blend",
+                    "Blend",
+                    Some(icons::VIEW_BLEND),
+                    SliderOpts { min: 0.0, max: 1.0, value: 0.5, step: 0.01 },
                 );
             });
-        });
-
-        div.div().class("image-diff-wrapper").with(|div| {
-            let image = |parent: &mut HtmlElem<'_>, data_url: &str| {
-                parent
-                    .img()
-                    .src(data_url)
-                    .alt(display!("The {output} image of `{name}` test"));
-            };
-
-            div.canvas().class("image-canvas").with(|canvas| {
-                let data_url = (diff.left())
-                    .and_then(|old| old.data())
-                    .map(|img| img.data_url.as_str())
-                    .unwrap_or("");
-                image(canvas, data_url);
-
-                let data_url = (diff.right())
-                    .and_then(|res| res.as_ref().ok())
-                    .map(|img| img.data_url.as_str())
-                    .unwrap_or("");
-                image(canvas, data_url);
-            });
-        });
-
-        div.div().class("image-mode-controls").with(|div| {
-            div.fieldset().class("control-group image-align-y-control").with(
-                |fieldset| {
-                    radio_icon_button(
-                        fieldset,
-                        "image-align-y",
-                        "top",
-                        "Vertical-align top",
-                        icons::ALIGN_TOP,
-                        true,
-                    );
-                    radio_icon_button(
-                        fieldset,
-                        "image-align-y",
-                        "center",
-                        "Vertical-align center",
-                        icons::ALIGN_HORIZON,
-                        false,
-                    );
-                    radio_icon_button(
-                        fieldset,
-                        "image-align-y",
-                        "bottom",
-                        "Vertical-align bottom",
-                        icons::ALIGN_BOTTOM,
-                        false,
-                    );
-                },
-            );
-
-            div.fieldset().class("control-group image-align-x-control").with(
-                |fieldset| {
-                    radio_icon_button(
-                        fieldset,
-                        "image-align-x",
-                        "left",
-                        "Horizontal-align left",
-                        icons::ALIGN_LEFT,
-                        true,
-                    );
-                    radio_icon_button(
-                        fieldset,
-                        "image-align-x",
-                        "center",
-                        "Horizontal-align center",
-                        icons::ALIGN_CENTER,
-                        false,
-                    );
-                    radio_icon_button(
-                        fieldset,
-                        "image-align-x",
-                        "right",
-                        "Horizontal-align right",
-                        icons::ALIGN_RIGHT,
-                        false,
-                    );
-                },
-            );
-
-            div.fieldset()
-                .class("control-group image-blend-control")
-                .with(|fieldset| {
-                    slider(
-                        fieldset,
-                        "image-blend",
-                        "Blend",
-                        Some(icons::VIEW_BLEND),
-                        SliderOpts { min: 0.0, max: 1.0, value: 0.5, step: 0.01 },
-                    );
-                });
-        });
     });
 }
 
@@ -1320,19 +1331,17 @@ fn html_diff(parent: &mut HtmlElem, diff: &FileDiff<diff::Html>) {
             .opt_attr("style", data_url.is_empty().then_some("visibility: hidden"));
     };
 
-    parent.div().class("html-diff").with(|div| {
-        let data_url = (diff.left())
-            .and_then(|old| old.data())
-            .map(|html| html.data_url.as_str())
-            .unwrap_or("");
-        iframe(div, data_url);
+    let data_url = (diff.left())
+        .and_then(|old| old.data())
+        .map(|html| html.data_url.as_str())
+        .unwrap_or("");
+    iframe(parent, data_url);
 
-        let data_url = (diff.right())
-            .and_then(|res| res.as_ref().ok())
-            .map(|html| html.data_url.as_str())
-            .unwrap_or("");
-        iframe(div, data_url);
-    });
+    let data_url = (diff.right())
+        .and_then(|res| res.as_ref().ok())
+        .map(|html| html.data_url.as_str())
+        .unwrap_or("");
+    iframe(parent, data_url);
 }
 
 #[rustfmt::skip]

--- a/tests/src/report/report.css
+++ b/tests/src/report/report.css
@@ -224,6 +224,11 @@ h2.diff-container-header {
   }
 }
 
+.test-report-body {
+  position: relative;
+  width: 100%;
+}
+
 .test-report-source {
   border-bottom: 1.25rem solid var(--layer-2);
 }
@@ -338,10 +343,73 @@ a.report-file-link:active {
 }
 
 .report-file {
+  width: 100%;
+  height: 100%;
   position: relative;
 }
 
+.file-diff {
+  width: 100%;
+  height: 100%;
+}
+
+/* ========== Image diff ========== */
+
+.test-report-body > .image-controls {
+  visibility: hidden;
+}
+
+.test-report-body.image > .image-controls {
+  visibility: visible;
+}
+
+.test-report-body.image:not(:hover,:has(*:focus-visible)) > .image-controls {
+  /* Avoid flicker in some cases */
+  transition: opacity 0.1s cubic-bezier(0.64, 0, 0.78, 0) 0.1s;
+  opacity: 0;
+}
+
+.image-controls {
+  position: absolute;
+  width: 100%;
+  margin: var(--size-xxxsmall) 0;
+  padding: 0 var(--size-xxxsmall);
+
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: var(--size-xxxsmall);
+
+  z-index: 100;
+}
+
+.image-controls.top {
+  top: 0;
+}
+
+.image-controls.bottom {
+  bottom: 0;
+}
+
+.file-diff.image {
+  width: 100%;
+  height: 400px;
+  min-height: 100px;
+  max-height: 100vh;
+  resize: vertical;
+  overflow: hidden;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
 /* ========== Text diff ========== */
+
+.file-diff.text {
+  width: 100%;
+}
 
 table.text-diff {
   width: 100%;
@@ -443,74 +511,11 @@ tr {
   margin: var(--line-margin) 0;
 }
 
-/* ========== Image diff ========== */
-
-.image-diff {
-  position: relative;
-  height: 400px;
-  width: 100%;
-  min-height: 100px;
-  max-height: 100vh;
-  resize: vertical;
-  overflow: hidden;
-
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-}
-
-/* Only show image controls on hover */
-.image-diff:not(:hover,:has(*:focus-visible)) {
-  > .image-controls,
-  > .image-mode-controls {
-    /* Avoid flicker in some cases */
-    transition: opacity 0.1s cubic-bezier(0.64, 0, 0.78, 0) 0.1s;
-    opacity: 0;
-  }
-}
-
-.image-controls {
-  position: absolute;
-  top: 0;
-  width: 100%;
-  padding: var(--size-xxxsmall);
-
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  gap: var(--size-xxxsmall);
-
-  z-index: 100;
-}
-
-.image-mode-controls {
-  position: absolute;
-  bottom: 0;
-  width: 100%;
-  padding: var(--size-xxxsmall);
-
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  gap: var(--size-xxxsmall);
-
-  z-index: 100;
-}
-
-.image-diff-wrapper {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
 /* ========== HTML diff ========== */
 
-.html-diff {
-  height: 400px;
+.file-diff.html {
   width: 100%;
+  height: 400px;
   min-height: 100px;
   max-height: 100vh;
   resize: vertical;

--- a/tests/src/report/report.js
+++ b/tests/src/report/report.js
@@ -218,6 +218,7 @@ for (const testReport of document.getElementsByClassName("test-report")) {
   if (imageControlsTop != null && imageControlsBottom != null) {
     const imageModes = imageControlsTop.querySelectorAll("input.image-view-mode")
     const imageAntialiasing = imageControlsTop.querySelector("input.image-antialiasing")
+    /** @type {HTMLInputElement} */
     const imageZoom = imageControlsTop.querySelector("input.image-zoom")
     const imageZoomPlus = imageControlsTop.querySelector("button.image-zoom-plus")
     const imageZoomMinus = imageControlsTop.querySelector("button.image-zoom-minus")
@@ -290,6 +291,16 @@ for (const testReport of document.getElementsByClassName("test-report")) {
         images,
       };
 
+      // CTRL+scroll and pinch to zoom.
+      imageDiff.addEventListener("wheel", /** @param e {WheelEvent} */ e => {
+        if (e.ctrlKey) {
+          e.preventDefault();
+
+          imageZoom.value = zoomFactor(Number(imageZoom.value), e);
+          imageDiffChanged(imageState);
+        }
+      });
+
       // Issue a lazy canvas redaw when the images have been decoded.
       let numDecoded = 0;
       for (const img of images) {
@@ -312,6 +323,19 @@ for (const testReport of document.getElementsByClassName("test-report")) {
       imageState.canvases.push(canvasState);
     }
   }
+}
+
+/**
+ * @param previous {number}
+ * @param e {WheelEvent}
+ * @return {number}
+ */
+function zoomFactor(previous, e) {
+  // Make zooming more proportional to the current zoom factor.
+  // When zoomed in closely apply a larger delta because the change from 7x to
+  // 7.1x isn't as noticable as from 0.5x to 0.6x scale.
+  const scaleCorrection = Math.log2(1 + previous);
+  return previous - 0.01 * scaleCorrection * e.deltaY;
 }
 
 let outputs = ["render", "pdf", "pdftags", "svg", "html"]

--- a/tests/src/report/report.js
+++ b/tests/src/report/report.js
@@ -75,7 +75,7 @@ for (const report of document.getElementsByClassName("test-report")) {
     const expanded = !(reportSourceToggle.ariaExpanded == "true");
     reportSource.hidden = !expanded;
     reportSourceToggle.ariaExpanded = expanded;
-    
+
     if (expanded) {
       activeTestSources += 1;
     } else {
@@ -84,7 +84,7 @@ for (const report of document.getElementsByClassName("test-report")) {
 
     globalSourceToggle.checked = activeTestSources > 0;
   });
-  
+
   for (const button of reportHeader.querySelectorAll(".copy-button")) {
     button.addEventListener("click", () => {
       navigator.clipboard.writeText(button.dataset.filePath);
@@ -493,6 +493,7 @@ function disableImageControls(state, mode) {
  * @property h {number}
  * @property clip {Path2D?}
  * @property opacity {number}
+ * @property border_color {string}
  */
 
 /**
@@ -528,6 +529,7 @@ function redrawImageDiff(state) {
     w: scale * state.images[0].naturalWidth,
     h: scale * state.images[0].naturalHeight,
     opacity: 1,
+    border_color: "#FF0000",
   };
   /** @type {ImageParams} */
   const b = {
@@ -536,18 +538,20 @@ function redrawImageDiff(state) {
     w: scale * state.images[1].naturalWidth,
     h: scale * state.images[1].naturalHeight,
     opacity: 1,
+    border_color: "#00e030",
   };
 
   const maxWidth = Math.max(a.w, b.w);
   const maxHeight = Math.max(a.h, b.h);
 
-  const sideBySideGap = 1;
+  const sideBySideGap = 2;
 
-  const swipeYPadding = scale * 8;
-  const swipeXPadding = 2;
+  const swipeMargin = { x: 2, y: scale * 8};
   const swipeDividerWidth = 1;
 
+  // Logical size of the canvas without the margin.
   let canvasSize = { w: maxWidth, h: maxHeight };
+  let canvasMargin = { x: 2, y: 2 };
   let compositeMode;
   let swipeDividerPos = null;
   switch (mode) {
@@ -556,7 +560,7 @@ function redrawImageDiff(state) {
 
       canvasSize = { w: 2 * maxWidth + sideBySideGap, h: maxHeight };
 
-      // Center align images
+      // Center align images.
       a.x = maxWidth - a.w;
       b.x = maxWidth + sideBySideGap;
 
@@ -568,23 +572,25 @@ function redrawImageDiff(state) {
     case "swipe": {
       compositeMode = "source-over";
 
-      const logicalCanvasSize = canvasSize;
-      canvasSize = { w: maxWidth + 2 * swipeXPadding, h: maxHeight + 2 * swipeYPadding };
+      canvasMargin = swipeMargin;
 
-      a.x = horizontalAlignImage(a, logicalCanvasSize, alignX) + swipeXPadding;
-      b.x = horizontalAlignImage(b, logicalCanvasSize, alignX) + swipeXPadding;
-      a.y = verticalAlignImage(a, logicalCanvasSize, alignY) + swipeYPadding;
-      b.y = verticalAlignImage(b, logicalCanvasSize, alignY) + swipeYPadding;
+      a.x = horizontalAlignImage(a, canvasSize, alignX)
+      b.x = horizontalAlignImage(b, canvasSize, alignX)
+      a.y = verticalAlignImage(a, canvasSize, alignY)
+      b.y = verticalAlignImage(b, canvasSize, alignY)
 
-      swipeDividerPos = Math.round(blend * (canvasSize.w - swipeDividerWidth));
+      swipeDividerPos = {
+        x: Math.round(blend * canvasSize.w),
+        y: -swipeMargin.y,
+      };
 
       // Use clip paths instead of the `drawImage` source paramters to avoid
       // wobble of the images when moving the slider.
       a.clip = new Path2D();
-      a.clip.rect(0, 0, swipeDividerPos, canvasSize.h);
+      a.clip.rect(0, 0, swipeDividerPos.x, canvasSize.h);
 
       b.clip = new Path2D();
-      b.clip.rect(swipeDividerPos, 0, canvasSize.w - swipeDividerPos, canvasSize.h);
+      b.clip.rect(swipeDividerPos.x, 0, canvasSize.w - swipeDividerPos.x, canvasSize.h);
 
       break;
     }
@@ -624,14 +630,15 @@ function redrawImageDiff(state) {
   }
 
   // Computation is done, do the actual drawing.
-  state.imageCanvas.width = canvasSize.w;
-  state.imageCanvas.height = canvasSize.h;
+  state.imageCanvas.width = canvasSize.w + 2 * canvasMargin.x;
+  state.imageCanvas.height = canvasSize.h + 2 * canvasMargin.y;
 
   const ctx = state.imageCanvas.getContext("2d")
   ctx.clearRect(0, 0, state.imageCanvas.width, state.imageCanvas.height);
 
   ctx.imageSmoothingEnabled = antialiased;
   ctx.globalCompositeOperation = compositeMode;
+  ctx.translate(canvasMargin.x, canvasMargin.y);
 
   drawImage(ctx, state.images[0], a);
   drawImage(ctx, state.images[1], b);
@@ -639,11 +646,10 @@ function redrawImageDiff(state) {
   // Divider.
   if (swipeDividerPos != null) {
     ctx.lineWidth = swipeDividerWidth;
-    ctx.strokeStyle = "red";
+    ctx.strokeStyle = "#007BFF";
     const divider = new Path2D();
-    console.log(swipeDividerPos);
-    divider.moveTo(swipeDividerPos, 0);
-    divider.lineTo(swipeDividerPos, canvasSize.h);
+    divider.moveTo(swipeDividerPos.x, swipeDividerPos.y);
+    divider.lineTo(swipeDividerPos.x, state.imageCanvas.height);
     ctx.stroke(divider);
   }
 }
@@ -656,8 +662,16 @@ function redrawImageDiff(state) {
 function drawImage(ctx, img, p) {
   ctx.save();
   ctx.globalAlpha = p.opacity;
+
+  // Draw image.
   if (p.clip != null) ctx.clip(p.clip);
   ctx.drawImage(img, p.x, p.y, p.w, p.h);
+
+  // Draw outline.
+  ctx.lineWidth = 2;
+  ctx.strokeStyle = p.border_color;
+  ctx.strokeRect(p.x, p.y, p.w, p.h);
+
   ctx.restore();
 }
 

--- a/tests/src/report/report.js
+++ b/tests/src/report/report.js
@@ -5,8 +5,8 @@ const sidebarLinks = sidebarList.querySelectorAll("a")
 
 /** @type {TestReportState[]} */
 const testReports = []
-/** @type {ReportFileState[]} */
-const reportFiles = []
+/** @type {ImageDiffState} */
+const imageDiffs = []
 
 /**
  * @typedef TestReportState
@@ -14,11 +14,28 @@ const reportFiles = []
  * @property report {HTMLDetailsElement}
  * @property reportToggle {HTMLButtonElement}
  * @property reportSourceToggle {HTMLButtonElement}
- * @property reportFileHeaders {NodeListOf<HTMLDivElement>}
- * @property reportFileTabs {NodeListOf<HTMLInputElement>}
- * @property reportBody HTMLDivElement
- * @property reportSource HTMLDivElement
- * @property reportFileTabpanels {NodeListOf<HTMLElement>}
+ * @property reportBody {HTMLDivElement}
+ * @property reportSource {HTMLDivElement}
+ * @property files {ReportFileState[]}
+ */
+
+/**
+ * @typedef ReportFileState
+ * @type {object}
+ * @property report {TestReportState}
+ * @property header {HTMLDivElement}
+ * @property tab {HTMLInputElement}
+ * @property tabpanel {HTMLElement}
+ * @property diffs {FileDiffState[]}
+ */
+
+/**
+ * @typedef FileDiffState
+ * @type {object}
+ * @property file {ReportFileState}
+ * @property kind {DiffKind}
+ * @property tab {HTMLInputElement?}
+ * @property tabpanel {HTMLElement}
  */
 
 /**
@@ -26,14 +43,46 @@ const reportFiles = []
  */
 
 /**
- * @typedef ReportFileState
- * @type {object}
- * @property fileDiffTabs {NodeListOf<HTMLInputElement>}
- * @property fileDiffTabpanels {NodeListOf<HTMLElement>}
+ * @typedef {"visual" | "text"} DiffMode
  */
 
 /**
- * @typedef {"visual" | "text"} DiffMode
+ * @typedef {"text" | "image" | "html"} DiffKind
+ */
+
+/**
+ * @typedef ImageDiffState
+ * @type {object}
+ * @property imageModes {HTMLInputElement[]}
+ * @property imageAntialiasing {HTMLInputElement}
+ * @property imageZoom {HTMLInputElement}
+ * @property imageAlignXControl {HTMLElement}
+ * @property imageAlignY {HTMLInputElement[]}
+ * @property imageAlignX {HTMLInputElement[]}
+ * @property imageBlendControl {HTMLElement}
+ * @property imageBlend {HTMLInputElement}
+ * @property canvases {ImageDiffCanvas[]}
+ */
+
+
+/**
+ * @typedef ImageDiffCanvas
+ * @type {object}
+ * @property output {TestOutput}
+ * @property visible {bool} Whether the canvas is visible.
+ * @property imagesDecoded {bool} Whether the images have been decoded and their
+ *                                natural dimensions are known.
+ * @property state {CanvasDrawState} Whether the canvas should be (re-)drawn.
+ * @property imageCanvas {HTMLCanvasElement}
+ * @property images {HTMLImageElement[]}
+ */
+
+/**
+ * @typedef {"side-by-side" | "swipe" | "blend" | "difference"} ImageViewMode
+ */
+
+/**
+ * @typedef {"hidden" | "dirty" | "up-to-date"} CanvasDrawState
  */
 
 let activeTestSources = 0
@@ -41,29 +90,27 @@ let activeTestSources = 0
 // Avoid implicit statefulness by the browser
 globalSourceToggle.checked = false
 
-for (const report of document.getElementsByClassName("test-report")) {
-  const reportHeader = report.querySelector(".test-report-header")
+for (const testReport of document.getElementsByClassName("test-report")) {
+  const reportHeader = testReport.querySelector(".test-report-header")
   const reportToggle = reportHeader.querySelector(".test-report-toggle")
   const reportSourceToggle = reportHeader.querySelector(".test-report-source-toggle")
   const reportFileHeaders = reportHeader.querySelectorAll(".report-file-header");
   const reportFileTabGroup = reportHeader.querySelector(".report-file-tab-group");
   const reportFileTabs = reportFileTabGroup.querySelectorAll(".report-file-tab");
-  const reportBody = report.querySelector(".test-report-body")
-  const reportSource = report.querySelector(".test-report-source")
+  const reportBody = testReport.querySelector(".test-report-body")
+  const reportSource = reportBody.querySelector(".test-report-source")
   const reportFileTabpanels = reportBody.querySelectorAll(":scope > .report-file");
 
   /** @type {TestReportState} */
-  const state = {
-    report,
+  const report = {
+    report: testReport,
     reportBody,
-    reportFileHeaders,
-    reportFileTabs,
-    reportFileTabpanels,
     reportToggle,
     reportSourceToggle,
     reportSource,
+    files: [],
   }
-  testReports.push(state);
+  testReports.push(report);
 
   reportToggle.addEventListener("click", () => {
     const expanded = !(reportToggle.ariaExpanded == "true");
@@ -93,38 +140,177 @@ for (const report of document.getElementsByClassName("test-report")) {
     })
   }
 
-  for (const tab of reportFileTabs) {
+  for (const [idx, tab] of reportFileTabs.entries()) {
+    /** @type {ReportFileState} */
+    const file = {
+      report,
+      tab,
+      header: reportFileHeaders[idx],
+      tabpanel: reportFileTabpanels[idx],
+      diffs: [],
+    };
+
+    report.files.push(file)
+
     tab.addEventListener("change", (e) => {
-      reportFileTabChanged(state, e.target.value)
+      reportFileTabChanged(report, e.target.value, true)
     })
   }
-  reportFileTabChanged(state, currentReportFileTab(state))
+  reportFileTabChanged(report, currentReportFileTab(report), false)
 
-  for (const [idx, child] of reportFileTabGroup.childNodes.entries()) {
-    const fileDiffTabGroup = child.querySelector(".file-diff-tab-group");
 
+  /** @type {FileDiffState} */
+  const reportImageDiffs = [];
+  // Bind the height of the image diffs in a report.
+  const resizeObserver = new ResizeObserver(entries => {
+    const entry = entries[entries.length - 1];
+    const newHeight = entry.target.style.height || "400px";
+    for (const diff of reportImageDiffs) {
+      if (diff.tabpanel != entry.target) {
+        diff.tabpanel.style.height = newHeight;
+      }
+    }
+  });
+
+  for (const file of report.files) {
     // Not all file reports have multiple diffs. File diff tabs are only
     // generated when necessary.
-    if (fileDiffTabGroup == null) {
-      continue;
+    const tabWrapper = file.tab.parentElement.parentElement;
+    let fileDiffTabs = []
+    if (tabWrapper.classList.contains("report-file-tab-wrapper")) {
+      fileDiffTabs = tabWrapper.querySelectorAll(".file-diff-tab");
     }
 
-    const fileDiffTabs = fileDiffTabGroup.querySelectorAll(".file-diff-tab");
-    const fileDiffTabpanels = reportFileTabpanels[idx].querySelectorAll(":scope > .file-diff");
+    const fileDiffTabpanels = file.tabpanel.querySelectorAll(":scope > .file-diff");
+    for (const [idx, tabpanel] of fileDiffTabpanels.entries()) {
+      const tab = fileDiffTabs[idx] || null;
+      const kind = tabpanel.dataset.kind;
+      /** @type {FileDiffState} */
+      const diff = {
+        file,
+        kind,
+        tab,
+        tabpanel,
+      };
 
-    /** @type {ReportFileState} */
-    const state = {
-      fileDiffTabs,
-      fileDiffTabpanels,
-    }
-    reportFiles.push(state);
+      if (kind == "image") {
+        resizeObserver.observe(diff.tabpanel);
+        reportImageDiffs.push(diff);
+      }
 
-    for (const tab of fileDiffTabs) {
-      tab.addEventListener("change", (e) => {
-        fileDiffTabChanged(state, e.target.value)
-      })
+      file.diffs.push(diff);
+
+      if (tab != null) {
+        tab.addEventListener("change", (e) => {
+          fileDiffTabChanged(file, e.target.value, true)
+        })
+      }
     }
-    fileDiffTabChanged(state, currentFileDiffTab(state))
+
+    fileDiffTabChanged(file, currentFileDiffTab(file), false);
+  }
+
+  // There is one set of image controls for the image diffs of all output
+  // formats inside a test report. This makes comparing the different formats
+  // more convenient.
+  const imageControlsTop = reportBody.querySelector(":scope > .image-controls.top")
+  const imageControlsBottom = reportBody.querySelector(":scope > .image-controls.bottom")
+  if (imageControlsTop != null && imageControlsBottom != null) {
+    const imageModes = imageControlsTop.querySelectorAll("input.image-view-mode")
+    const imageAntialiasing = imageControlsTop.querySelector("input.image-antialiasing")
+    const imageZoom = imageControlsTop.querySelector("input.image-zoom")
+    const imageZoomPlus = imageControlsTop.querySelector("button.image-zoom-plus")
+    const imageZoomMinus = imageControlsTop.querySelector("button.image-zoom-minus")
+
+    const imageAlignXControl = imageControlsBottom.querySelector(".image-align-x-control")
+    const imageAlignX = imageAlignXControl.querySelectorAll(".image-align-x")
+    const imageAlignYControl = imageControlsBottom.querySelector(".image-align-y-control")
+    const imageAlignY = imageAlignYControl.querySelectorAll(".image-align-y")
+    const imageBlendControl = imageControlsBottom.querySelector(".image-blend-control")
+    const imageBlend = imageControlsBottom.querySelector("input.image-blend")
+
+    /** @type {ImageDiffState} */
+    const imageState = {
+      imageModes,
+      imageAntialiasing,
+      imageZoom,
+      imageAlignXControl,
+      imageAlignX,
+      imageAlignY,
+      imageBlendControl,
+      imageBlend,
+      canvases: [],
+    };
+    imageDiffs.push(imageState);
+
+    for (const imageMode of imageModes) {
+      imageMode.addEventListener("change", (e) => {
+        imageModeChanged(imageState, e.target.value);
+      });
+    }
+
+    imageAntialiasing.addEventListener("change", () => imageDiffChanged(imageState));
+
+    imageZoom.addEventListener("change", () => imageDiffChanged(imageState));
+    imageZoom.addEventListener("input", () => imageDiffChanged(imageState));
+
+    imageZoomMinus.addEventListener("click", () => {
+      imageZoom.stepDown()
+      imageDiffChanged(imageState)
+    });
+    imageZoomPlus.addEventListener("click", () => {
+      imageZoom.stepUp()
+      imageDiffChanged(imageState)
+    });
+
+    for (const align of imageAlignX) {
+      align.addEventListener("change", () => imageDiffChanged(imageState));
+    }
+    for (const align of imageAlignY) {
+      align.addEventListener("change", () => imageDiffChanged(imageState));
+    }
+
+    imageBlend.addEventListener("change", () => imageDiffChanged(imageState));
+    imageBlend.addEventListener("input", () => imageDiffChanged(imageState));
+
+    // Initially enable/disable the image controls.
+    disableImageControls(imageState, currentImageMode(imageState));
+
+    for (const imageDiff of reportBody.querySelectorAll(".file-diff.image")) {
+      const imageCanvas = imageDiff.querySelector(".image-canvas")
+      const images = imageCanvas.querySelectorAll("img")
+
+      /** @type {ImageDiffCanvas} */
+      const canvasState = {
+        output: imageCanvas.dataset.output,
+        visible: false,
+        imagesDecoded: false,
+        state: "hidden",
+        imageCanvas,
+        images,
+      };
+
+      // Issue a lazy canvas redaw when the images have been decoded.
+      let numDecoded = 0;
+      for (const img of images) {
+        // Ignore invalid images.
+        img.decode().catch(() => { }).then(() => {
+          numDecoded += 1;
+          if (numDecoded == images.length) {
+            canvasState.imagesDecoded = true;
+            redrawImageDiff(imageState, canvasState);
+          }
+        })
+      }
+
+      // Issue a lazy canvas redaw if the images become visible on screen.
+      onViewportIntersectionChanged(imageDiff, (visible) => {
+        canvasState.visible = visible;
+        redrawImageDiff(imageState, canvasState);
+      });
+
+      imageState.canvases.push(canvasState);
+    }
   }
 }
 
@@ -152,8 +338,8 @@ filterSearch.addEventListener("change", () => {
 
 filterDiffs()
 
-let diff_modes = ["visual", "text"]
-for (const mode of diff_modes) {
+const diffModes = ["visual", "text"]
+for (const mode of diffModes) {
   document.getElementById(`global-diff-mode-${mode}`)
     .addEventListener("click", () => {
       changeGlobalDiffMode(mode)
@@ -185,8 +371,8 @@ function filterDiffs() {
     // Filter format
     if (outputs.length > 0 && !filteredOut) {
       filteredOut = true;
-      for (const tab of report.reportFileTabs) {
-        if (outputs.includes(tab.value)) {
+      for (const file of report.files) {
+        if (outputs.includes(file.tab.value)) {
           filteredOut = false;
           break;
         }
@@ -202,213 +388,131 @@ function filterDiffs() {
  * @param output {TestOutput}
  */
 function changeGlobalDiffFormat(output) {
-  for (const state of testReports) {
+  for (const report of testReports) {
     let found = false
-    for (const tab of state.reportFileTabs) {
-      if (tab.value == output) {
-        tab.checked = true;
+    for (const file of report.files) {
+      if (file.tab.value == output) {
+        file.tab.checked = true;
         found = true;
         break;
       }
     }
     if (found) {
-      reportFileTabChanged(state, output)
+      reportFileTabChanged(report, output, true)
     }
   }
 }
 
 /**
- * @param state {TestReportState}
+ * @param report {TestReportState}
  * @param output {TestOutput}
+ * @param update_child {boolean}
  */
-function reportFileTabChanged(state, output) {
-  for (const [idx, tab] of state.reportFileTabs.entries()) {
-    const selected = tab.value == output;
-    tab.ariaSelected = selected;
-    state.reportFileTabpanels[idx].hidden = !selected;
-    state.reportFileHeaders[idx].hidden = !selected;
+function reportFileTabChanged(report, output, update_child) {
+  for (const file of report.files) {
+    const selected = file.tab.value == output;
+    file.tab.ariaSelected = selected;
+    file.tabpanel.hidden = !selected;
+    file.header.hidden = !selected;
+
+    // Check which file is visible.
+    if (update_child && selected) {
+      fileDiffTabChanged(file, currentFileDiffTab(file), false);
+    }
   }
 }
 
 /**
- * @param state {TestReportState}
+ * @param report {TestReportState}
  * @return {TestOutput}
  */
-function currentReportFileTab(state) {
-  for (const tab of state.reportFileTabs) {
-    if (tab.checked) {
-      return tab.value
+function currentReportFileTab(report) {
+  for (const file of report.files) {
+    if (file.tab.checked) {
+      return file.tab.value
     }
   }
 }
 
 /**
- * @param diff_mode {DiffMode}
+ * @param diffMode {DiffMode}
  */
-function changeGlobalDiffMode(diff_mode) {
-  for (const state of reportFiles) {
-    let found = false
-    for (const tab of state.fileDiffTabs) {
-      if (tab.value == diff_mode) {
-        tab.checked = true;
-        found = true;
-        break;
+function changeGlobalDiffMode(diffMode) {
+  for (const report of testReports) {
+    for (const file of report.files) {
+      let found = false
+      for (const diff of file.diffs) {
+        if (diff.tab?.value == diffMode) {
+          diff.tab.checked = true;
+          found = true;
+          break;
+        }
+      }
+      if (found) {
+        fileDiffTabChanged(file, diffMode, false)
       }
     }
-    if (found) {
-      fileDiffTabChanged(state, diff_mode)
-    }
   }
 }
 
 /**
-  * @param state {ReportFileState}
-  * @param diff_mode {DiffMode}
+  * @param file {ReportFileState}
+  * @param diffMode {DiffMode?}
+  * @param update_parent {boolean}
   */
-function fileDiffTabChanged(state, diff_mode) {
-  for (const [idx, tab] of state.fileDiffTabs.entries()) {
-    const selected = tab.value == diff_mode;
-    tab.ariaSelected = selected;
-    state.fileDiffTabpanels[idx].hidden = !selected;
+function fileDiffTabChanged(file, diffMode, update_parent) {
+  let kind = null;
+  if (diffMode == null) {
+    console.assert(file.diffs.length == 1, "expected exactly one report file diff");
+
+    kind = file.diffs[0].kind;
+  } else {
+    for (const diff of file.diffs) {
+      const selected = diff.tab.value == diffMode;
+      diff.tab.ariaSelected = selected;
+      diff.tabpanel.hidden = !selected;
+
+      if (selected) kind = diff.kind;
+    }
+  }
+
+  // When the button of a nested tab is pressed, also update the parent tab.
+  if (update_parent) {
+    file.tab.checked = true;
+    reportFileTabChanged(file.report, file.tab.value, false)
+  }
+
+  // When this tab is visible update the test report diff kind.
+  if (file.tab.checked) {
+    file.report.reportBody.classList.toggle("image", kind == "image")
   }
 }
 
 /**
-  * @param state {ReportFileState}
-  * @return {DiffMode}
+  * @param file {ReportFileState}
+  * @return {DiffMode?}
   */
-function currentFileDiffTab(state) {
-  for (const tab of state.fileDiffTabs) {
-    if (tab.checked) {
-      return tab.value
+function currentFileDiffTab(file) {
+  for (const diff of file.diffs) {
+    if (diff.tab?.checked) {
+      return diff.tab.value
     }
   }
+
+  // This only happens if there is only one file diff.
+  return null;
 }
 
 /**
  * @param visible {boolean}
  */
 function changeGlobalSourceVisibility(visible) {
-  for (const state of testReports) {
-    state.reportSource.hidden = !visible;
-    state.reportSourceToggle.ariaExpanded = visible;
+  for (const report of testReports) {
+    report.reportSource.hidden = !visible;
+    report.reportSourceToggle.ariaExpanded = visible;
   }
 
   activeTestSources = visible ? testReports.length : 0;
-}
-
-/** @type {ImageDiffState} */
-const imageDiffs = []
-
-/**
- * @typedef ImageDiffState
- * @type {object}
- * @property visible {bool} Whether the canvas is visible.
- * @property imagesDecoded {bool} Whether the images have been decoded and their
- *                                natural dimensions are known.
- * @property dirty {bool} Whether the canvas should be (re-)drawn.
- * @property imageCanvas {HTMLCanvasElement}
- * @property images {HTMLImageElement[]}
- * @property imageModes {HTMLInputElement[]}
- * @property imageAntialiasing {HTMLInputElement}
- * @property imageZoom {HTMLInputElement}
- * @property imageAlignXControl {HTMLElement}
- * @property imageAlignY {HTMLInputElement[]}
- * @property imageAlignX {HTMLInputElement[]}
- * @property imageBlendControl {HTMLElement}
- * @property imageBlend {HTMLInputElement}
- */
-
-/**
- * @typedef {"side-by-side" | "swipe" | "blend" | "difference"} ImageViewMode
- */
-
-for (const imageDiff of document.getElementsByClassName("image-diff")) {
-  const imageWrapper = imageDiff.querySelector(".image-diff-wrapper")
-  const imageCanvas = imageWrapper.querySelector(".image-canvas")
-  const images = imageCanvas.querySelectorAll("img")
-
-  const imageModes = imageDiff.querySelectorAll("input.image-view-mode")
-  const imageAntialiasing = imageDiff.querySelector("input.image-antialiasing")
-  const imageZoom = imageDiff.querySelector("input.image-zoom")
-  const imageZoomPlus = imageDiff.querySelector("button.image-zoom-plus")
-  const imageZoomMinus = imageDiff.querySelector("button.image-zoom-minus")
-  const imageAlignXControl = imageDiff.querySelector(".image-align-x-control")
-  const imageAlignX = imageAlignXControl.querySelectorAll(".image-align-x")
-  const imageAlignYControl = imageDiff.querySelector(".image-align-y-control")
-  const imageAlignY = imageAlignYControl.querySelectorAll(".image-align-y")
-  const imageBlendControl = imageDiff.querySelector(".image-blend-control")
-  const imageBlend = imageDiff.querySelector("input.image-blend")
-
-  /** @type {ImageDiffState} */
-  const state = {
-    visible: false,
-    imagesLoaded: false,
-    dirty: true,
-    imageCanvas,
-    images,
-    imageModes,
-    imageAntialiasing,
-    imageZoom,
-    imageAlignXControl,
-    imageAlignX,
-    imageAlignY,
-    imageBlendControl,
-    imageBlend,
-  }
-  imageDiffs.push(state);
-
-  for (const imageMode of imageModes) {
-    imageMode.addEventListener("change", (e) => {
-      imageModeChanged(state, e.target.value);
-    });
-  }
-
-  imageAntialiasing.addEventListener("change", () => imageDiffChanged(state));
-
-  imageZoom.addEventListener("change", () => imageDiffChanged(state));
-  imageZoom.addEventListener("input", () => imageDiffChanged(state));
-
-  imageZoomMinus.addEventListener("click", () => {
-    imageZoom.stepDown()
-    imageDiffChanged(state)
-  });
-  imageZoomPlus.addEventListener("click", () => {
-    imageZoom.stepUp()
-    imageDiffChanged(state)
-  });
-
-  for (const align of imageAlignX) {
-    align.addEventListener("change", () => imageDiffChanged(state));
-  }
-  for (const align of imageAlignY) {
-    align.addEventListener("change", () => imageDiffChanged(state));
-  }
-
-  imageBlend.addEventListener("change", () => imageDiffChanged(state));
-  imageBlend.addEventListener("input", () => imageDiffChanged(state));
-
-  // Initially enable/disable the image controls.
-  disableImageControls(state, currentImageMode(state));
-
-  // Issue a lazy canvas redaw when the images have been decoded.
-  let numDecoded = 0;
-  for (const img of images) {
-    // Ignore invalid images.
-    img.decode().catch(() => {}).then(() => {
-      numDecoded += 1;
-      if (numDecoded == images.length) {
-        state.imagesDecoded = true;
-        redrawImageDiff(state);
-      }
-    })
-  }
-
-  // Issue a lazy canvas redaw if the images become visible on screen.
-  onViewportIntersectionChanged(imageWrapper, (visible) => {
-    state.visible = visible;
-    redrawImageDiff(state);
-  });
 }
 
 /**
@@ -416,7 +520,7 @@ for (const imageDiff of document.getElementsByClassName("image-diff")) {
  * @param callback {(visible: bool) => void}
  */
 function onViewportIntersectionChanged(element, callback) {
-  var observer = new IntersectionObserver((entries, _observer) => {
+  const observer = new IntersectionObserver((entries, _observer) => {
     for (const entry of entries) {
       callback(entry.intersectionRatio > 0);
     }
@@ -500,22 +604,42 @@ function disableImageControls(state, mode) {
  * @param state {ImageDiffState}
  */
 function imageDiffChanged(state) {
-  state.dirty = true;
-  redrawImageDiff(state);
+  for (const canvas of state.canvases) {
+    // Only mark the canvas as dirty if it was drawn to.
+    // If it was "hidden" it is still hidden.
+    if (canvas.state == "up-to-date") {
+      canvas.state = "dirty";
+    }
+    redrawImageDiff(state, canvas);
+  }
 }
 
 /**
  * @param state {ImageDiffState}
+ * @param canvas {ImageDiffCanvas}
  */
-function redrawImageDiff(state) {
+function redrawImageDiff(state, canvas) {
   // In large test reports drawing only the image diffs that are on screen is
   // necessary to create a somewhat usable experience. It also dramatically
   // reduces loading time.
-  if (!(state.visible  && state.dirty && state.imagesDecoded)) return;
+  if (!(canvas.visible && canvas.state != "up-to-date" && canvas.imagesDecoded)) {
+    if (canvas.state == "dirty") {
+      // Hide the canvas to avoid showing outdated drawn diff, when the canvas
+      // comes into view.
+      canvas.imageCanvas.hidden = true;
+      canvas.state = "hidden";
+    }
+    return;
+  }
 
-  state.dirty = false;
+  canvas.imageCanvas.hidden = false;
+  canvas.state = "up-to-date";
 
-  const scale = state.imageZoom.value
+  // HACK: Scale factor of HTML pt (`1/72 inch`) to px (`1/96 inch`).
+  // Since PNG images are rendered with 1 px/pt and PDFs converted
+  // to SVGs don't currently specify a unit thus default to px.
+  const factor = (canvas.output == "svg") ? (72.0 / 96.0) : 1.0;
+  const scale = factor * state.imageZoom.value
   const antialiased = state.imageAntialiasing.checked;
   const mode = currentImageMode(state)
   const alignX = currentImageAlignX(state);
@@ -526,8 +650,8 @@ function redrawImageDiff(state) {
   const a = {
     x: 0,
     y: 0,
-    w: scale * state.images[0].naturalWidth,
-    h: scale * state.images[0].naturalHeight,
+    w: scale * canvas.images[0].naturalWidth,
+    h: scale * canvas.images[0].naturalHeight,
     opacity: 1,
     border_color: "#FF0000",
   };
@@ -535,8 +659,8 @@ function redrawImageDiff(state) {
   const b = {
     x: 0,
     y: 0,
-    w: scale * state.images[1].naturalWidth,
-    h: scale * state.images[1].naturalHeight,
+    w: scale * canvas.images[1].naturalWidth,
+    h: scale * canvas.images[1].naturalHeight,
     opacity: 1,
     border_color: "#00e030",
   };
@@ -546,7 +670,7 @@ function redrawImageDiff(state) {
 
   const sideBySideGap = 2;
 
-  const swipeMargin = { x: 2, y: scale * 8};
+  const swipeMargin = { x: 2, y: scale * 8 };
   const swipeDividerWidth = 1;
 
   // Logical size of the canvas without the margin.
@@ -630,18 +754,18 @@ function redrawImageDiff(state) {
   }
 
   // Computation is done, do the actual drawing.
-  state.imageCanvas.width = canvasSize.w + 2 * canvasMargin.x;
-  state.imageCanvas.height = canvasSize.h + 2 * canvasMargin.y;
+  canvas.imageCanvas.width = canvasSize.w + 2 * canvasMargin.x;
+  canvas.imageCanvas.height = canvasSize.h + 2 * canvasMargin.y;
 
-  const ctx = state.imageCanvas.getContext("2d")
-  ctx.clearRect(0, 0, state.imageCanvas.width, state.imageCanvas.height);
+  const ctx = canvas.imageCanvas.getContext("2d")
+  ctx.clearRect(0, 0, canvas.imageCanvas.width, canvas.imageCanvas.height);
 
   ctx.imageSmoothingEnabled = antialiased;
   ctx.globalCompositeOperation = compositeMode;
   ctx.translate(canvasMargin.x, canvasMargin.y);
 
-  drawImage(ctx, state.images[0], a);
-  drawImage(ctx, state.images[1], b);
+  drawImage(ctx, canvas.images[0], a);
+  drawImage(ctx, canvas.images[1], b);
 
   // Divider.
   if (swipeDividerPos != null) {
@@ -649,7 +773,7 @@ function redrawImageDiff(state) {
     ctx.strokeStyle = "#007BFF";
     const divider = new Path2D();
     divider.moveTo(swipeDividerPos.x, swipeDividerPos.y);
-    divider.lineTo(swipeDividerPos.x, state.imageCanvas.height);
+    divider.lineTo(swipeDividerPos.x, canvas.imageCanvas.height);
     ctx.stroke(divider);
   }
 }
@@ -707,6 +831,7 @@ function verticalAlignImage(img, size, align) {
 
 /**
  * @param state {ImageDiffState}
+ * @returns {ImageViewMode}
  */
 function currentImageMode(state) {
   for (const imageMode of state.imageModes) {


### PR DESCRIPTION
This adds a few improvements to the test reports.

1. Similar to github image diffs red and green outlines are drawn around the old and new images.
<img width="771" height="431" alt="image" src="https://github.com/user-attachments/assets/2cd20b0c-668e-45ea-a91f-9d61cb9c0846" />

2. The image diff controls are shared between the image diffs for a single test and the height of the diffs is also linked. Previously every format had its own controls which meant the changes had to be made for the PNG, SVG, and PDF image diff. This makes it easier to compare output of the different formats, because they will have the same size position etc.

https://github.com/user-attachments/assets/f279d483-f2ae-449c-a30e-3ff5b270a84b

3. When clicking the text/visual nested tab buttons the parent tab is selected.

https://github.com/user-attachments/assets/1c498989-4b78-467f-a76a-b3d529c49381

