### PR TITLE
Replace `sort_unstable` with `sort` to revert small performance regression

### DIFF
--- a/crates/typst-library/src/text/font/info.rs
+++ b/crates/typst-library/src/text/font/info.rs
@@ -289,7 +289,12 @@ pub struct Coverage(Vec<u32>);
 impl Coverage {
     /// Encode a vector of codepoints.
     pub fn from_vec(mut codepoints: Vec<u32>) -> Self {
-        codepoints.sort_unstable();
+        #[expect(
+            clippy::stable_sort_primitive,
+            reason = "`sort_unstable` hurts performance here. Compiling a 'Hello World!' \
+            PDF with `--ignore-system-fonts` goes from 7.8ms to 9.1ms or +16%."
+        )]
+        codepoints.sort();
         codepoints.dedup();
 
         let mut runs = Vec::new();


### PR DESCRIPTION
Unfortunately, the lint PRs (#8539) did introduce a tiny but repeatable performance regression. With the [`stable_sort_primitive`](https://rust-lang.github.io/rust-clippy/master/index.html#stable_sort_primitive) lint ([commit](https://github.com/typst/typst/pull/8539/changes/96dec31cc0a8a4ac53ebc9a8ab62a7bb3e256fcb)), we changed a codepoint sorting method from `sort` to `sort_unstable`, but the unstable sort consistently adds around 1ms to the processing time for a simple "Hello World!" document (which, given it takes ~8ms total, is significant).

This is a [known problem](https://rust-lang.github.io/rust-clippy/master/index.html#stable_sort_primitive) with the lint (which links to https://github.com/rust-lang/rust-clippy/issues/8241), but I think it's still good to keep since unstable sorting should be a better default unless a performance problem is found.

So I've reverted to `sort` and added an `expect` attribute explaning the rationale.