### PR TITLE
feat: Let `datetime.today()` include the time of day when reproducible

### DIFF
--- a/crates/typst-cli/src/eval.rs
+++ b/crates/typst-cli/src/eval.rs
@@ -186,4 +186,8 @@ impl World for ExpressionWorld {
     fn today(&self, offset: Option<Duration>) -> Option<Datetime> {
         self.world.today(offset)
     }
+
+    fn today_with_time(&self, offset: Option<Duration>) -> Option<Datetime> {
+        self.world.today_with_time(offset)
+    }
 }

--- a/crates/typst-cli/src/world.rs
+++ b/crates/typst-cli/src/world.rs
@@ -142,6 +142,10 @@ impl World for SystemWorld {
     fn today(&self, offset: Option<Duration>) -> Option<Datetime> {
         self.now.today(offset)
     }
+
+    fn today_with_time(&self, offset: Option<Duration>) -> Option<Datetime> {
+        self.now.today_with_time(offset)
+    }
 }
 
 impl DiagnosticWorld for SystemWorld {

--- a/crates/typst-kit/src/datetime.rs
+++ b/crates/typst-kit/src/datetime.rs
@@ -7,7 +7,7 @@
 
 use std::sync::OnceLock;
 
-use chrono::{DateTime, Datelike, FixedOffset, Local, NaiveTime, Utc};
+use chrono::{DateTime, Datelike, FixedOffset, Local, NaiveTime, Timelike, Utc};
 use chrono::{NaiveDate, NaiveDateTime};
 
 use typst_library::diag::{StrResult, bail};
@@ -73,14 +73,8 @@ impl Time {
         Time(TimeInner::System(OnceLock::new()))
     }
 
-    /// The current date.
-    ///
-    /// A timezone offset can be given to obtain the current date in this
-    /// timezone.
-    ///
-    /// This can directly be used to implement
-    /// [`World::today`](typst_library::World::today).
-    pub fn today(&self, offset: Option<Duration>) -> Option<Datetime> {
+    /// The time with the given UTC offset applied.
+    fn with_offset(&self, offset: Option<Duration>) -> Option<DateTime<FixedOffset>> {
         let now = match &self.0 {
             TimeInner::Fixed(time) => time.fixed_offset(),
             TimeInner::System(time) => {
@@ -94,9 +88,8 @@ impl Time {
             }
         };
 
-        // The time with the specified UTC offset.
-        let with_offset = match offset {
-            None => now,
+        match offset {
+            None => Some(now),
             Some(offset) => {
                 let seconds = offset.seconds().trunc();
                 // Check whether we can convert seconds from f64 to i32
@@ -106,14 +99,48 @@ impl Time {
                 {
                     return None;
                 }
-                now.with_timezone(&FixedOffset::east_opt(seconds as i32)?)
+                Some(now.with_timezone(&FixedOffset::east_opt(seconds as i32)?))
             }
-        };
+        }
+    }
 
+    /// The current date.
+    ///
+    /// A timezone offset can be given to obtain the current date in this
+    /// timezone.
+    ///
+    /// This can directly be used to implement
+    /// [`World::today`](typst_library::World::today).
+    pub fn today(&self, offset: Option<Duration>) -> Option<Datetime> {
+        let with_offset = self.with_offset(offset)?;
         Datetime::from_ymd(
             with_offset.year(),
             with_offset.month().try_into().ok()?,
             with_offset.day().try_into().ok()?,
+        )
+    }
+
+    /// The current date and time, including the time of day.
+    ///
+    /// Unlike [`today`](Self::today), this only succeeds if the time is
+    /// [fixed](Self::fixed) or [fixed to a timestamp](Self::fixed_timestamp),
+    /// returning `None` for the live system clock. See [`Datetime::today`] for
+    /// more details.
+    ///
+    /// This can directly be used to implement
+    /// [`World::today_with_time`](typst_library::World::today_with_time).
+    pub fn today_with_time(&self, offset: Option<Duration>) -> Option<Datetime> {
+        if !matches!(self.0, TimeInner::Fixed(_)) {
+            return None;
+        }
+        let with_offset = self.with_offset(offset)?;
+        Datetime::from_ymd_hms(
+            with_offset.year(),
+            with_offset.month().try_into().ok()?,
+            with_offset.day().try_into().ok()?,
+            with_offset.hour().try_into().ok()?,
+            with_offset.minute().try_into().ok()?,
+            with_offset.second().try_into().ok()?,
         )
     }
 
@@ -125,5 +152,32 @@ impl Time {
         if let TimeInner::System(ref mut time_lock) = self.0 {
             time_lock.take();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use typst_library::foundations::Datetime;
+
+    use super::Time;
+
+    #[test]
+    fn today_with_time_succeeds_when_fixed() {
+        let datetime = Datetime::from_ymd_hms(2024, 4, 3, 10, 39, 30).unwrap();
+        let time = Time::fixed(datetime).unwrap();
+        assert_eq!(time.today_with_time(None), Some(datetime));
+    }
+
+    #[test]
+    fn today_with_time_succeeds_when_fixed_timestamp() {
+        let datetime = Datetime::from_ymd_hms(2024, 4, 3, 10, 39, 30).unwrap();
+        let time = Time::fixed_timestamp(1712140770).unwrap();
+        assert_eq!(time.today_with_time(None), Some(datetime));
+    }
+
+    #[test]
+    fn today_with_time_fails_when_system() {
+        let time = Time::system();
+        assert_eq!(time.today_with_time(None), None);
     }
 }

--- a/crates/typst-library/src/foundations/datetime.rs
+++ b/crates/typst-library/src/foundations/datetime.rs
@@ -377,9 +377,27 @@ impl Datetime {
         #[named]
         #[default]
         offset: Smart<TodayOffset>,
+        /// Whether to include the time of day.
+        ///
+        /// This only succeeds if the current build has a fixed, reproducible
+        /// time source, as described above.
+        ///
+        /// It fails when relying on the live system clock, since the time of
+        /// day would then change on every recompilation, breaking
+        /// reproducibility and incremental compilation in `typst watch`.
+        #[named]
+        #[default(false)]
+        time: bool,
     ) -> StrResult<Datetime> {
         let offset = offset.custom().map(|v| v.0);
-        Ok(engine.world.today(offset).ok_or("unable to get the current date")?)
+        if time {
+            Ok(engine
+                .world
+                .today_with_time(offset)
+                .ok_or("unable to get the current time of day")?)
+        } else {
+            Ok(engine.world.today(offset).ok_or("unable to get the current date")?)
+        }
     }
 
     /// Displays the datetime in a specified format.

--- a/crates/typst-library/src/lib.rs
+++ b/crates/typst-library/src/lib.rs
@@ -95,6 +95,22 @@ pub trait World: Send + Sync {
     /// If this function returns `None`, Typst's `datetime` function will
     /// return an error.
     fn today(&self, offset: Option<Duration>) -> Option<Datetime>;
+
+    /// Get the current date and time, including the time of day. The `offset`
+    /// parameter behaves as in [`today`](Self::today).
+    ///
+    /// Unlike [`today`](Self::today), this should only succeed with a fixed,
+    /// reproducible time source; implementations backed by the live system
+    /// clock should return `None`. See [`Datetime::today`] for more details.
+    ///
+    /// If this function returns `None`, Typst's `datetime` function will return
+    /// an error.
+    ///
+    /// The default implementation returns `None`.
+    fn today_with_time(&self, offset: Option<Duration>) -> Option<Datetime> {
+        let _ = offset;
+        None
+    }
 }
 
 macro_rules! world_impl {
@@ -126,6 +142,10 @@ macro_rules! world_impl {
 
             fn today(&self, offset: Option<Duration>) -> Option<Datetime> {
                 self.deref().today(offset)
+            }
+
+            fn today_with_time(&self, offset: Option<Duration>) -> Option<Datetime> {
+                self.deref().today_with_time(offset)
             }
         }
     };

--- a/docs/src/example.rs
+++ b/docs/src/example.rs
@@ -300,6 +300,10 @@ impl World for ExampleWorld {
     fn today(&self, _: Option<Duration>) -> Option<Datetime> {
         Some(Datetime::from_ymd(1970, 1, 1).unwrap())
     }
+
+    fn today_with_time(&self, _: Option<Duration>) -> Option<Datetime> {
+        Some(Datetime::from_ymd_hms(1970, 1, 1, 0, 0, 0).unwrap())
+    }
 }
 
 static EXAMPLE_LIBRARY: LazyLock<LazyHash<Library>> = LazyLock::new(|| {

--- a/docs/src/world.rs
+++ b/docs/src/world.rs
@@ -114,6 +114,10 @@ impl World for DocWorld {
     fn today(&self, offset: Option<Duration>) -> Option<Datetime> {
         self.now.today(offset)
     }
+
+    fn today_with_time(&self, offset: Option<Duration>) -> Option<Datetime> {
+        self.now.today_with_time(offset)
+    }
 }
 
 impl DiagnosticWorld for DocWorld {

--- a/tests/src/world.rs
+++ b/tests/src/world.rs
@@ -82,6 +82,11 @@ impl World for TestWorld {
         let datetime = Datetime::from_ymd_hms(1970, 1, 1, 12, 0, 0).unwrap();
         Time::fixed(datetime).unwrap().today(offset)
     }
+
+    fn today_with_time(&self, offset: Option<Duration>) -> Option<Datetime> {
+        let datetime = Datetime::from_ymd_hms(1970, 1, 1, 12, 0, 0).unwrap();
+        Time::fixed(datetime).unwrap().today_with_time(offset)
+    }
 }
 
 /// Shared foundation of all test worlds.

--- a/tests/suite/foundations/datetime.typ
+++ b/tests/suite/foundations/datetime.typ
@@ -69,6 +69,11 @@
 #test(datetime.today(offset: -14).display(), "1969-12-31")
 #test(datetime.today(offset: duration(hours: 5, minutes: 45)).display(), "1970-01-01")
 
+// Test today with time of day
+#test(datetime.today(time: true).display(), "1970-01-01 12:00:00")
+#test(datetime.today(offset: auto, time: true).display(), "1970-01-01 12:00:00")
+#test(datetime.today(offset: 2, time: true).display(), "1970-01-01 14:00:00")
+
 --- datetime-ordinal eval ---
 // Test date methods.
 #test(datetime(day: 1, month: 1, year: 2000).ordinal(), 1);


### PR DESCRIPTION
I would like to embed the Git commit timestamp of my documents with:

```typ
#set document(
  // ...
  date: datetime.today(time: true),
)
```

Currently `datetime.today()` already reads `SOURCE_DATE_EPOCH` or `--creation-timestamp` for fixed timestamps, but only ever surfaced the date portion, dropping the timestamp segment.

This PRs add a `time` parameter to `datetime.today()` that will include this timestamp.

<!--
Thanks for your interest in landing a change in Typst! Before opening the PR, please review our contribution guidelines: https://github.com/typst/typst/blob/main/CONTRIBUTING.md

In particular, please keep in mind that we do not accept contributions implemented by an AI model. We would also ask you to refrain from using AI to write your pull request description. Summarizing your work helps organizing your thoughts as much as it helps us with seeing the human thought process behind a particular change.
-->
