### PR TITLE
Support filtering by math class in symbol search

### DIFF
--- a/docs/assets/docs.js
+++ b/docs/assets/docs.js
@@ -1037,8 +1037,50 @@ function buildSymbolScoringFunction(query) {
   const queryParts = lowerQuery
     .split(/\s*[.\s]\s*/)
     .filter((part) => part.length > 0);
+  const isFilter = (part) => /-?\w+:\w+/.test(part);
+  const queryFilters = queryParts.filter(isFilter);
+  const queryTerms = queryParts.filter((part) => !isFilter(part));
+
+  const filters = {
+    "class": (value, result) => {
+      if (!("mathClass" in result.dataset)) {
+        return value === "none";
+      }
+      const classes = {
+        "Normal": ["n", "normal"],
+        "Alphabetic": ["a", "alphabetic"],
+        "Binary": ["b", "binary"],
+        "Closing": ["c", "closing"],
+        "Diacritic": ["d", "diacritic"],
+        "Fence": ["f", "fence"],
+        // The Unicode name is "Glyph_Part", but Typst uses "glyphpart".
+        "Glyph_Part": ["g", "glyph_part", "glyph-part"],
+        "Opening": ["o", "opening"],
+        "Large": ["l", "large"],
+        "Punctuation": ["p", "punctuation"],
+        "Relation": ["r", "relation"],
+        "Space": ["s", "space"],
+        "Unary": ["u", "unary"],
+        "Vary": ["v", "vary"],
+        "Special": ["x", "special"],
+      };
+      return classes[result.dataset.mathClass].includes(value);
+    },
+  };
 
   return (result) => {
+    // First, ensure all filters pass.
+    for (const filter of queryFilters) {
+      const isNegative = filter.startsWith("-");
+      const i = filter.indexOf(":");
+      const filterKind = filter.slice(isNegative ? 1 : 0, i);
+      const filterValue = filter.slice(i + ":".length);
+      // If the filter does not pass, the result should be hidden immediately.
+      if (!(filterKind in filters) || filters[filterKind](filterValue, result) === isNegative) {
+        return 0.0;
+      }
+    }
+
     // We try multiple ways to match the search result with the query and keep
     // the best score.
     let score = 0.0;
@@ -1076,11 +1118,11 @@ function buildSymbolScoringFunction(query) {
     }
 
     // Match Codex name.
-    if (result.dataset.codexName !== undefined && queryParts.length > 0) {
+    if (result.dataset.codexName !== undefined && queryTerms.length > 0) {
       const codexParts = result.dataset.codexName.split(".");
       let thisScore = 1.0;
       let bad = false;
-      for (const queryPart of queryParts) {
+      for (const term of queryTerms) {
         const partScore = Math.max(
           ...codexParts.entries().map(([i, codexPart]) => {
             // The edit distance is not symmetric: deletions are more costly than
@@ -1089,7 +1131,7 @@ function buildSymbolScoringFunction(query) {
             // results like "arrow.l" when the query is "long" (the user typed all
             // those letters for a reason).
             const s =
-              1.0 - normalizedEditDistance(queryPart, codexPart.toLowerCase());
+              1.0 - normalizedEditDistance(term, codexPart.toLowerCase());
             if (i === 0) {
               return s;
             } else {
@@ -1134,13 +1176,13 @@ function buildSymbolScoringFunction(query) {
       // for, e.g., "hebrew" to find all Hebrew letters.
       let thisScore = 1.0;
       let bad = false;
-      for (const queryPart of queryParts) {
+      for (const term of queryTerms) {
         const nameParts = result.dataset.unicName
           .split(/\s+/)
           .filter((p) => p.length > 0);
         const distance = Math.min(
           ...nameParts.map((namePart) => {
-            return normalizedEditDistance(queryPart, namePart.toLowerCase());
+            return normalizedEditDistance(term, namePart.toLowerCase());
           }),
         );
         // We are very strict about the user typing a word that appears in the

--- a/docs/content/reference/library/symbols.typ
+++ b/docs/content/reference/library/symbols.typ
@@ -1,5 +1,5 @@
 #import "../../../components/index.typ": (
-  classnames, colors, docs-category, docs-section, fonts, icon,
+  classnames, colors, details, docs-category, docs-section, fonts, icon,
   paged-heading-offset, prose-styling, search-box, ty-pill, use-icon,
 )
 
@@ -308,6 +308,11 @@
         par[Click on a #ty-pill(symbol) to copy it to the clipboard.]
         search-box(id: "symbol-search", placeholder: "Search in symbols")
       })
+      details[Show search features][
+        - Use "class:#html.i[\<class>]" to search for symbols with a specific
+          math class (e.g., "class:large" or "class:none").
+        - Negate a filter with a leading hyphen-minus (e.g., "-class:relation").
+      ]
     }
     symbol-name-list(mod, emoji: emoji)
     context if target() == "html" {

--- a/docs/content/reference/library/symbols.typ
+++ b/docs/content/reference/library/symbols.typ
@@ -47,7 +47,7 @@
   "closing": "Closing",
   "diacritic": "Diacritic",
   "fence": "Fence",
-  "glyphpart": "Glyph Part",
+  "glyph-part": "Glyph Part",
   "large": "Large",
   "opening": "Opening",
   "punctuation": "Punctuation",


### PR DESCRIPTION
Closes https://github.com/typst/typst/issues/8265.

This implements support for filtering symbols by math class in symbol search by adding <code>class:<i>&lt;class&gt;</i></code> as a search term, where <code><i>&lt;class&gt;</i></code> is case-insensitive and can be:
- `none`, matching symbols without a math class;
- a Unicode math class or class name[^1] (i.e., the one-letter form, like `X`, or the full name, like `Special`), matching symbols with this math class.[^2]

Alternatively, one can filter _out_ symbols by adding a minus sign before the filter (e.g., `-class:none` displays all symbols that _do_ have a math class). Note that this operates on the default math class assigned to each symbol by Typst. Notably, Typst does not fully follow UTR <span>#</span>25 as it overrides the default math class for some symbols.[^3]

This is currently a draft because I am unsure whether this is the right way to expose this feature. This also needs to be documented, which is done is perhaps the most ugly way right now. Any input is welcome!

Also, I implemented this in a way that makes it easy to define further filters in the future.

The first commit is a somewhat-related minor fix. Since Codex doesn't assign names to Glyph_Part symbols, and likely never will, the bug is unlikely to ever surface anyway.

[^1]: https://www.unicode.org/reports/tr25/
[^2]: The underscore can be replaced with a hyphen in `Glyph_Part`, matching the convention used by Typst.
[^3]: https://github.com/typst/typst/blob/ed1973b0aec242a41cd3331b266ca13fb887fd59/crates/typst-utils/src/lib.rs#L385