### PR TITLE
Bump `spin`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2690,9 +2690,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "stable_deref_trait"


### PR DESCRIPTION
The currently locked `spin` version is yanked because of https://codeberg.org/zesterer/spin/issues/192. However, in our case, `spin` is only used via `wasmi 1.0.9`, which does not make use of the affected APIs, so there isn't a real issue.

Closes https://github.com/typst/typst/issues/8655.
