### PR TITLE
Add method to return the string representing a path

### DIFF
--- a/crates/typst-library/src/foundations/path.rs
+++ b/crates/typst-library/src/foundations/path.rs
@@ -163,6 +163,14 @@ impl RootedPath {
     ) -> SourceResult<RootedPath> {
         path.v.resolve_if_some(path.span.id()).at(path.span)
     }
+
+    ///Returns the string representation of the absolute path.
+    #[func]
+    pub fn value(
+        &self,
+    ) -> Str {
+        self.vpath().get_with_slash().into()
+    }
 }
 
 impl Repr for RootedPath {

--- a/crates/typst-library/src/foundations/path.rs
+++ b/crates/typst-library/src/foundations/path.rs
@@ -166,9 +166,7 @@ impl RootedPath {
 
     ///Returns the string representation of the absolute path.
     #[func]
-    pub fn value(
-        &self,
-    ) -> Str {
+    pub fn value(&self) -> Str {
         self.vpath().get_with_slash().into()
     }
 }

--- a/crates/typst-library/src/foundations/path.rs
+++ b/crates/typst-library/src/foundations/path.rs
@@ -166,7 +166,7 @@ impl RootedPath {
 
     ///Returns the string representation of the absolute path.
     #[func]
-    pub fn value(&self) -> Str {
+    pub fn absolute(&self) -> Str {
         self.vpath().get_with_slash().into()
     }
 }

--- a/crates/typst-library/src/foundations/path.rs
+++ b/crates/typst-library/src/foundations/path.rs
@@ -165,7 +165,7 @@ impl RootedPath {
     }
 
     ///Returns the string representation of the absolute path.
-    #[func]
+    #[func(since = "0.16.0")]
     pub fn absolute(&self) -> Str {
         self.vpath().get_with_slash().into()
     }


### PR DESCRIPTION
This is a very straightforward PR that adds a `value()` method to `path` objects, returning the string representing the absolute path. This is very close to what #8657 wants; the caveat is that the path returned is the absolute path even if a relative path was passed originally. This is because the object itself does not actually store the original path, only the resolve version. I feel that this is an acceptable compromise, especially given that it behaves nicely in the sense that `#path(path("foo").value()) = path("foo")`.

(also I am not sure that the method name choice is the best).