### PR TITLE
Optimize calculation of font coverage maps

### DIFF
--- a/crates/typst-library/src/text/font/book.rs
+++ b/crates/typst-library/src/text/font/book.rs
@@ -308,7 +308,7 @@ mod tests {
                     default: AxisValue((min + max) / 2.0),
                 })
                 .collect(),
-            coverage: Coverage::from_vec(vec![]),
+            coverage: Coverage::default(),
         }
     }
 

--- a/crates/typst-library/src/text/font/info.rs
+++ b/crates/typst-library/src/text/font/info.rs
@@ -115,10 +115,12 @@ impl FontInfo {
         };
 
         // Determine the unicode coverage.
-        let mut codepoints = vec![];
+        let mut coverage = Coverage::default();
         for subtable in ttf.tables().cmap.into_iter().flat_map(|table| table.subtables) {
             if subtable.is_unicode() {
-                subtable.codepoints(|c| codepoints.push(c));
+                let mut subtable_coverage = CoverageBuilder::new();
+                subtable.codepoints(|c| subtable_coverage.add_codepoint(c));
+                coverage = coverage.union(&subtable_coverage.build());
             }
         }
 
@@ -148,13 +150,7 @@ impl FontInfo {
             })
             .collect();
 
-        Some(FontInfo {
-            family,
-            variant,
-            axes,
-            flags,
-            coverage: Coverage::from_vec(codepoints),
-        })
+        Some(FontInfo { family, variant, flags, axes, coverage })
     }
 
     /// Whether this is the macOS LastResort font. It can yield tofus with
@@ -282,7 +278,7 @@ fn typographic_family(mut family: &str) -> &str {
 /// - 2 codepoints inside (18, 19)
 ///
 /// So the resulting encoding is `[2, 3, 4, 3, 3, 1, 2, 2]`.
-#[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Default)]
 #[serde(transparent)]
 pub struct Coverage(Vec<u32>);
 
@@ -297,21 +293,11 @@ impl Coverage {
         codepoints.sort();
         codepoints.dedup();
 
-        let mut runs = Vec::new();
-        let mut next = 0;
-
+        let mut builder = CoverageBuilder::new();
         for c in codepoints {
-            if let Some(run) = runs.last_mut().filter(|_| c == next) {
-                *run += 1;
-            } else {
-                runs.push(c - next);
-                runs.push(1);
-            }
-
-            next = c + 1;
+            builder.add_codepoint(c);
         }
-
-        Self(runs)
+        builder.build()
     }
 
     /// Whether the codepoint is covered.
@@ -341,11 +327,92 @@ impl Coverage {
             range
         })
     }
+
+    /// Returns an encoding of the set of codepoints covered by either `self` or `other`.
+    pub fn union(&self, other: &Coverage) -> Self {
+        let (self_ranges, _) = self.0.as_chunks::<2>();
+        let (other_ranges, _) = other.0.as_chunks::<2>();
+
+        let (mut i, mut j) = (0, 0);
+        let (mut self_offset, mut other_offset) = (0, 0);
+
+        let mut builder = CoverageBuilder::new();
+
+        while i < self_ranges.len() && j < other_ranges.len() {
+            let [self_gap, self_count] = self_ranges[i];
+            let [other_gap, other_count] = other_ranges[j];
+
+            if self_offset + self_gap < other_offset + other_gap {
+                builder.add_codepoint_range(self_offset + self_gap, self_count);
+                i += 1;
+                self_offset += self_gap + self_count;
+            } else {
+                builder.add_codepoint_range(other_offset + other_gap, other_count);
+                j += 1;
+                other_offset += other_gap + other_count;
+            }
+        }
+
+        while i < self_ranges.len() {
+            let [self_gap, self_count] = self_ranges[i];
+            builder.add_codepoint_range(self_offset + self_gap, self_count);
+            i += 1;
+            self_offset += self_gap + self_count;
+        }
+        while j < other_ranges.len() {
+            let [other_gap, other_count] = other_ranges[j];
+            builder.add_codepoint_range(other_offset + other_gap, other_count);
+            j += 1;
+            other_offset += other_gap + other_count;
+        }
+
+        builder.build()
+    }
 }
 
 impl Debug for Coverage {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         f.pad("Coverage(..)")
+    }
+}
+
+/// Incrementally builds a `Coverage` compact representation from a
+/// non-decreasing series of codepoints, or ranges thereof.
+struct CoverageBuilder {
+    runs: Vec<u32>,
+    next: u32,
+}
+
+impl CoverageBuilder {
+    fn new() -> Self {
+        Self { runs: vec![], next: 0 }
+    }
+
+    fn add_codepoint(&mut self, codepoint: u32) {
+        debug_assert!(codepoint >= self.next, "Codepoints provided in wrong order");
+
+        self.add_codepoint_range(codepoint, 1);
+    }
+
+    fn add_codepoint_range(&mut self, start: u32, count: u32) {
+        if let Some(run) = self
+            .runs
+            .last_mut()
+            .filter(|_| start <= self.next && start + count > self.next)
+        {
+            *run += start + count - self.next;
+        } else if start >= self.next {
+            self.runs.push(start - self.next);
+            self.runs.push(count);
+        } else {
+            return;
+        }
+
+        self.next = start + count;
+    }
+
+    fn build(self) -> Coverage {
+        Coverage(self.runs)
     }
 }
 
@@ -401,5 +468,21 @@ mod tests {
         let codepoints = vec![2, 3, 7, 8, 9, 14, 15, 19, 21];
         let coverage = Coverage::from_vec(codepoints.clone());
         assert_eq!(coverage.iter().collect::<Vec<_>>(), codepoints);
+    }
+
+    #[test]
+    fn test_coverage_union() {
+        let right = Coverage::from_vec(vec![2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 14]);
+        let left =
+            Coverage::from_vec(vec![0, 1, 2, 3, 5, 6, 9, 10, 11, 12, 13, 16, 17, 18]);
+
+        let combined = right.union(&left);
+
+        let codepoints = combined.iter().collect::<Vec<_>>();
+        assert_eq!(
+            codepoints,
+            vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 18]
+        );
+        assert_eq!(combined.0, vec![0, 15, 1, 3]);
     }
 }

--- a/crates/typst-library/src/text/font/info.rs
+++ b/crates/typst-library/src/text/font/info.rs
@@ -1,4 +1,7 @@
-use std::fmt::{self, Debug, Formatter};
+use std::{
+    fmt::{self, Debug, Formatter},
+    ops::Range,
+};
 
 use serde::{Deserialize, Serialize};
 use ttf_parser::{PlatformId, name_id};
@@ -115,10 +118,17 @@ impl FontInfo {
         };
 
         // Determine the unicode coverage.
-        let mut codepoints = vec![];
-        for subtable in ttf.tables().cmap.into_iter().flat_map(|table| table.subtables) {
-            if subtable.is_unicode() {
-                subtable.codepoints(|c| codepoints.push(c));
+        let mut coverage = Coverage::default();
+        if let Some(cmap) = ttf.tables().cmap {
+            for subtable in cmap.subtables {
+                if subtable.is_unicode() {
+                    let mut subtable_coverage = CoverageBuilder::new();
+                    subtable.codepoints(|c| {
+                        // We expect codepoints in CMAP subtables to be already sorted
+                        subtable_coverage.add_codepoint(c);
+                    });
+                    coverage = coverage.union(&subtable_coverage.build());
+                }
             }
         }
 
@@ -148,13 +158,7 @@ impl FontInfo {
             })
             .collect();
 
-        Some(FontInfo {
-            family,
-            variant,
-            axes,
-            flags,
-            coverage: Coverage::from_vec(codepoints),
-        })
+        Some(FontInfo { family, variant, flags, axes, coverage })
     }
 
     /// Whether this is the macOS LastResort font. It can yield tofus with
@@ -282,7 +286,7 @@ fn typographic_family(mut family: &str) -> &str {
 /// - 2 codepoints inside (18, 19)
 ///
 /// So the resulting encoding is `[2, 3, 4, 3, 3, 1, 2, 2]`.
-#[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Default, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Coverage(Vec<u32>);
 
@@ -297,21 +301,11 @@ impl Coverage {
         codepoints.sort();
         codepoints.dedup();
 
-        let mut runs = Vec::new();
-        let mut next = 0;
-
+        let mut builder = CoverageBuilder::new();
         for c in codepoints {
-            if let Some(run) = runs.last_mut().filter(|_| c == next) {
-                *run += 1;
-            } else {
-                runs.push(c - next);
-                runs.push(1);
-            }
-
-            next = c + 1;
+            builder.add_codepoint(c);
         }
-
-        Self(runs)
+        builder.build()
     }
 
     /// Whether the codepoint is covered.
@@ -332,20 +326,98 @@ impl Coverage {
 
     /// Iterate over all covered codepoints.
     pub fn iter(&self) -> impl Iterator<Item = u32> + '_ {
-        let mut inside = false;
-        let mut cursor = 0;
-        self.0.iter().flat_map(move |run| {
-            let range = if inside { cursor..cursor + run } else { 0..0 };
-            inside = !inside;
-            cursor += run;
-            range
+        self.iter_ranges().flatten()
+    }
+
+    /// Iterate over all continuous ranges of covered codepoints.
+    fn iter_ranges(&self) -> impl Iterator<Item = Range<u32>> {
+        let mut offset = 0;
+        let (pairs, _) = self.0.as_chunks::<2>();
+
+        pairs.iter().map(move |&[gap, count]| {
+            offset += gap;
+            let start = offset;
+            offset += count;
+            start..offset
         })
+    }
+
+    /// Returns an encoding of the set of codepoints covered by either `self` or `other`.
+    fn union(&self, other: &Coverage) -> Self {
+        let mut builder = CoverageBuilder::new();
+
+        let mut self_ranges = self.iter_ranges().peekable();
+        let mut other_ranges = other.iter_ranges().peekable();
+
+        while let Some(self_range) = self_ranges.peek()
+            && let Some(other_range) = other_ranges.peek()
+        {
+            if self_range.start < other_range.start {
+                builder.add_codepoint_range(self_range);
+                self_ranges.next();
+            } else {
+                builder.add_codepoint_range(other_range);
+                other_ranges.next();
+            }
+        }
+
+        for self_range in self_ranges {
+            builder.add_codepoint_range(&self_range);
+        }
+        for other_range in other_ranges {
+            builder.add_codepoint_range(&other_range);
+        }
+
+        builder.build()
     }
 }
 
 impl Debug for Coverage {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         f.pad("Coverage(..)")
+    }
+}
+
+/// Incrementally builds a `Coverage` compact representation from a
+/// non-decreasing series of codepoints, or ranges thereof.
+struct CoverageBuilder {
+    runs: Vec<u32>,
+    next: u32,
+}
+
+impl CoverageBuilder {
+    fn new() -> Self {
+        Self { runs: vec![], next: 0 }
+    }
+
+    fn build(self) -> Coverage {
+        Coverage(self.runs)
+    }
+
+    /// Add a single codepoint to the set being built. Codepoints must be
+    /// added in a strictly increasing order.
+    fn add_codepoint(&mut self, codepoint: u32) {
+        debug_assert!(codepoint >= self.next, "Codepoints provided in wrong order");
+
+        let range = codepoint..(codepoint.saturating_add(1));
+        self.add_codepoint_range(&range);
+    }
+
+    /// Add a continuous range of codepoints to the set being built. Ranges
+    /// must be added in non-decreasing order of start points, but may
+    /// intersect or be contained in previously added ranges.
+    fn add_codepoint_range(&mut self, range: &Range<u32>) {
+        if range.end <= self.next || range.is_empty() {
+            return;
+        } else if range.start <= self.next
+            && let Some(run) = self.runs.last_mut()
+        {
+            *run += range.end - self.next;
+        } else {
+            self.runs.extend(&[range.start - self.next, range.end - range.start]);
+        }
+
+        self.next = range.end;
     }
 }
 
@@ -401,5 +473,21 @@ mod tests {
         let codepoints = vec![2, 3, 7, 8, 9, 14, 15, 19, 21];
         let coverage = Coverage::from_vec(codepoints.clone());
         assert_eq!(coverage.iter().collect::<Vec<_>>(), codepoints);
+    }
+
+    #[test]
+    fn test_coverage_union() {
+        let right = Coverage::from_vec(vec![2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 14]);
+        let left =
+            Coverage::from_vec(vec![0, 1, 2, 3, 5, 6, 9, 10, 11, 12, 13, 16, 17, 18]);
+
+        let combined = right.union(&left);
+
+        let codepoints = combined.iter().collect::<Vec<_>>();
+        assert_eq!(
+            codepoints,
+            vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 18]
+        );
+        assert_eq!(combined.0, vec![0, 15, 1, 3]);
     }
 }


### PR DESCRIPTION
A large chunk of the cold start time of the `typst` CLI is the initialization of the font book by scanning system fonts. Profiling has shown that the run time of this phase is entirely dominated by calculating the font coverage maps, that indicate to the compiler which fonts have a glyph mapped for a specific Unicode code point.

Currently this is done by collecting the individual codepoints covered by every scanned font face into a large vector, and then compressing it into a compact range-based representation. To do so, the vector is de-duplicated and sorted, which is required because it is assembled by reading each CMAP sub-table in turn, and very often more than one sub-table can include a glyph for the same codepoint. These vectors include tens, or even hundreds, of thousands of entries; both the incremental allocation of the vector (causing multiple re-allocations and copies) and the sorting have large overhead.

We can avoid that through the observation that the codepoints in each sub-table already come out of `ttf-parser` unique and sorted (though see caveat). With this we can directly collect the codepoints covered by each sub-table into the compact representation without needing to keep a vector of all codepoints in memory, and form the final coverage map by taking the union of all the sub-table coverage maps. The union is calculated with a typical linear sorted array merge algorithm.

### Benchmarks

Measurements taken with `hyperfine` (excluding warmup) with the `dev-fast` build configuration on a circa-2019 Intel-based Linux laptop with a relatively typical selection of 289 font families installed.

Comparing time to run `typst fonts`:
```
Benchmark 1: typst-old fonts
  Time (mean ± σ):     389.7 ms ±  10.8 ms    [User: 339.8 ms, System: 47.4 ms]
  Range (min … max):   375.6 ms … 407.6 ms    10 runs

Benchmark 2: typst-new fonts
  Time (mean ± σ):     251.4 ms ±  13.2 ms    [User: 206.1 ms, System: 43.4 ms]
  Range (min … max):   234.4 ms … 273.0 ms    12 runs

Summary
  typst-new fonts ran 1.55 ± 0.09 times faster than typst-old fonts
 ```
 
 Comparing the time to cold compile a small "Hello World" document to PDF:
```
Benchmark 1: typst-old compile test.typ
  Time (mean ± σ):     395.0 ms ±  12.8 ms    [User: 344.0 ms, System: 49.4 ms]
  Range (min … max):   378.0 ms … 422.4 ms    10 runs

Benchmark 2: typst-new compile test.typ
  Time (mean ± σ):     256.2 ms ±  12.2 ms    [User: 213.8 ms, System: 42.4 ms]
  Range (min … max):   243.4 ms … 282.5 ms    10 runs

Summary
  typst-new compile test.typ ran 1.54 ± 0.09 times faster than typst-old compile test.typ
 ```
 
We can see that on average this PR shaves ~140ms from the CLI run time, and is likely to be far more significant on pathological cases such as #8561.
 
### Caveat

As noted above, this relies on the observation that "the codepoints in each sub-table already come out of `ttf-parser` unique and sorted". This is actually not a structural property of all CMAP sub-table formats, e.g. formats 4 and 12 _could_ be stored in an unsorted order or have duplicates. However this appears to be at least an implicit requirement of the TrueType/OpenType specifications, as the CMAP formats are expected to be laid out in a way that allows font engines to binary search for the corresponding glyph for a codepoint. It is possible that there are broken fonts out there that don't maintain this expectation, but I didn't find any among the fonts available to me.