### PR TITLE
Add `--no-fullscreen` flag to `typst watch`

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -130,6 +130,10 @@ pub struct WatchCommand {
     #[cfg(feature = "http-server")]
     #[clap(flatten)]
     pub server: ServerArgs,
+
+    /// Do not the terminal on recompilation
+    #[arg(long, default_value_t = false)]
+    pub no_clear: bool,
 }
 
 /// Initializes a new project from a template.

--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -133,7 +133,7 @@ pub struct WatchCommand {
 
     /// Do not clear the terminal on recompilation.
     #[arg(long)]
-    pub no_clear: bool,
+    pub no_fullscreen: bool,
 }
 
 /// Initializes a new project from a template.

--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -131,7 +131,7 @@ pub struct WatchCommand {
     #[clap(flatten)]
     pub server: ServerArgs,
 
-    /// Do not the terminal on recompilation
+    /// Do not clear the terminal on recompilation.
     #[arg(long, default_value_t = false)]
     pub no_clear: bool,
 }

--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -126,14 +126,17 @@ pub struct WatchCommand {
     #[clap(flatten)]
     pub args: CompileArgs,
 
+    /// Stops the watcher from taking over the terminal.
+    ///
+    /// With this flag, the watcher will only ever print normal output lines,
+    /// not clear or reconfigure the terminal.
+    #[arg(long)]
+    pub no_fullscreen: bool,
+
     /// Arguments for the HTTP server.
     #[cfg(feature = "http-server")]
     #[clap(flatten)]
     pub server: ServerArgs,
-
-    /// Do not clear the terminal on recompilation.
-    #[arg(long)]
-    pub no_fullscreen: bool,
 }
 
 /// Initializes a new project from a template.

--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -132,7 +132,7 @@ pub struct WatchCommand {
     pub server: ServerArgs,
 
     /// Do not clear the terminal on recompilation.
-    #[arg(long, default_value_t = false)]
+    #[arg(long)]
     pub no_clear: bool,
 }
 

--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -53,6 +53,8 @@ pub struct CompileConfig {
     pub warnings: Vec<HintedString>,
     /// Whether we are watching.
     pub watching: bool,
+    /// Whether to clear the terminal on recompilation (only while watching)
+    pub clear_terminal: bool,
     /// Path to input Typst file or stdin.
     pub input: Input,
     /// Path to output file (PDF, PNG, SVG, or HTML).
@@ -195,6 +197,8 @@ impl CompileConfig {
             None
         };
 
+        let clear_terminal = watch.map(|command| !command.no_clear).unwrap_or(true);
+
         let mut deps = args.deps.clone();
         let mut deps_format = args.deps_format;
 
@@ -247,6 +251,7 @@ impl CompileConfig {
             deps_format,
             #[cfg(feature = "http-server")]
             server,
+            clear_terminal,
         })
     }
 }

--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -54,7 +54,7 @@ pub struct CompileConfig {
     /// Whether we are watching.
     pub watching: bool,
     /// Whether to clear the terminal on recompilation (only while watching).
-    pub clear_terminal: bool,
+    pub fullscreen: bool,
     /// Path to input Typst file or stdin.
     pub input: Input,
     /// Path to output file (PDF, PNG, SVG, or HTML).
@@ -197,7 +197,7 @@ impl CompileConfig {
             None
         };
 
-        let clear_terminal = watch.map(|command| !command.no_clear).unwrap_or(true);
+        let fullscreen = watch.map(|command| !command.no_fullscreen).unwrap_or(true);
 
         let mut deps = args.deps.clone();
         let mut deps_format = args.deps_format;
@@ -251,7 +251,7 @@ impl CompileConfig {
             deps_format,
             #[cfg(feature = "http-server")]
             server,
-            clear_terminal,
+            fullscreen,
         })
     }
 }

--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -53,7 +53,7 @@ pub struct CompileConfig {
     pub warnings: Vec<HintedString>,
     /// Whether we are watching.
     pub watching: bool,
-    /// Whether to clear the terminal on recompilation (only while watching)
+    /// Whether to clear the terminal on recompilation (only while watching).
     pub clear_terminal: bool,
     /// Path to input Typst file or stdin.
     pub input: Input,

--- a/crates/typst-cli/src/watch.rs
+++ b/crates/typst-cli/src/watch.rs
@@ -98,7 +98,10 @@ impl Status {
         let color = self.color();
 
         let mut out = terminal::out();
-        out.clear_screen()?;
+
+        if config.clear_terminal {
+            out.clear_screen()?;
+        }
 
         out.set_color(&color)?;
         write!(out, "watching")?;

--- a/crates/typst-cli/src/watch.rs
+++ b/crates/typst-cli/src/watch.rs
@@ -99,7 +99,7 @@ impl Status {
 
         let mut out = terminal::out();
 
-        if config.clear_terminal {
+        if config.fullscreen {
             out.clear_screen()?;
         }
 

--- a/crates/typst-cli/src/watch.rs
+++ b/crates/typst-cli/src/watch.rs
@@ -11,6 +11,7 @@ use typst_kit::watcher::Watcher;
 
 use crate::args::{Input, Output, WatchCommand};
 use crate::compile::{CompileConfig, compile_once, print_diagnostics};
+use crate::terminal::TermOut;
 use crate::world::{SystemWorld, WorldCreationError};
 use crate::{print_error, terminal};
 
@@ -94,44 +95,57 @@ pub enum Status {
 impl Status {
     /// Clear the terminal and render the status message.
     pub fn print(&self, config: &CompileConfig) -> io::Result<()> {
-        let timestamp = chrono::offset::Local::now().format("%H:%M:%S");
-        let color = self.color();
-
         let mut out = terminal::out();
 
         if config.fullscreen {
-            out.clear_screen()?;
-
-            out.set_color(&color)?;
-            write!(out, "watching")?;
-            out.reset()?;
-            match &config.input {
-                Input::Stdin => writeln!(out, " <stdin>"),
-                Input::Path(path) => writeln!(out, " {}", path.display()),
-            }?;
-
-            out.set_color(&color)?;
-            write!(out, "writing to")?;
-            out.reset()?;
-            writeln!(out, " {}", config.output)?;
-
-            #[cfg(feature = "http-server")]
-            if let Some(server) = &config.server {
-                out.set_color(&color)?;
-                write!(out, "serving at")?;
-                out.reset()?;
-                writeln!(out, " http://{}", server.addr())?;
-            }
-
-            writeln!(out)?;
-            writeln!(out, "[{timestamp}] {}", self.message())?;
-            writeln!(out)?;
+            self.print_fullscreen(&mut out, config)?;
         } else {
             // Just print the status
-            writeln!(out, "[{timestamp}] {}", self.message())?;
+            self.print_message(&mut out)?;
         }
 
         out.flush()
+    }
+
+    fn print_fullscreen(
+        &self,
+        out: &mut TermOut,
+        config: &CompileConfig,
+    ) -> io::Result<()> {
+        let color = self.color();
+        out.clear_screen()?;
+
+        out.set_color(&color)?;
+        write!(out, "watching")?;
+        out.reset()?;
+        match &config.input {
+            Input::Stdin => writeln!(out, " <stdin>"),
+            Input::Path(path) => writeln!(out, " {}", path.display()),
+        }?;
+
+        out.set_color(&color)?;
+        write!(out, "writing to")?;
+        out.reset()?;
+        writeln!(out, " {}", config.output)?;
+
+        #[cfg(feature = "http-server")]
+        if let Some(server) = &config.server {
+            out.set_color(&color)?;
+            write!(out, "serving at")?;
+            out.reset()?;
+            writeln!(out, " http://{}", server.addr())?;
+        }
+
+        writeln!(out)?;
+        self.print_message(out)?;
+        writeln!(out)?;
+
+        Ok(())
+    }
+
+    fn print_message(&self, out: &mut TermOut) -> io::Result<()> {
+        let timestamp = chrono::offset::Local::now().format("%H:%M:%S");
+        writeln!(out, "[{timestamp}] {}", self.message())
     }
 
     fn message(&self) -> String {

--- a/crates/typst-cli/src/watch.rs
+++ b/crates/typst-cli/src/watch.rs
@@ -100,8 +100,10 @@ impl Status {
         if config.fullscreen {
             self.print_fullscreen(&mut out, config)?;
         } else {
-            // Just print the status
             self.print_message(&mut out)?;
+            if !matches!(self, Status::Compiling) {
+                writeln!(out)?;
+            }
         }
 
         out.flush()

--- a/crates/typst-cli/src/watch.rs
+++ b/crates/typst-cli/src/watch.rs
@@ -101,32 +101,35 @@ impl Status {
 
         if config.fullscreen {
             out.clear_screen()?;
-        }
 
-        out.set_color(&color)?;
-        write!(out, "watching")?;
-        out.reset()?;
-        match &config.input {
-            Input::Stdin => writeln!(out, " <stdin>"),
-            Input::Path(path) => writeln!(out, " {}", path.display()),
-        }?;
-
-        out.set_color(&color)?;
-        write!(out, "writing to")?;
-        out.reset()?;
-        writeln!(out, " {}", config.output)?;
-
-        #[cfg(feature = "http-server")]
-        if let Some(server) = &config.server {
             out.set_color(&color)?;
-            write!(out, "serving at")?;
+            write!(out, "watching")?;
             out.reset()?;
-            writeln!(out, " http://{}", server.addr())?;
-        }
+            match &config.input {
+                Input::Stdin => writeln!(out, " <stdin>"),
+                Input::Path(path) => writeln!(out, " {}", path.display()),
+            }?;
 
-        writeln!(out)?;
-        writeln!(out, "[{timestamp}] {}", self.message())?;
-        writeln!(out)?;
+            out.set_color(&color)?;
+            write!(out, "writing to")?;
+            out.reset()?;
+            writeln!(out, " {}", config.output)?;
+
+            #[cfg(feature = "http-server")]
+            if let Some(server) = &config.server {
+                out.set_color(&color)?;
+                write!(out, "serving at")?;
+                out.reset()?;
+                writeln!(out, " http://{}", server.addr())?;
+            }
+
+            writeln!(out)?;
+            writeln!(out, "[{timestamp}] {}", self.message())?;
+            writeln!(out)?;
+        } else {
+            // Just print the status
+            writeln!(out, "[{timestamp}] {}", self.message())?;
+        }
 
         out.flush()
     }


### PR DESCRIPTION
This PR adds a flag to disable the clearing of the terminal before recompilation during `typst watch`. Rather than disabling ANSI escape sequences entirely like `--no-color`, this skips only the terminal-clearing sequences. This prevents the compiler from clobbering old errors that the user still may want to reference, and is also useful for running `typst watch` alongside other programs' 'watch' commands.

I went with `--no-clear` over `--clear=false` to align with the `--no-serve`/`--no-reload` flags in `ServerArgs`, but I can invert it if desired. I also put it in `WatchCommand` directly since it's only useful to `watch`, and it didn't seem to fit under `CompileArgs` or `ServerArgs` either.