### PR TITLE
Add reference scoping using the within selector

### DIFF
--- a/crates/typst-bundle/src/introspect.rs
+++ b/crates/typst-bundle/src/introspect.rs
@@ -89,7 +89,7 @@ impl Introspector for BundleIntrospector {
         self.elements.query_unique(selector)
     }
 
-    fn query_label(&self, label: Label) -> StrResult<&Content> {
+    fn query_label(&self, label: Label) -> StrResult<Content> {
         self.elements.query_label(label)
     }
 

--- a/crates/typst-eval/src/markup.rs
+++ b/crates/typst-eval/src/markup.rs
@@ -1,6 +1,6 @@
-use typst_library::diag::{At, SourceResult, warning};
+use typst_library::diag::{At, SourceResult, bail, warning};
 use typst_library::foundations::{
-    Content, Label, NativeElement, Repr, Smart, Symbol, Unlabellable, Value,
+    Content, IntoValue, Label, NativeElement, Repr, Smart, Symbol, Unlabellable, Value,
 };
 use typst_library::model::{
     EmphElem, EnumItem, HeadingElem, LinkElem, ListItem, ParbreakElem, RefElem,
@@ -50,6 +50,12 @@ fn eval_markup<'a>(
                 seq.push(tail.styled_with_recipe(&mut vm.engine, vm.context, recipe)?);
             }
             expr => match expr.eval(vm)? {
+                Value::Label(label) if label.resolve().as_str().contains('/') => {
+                    bail!(
+                        expr.span(),
+                        "label paths cannot be used to label content";
+                    );
+                }
                 Value::Label(label) => {
                     if let Some(elem) =
                         seq.iter_mut().rev().find(|node| !node.can::<dyn Unlabellable>())
@@ -186,9 +192,9 @@ impl Eval for ast::Label<'_> {
     type Output = Value;
 
     fn eval(self, _: &mut Vm) -> SourceResult<Self::Output> {
-        Ok(Value::Label(
-            Label::new(PicoStr::intern(self.get())).expect("unexpected empty label"),
-        ))
+        Ok(Label::new(PicoStr::intern(self.get()))
+            .expect("unexpected empty label")
+            .into_value())
     }
 }
 

--- a/crates/typst-eval/src/markup.rs
+++ b/crates/typst-eval/src/markup.rs
@@ -1,6 +1,6 @@
 use typst_library::diag::{At, SourceResult, bail, warning};
 use typst_library::foundations::{
-    Content, IntoValue, Label, NativeElement, Repr, Smart, Symbol, Unlabellable, Value,
+    Content, Label, NativeElement, Repr, Smart, Symbol, Unlabellable, Value,
 };
 use typst_library::model::{
     EmphElem, EnumItem, HeadingElem, LinkElem, ListItem, ParbreakElem, RefElem,
@@ -192,9 +192,9 @@ impl Eval for ast::Label<'_> {
     type Output = Value;
 
     fn eval(self, _: &mut Vm) -> SourceResult<Self::Output> {
-        Ok(Label::new(PicoStr::intern(self.get()))
-            .expect("unexpected empty label")
-            .into_value())
+        Ok(Value::Label(
+            Label::new(PicoStr::intern(self.get())).expect("unexpected empty label"),
+        ))
     }
 }
 

--- a/crates/typst-html/src/introspect.rs
+++ b/crates/typst-html/src/introspect.rs
@@ -80,7 +80,7 @@ impl Introspector for HtmlIntrospector {
         self.elements.query_unique(selector)
     }
 
-    fn query_label(&self, label: Label) -> StrResult<&Content> {
+    fn query_label(&self, label: Label) -> StrResult<Content> {
         self.elements.query_label(label)
     }
 

--- a/crates/typst-layout/src/introspect.rs
+++ b/crates/typst-layout/src/introspect.rs
@@ -87,7 +87,7 @@ impl Introspector for PagedIntrospector {
         self.elements.query_unique(selector)
     }
 
-    fn query_label(&self, label: Label) -> StrResult<&Content> {
+    fn query_label(&self, label: Label) -> StrResult<Content> {
         self.elements.query_label(label)
     }
 

--- a/crates/typst-library/src/foundations/ops.rs
+++ b/crates/typst-library/src/foundations/ops.rs
@@ -3,11 +3,11 @@
 use std::cmp::Ordering;
 
 use ecow::eco_format;
-use typst_utils::Numeric;
+use typst_utils::{Numeric, PicoStr};
 
 use crate::diag::{HintedStrResult, StrResult, bail};
 use crate::foundations::{
-    Datetime, IntoValue, Regex, Repr, SymbolElem, Value, format_str,
+    Datetime, IntoValue, Label as LabelValue, Regex, Repr, SymbolElem, Value, format_str,
 };
 use crate::layout::{Alignment, Length, Rel};
 use crate::text::TextElem;
@@ -290,6 +290,11 @@ pub fn div(lhs: Value, rhs: Value) -> HintedStrResult<Value> {
     use Value::*;
     if is_zero(&rhs) {
         bail!("cannot divide by zero");
+    }
+
+    if let (Label(lhs), Label(rhs)) = (&lhs, &rhs) {
+        let path = eco_format!("{}/{}", lhs.resolve().as_str(), rhs.resolve().as_str());
+        return Ok(Label(LabelValue::new(PicoStr::intern(&path)).unwrap()).into_value());
     }
 
     Ok(match (lhs, rhs) {

--- a/crates/typst-library/src/foundations/ops.rs
+++ b/crates/typst-library/src/foundations/ops.rs
@@ -7,7 +7,7 @@ use typst_utils::{Numeric, PicoStr};
 
 use crate::diag::{HintedStrResult, StrResult, bail};
 use crate::foundations::{
-    Datetime, IntoValue, Label as LabelValue, Regex, Repr, SymbolElem, Value, format_str,
+    Datetime, IntoValue, Regex, Repr, SymbolElem, Value, format_str,
 };
 use crate::layout::{Alignment, Length, Rel};
 use crate::text::TextElem;
@@ -292,12 +292,12 @@ pub fn div(lhs: Value, rhs: Value) -> HintedStrResult<Value> {
         bail!("cannot divide by zero");
     }
 
-    if let (Label(lhs), Label(rhs)) = (&lhs, &rhs) {
-        let path = eco_format!("{}/{}", lhs.resolve().as_str(), rhs.resolve().as_str());
-        return Ok(Label(LabelValue::new(PicoStr::intern(&path)).unwrap()).into_value());
-    }
-
     Ok(match (lhs, rhs) {
+        (Label(a), Label(b)) => {
+            let path = eco_format!("{}/{}", a.resolve().as_str(), b.resolve().as_str());
+            Label(crate::foundations::Label::new(PicoStr::intern(&path)).unwrap())
+        }
+
         (Int(a), Int(b)) => Float(a as f64 / b as f64),
         (Int(a), Float(b)) => Float(a as f64 / b),
         (Float(a), Int(b)) => Float(a / b as f64),

--- a/crates/typst-library/src/foundations/selector.rs
+++ b/crates/typst-library/src/foundations/selector.rs
@@ -105,7 +105,7 @@ pub enum Selector {
 }
 
 impl Selector {
-    /// Convert a slash-separated label path into nested within selectors.
+    /// Converts a slash-separated label path into nested within selectors.
     pub fn label_path(label: Label) -> Self {
         let resolved = label.resolve();
         let path = resolved.as_str();

--- a/crates/typst-library/src/foundations/selector.rs
+++ b/crates/typst-library/src/foundations/selector.rs
@@ -5,6 +5,7 @@ use comemo::Tracked;
 use ecow::{EcoString, EcoVec, eco_format};
 use smallvec::SmallVec;
 use typst_syntax::Span;
+use typst_utils::PicoStr;
 
 use crate::diag::{At, HintedStrResult, SourceResult, StrResult, bail};
 use crate::engine::Engine;
@@ -104,6 +105,30 @@ pub enum Selector {
 }
 
 impl Selector {
+    /// Convert a slash-separated label path into nested within selectors.
+    pub fn label_path(label: Label) -> Self {
+        let resolved = label.resolve();
+        let path = resolved.as_str();
+        if !path.contains('/') || path.split('/').any(str::is_empty) {
+            return Self::Label(label);
+        }
+
+        let mut pieces = path.rsplit('/');
+        let target = pieces.next().unwrap();
+        let ancestor = pieces
+            .map(|piece| Self::Label(Label::new(PicoStr::intern(piece)).unwrap()))
+            .reduce(|selector, ancestor| Self::Within {
+                selector: Arc::new(selector),
+                ancestor: Arc::new(ancestor),
+            })
+            .unwrap();
+
+        Self::Within {
+            selector: Arc::new(Self::Label(Label::new(PicoStr::intern(target)).unwrap())),
+            ancestor: Arc::new(ancestor),
+        }
+    }
+
     /// Define a simple text selector.
     pub fn text(text: &str) -> StrResult<Self> {
         if text.is_empty() {
@@ -358,7 +383,7 @@ cast! {
         .to_element()
         .ok_or("only element functions can be used as selectors")?
         .select(),
-    label: Label => Self::Label(label),
+    label: Label => Self::label_path(label),
     regex: Regex => Self::regex(regex)?,
     location: Location => Self::Location(location),
 }

--- a/crates/typst-library/src/introspection/introspector.rs
+++ b/crates/typst-library/src/introspection/introspector.rs
@@ -36,8 +36,8 @@ pub trait Introspector: Send + Sync {
     /// Queries for the first element that matches the selector.
     fn query_unique(&self, selector: &Selector) -> StrResult<Content>;
 
-    /// Queries for a unique element with the label.
-    fn query_label(&self, label: Label) -> StrResult<&Content>;
+    /// Queries for a unique element with the label or label path.
+    fn query_label(&self, label: Label) -> StrResult<Content>;
 
     /// Queries for all elements with a label.
     fn query_labelled(&self) -> EcoVec<Content>;
@@ -110,8 +110,8 @@ impl Introspector for EmptyIntrospector {
         bail!("selector does not match any element");
     }
 
-    fn query_label(&self, label: Label) -> StrResult<&Content> {
-        bail!("label `{}` does not exist in the document", label.repr());
+    fn query_label(&self, label: Label) -> StrResult<Content> {
+        unique_label_match(label, &[]).cloned()
     }
 
     fn query_labelled(&self) -> EcoVec<Content> {
@@ -361,7 +361,7 @@ impl<P> ElementIntrospector<P> {
                 .get_by_loc(location)
                 .cloned()
                 .ok_or_else(|| "element does not exist in the document".into()),
-            Selector::Label(label) => self.query_label(*label).cloned(),
+            Selector::Label(label) => self.query_label(*label),
             _ => {
                 let elems = self.query(selector);
                 if elems.len() > 1 {
@@ -375,13 +375,16 @@ impl<P> ElementIntrospector<P> {
         }
     }
 
-    /// Queries for a unique element with the label.
-    pub fn query_label(&self, label: Label) -> StrResult<&Content> {
-        match *self.labels.get(&label) {
-            [idx] => Ok(self.get_by_idx(idx)),
-            [] => bail!("label `{}` does not exist in the document", label.repr()),
-            _ => bail!("label `{}` occurs multiple times in the document", label.repr()),
+    /// Queries for a unique element with the label or label path.
+    pub fn query_label(&self, label: Label) -> StrResult<Content> {
+        let selector = Selector::label_path(label);
+        if let Selector::Label(label) = selector {
+            let idx = unique_label_match(label, self.labels.get(&label))?;
+            return Ok(self.get_by_idx(*idx).clone());
         }
+
+        let matches = self.query(&selector);
+        unique_label_match(label, &matches).cloned()
     }
 
     /// Queries for all elements with a label.
@@ -473,6 +476,15 @@ impl<P> ElementIntrospector<P> {
             .get(location)
             .cloned()
             .unwrap_or(usize::MAX..usize::MAX)
+    }
+}
+
+/// Retrieves the unique match for a label.
+pub(crate) fn unique_label_match<T>(label: Label, matches: &[T]) -> StrResult<&T> {
+    match matches {
+        [target] => Ok(target),
+        [] => bail!("label `{}` does not exist in the document", label.repr()),
+        _ => bail!("label `{}` occurs multiple times in the document", label.repr()),
     }
 }
 

--- a/crates/typst-library/src/introspection/query.rs
+++ b/crates/typst-library/src/introspection/query.rs
@@ -264,11 +264,11 @@ impl Introspect for QueryLabelIntrospection {
         _: &mut Engine,
         introspector: Tracked<dyn Introspector + '_>,
     ) -> Self::Output {
-        introspector.query_label(self.0).cloned()
+        introspector.query_unique(&Selector::label_path(self.0))
     }
 
     fn diagnose(&self, history: &History<Self::Output>) -> SourceDiagnostic {
-        QueryUniqueIntrospection(Selector::Label(self.0), self.1).diagnose(history)
+        QueryUniqueIntrospection(Selector::label_path(self.0), self.1).diagnose(history)
     }
 }
 

--- a/crates/typst-library/src/introspection/query.rs
+++ b/crates/typst-library/src/introspection/query.rs
@@ -264,7 +264,7 @@ impl Introspect for QueryLabelIntrospection {
         _: &mut Engine,
         introspector: Tracked<dyn Introspector + '_>,
     ) -> Self::Output {
-        introspector.query_unique(&Selector::label_path(self.0))
+        introspector.query_label(self.0)
     }
 
     fn diagnose(&self, history: &History<Self::Output>) -> SourceDiagnostic {

--- a/crates/typst-library/src/model/reference.rs
+++ b/crates/typst-library/src/model/reference.rs
@@ -79,6 +79,9 @@ use crate::text::TextElem;
 /// can be created by typing an `[@]` followed by the name of the label (e.g.
 /// `[= Introduction <intro>]` can be referenced by typing `[@intro]`).
 ///
+/// A slash-separated path like `[@chapter/result]` references `result` within
+/// content labelled `chapter`. Longer paths narrow the scope from left to right.
+///
 /// To customize the supplement, add content in square brackets after the
 /// reference: `[@intro[Chapter]]`.
 ///

--- a/crates/typst-syntax/src/lexer.rs
+++ b/crates/typst-syntax/src/lexer.rs
@@ -574,20 +574,30 @@ impl Lexer<'_> {
     }
 
     fn ref_marker(&mut self) -> SyntaxKind {
-        self.s.eat_while(is_valid_in_label_literal);
+        let start = self.s.cursor();
+        self.s.eat_while(is_valid_in_label_path);
 
         // Don't include the trailing characters likely to be part of text.
         while matches!(self.s.scout(-1), Some('.' | ':')) {
             self.s.uneat();
         }
 
+        let target = self.s.from(start);
+        if has_empty_label_path_component(target) {
+            return self.error("label path cannot contain empty components");
+        }
+
         SyntaxKind::RefMarker
     }
 
     fn label(&mut self) -> SyntaxKind {
-        let label = self.s.eat_while(is_valid_in_label_literal);
+        let label = self.s.eat_while(is_valid_in_label_path);
         if label.is_empty() {
             return self.error("label cannot be empty");
+        }
+
+        if has_empty_label_path_component(label) {
+            return self.error("label path cannot contain empty components");
         }
 
         if !self.s.eat_if('>') {
@@ -1269,6 +1279,18 @@ fn is_math_id_continue(c: char) -> bool {
 #[inline]
 fn is_valid_in_label_literal(c: char) -> bool {
     is_id_continue(c) || matches!(c, ':' | '.')
+}
+
+/// Whether a character can be part of a label or reference path literal.
+#[inline]
+fn is_valid_in_label_path(c: char) -> bool {
+    is_valid_in_label_literal(c) || c == '/'
+}
+
+/// Whether a label path contains an empty component.
+#[inline]
+fn has_empty_label_path_component(path: &str) -> bool {
+    path.starts_with('/') || path.ends_with('/') || path.contains("//")
 }
 
 /// Returns true if this string is valid in a label literal.

--- a/crates/typst-syntax/src/lexer.rs
+++ b/crates/typst-syntax/src/lexer.rs
@@ -1295,5 +1295,7 @@ fn has_empty_label_path_component(path: &str) -> bool {
 
 /// Returns true if this string is valid in a label literal.
 pub fn is_valid_label_literal_id(id: &str) -> bool {
-    !id.is_empty() && id.chars().all(is_valid_in_label_literal)
+    !id.is_empty()
+        && id.chars().all(is_valid_in_label_path)
+        && !has_empty_label_path_component(id)
 }

--- a/tests/ref/bundle/ref-within-label-path-repeat.txt
+++ b/tests/ref/bundle/ref-within-label-path-repeat.txt
@@ -1,0 +1,2 @@
+1dc1005f18ad4c0971afe9aecc42c370 a.pdf
+43ba16d7d98ad2bc600ab067908830de b.pdf

--- a/tests/ref/bundle/ref-within-label-path.txt
+++ b/tests/ref/bundle/ref-within-label-path.txt
@@ -1,0 +1,3 @@
+43b6d591e0af0697f7409a85d32a0bd4 alpha.pdf
+04d626b659fbf60cf351eea23adde762 beta.pdf
+67ec0ae77e6fb7e6a5dce236fb482250 gamma.pdf

--- a/tests/ref/html/hashes.txt
+++ b/tests/ref/html/hashes.txt
@@ -102,6 +102,7 @@ aecca822229f41f10fdcfae3954413f1 link-html-frame-ref
 5ffe20ca590c5e8ce14f77537aae6b31 link-html-id-existing
 2a4bbc3c8c4f18c632909849abd6fc1d link-html-label-disambiguation
 128fcc9c404014198f9fa29210e1864d link-html-nested-empty
+1ce053adccf3d2726148d8183d22a2cd link-label-path
 bcefcf7a18422abf0da566507d6080fc list-par
 df1f8e682fe06efe28078e8beec14038 math-accent-align
 bbade493e498eab7cea3610d84eee723 math-accent-bottom

--- a/tests/suite/foundations/label.typ
+++ b/tests/suite/foundations/label.typ
@@ -60,6 +60,16 @@ _Visible_
 #test(str(<hey>), "hey")
 #test(str(label("hey")), "hey")
 #test(str([Hmm<hey>].label), "hey")
+#test(repr(<a/b-c>), "<a/b-c>")
+#test(repr(label("a/b-c")), "<a/b-c>")
+
+--- label-path-empty-middle eval ---
+// Error: 1-6 label path cannot contain empty components
+<a//b>
+
+--- label-path-empty-trailing eval ---
+// Error: 1-6 label path cannot contain empty components
+<a/b/>
 
 --- label-in-code-mode-hint eval ---
 // Error: 7-7 expected semicolon or line break

--- a/tests/suite/model/link.typ
+++ b/tests/suite/model/link.typ
@@ -209,6 +209,10 @@ See #metadata(none) <t8>
 #html.frame[@intro]
 = Introduction <intro>
 
+--- link-label-path html ---
+#link(<scope/target>)[Go to target]
+#[= Target <target>] <scope>
+
 --- link-bundle-to-doc bundle ---
 // Test directly linking to a different document in the bundle.
 #document("index.html")[

--- a/tests/suite/model/ref.typ
+++ b/tests/suite/model/ref.typ
@@ -20,6 +20,92 @@ As seen in @intro, we proceed.
 // Error: 1-5 label `<foo>` occurs multiple times in the document
 @foo
 
+--- ref-within-label-path bundle ---
+#set heading(numbering: "1.")
+
+#[
+  #document("alpha.pdf")[
+    = #lorem(3) <heading-1>
+    #[
+      == #lorem(5) <subheading>
+    ] <subscope-1>
+  ] <doc-1>
+  #document("beta.pdf")[
+    = #lorem(4) <subheading>
+  ] <doc-2>
+] <scope>
+
+#document("gamma.pdf")[
+  @doc-1/subheading
+  @subscope-1/subheading
+  @doc-1/subscope-1/subheading
+  #ref(<doc-1/subscope-1/subheading>)
+  #ref(<doc-1>/<subscope-1>/<subheading>)
+
+  #context test(str(<doc-1>/<subscope-1>), "doc-1/subscope-1")
+  #context test(query(<doc-1/subscope-1/subheading>).len(), 1)
+  #context test(query(<subscope-1/doc-1/subheading>).len(), 0)
+]
+
+--- ref-within-label-path-ambiguous bundle ---
+#set heading(numbering: "1.")
+
+#[
+  #document("alpha.pdf")[
+    = #lorem(3) <heading-1>
+    #[
+      == #lorem(5) <subheading>
+    ] <subscope-1>
+  ] <doc-1>
+  #document("beta.pdf")[
+    = #lorem(4) <subheading>
+  ] <doc-2>
+] <scope>
+
+#document("gamma.pdf")[
+  // Error: 3-14 label `<subheading>` occurs multiple times in the document
+  @subheading
+
+  // Error: 3-20 selector matches multiple elements
+  @scope/subheading
+]
+
+--- ref-within-label-path-repeat bundle ---
+#set heading(numbering: "1.")
+#set math.equation(numbering: "(1)")
+
+#let ct = [
+  $ E = m c^2 $ <eq1>
+  $ F = m a $ <eq2>
+  #[= #lorem(2) <head>] <scope1>
+  #[= #lorem(2) <head>] <scope2>
+  - See @eq1, @eq2, @scope1/head, @scope2/head
+  - Also look at @doc-a/eq1 and @doc-b/eq1.
+]
+
+#let prefix-reference(it, prefix: "") = if not str(it.target).contains("doc-") {
+  ref(label(prefix + "/" + str(it.target)))
+} else {
+  it
+}
+
+#document("a.pdf")[
+  #show ref: prefix-reference.with(prefix: "doc-a")
+  #ct
+] <doc-a>
+
+#counter(heading).update(0)
+#counter(math.equation).update(0)
+
+#document("b.pdf")[
+  #show ref: prefix-reference.with(prefix: "doc-b")
+  #ct
+] <doc-b>
+
+--- ref-label-contains-paths eval ---
+// Error: 11-27 label paths cannot be used to label content
+= Heading <heading/syntax>
+
 --- ref-supplements paged ---
 #set heading(numbering: "1.", supplement: [Chapter])
 #set math.equation(numbering: "(1)", supplement: [Eq.])

--- a/tests/suite/model/ref.typ
+++ b/tests/suite/model/ref.typ
@@ -66,8 +66,11 @@ As seen in @intro, we proceed.
   // Error: 3-14 label `<subheading>` occurs multiple times in the document
   @subheading
 
-  // Error: 3-20 selector matches multiple elements
+  // Error: 3-20 label `<scope/subheading>` occurs multiple times in the document
   @scope/subheading
+
+  // Error: 3-17 label `<doc-1/missing>` does not exist in the document
+  @doc-1/missing
 ]
 
 --- ref-within-label-path-repeat bundle ---
@@ -105,6 +108,14 @@ As seen in @intro, we proceed.
 --- ref-label-contains-paths eval ---
 // Error: 11-27 label paths cannot be used to label content
 = Heading <heading/syntax>
+
+--- ref-label-path-empty-middle eval ---
+// Error: 1-6 label path cannot contain empty components
+@a//b
+
+--- ref-label-path-empty-trailing eval ---
+// Error: 1-6 label path cannot contain empty components
+@a/b/
 
 --- ref-supplements paged ---
 #set heading(numbering: "1.", supplement: [Chapter])


### PR DESCRIPTION
This implements the design proposed in https://github.com/typst/typst/issues/7998, specifically label paths of the format `<a/b/c>` (when queried, expands approximately to `selector(<c>).within(selector(<b>).within(<a>)))`, and references it if the length of this query is 1 (although now I do feel like it would be nice to let refs support arbitrary selectors/specific elements etc for more fine-grained control).

To simplify this logic, I made it illegal to label content with a path (a user can instead wrap their content in multiple `#[...]` scopes to achieve this) which is in the test `ref-within-label-path-ambiguous`.

The main use case (as mentioned) was to use a single instance of code to generate multiple files, preferable in multiple formats. Using the system introduced, this is achievable with the following show rule example (although obviously it can likely be improved upon):

<details>
<summary>Expand</summary>

```
#set heading(numbering: "1.")
#set math.equation(numbering: "(1)")

#let ct = [
  $ E = m c^2 $ <eq1>
  $ F = m a $ <eq2>
  #[= #lorem(2) <head>] <scope1>
  #[= #lorem(2) <head>] <scope2>
  - See @eq1, @eq2, @scope1/head, @scope2/head
  - Also look at @doc-a/eq1 and @doc-b/eq1.
]

#let prefix-reference(it, prefix: "") = if not str(it.target).contains("doc-") {
  ref(label(prefix + "/" + str(it.target)))
} else {
  it
}

#document("a.pdf")[
  #show ref: prefix-reference.with(prefix: "doc-a")
  #ct
] <doc-a>

#counter(heading).update(0)
#counter(math.equation).update(0)

#document("b.pdf")[
  #show ref: prefix-reference.with(prefix: "doc-b")
  #ct
] <doc-b>
```

</details>