### PR TITLE
Fix invalid `luma` argument handling and allow integers for `alpha` component

### DIFF
--- a/crates/typst-library/src/foundations/args.rs
+++ b/crates/typst-library/src/foundations/args.rs
@@ -160,8 +160,9 @@ impl Args {
     /// The error message for missing arguments.
     fn missing_argument(&self, what: &str) -> SourceDiagnostic {
         for item in &self.items {
-            let Some(name) = item.name.as_deref() else { continue };
-            if name == what {
+            if let Some(name) = item.name.as_deref()
+                && name == what
+            {
                 return error!(
                     item.span,
                     "the argument `{what}` is positional";

--- a/crates/typst-library/src/visualize/color.rs
+++ b/crates/typst-library/src/visualize/color.rs
@@ -345,7 +345,7 @@ impl Color {
         lightness: Component,
         /// The alpha component.
         #[external]
-        alpha: RatioComponent,
+        alpha: Component,
         /// Alternatively: The color to convert to grayscale.
         ///
         /// If this is given, the individual components should not be given.
@@ -357,8 +357,7 @@ impl Color {
                 color.to_luma()
             } else {
                 let Component(l) = args.expect("lightness component")?;
-                let RatioComponent(alpha) =
-                    args.eat()?.unwrap_or(RatioComponent(Ratio::one()));
+                let Component(alpha) = args.eat()?.unwrap_or(Component(Ratio::one()));
                 Luma::new(l.get() as f32, alpha.get() as f32)
             },
         )))

--- a/crates/typst-library/src/visualize/color.rs
+++ b/crates/typst-library/src/visualize/color.rs
@@ -356,7 +356,18 @@ impl Color {
             if let Some(color) = args.find::<Color>()? {
                 color.to_luma()
             } else {
-                let Component(l) = args.expect("lightness component")?;
+                let missing_lightness = args.is_empty();
+                let Component(l) =
+                    args.expect("lightness component").map_err(|mut err| {
+                        if missing_lightness {
+                            // Before 0.16, lightness accidentally defaulted to
+                            // `100%`, so this should help with breakage. I
+                            // could not find a cleaner way to add the hint >:(
+                            let last = err.make_mut().last_mut().unwrap();
+                            last.hint("try writing `white` or `luma(100%)`");
+                        }
+                        err
+                    })?;
                 let Component(alpha) = args.eat()?.unwrap_or(Component(Ratio::one()));
                 Luma::new(l.get() as f32, alpha.get() as f32)
             },

--- a/crates/typst-library/src/visualize/color.rs
+++ b/crates/typst-library/src/visualize/color.rs
@@ -326,8 +326,8 @@ impl Color {
 
     /// Create a grayscale color.
     ///
-    /// A grayscale color is represented internally by a single `lightness`
-    /// component.
+    /// A grayscale color is represented by `lightness` (@ratio) and `alpha`
+    /// (@ratio) components.
     ///
     /// These components are also available using the
     /// @color.components[`components`] method.
@@ -348,7 +348,7 @@ impl Color {
         alpha: RatioComponent,
         /// Alternatively: The color to convert to grayscale.
         ///
-        /// If this is given, the `lightness` should not be given.
+        /// If this is given, the individual components should not be given.
         #[external]
         color: Color,
     ) -> SourceResult<Color> {
@@ -356,11 +356,10 @@ impl Color {
             if let Some(color) = args.find::<Color>()? {
                 color.to_luma()
             } else {
-                let Component(gray) =
-                    args.expect("gray component").unwrap_or(Component(Ratio::one()));
+                let Component(l) = args.expect("lightness component")?;
                 let RatioComponent(alpha) =
                     args.eat()?.unwrap_or(RatioComponent(Ratio::one()));
-                Luma::new(gray.get() as f32, alpha.get() as f32)
+                Luma::new(l.get() as f32, alpha.get() as f32)
             },
         )))
     }

--- a/tests/suite/visualize/color.typ
+++ b/tests/suite/visualize/color.typ
@@ -211,6 +211,7 @@
 
 --- color-luma-empty-arguments eval ---
 // Error: 7-13 missing argument: lightness component
+// Hint: 7-13 try writing `white` or `luma(100%)`
 #test(luma(), white)
 
 --- color-luma-invalid-alpha eval ---

--- a/tests/suite/visualize/color.typ
+++ b/tests/suite/visualize/color.typ
@@ -172,6 +172,9 @@
 #test-components(rgb(1, 2, 3, 4), (0.39%, 0.78%, 1.18%, 1.57%))
 #test-components(luma(40), (15.69%, 100%))
 #test-components(luma(40, 50%), (15.69%, 50%))
+#test-components(luma(40, 127), (15.69%, 49.8%))
+#test-components(luma(40, 0), (15.69%, 0%))
+#test-components(luma(40, 255), (15.69%, 100%))
 #test-components(cmyk(4%, 5%, 6%, 7%), (4%, 5%, 6%, 7%), has-alpha: false)
 #test-components(oklab(10%, 0.2, 0.4), (10%, 0.2, 0.4, 100%))
 #test-components(oklch(10%, 0.2, 90deg), (10%, 0.2, 90deg, 100%))
@@ -215,7 +218,7 @@
 #luma("invalid")
 
 --- color-luma-invalid-lightness eval ---
-// Error: 12-21 expected ratio, found string
+// Error: 12-21 expected integer or ratio, found string
 #luma(10%, "invalid")
 
 --- color-luma-unexpected-argument eval ---

--- a/tests/suite/visualize/color.typ
+++ b/tests/suite/visualize/color.typ
@@ -206,9 +206,25 @@
 // Error: 21-26 expected integer or ratio, found boolean
 #rgb(10%, 20%, 30%, false)
 
+--- color-luma-empty-arguments eval ---
+// Error: 7-13 missing argument: lightness component
+#test(luma(), white)
+
+--- color-luma-invalid-alpha eval ---
+// Error: 7-16 expected integer or ratio, found string
+#luma("invalid")
+
+--- color-luma-invalid-lightness eval ---
+// Error: 12-21 expected ratio, found string
+#luma(10%, "invalid")
+
 --- color-luma-unexpected-argument eval ---
-// Error: 10-20 unexpected argument: key
-#luma(1, key: "val")
+// Error: 12-22 unexpected argument: key
+#luma(255, key: "val")
+
+--- color-luma-unexpected-pos-argument eval ---
+// Error: 17-22 unexpected argument
+#luma(25%, 50%, "val")
 
 --- color-mix-bad-amount-type eval ---
 // Error: 12-24 expected float or ratio, found string


### PR DESCRIPTION
Fixes #8679

I updated `luma` to error when given empty arguments or an invalid first argument. I also updated the docs to be a bit more consistent with the other color space wordings, although I still find the overall color docs a bit akward.

While doing so I noticed that `lightness` is a `Component` (accepts a ratio or an int), but `alpha` is a `RatioComponent` (only accepts a ratio), and I decided to change `alpha` to a `Component` as well, since every other color space that takes a `Component` also does so for `alpha`.

In the issue I mentioned that erroring for empty arguments is likely to break some existing projects, and I would be open to adding a custom error that hints to use `white` in place of `luma()` since the two should be exactly equivalent. But I'll wait for feedback before doing so.
