### PR TITLE
Make `IdeWorld::files` more flexible

### DIFF
--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -11,7 +11,7 @@ use typst::foundations::{
 use typst::layout::{Alignment, Dir};
 use typst::syntax::ast::AstNode;
 use typst::syntax::{
-    FileId, LinkedNode, Side, Source, SyntaxKind, SyntaxMode, ast, is_id_continue,
+    LinkedNode, Side, Source, SyntaxKind, SyntaxMode, VirtualPath, ast, is_id_continue,
     is_id_start, is_ident,
 };
 use typst::text::{FontFlags, RawElem};
@@ -1153,16 +1153,19 @@ impl<'a> CompletionContext<'a> {
     }
 
     /// Add completions for all available files.
-    fn file_completions(&mut self, mut filter: impl FnMut(FileId) -> bool) {
+    fn file_completions(&mut self, mut filter: impl FnMut(&VirtualPath) -> bool) {
         let Some(current_id) = self.leaf.span().id() else { return };
         let Some(current_dir) = current_id.vpath().parent() else { return };
 
+        let prefix =
+            Some(self.before[self.from..].trim_matches('\"')).filter(|s| !s.is_empty());
+
         let mut paths: Vec<EcoString> = self
             .world
-            .files()
+            .files(current_id, prefix)
             .iter()
-            .filter(|&&id| id != current_id && filter(id))
-            .map(|id| id.vpath().relative_from(&current_dir))
+            .filter(|&path| path != current_id.vpath() && filter(path))
+            .map(|path| path.relative_from(&current_dir))
             .collect();
 
         paths.sort();
@@ -1179,9 +1182,8 @@ impl<'a> CompletionContext<'a> {
         if extensions.is_empty() {
             self.file_completions(|_| true);
         }
-        self.file_completions(|id| {
-            let ext = id
-                .vpath()
+        self.file_completions(|path| {
+            let ext = path
                 .extension()
                 .map(EcoString::from)
                 .unwrap_or_default()
@@ -1902,6 +1904,30 @@ mod tests {
                 q!("../data/example.csv"),
             ])
             .must_exclude([q!("f.typ")]);
+    }
+
+    #[test]
+    fn test_autocomplete_file_path_with_prefix() {
+        let world = TestWorld::new("")
+            .with_source("content/main.typ", "#read(\"a\")")
+            .with_source("content/test.typ", "#read(\"../assets/t\")")
+            .with_source("content/aux.typ", "")
+            .with_asset_at("assets/tiger.jpg", "tiger.jpg")
+            .with_asset_at("assets/rhino.png", "rhino.png");
+
+        test(&world, ("content/main.typ", -3))
+            .must_include([q!("aux.typ")])
+            .must_exclude([q!("test.typ")]);
+
+        test(&world, ("content/test.typ", -12))
+            .must_include([q!("../assets/tiger.jpg"), q!("../assets/rhino.png")]);
+
+        test(&world, ("content/test.typ", -4))
+            .must_include([q!("../assets/tiger.jpg"), q!("../assets/rhino.png")]);
+
+        test(&world, ("content/test.typ", -3))
+            .must_include([q!("../assets/tiger.jpg")])
+            .must_exclude([q!("../assets/rhino.png")]);
     }
 
     #[test]

--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -11,7 +11,7 @@ use typst::foundations::{
 use typst::layout::{Alignment, Dir};
 use typst::syntax::ast::AstNode;
 use typst::syntax::{
-    FileId, LinkedNode, Side, Source, SyntaxKind, SyntaxMode, ast, is_id_continue,
+    LinkedNode, Side, Source, SyntaxKind, SyntaxMode, VirtualPath, ast, is_id_continue,
     is_id_start, is_ident,
 };
 use typst::text::{FontFlags, RawElem};
@@ -1153,16 +1153,19 @@ impl<'a> CompletionContext<'a> {
     }
 
     /// Add completions for all available files.
-    fn file_completions(&mut self, mut filter: impl FnMut(FileId) -> bool) {
+    fn file_completions(&mut self, mut filter: impl FnMut(&VirtualPath) -> bool) {
         let Some(current_id) = self.leaf.span().id() else { return };
         let Some(current_dir) = current_id.vpath().parent() else { return };
 
+        let prefix =
+            Some(self.before[self.from..].trim_matches('\"')).filter(|s| !s.is_empty());
+
         let mut paths: Vec<EcoString> = self
             .world
-            .files()
+            .files(current_id, prefix)
             .iter()
-            .filter(|&&id| id != current_id && filter(id))
-            .map(|id| id.vpath().relative_from(&current_dir))
+            .filter(|&path| path != current_id.vpath() && filter(path))
+            .map(|path| path.relative_from(&current_dir))
             .collect();
 
         paths.sort();
@@ -1179,9 +1182,8 @@ impl<'a> CompletionContext<'a> {
         if extensions.is_empty() {
             self.file_completions(|_| true);
         }
-        self.file_completions(|id| {
-            let ext = id
-                .vpath()
+        self.file_completions(|path| {
+            let ext = path
                 .extension()
                 .map(EcoString::from)
                 .unwrap_or_default()
@@ -1902,6 +1904,17 @@ mod tests {
                 q!("../data/example.csv"),
             ])
             .must_exclude([q!("f.typ")]);
+    }
+
+    #[test]
+    fn test_autocomplete_file_path_with_prefix() {
+        let world = TestWorld::new("#read(\"t\")")
+            .with_asset_at("tiger.jpg", "tiger.jpg")
+            .with_asset_at("rhino.png", "rhino.png");
+
+        test(&world, -3)
+            .must_include([q!("tiger.jpg")])
+            .must_exclude([q!("rhino.jpg")]);
     }
 
     #[test]

--- a/crates/typst-ide/src/complete.rs
+++ b/crates/typst-ide/src/complete.rs
@@ -1910,7 +1910,9 @@ mod tests {
     fn test_autocomplete_file_path_with_prefix() {
         let world = TestWorld::new("")
             .with_source("content/main.typ", "#read(\"a\")")
-            .with_source("content/test.typ", "#read(\"../assets/t\")")
+            .with_source("content/test1.typ", "#read(\"\")")
+            .with_source("content/test2.typ", "#read(\"..\")")
+            .with_source("content/test3.typ", "#read(\"../assets/r\")")
             .with_source("content/aux.typ", "")
             .with_asset_at("assets/tiger.jpg", "tiger.jpg")
             .with_asset_at("assets/rhino.png", "rhino.png");
@@ -1919,15 +1921,19 @@ mod tests {
             .must_include([q!("aux.typ")])
             .must_exclude([q!("test.typ")]);
 
-        test(&world, ("content/test.typ", -12))
-            .must_include([q!("../assets/tiger.jpg"), q!("../assets/rhino.png")]);
+        test(&world, ("content/test1.typ", -3)).must_include([
+            q!("aux.typ"),
+            q!("../assets/tiger.jpg"),
+            q!("../assets/tiger.jpg"),
+        ]);
 
-        test(&world, ("content/test.typ", -4))
-            .must_include([q!("../assets/tiger.jpg"), q!("../assets/rhino.png")]);
+        test(&world, ("content/test2.typ", -3))
+            .must_include([q!("../assets/rhino.png"), q!("../assets/tiger.jpg")])
+            .must_exclude([q!("aux.typ")]);
 
-        test(&world, ("content/test.typ", -3))
-            .must_include([q!("../assets/tiger.jpg")])
-            .must_exclude([q!("../assets/rhino.png")]);
+        test(&world, ("content/test3.typ", -3))
+            .must_include([q!("../assets/rhino.png")])
+            .must_exclude([q!("aux.typ"), q!("../assets/tiger.jpg")]);
     }
 
     #[test]

--- a/crates/typst-ide/src/lib.rs
+++ b/crates/typst-ide/src/lib.rs
@@ -18,8 +18,8 @@ pub use self::tooltip::{Tooltip, tooltip};
 
 use ecow::EcoString;
 use typst::World;
-use typst::syntax::FileId;
 use typst::syntax::package::PackageSpec;
+use typst::syntax::{FileId, VirtualPath};
 
 /// Extends the `World` for IDE functionality.
 pub trait IdeWorld: World {
@@ -41,11 +41,18 @@ pub trait IdeWorld: World {
         &[]
     }
 
-    /// Returns a list of all known files.
+    /// Returns a list of relevant path completion candidates.
+    ///
+    /// `base` refers to the source file where the completion is being
+    /// performed, and `prefix` possibly contains an already entered path to be
+    /// extended. Implementations may use either piece of information at their
+    /// discretion to narrow down the list of candidates, i.e. for relevance or
+    /// performance.
     ///
     /// This function is **optional** to implement. It enhances the user
     /// experience by enabling autocompletion for file paths.
-    fn files(&self) -> Vec<FileId> {
+    #[allow(unused_variables)]
+    fn files(&self, base: FileId, prefix: Option<&str>) -> Vec<VirtualPath> {
         vec![]
     }
 }

--- a/crates/typst-ide/src/lib.rs
+++ b/crates/typst-ide/src/lib.rs
@@ -43,11 +43,11 @@ pub trait IdeWorld: World {
 
     /// Returns a list of relevant path completion candidates.
     ///
-    /// `base` refers to the source file where the completion is being
-    /// performed, and `prefix` possibly contains an already entered path to be
-    /// extended. Implementations may use either piece of information at their
-    /// discretion to narrow down the list of candidates, i.e. for relevance or
-    /// performance.
+    /// The `base` parameter refers to the source file where the completion is
+    /// being performed, and `prefix` contains an already entered path to be
+    /// extended (if any). Implementations may use either piece of information
+    /// at their discretion to narrow down the list of candidates, i.e. for
+    /// relevance or performance.
     ///
     /// This function is **optional** to implement. It enhances the user
     /// experience by enabling autocompletion for file paths.

--- a/crates/typst-ide/src/tests.rs
+++ b/crates/typst-ide/src/tests.rs
@@ -117,10 +117,20 @@ impl IdeWorld for TestWorld {
         self
     }
 
-    fn files(&self) -> Vec<FileId> {
+    fn files(&self, base: FileId, prefix: Option<&str>) -> Vec<VirtualPath> {
+        let dir = base.vpath().parent();
+
         std::iter::once(self.main.id())
             .chain(self.files.sources.keys().copied())
             .chain(self.files.assets.keys().copied())
+            .map(|id| id.vpath().clone())
+            .filter(|path| {
+                prefix.is_none_or(|prefix| {
+                    dir.as_ref()
+                        .map(|dir| path.relative_from(dir))
+                        .is_none_or(|relative| relative.starts_with(prefix))
+                })
+            })
             .collect()
     }
 

--- a/crates/typst-ide/src/tests.rs
+++ b/crates/typst-ide/src/tests.rs
@@ -117,10 +117,16 @@ impl IdeWorld for TestWorld {
         self
     }
 
-    fn files(&self) -> Vec<FileId> {
+    fn files(&self, _base: FileId, prefix: Option<&str>) -> Vec<VirtualPath> {
         std::iter::once(self.main.id())
             .chain(self.files.sources.keys().copied())
             .chain(self.files.assets.keys().copied())
+            .map(|id| id.vpath().clone())
+            .filter(|path| {
+                prefix.is_none_or(|prefix| {
+                    path.file_name().is_none_or(|name| name.starts_with(prefix))
+                })
+            })
             .collect()
     }
 


### PR DESCRIPTION
The `IdeWorld::files` trait method is an existing method that powers `typst-ide`'s path autocomplete functionality by providing possible files that may be referenced in Typst source code. However, the ability to efficiently implement it is restricted by its' current signature which appears to have a couple of underlying assumptions:

* That the World implementation knows at all times about all files that could be possibly referenced by any Typst source file, and can efficiently come up with a copy of this list on-demand.
* That there aren't "too many" possible files - there is an upper limit to how many distinct `FileId` values can exist during the program's lifetime, and it is not very high.

These assumptions make sense if the embedding program is an IDE with a well-defined project structure to which files are added and removed manually. But they don't really work for local editors where the "project" is just an arbitrary filesystem directory, or if there is no concept of a "project" at all.

This PR changes the signature of the method so it is easier to implement in more environments. The proposed changes are:

1. The return type changes from `Vec<FileId>` to `Vec<VirtualPath>`. That means that the path to any random file that happens to be in the same directory as a Typst source file doesn't need to be interned, wasting a `FileId` on something which likely won't ever be used.

2. The method accepts an additional `base` argument, which refers to a source file in the context of which a completion is being asked for. This caters for "project-less" embedding programs.

This change proposal was originally discussed in the Typst Discord.