### PR TITLE
Test report source fixes

### DIFF
--- a/tests/src/report/html.rs
+++ b/tests/src/report/html.rs
@@ -786,28 +786,24 @@ fn test_report_header(
 
 fn test_report_source(parent: &mut HtmlElem, test_report: &TestReport, test_idx: usize) {
     parent
-        .div()
+        .table()
         .class("test-report-source")
         .hidden(true)
         .id(display!("test-report-source-{test_idx}"))
-        .with(|div| {
-            div.table().class("file-diff html").with(|table| {
-                table.colgroup().with(|colgroup| {
-                    colgroup.col().attr("span", 1).class("col-line-gutter");
-                    colgroup.col().attr("span", 1).class("col-source-line-body");
-                });
-
-                let lines = super::diff::file_lines(
-                    test_report.source.text(),
-                    LineKind::Unchanged,
-                );
-
-                for line in lines.lines {
-                    table.tr().class("diff-line").with(|tr| {
-                        diff_cells(tr, &line);
-                    });
-                }
+        .with(|table| {
+            table.colgroup().with(|colgroup| {
+                colgroup.col().attr("span", 1).class("col-line-gutter");
+                colgroup.col().attr("span", 1).class("col-source-line-body");
             });
+
+            let lines =
+                super::diff::file_lines(test_report.source.text(), LineKind::Unchanged);
+
+            for line in lines.lines {
+                table.tr().class("diff-line").with(|tr| {
+                    diff_cells(tr, &line);
+                });
+            }
         });
 }
 

--- a/tests/src/report/html.rs
+++ b/tests/src/report/html.rs
@@ -497,31 +497,35 @@ fn test_reports(body: &mut HtmlElem, reports: &[TestReport]) {
                         };
                         div.div()
                             .id(display!("test-report-body-{test_idx}"))
-                            .class(display!("test-report-body{image_kind}"))
+                            .class("test-report-body")
                             .hidden(close)
                             .with(|div| {
                                 test_report_source(div, test_report, test_idx);
 
-                                for (file_idx, report_file) in
-                                    test_report.files.iter().enumerate()
-                                {
-                                    report_file_tab_panel(
-                                        div,
-                                        test_report,
-                                        report_file,
-                                        test_idx,
-                                        file_idx,
-                                    );
-                                }
+                                div.div()
+                                    .class(display!("test-report-area{image_kind}"))
+                                    .with(|div| {
+                                        for (file_idx, report_file) in
+                                            test_report.files.iter().enumerate()
+                                        {
+                                            report_file_tab_panel(
+                                                div,
+                                                test_report,
+                                                report_file,
+                                                test_idx,
+                                                file_idx,
+                                            );
+                                        }
 
-                                // There is one set of image controls for the
-                                // image diffs of all outputs of a test report.
-                                let has_image_diff = (test_report.files.iter())
-                                    .flat_map(|f| f.diffs.iter())
-                                    .any(Diff::is_image);
-                                if has_image_diff {
-                                    image_diff_controls(div, test_idx);
-                                }
+                                        // There is one set of image controls for the
+                                        // image diffs of all outputs of a test report.
+                                        let has_image_diff = (test_report.files.iter())
+                                            .flat_map(|f| f.diffs.iter())
+                                            .any(Diff::is_image);
+                                        if has_image_diff {
+                                            image_diff_controls(div, test_idx);
+                                        }
+                                    });
                             });
                     });
             }

--- a/tests/src/report/report.css
+++ b/tests/src/report/report.css
@@ -225,6 +225,10 @@ h2.diff-container-header {
 }
 
 .test-report-body {
+  width: 100%;
+}
+
+.test-report-area {
   position: relative;
   width: 100%;
 }
@@ -355,15 +359,15 @@ a.report-file-link:active {
 
 /* ========== Image diff ========== */
 
-.test-report-body > .image-controls {
+.test-report-area > .image-controls {
   visibility: hidden;
 }
 
-.test-report-body.image > .image-controls {
+.test-report-area.image > .image-controls {
   visibility: visible;
 }
 
-.test-report-body.image:not(:hover,:has(*:focus-visible)) > .image-controls {
+.test-report-area.image:not(:hover,:has(*:focus-visible)) > .image-controls {
   /* Avoid flicker in some cases */
   transition: opacity 0.1s cubic-bezier(0.64, 0, 0.78, 0) 0.1s;
   opacity: 0;

--- a/tests/src/report/report.js
+++ b/tests/src/report/report.js
@@ -14,7 +14,7 @@ const imageDiffs = []
  * @property report {HTMLDetailsElement}
  * @property reportToggle {HTMLButtonElement}
  * @property reportSourceToggle {HTMLButtonElement}
- * @property reportBody {HTMLDivElement}
+ * @property reportArea {HTMLDivElement}
  * @property reportSource {HTMLDivElement}
  * @property files {ReportFileState[]}
  */
@@ -99,12 +99,13 @@ for (const testReport of document.getElementsByClassName("test-report")) {
   const reportFileTabs = reportFileTabGroup.querySelectorAll(".report-file-tab");
   const reportBody = testReport.querySelector(".test-report-body")
   const reportSource = reportBody.querySelector(".test-report-source")
-  const reportFileTabpanels = reportBody.querySelectorAll(":scope > .report-file");
+  const reportArea = reportBody.querySelector(".test-report-area")
+  const reportFileTabpanels = reportArea.querySelectorAll(":scope > .report-file");
 
   /** @type {TestReportState} */
   const report = {
     report: testReport,
-    reportBody,
+    reportArea,
     reportToggle,
     reportSourceToggle,
     reportSource,
@@ -213,8 +214,8 @@ for (const testReport of document.getElementsByClassName("test-report")) {
   // There is one set of image controls for the image diffs of all output
   // formats inside a test report. This makes comparing the different formats
   // more convenient.
-  const imageControlsTop = reportBody.querySelector(":scope > .image-controls.top")
-  const imageControlsBottom = reportBody.querySelector(":scope > .image-controls.bottom")
+  const imageControlsTop = reportArea.querySelector(":scope > .image-controls.top")
+  const imageControlsBottom = reportArea.querySelector(":scope > .image-controls.bottom")
   if (imageControlsTop != null && imageControlsBottom != null) {
     const imageModes = imageControlsTop.querySelectorAll("input.image-view-mode")
     const imageAntialiasing = imageControlsTop.querySelector("input.image-antialiasing")
@@ -277,7 +278,7 @@ for (const testReport of document.getElementsByClassName("test-report")) {
     // Initially enable/disable the image controls.
     disableImageControls(imageState, currentImageMode(imageState));
 
-    for (const imageDiff of reportBody.querySelectorAll(".file-diff.image")) {
+    for (const imageDiff of reportArea.querySelectorAll(".file-diff.image")) {
       const imageCanvas = imageDiff.querySelector(".image-canvas")
       const images = imageCanvas.querySelectorAll("img")
 
@@ -508,7 +509,7 @@ function fileDiffTabChanged(file, diffMode, update_parent) {
 
   // When this tab is visible update the test report diff kind.
   if (file.tab.checked) {
-    file.report.reportBody.classList.toggle("image", kind == "image")
+    file.report.reportArea.classList.toggle("image", kind == "image")
   }
 }
 


### PR DESCRIPTION
This fixes two issues within the test reports.
1. The test report was resizable, because it was wrapped in a `div` that had the `file-diff html` classes. The div was redundant and is now removed.
2. The image controls were shown over the source when it was expanded. Now there is a div that wraps the test report files and image controls.