### PR TITLE
Added `fill` and `stroke` fields to `HideElem`

### DIFF
--- a/crates/typst-layout/src/modifiers.rs
+++ b/crates/typst-layout/src/modifiers.rs
@@ -1,6 +1,9 @@
+use std::sync::Arc;
+
 use typst_library::foundations::StyleChain;
 use typst_library::layout::{Abs, Fragment, Frame, FrameItem, HideElem, Point, Sides};
 use typst_library::model::{Destination, LinkElem, ParElem};
+use typst_library::visualize::{Paint, Stroke};
 
 /// Frame-level modifications resulting from styles that do not impose any
 /// layout structure.
@@ -16,6 +19,8 @@ use typst_library::model::{Destination, LinkElem, ParElem};
 ///
 /// Currently existing frame modifiers are:
 /// - `HideElem::hidden`
+/// - `HideElem::hidden_fill`
+/// - `HideElem::hidden_stroke`
 /// - `LinkElem::dests`
 #[derive(Debug, Clone)]
 pub struct FrameModifiers {
@@ -23,14 +28,34 @@ pub struct FrameModifiers {
     dest: Option<Destination>,
     /// Whether the contents of the frame should be hidden.
     hidden: bool,
+    /// Stroke and fill that will be applied to the space taken by the hidden content.
+    hidden_visuals: Option<Arc<FrameHiddenVisuals>>,
+}
+
+/// Visuals that will be applied to the space taken by hidden content.
+///
+/// This struct is separated from [`FrameModifiers`] in order to keep
+/// the size of most Frames smaller.
+#[derive(Debug, Clone)]
+pub struct FrameHiddenVisuals {
+    /// How to fill the space taken by hidden content.
+    fill: Option<Paint>,
+    /// How to stroke around the space taken by hidden content.
+    stroke: Option<Stroke<Abs>>,
 }
 
 impl FrameModifiers {
     /// Retrieve all modifications that should be applied per-frame.
     pub fn get_in(styles: StyleChain) -> Self {
+        let fill = styles.get_cloned(HideElem::hidden_fill);
+        let stroke = styles.get_cloned(HideElem::hidden_stroke);
+        let visuals = (fill.is_some() || stroke.is_some())
+            .then(|| Arc::new(FrameHiddenVisuals { fill, stroke }));
+
         Self {
             dest: styles.get_cloned(LinkElem::current),
             hidden: styles.get(HideElem::hidden),
+            hidden_visuals: visuals,
         }
     }
 }
@@ -106,7 +131,12 @@ fn modify_frame(
     }
 
     if modifiers.hidden {
-        frame.hide();
+        let (fill, stroke) = modifiers
+            .hidden_visuals
+            .as_ref()
+            .map(|v| (v.fill.clone(), v.stroke.clone()))
+            .unwrap_or_default();
+        frame.hide(fill, stroke);
     }
 }
 

--- a/crates/typst-layout/src/rules.rs
+++ b/crates/typst-layout/src/rules.rs
@@ -733,8 +733,17 @@ const REPEAT_RULE: ShowFn<RepeatElem> = |elem, _, _| {
     Ok(BlockElem::single_layouter(elem.clone(), crate::repeat::layout_repeat).pack())
 };
 
-const HIDE_RULE: ShowFn<HideElem> =
-    |elem, _, _| Ok(elem.body.clone().set(HideElem::hidden, true));
+const HIDE_RULE: ShowFn<HideElem> = |elem, _, styles| {
+    let fill = elem.fill.get_cloned(styles);
+    let stroke = elem.stroke.resolve(styles);
+
+    Ok(elem
+        .body
+        .clone()
+        .set(HideElem::hidden, true)
+        .set(HideElem::hidden_fill, fill)
+        .set(HideElem::hidden_stroke, stroke))
+};
 
 const LAYOUT_RULE: ShowFn<LayoutElem> = |elem, _, _| {
     Ok(BlockElem::multi_layouter(

--- a/crates/typst-library/src/layout/frame.rs
+++ b/crates/typst-library/src/layout/frame.rs
@@ -11,7 +11,9 @@ use crate::introspection::{Location, Tag};
 use crate::layout::{Abs, Axes, FixedAlignment, Point, Size, Transform};
 use crate::model::Destination;
 use crate::text::TextItem;
-use crate::visualize::{Color, Curve, FixedStroke, Geometry, Image, Paint, Shape};
+use crate::visualize::{
+    Color, Curve, FillRule, FixedStroke, Geometry, Image, Paint, Shape, Stroke,
+};
 
 /// A finished layout with items at fixed positions.
 #[derive(Default, Clone, Hash)]
@@ -322,15 +324,33 @@ impl Frame {
     }
 
     /// Hide all content in the frame, but keep metadata.
-    pub fn hide(&mut self) {
+    ///
+    /// Optionally applies `fill` and `stroke` to the space taken by the hidden content.
+    pub fn hide(&mut self, fill: Option<Paint>, stroke: Option<Stroke<Abs>>) {
         self.retain(|item| match item {
             FrameItem::Group(group) => {
-                group.frame.hide();
+                group.frame.hide(None, None);
                 !group.frame.is_empty()
             }
             FrameItem::Tag(_) => true,
             _ => false,
         });
+
+        // optionally add a single shape filling the entire frame with the given fill and stroke
+        if fill.is_some() || stroke.is_some() {
+            self.push(
+                Point::zero(),
+                FrameItem::Shape(
+                    Shape {
+                        geometry: Geometry::Rect(self.size),
+                        fill,
+                        fill_rule: FillRule::default(),
+                        stroke: stroke.map(|s| s.unwrap_or_default()),
+                    },
+                    Span::detached(),
+                ),
+            );
+        }
     }
 
     /// Add a background fill.

--- a/crates/typst-library/src/layout/hide.rs
+++ b/crates/typst-library/src/layout/hide.rs
@@ -1,4 +1,8 @@
-use crate::foundations::{Content, elem};
+use crate::{
+    foundations::{Content, elem},
+    layout::Abs,
+    visualize::{Paint, Stroke},
+};
 
 /// Hides content without affecting layout.
 ///
@@ -23,6 +27,11 @@ use crate::foundations::{Content, elem};
 /// recommend using this function to hide highly sensitive information.
 #[elem(since = "forever", Tagged)]
 pub struct HideElem {
+    /// The background fill that will applied to the space taken by the hidden content.
+    pub fill: Option<Paint>,
+    /// The stroke that will be applied to the space taken by the hidden content.
+    pub stroke: Option<Stroke>,
+
     /// The content to hide.
     #[required]
     pub body: Content,
@@ -31,4 +40,14 @@ pub struct HideElem {
     #[internal]
     #[ghost]
     pub hidden: bool,
+
+    /// This style is set on the content contained in the `hide` element.
+    #[internal]
+    #[ghost]
+    pub hidden_fill: Option<Paint>,
+
+    /// This style is set on the content contained in the `hide` element.
+    #[internal]
+    #[ghost]
+    pub hidden_stroke: Option<Stroke<Abs>>,
 }


### PR DESCRIPTION
# Functionality
Inspired by #4511, this PR adds the `fill` and `stroke` fields to the `#hide` element. These allow filling the space taken by the hidden content.

*Code*
```typst
#let redact(content) = {
  hide(fill: black, content)
}

#lorem(17)
#redact[#lorem(23)]
#lorem(20)

#redact[
  #figure(caption: [#lorem(7)])[
    #table(columns: (1fr, 1fr),
      [#lorem(5)], [#lorem(5)]
    )
  ]
]

#show regex(".+"): redact

#set hide(stroke: 2pt + red)

#figure(caption: [#lorem(7)])[
  #table(columns: (1fr, 1fr),
    [#lorem(5)], [#lorem(5)]
  )
]
```

*Rendered*

<img width="1450" height="684" alt="image" src="https://github.com/user-attachments/assets/8689b301-ada5-4d9a-baa8-6cb9bdb17519" />

# Implementation

The styling is propagated in the same way as `HideElem::hidden` using the two new ghost fields `HideElem::hidden_stroke` and `HideElem::hidden_fill`.

If a `hidden_fill` or `hidden_stroke` is set on a frame, after removing visible content, a single `Rect` with `stroke` and `fill` will be added to the frame.

# Use Case

The new functionality allows implementing quite a useful redaction function.
Currently, redaction can be achieved by randomizing letters and setting text `stroke` and `fill` to the same color.
This, however, has a few shortcoming:
- only text can be redacted
- even if randomized, the text can still be selected and copied in a pdf viewer, which seems like an ugly side-effect.

With the new `#hide` functionality, any content can be redacted and the content will actually disappear in the rendered document. For additional security, letters could still be randomized prior to hiding.