### PR TITLE
Show key type instead of value in error when calling to-dict

### DIFF
--- a/crates/typst-library/src/foundations/array.rs
+++ b/crates/typst-library/src/foundations/array.rs
@@ -1124,7 +1124,7 @@ impl Array {
                 })?;
                 if let [key, value] = pair.as_slice() {
                     let key = key.clone().cast::<Str>().map_err(|_| {
-                        eco_format!("expected key of type str, found {}", key.ty())
+                        eco_format!("expected key of type string, found {}", key.ty())
                     })?;
                     Ok((key, value.clone()))
                 } else {

--- a/crates/typst-library/src/foundations/array.rs
+++ b/crates/typst-library/src/foundations/array.rs
@@ -1124,7 +1124,7 @@ impl Array {
                 })?;
                 if let [key, value] = pair.as_slice() {
                     let key = key.clone().cast::<Str>().map_err(|_| {
-                        eco_format!("expected key of type str, found {}", value.ty())
+                        eco_format!("expected key of type str, found {}", key.ty())
                     })?;
                     Ok((key, value.clone()))
                 } else {

--- a/tests/suite/foundations/array.typ
+++ b/tests/suite/foundations/array.typ
@@ -482,11 +482,11 @@
 #(("key",1,2),).to-dict()
 
 --- array-to-dict-bad-key-type eval ---
-// Error: 2-21 expected key of type str, found integer
+// Error: 2-21 expected key of type string, found integer
 #((1, 2),).to-dict()
 
 --- array-to-dict-none-key-type eval ---
-// Error: 2-24 expected key of type str, found none
+// Error: 2-24 expected key of type string, found none
 #((none, 2),).to-dict()
 
 --- array-zip-positional-and-named-argument eval ---

--- a/tests/suite/foundations/array.typ
+++ b/tests/suite/foundations/array.typ
@@ -485,6 +485,10 @@
 // Error: 2-21 expected key of type str, found integer
 #((1, 2),).to-dict()
 
+--- array-to-dict-none-key-type eval ---
+// Error: 2-24 expected key of type str, found none
+#((none, 2),).to-dict()
+
 --- array-zip-positional-and-named-argument eval ---
 // Error: 13-30 unexpected argument: val
 #().zip((), val: "applicable")


### PR DESCRIPTION
Before this change:

```typ
#((none, "a"),).to-dict() // Expected key of type str, found string
#((none, 5),).to-dict()   // Expected key of type str, found integer

// Expected string, found none
#(none: "a")
```