### PR TITLE
Add `-i` shorthand for `--input`

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -102,6 +102,7 @@ pub enum Command {
 
     /// Self update the Typst CLI.
     #[cfg_attr(not(feature = "self-update"), clap(hide = true))]
+    #[command(visible_alias = "up")]
     Update(UpdateCommand),
 
     /// Generates shell completion scripts.
@@ -337,7 +338,7 @@ pub struct CompileArgs {
     /// Page numbers are one-indexed and correspond to physical page numbers in
     /// the document (therefore not being affected by the document's page
     /// counter).
-    #[arg(long = "pages", value_delimiter = ',')]
+    #[arg(short = 'p', long = "pages", value_delimiter = ',')]
     pub pages: Option<Vec<Pages>>,
 
     /// One (or multiple comma-separated) PDF standards that Typst will enforce
@@ -381,7 +382,7 @@ pub struct CompileArgs {
 
     /// Opens the output file with the default viewer or a specific program
     /// after compilation. Ignored if output is stdout.
-    #[arg(long = "open", value_name = "VIEWER")]
+    #[arg(short = 'o', long = "open", value_name = "VIEWER")]
     pub open: Option<Option<String>>,
 
     /// Produces performance timings of the compilation process. (experimental)
@@ -403,6 +404,7 @@ pub struct WorldArgs {
 
     /// Add a string key-value pair visible through `sys.inputs`.
     #[clap(
+        short = 'i',
         long = "input",
         value_name = "key=value",
         action = ArgAction::Append,

--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -102,7 +102,6 @@ pub enum Command {
 
     /// Self update the Typst CLI.
     #[cfg_attr(not(feature = "self-update"), clap(hide = true))]
-    #[command(visible_alias = "up")]
     Update(UpdateCommand),
 
     /// Generates shell completion scripts.
@@ -338,7 +337,7 @@ pub struct CompileArgs {
     /// Page numbers are one-indexed and correspond to physical page numbers in
     /// the document (therefore not being affected by the document's page
     /// counter).
-    #[arg(short = 'p', long = "pages", value_delimiter = ',')]
+    #[arg(long = "pages", value_delimiter = ',')]
     pub pages: Option<Vec<Pages>>,
 
     /// One (or multiple comma-separated) PDF standards that Typst will enforce
@@ -382,7 +381,7 @@ pub struct CompileArgs {
 
     /// Opens the output file with the default viewer or a specific program
     /// after compilation. Ignored if output is stdout.
-    #[arg(short = 'o', long = "open", value_name = "VIEWER")]
+    #[arg(long = "open", value_name = "VIEWER")]
     pub open: Option<Option<String>>,
 
     /// Produces performance timings of the compilation process. (experimental)


### PR DESCRIPTION
Add `-p` as a short option for `--pages`; this option is common enough
for a short option to make sense.

Add `-o` as a short option for `--open`; this option is common enough
for a short option to make sense.

Add `-i` as a short option for `--input`; this option is something typst
wants to encourage people to use more, and a short option will help with
that.

Add `up` as a short alias for `update`; this seems common among tools that have an `update` command.