### PR TITLE
Implement ability to embed metadata in SVG

### DIFF
--- a/crates/typst-bundle/src/export.rs
+++ b/crates/typst-bundle/src/export.rs
@@ -8,7 +8,7 @@ use typst_layout::PagedDocument;
 use typst_library::diag::{At, ParallelCollectCombinedResult, SourceResult};
 use typst_library::foundations::Bytes;
 use typst_library::introspection::Location;
-use typst_library::model::{LateLinkResolver, PagedFormat};
+use typst_library::model::{Document, LateLinkResolver, PagedFormat};
 use typst_pdf::PdfOptions;
 use typst_render::RenderOptions;
 use typst_svg::SvgOptions;
@@ -118,6 +118,7 @@ fn export_svg(
         .collect::<Vec<_>>();
     Ok(Bytes::from_string(typst_svg::svg_in_bundle(
         &doc.pages()[0],
+        doc.info(),
         options,
         &anchors,
         link_resolver,

--- a/crates/typst-cli/src/compile.rs
+++ b/crates/typst-cli/src/compile.rs
@@ -11,6 +11,7 @@ use typst::diag::{
 };
 use typst::foundations::{Datetime, Smart};
 use typst::layout::PageRanges;
+use typst::model::Document;
 use typst::syntax::Span;
 use typst_bundle::{Bundle, BundleOptions, VirtualFs};
 use typst_html::{HtmlDocument, HtmlOptions};
@@ -527,7 +528,7 @@ fn export_image(
                 Output::Stdout => Output::Stdout,
             };
 
-            export_image_page(config, page, &output, fmt)?;
+            export_image_page(config, page, document.info(), &output, fmt)?;
             Ok(output)
         })
         .collect::<StrResult<Vec<Output>>>()
@@ -566,6 +567,7 @@ mod output_template {
 fn export_image_page(
     config: &CompileConfig,
     page: &Page,
+    info: &typst::model::DocumentInfo,
     output: &Output,
     fmt: ImageExportFormat,
 ) -> StrResult<()> {
@@ -582,7 +584,7 @@ fn export_image_page(
         }
         ImageExportFormat::Svg => {
             let options = svg_options(config);
-            let svg = typst_svg::svg(page, &options);
+            let svg = typst_svg::svg(page, info, &options);
             output
                 .write(svg.as_bytes())
                 .map_err(|err| eco_format!("failed to write SVG file ({err})"))?;

--- a/crates/typst-svg/src/lib.rs
+++ b/crates/typst-svg/src/lib.rs
@@ -11,15 +11,17 @@ use comemo::Tracked;
 pub use image::{WebImage, convert_image_scaling};
 use indexmap::IndexMap;
 use rustc_hash::FxBuildHasher;
-use typst_library::model::{Destination, LateLinkResolver};
+use typst_library::model::{Destination, Document, DocumentInfo, LateLinkResolver};
 
 use std::hash::Hash;
 
 use ecow::EcoString;
 use typst_layout::{Page, PagedDocument};
+use typst_library::foundations::Smart;
 use typst_library::layout::{
     Abs, Frame, FrameItem, FrameKind, GroupItem, Point, Ratio, Sides, Size, Transform,
 };
+use typst_library::text::Locale;
 use typst_library::visualize::{Geometry, Gradient, Tiling};
 use xmlwriter::XmlWriter;
 
@@ -29,12 +31,13 @@ use crate::write::{SvgDisplay, SvgElem, SvgTransform, SvgUrl, SvgWrite};
 
 /// Export a frame into an SVG file.
 #[typst_macros::time(name = "svg")]
-pub fn svg(page: &Page, opts: &SvgOptions) -> String {
+pub fn svg(page: &Page, info: &DocumentInfo, opts: &SvgOptions) -> String {
     let (size, ts) = page_bleed(page, opts);
 
     let mut renderer = SVGRenderer::new();
     let mut xml = XmlWriter::new(xml_options(opts.pretty));
     let mut svg = svg_header(&mut xml, size);
+    write_metadata(&mut svg, info);
 
     let state = State::new(size);
     renderer.render_page(&mut svg, &state, ts, page);
@@ -51,6 +54,7 @@ pub fn svg(page: &Page, opts: &SvgOptions) -> String {
 #[typst_macros::time(name = "svg in bundle")]
 pub fn svg_in_bundle(
     page: &Page,
+    info: &DocumentInfo,
     opts: &SvgOptions,
     anchors: &[(Point, EcoString)],
     link_resolver: Tracked<LateLinkResolver>,
@@ -60,6 +64,7 @@ pub fn svg_in_bundle(
     let mut renderer = SVGRenderer::with_options(Some(link_resolver));
     let mut xml = XmlWriter::new(xml_options(opts.pretty));
     let mut svg = svg_header(&mut xml, size);
+    write_metadata(&mut svg, info);
 
     let state = State::new(size);
     renderer.render_page(&mut svg, &state, ts, page);
@@ -134,6 +139,7 @@ pub fn svg_merged(document: &PagedDocument, opts: &SvgOptions, gap: Abs) -> Stri
     let mut renderer = SVGRenderer::new();
     let mut xml = XmlWriter::new(xml_options(opts.pretty));
     let mut svg = svg_header(&mut xml, size);
+    write_metadata(&mut svg, document.info());
 
     let mut y = Abs::zero();
     for page in document.pages() {
@@ -431,6 +437,71 @@ impl<'a> SVGRenderer<'a> {
             });
         }
     }
+}
+
+/// Write the document's metadata.
+///
+/// - Human-readable formats are: `<title>` and `<desc>`
+/// - Machine-readable formats are within the `<metadata>` element immediately after the previous ones, following the Dublin Core schema.
+///
+/// See:
+/// - [SVG 1.1 (2nd ed.), 21. Metadata](https://www.w3.org/TR/SVG11/metadata.html)
+/// - [DCMI Metadata Terms](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/)
+/// - [Orbis Cascade Alliance Dublin Core Best Practice Guidelines, 2018](https://bpb-us-e1.wpmucdn.com/sites.uw.edu/dist/8/33691/files/2025/08/Dublin-Core-Best-Practice-Guidelines-v.-2.3-February-2018-1.pdf>)
+fn write_metadata(svg: &mut SvgElem, info: &DocumentInfo) {
+    if let Some(title) = &info.title {
+        svg.elem("title").text(title);
+    }
+
+    if let Some(description) = &info.description {
+        svg.elem("desc").text(description);
+    }
+
+    let date = match &info.date {
+        Smart::Custom(Some(date)) => date.display(Smart::Auto).ok(),
+        _ => None,
+    };
+    let language = info.locale.custom().map(Locale::rfc_3066);
+
+    if info.title.is_none()
+        && info.description.is_none()
+        && info.author.is_empty()
+        && info.keywords.is_empty()
+        && date.is_none()
+        && language.is_none()
+    {
+        return;
+    }
+
+    svg.elem("metadata").with(|metadata| {
+        metadata
+            .elem("rdf:RDF")
+            .attr("xmlns:rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#")
+            .attr("xmlns:dc", "http://purl.org/dc/elements/1.1/")
+            .with(|rdf| {
+                rdf.elem("rdf:Description").with(|description| {
+                    if let Some(title) = &info.title {
+                        description.elem("dc:title").text(title);
+                    }
+                    if let Some(desc) = &info.description {
+                        description.elem("dc:description").text(desc);
+                    }
+                    for author in &info.author {
+                        description.elem("dc:creator").text(author);
+                    }
+                    for keyword in &info.keywords {
+                        description.elem("dc:subject").text(keyword);
+                    }
+                    if let Some(date) = &date {
+                        description.elem("dc:date").text(date);
+                    }
+                    description.elem("dc:format").text("image/svg+xml");
+                    if let Some(language) = &language {
+                        description.elem("dc:language").text(language);
+                    }
+                });
+            });
+    });
 }
 
 /// Write the default SVG header, including a `typst-doc` class, the

--- a/crates/typst-svg/src/write.rs
+++ b/crates/typst-svg/src/write.rs
@@ -45,6 +45,21 @@ impl<'a> SvgElem<'a> {
         f(self);
         self
     }
+
+    /// Write a text node, escaping XML metacharacters via [`escape_str`].
+    ///
+    /// `xmlwriter`'s text writer only escapes `<`, so we apply the same escaping used for attribute values before handing the string off.
+    pub fn text(&mut self, value: impl AsRef<str>) -> &mut Self {
+        let value = value.as_ref();
+        if value.bytes().any(|b| EscapedChar::from_byte(b).is_some()) {
+            let mut escaped = EcoString::new();
+            escape_str(value, |s| escaped.push_str(s));
+            self.xml.write_text(&escaped);
+        } else {
+            self.xml.write_text(value);
+        }
+        self
+    }
 }
 
 impl Drop for SvgElem<'_> {
@@ -164,9 +179,10 @@ impl SvgWrite for SvgFormatter<'_, EcoString> {
 }
 
 /// Append `value` to a buffer, escaping the XML metacharacters that
-/// `xmlwriter`'s raw attribute writer leaves untouched (it only escapes the
-/// quotation mark). Otherwise a value such as a link URL containing `&` or `<`
-/// yields malformed SVG. Runs of non-escaped characters are appended in one go.
+/// `xmlwriter` leaves untouched, attributes only escape the quotation mark,
+/// and text nodes only escape `<`. Otherwise a value containing `&`, `<`, or
+/// `>` yields malformed or brittle SVG. Runs of non-escaped characters are
+/// appended in one go.
 fn escape_str(mut value: &str, mut append: impl FnMut(&str)) {
     while let Some((i, c)) = value
         .bytes()
@@ -184,13 +200,15 @@ fn escape_str(mut value: &str, mut append: impl FnMut(&str)) {
     }
 }
 
-/// A character that should be escaped in XML attribute values.
+/// A character that should be escaped in XML attribute and text values.
 #[derive(Copy, Clone)]
 enum EscapedChar {
     /// `&`
     Amp,
     /// `<`
     Lt,
+    /// `>`
+    Gt,
 }
 
 impl EscapedChar {
@@ -198,6 +216,7 @@ impl EscapedChar {
         match byte {
             b'&' => Some(Self::Amp),
             b'<' => Some(Self::Lt),
+            b'>' => Some(Self::Gt),
             _ => None,
         }
     }
@@ -206,6 +225,7 @@ impl EscapedChar {
         match self {
             Self::Amp => "&amp;",
             Self::Lt => "&lt;",
+            Self::Gt => "&gt;",
         }
     }
 }

--- a/tests/fuzz/src/bin/paged.rs
+++ b/tests/fuzz/src/bin/paged.rs
@@ -1,6 +1,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
+use typst::model::Document;
 use typst_fuzz::FuzzWorld;
 use typst_layout::PagedDocument;
 use typst_pdf::PdfOptions;
@@ -12,7 +13,11 @@ fuzz_target!(|text: &str| {
     if let Ok(document) = typst::compile::<PagedDocument>(&world).output {
         if let Some(page) = document.pages().first() {
             std::hint::black_box(typst_render::render(page, &RenderOptions::default()));
-            std::hint::black_box(typst_svg::svg(page, &SvgOptions::default()));
+            std::hint::black_box(typst_svg::svg(
+                page,
+                document.info(),
+                &SvgOptions::default(),
+            ));
         }
         _ = std::hint::black_box(typst_pdf::pdf(&document, &PdfOptions::default()));
     }


### PR DESCRIPTION
Partially fixes #8678. I'd also like to try the PNG one.

Consequentially, SVG-based tests are now different due to the inclusion of metadata. So, I'll wait for a decision on what to do with those.

- Normal-stage results: 1797 passed, 1948 failed, 0 skipped.
- SVG-staged results: 199 passed, 1948 failed, 1598 skipped.

I didn't really know where to place the "Typst" value as the SVG creator as SVG doesn't really have one, the Dublin Core schema has publisher and collaborators which could be used but as mentioned in the _Dublin Core Best Practice Guidelines_ I'm not sure if that's appropriate.