### PR TITLE
Document associated constants

### DIFF
--- a/crates/typst-library/src/foundations/calc.rs
+++ b/crates/typst-library/src/foundations/calc.rs
@@ -8,7 +8,10 @@ use typst_syntax::{Span, Spanned};
 use typst_utils::{Scalar, round_int_with_precision, round_with_precision};
 
 use crate::diag::{At, HintedString, SourceResult, StrResult, bail};
-use crate::foundations::{Decimal, IntoValue, Module, Scope, Value, cast, func, ops};
+use crate::foundations::{
+    BindingDocumentation, Decimal, IntoValue, Module, Scope, Since, Value, cast, func,
+    ops,
+};
 use crate::layout::{Angle, Fr, Length, Ratio};
 
 /// A module with calculation definitions.
@@ -55,10 +58,76 @@ pub fn module() -> Module {
     scope.define_func::<rem_euclid>();
     scope.define_func::<quo>();
     scope.define_func::<norm>();
-    scope.define("inf", f64::INFINITY);
-    scope.define("pi", std::f64::consts::PI);
-    scope.define("tau", std::f64::consts::TAU);
-    scope.define("e", std::f64::consts::E);
+    scope
+        .define("inf", f64::INFINITY)
+        .with_documentation(BindingDocumentation {
+            name: "inf",
+            title: "Infinity",
+            docs: "
+            Infinity ($+oo$) as a value.
+
+            This is the same value as @float.inf. See the corresponding
+            documentation for more details.
+            ",
+            since: Some(Since::Forever),
+            keywords: &[],
+            def_site: None,
+        });
+    scope
+        .define("pi", std::f64::consts::PI)
+        .with_documentation(BindingDocumentation {
+            name: "pi",
+            title: "Pi",
+            docs: "
+            Archimedes' constant ($pi$).
+
+            This is the ratio of a circle's circumference to its diameter.
+
+            ```example
+            #calc.pi
+            ```
+            ",
+            since: Some(Since::Forever),
+            keywords: &["Archimedes"],
+            def_site: None,
+        });
+    scope
+        .define("tau", std::f64::consts::TAU)
+        .with_documentation(BindingDocumentation {
+            name: "tau",
+            title: "Tau",
+            docs: r"
+            The circumference of a unit circle ($tau$).
+
+            The constant $tau$ is defined by the relation $tau = 2 pi$.
+
+            ```example
+            #calc.tau \
+            #(2 * calc.pi)
+            ```
+            ",
+            since: Some(Since::Version([0, 8, 0])),
+            keywords: &[],
+            def_site: None,
+        });
+    scope
+        .define("e", std::f64::consts::E)
+        .with_documentation(BindingDocumentation {
+            name: "e",
+            title: "Euler's number",
+            docs: "
+            Euler's number ($e$).
+
+            This is the base of the natural logarithm and the exponential function.
+
+            ```example
+            #calc.e
+            ```
+            ",
+            since: Some(Since::Forever),
+            keywords: &[],
+            def_site: None,
+        });
     Module::new("calc", scope)
 }
 
@@ -833,7 +902,7 @@ pub fn fract(
 ///
 /// In addition, this function can error if there is an attempt to round beyond
 /// the maximum or minimum integer or `decimal`. If the number is a `float`,
-/// such an attempt will cause `{float.inf}` or `{-float.inf}` to be returned
+/// such an attempt will cause @calc.inf or `{-calc.inf}` to be returned
 /// for maximum and minimum respectively.
 ///
 /// ```example

--- a/crates/typst-library/src/foundations/content/element.rs
+++ b/crates/typst-library/src/foundations/content/element.rs
@@ -44,7 +44,7 @@ impl Element {
 
     /// The version of Typst the element was introduced in.
     pub fn since(&self) -> Option<Since> {
-        self.vtable().since.clone()
+        self.vtable().since
     }
 
     /// Documentation for the element (as Markdown).

--- a/crates/typst-library/src/foundations/float.rs
+++ b/crates/typst-library/src/foundations/float.rs
@@ -32,10 +32,12 @@ type f64;
 #[scope(ext)]
 impl f64 {
     /// Positive infinity.
+    #[constant(title = "Infinity", since = "0.12.0")]
     const INF: f64 = f64::INFINITY;
 
     /// A NaN value, as defined by the
     /// [IEEE 754 standard](https://en.wikipedia.org/wiki/IEEE_754).
+    #[constant(title = "NaN", since = "0.12.0")]
     const NAN: f64 = f64::NAN;
 
     /// Converts a value to a float.

--- a/crates/typst-library/src/foundations/float.rs
+++ b/crates/typst-library/src/foundations/float.rs
@@ -17,9 +17,6 @@ use crate::layout::Ratio;
 ///
 /// You can convert a value to a float with this type's constructor.
 ///
-/// NaN and positive infinity are available as `{float.nan}` and `{float.inf}`
-/// respectively.
-///
 /// = Example <example>
 /// ```example
 /// #3.14 \
@@ -31,12 +28,22 @@ type f64;
 
 #[scope(ext)]
 impl f64 {
-    /// Positive infinity.
+    /// Infinity ($+oo$) as a value.
+    ///
+    /// This value is greater than every real number.
+    ///
+    /// Negative infinity ($-oo$) can be obtained by negating this:
+    /// `{-float.inf}`.
+    ///
+    /// ```example
+    /// #(9999999 < float.inf) \
+    /// #(-float.inf < -9999999)
+    /// ```
     #[constant(title = "Infinity", since = "0.12.0")]
     const INF: f64 = f64::INFINITY;
 
     /// A NaN value, as defined by the
-    /// [IEEE 754 standard](https://en.wikipedia.org/wiki/IEEE_754).
+    /// #link("https://en.wikipedia.org/wiki/IEEE_754")[IEEE 754 standard].
     #[constant(title = "NaN", since = "0.12.0")]
     const NAN: f64 = f64::NAN;
 
@@ -69,14 +76,14 @@ impl f64 {
     /// Checks if a float is not a number.
     ///
     /// In IEEE 754, more than one bit pattern represents a NaN. This function
-    /// returns `true` if the float is any of those bit patterns.
+    /// returns `{true}` if the float is any of those bit patterns.
     ///
     /// ```example
     /// #float.is-nan(0) \
     /// #float.is-nan(1) \
     /// #float.is-nan(float.nan)
     /// ```
-    #[func(since = "0.11.0")]
+    #[func(title = "Is NaN", since = "0.11.0")]
     pub fn is_nan(self) -> bool {
         f64::is_nan(self)
     }
@@ -100,7 +107,7 @@ impl f64 {
     ///
     /// - If the number is positive (including `{+0.0}`), returns `{1.0}`.
     /// - If the number is negative (including `{-0.0}`), returns `{-1.0}`.
-    /// - If the number is NaN, returns `{float.nan}`.
+    /// - If the number is NaN, returns @float.nan.
     ///
     /// ```example
     /// #(5.0).signum() \

--- a/crates/typst-library/src/foundations/func.rs
+++ b/crates/typst-library/src/foundations/func.rs
@@ -189,7 +189,7 @@ impl Func {
     /// The version of Typst the function was introduced in.
     pub fn since(&self) -> Option<Since> {
         match &self.inner {
-            FuncInner::Native(native) => native.since.clone(),
+            FuncInner::Native(native) => native.since,
             FuncInner::Element(elem) => elem.since(),
             FuncInner::Closure(_) => None,
             FuncInner::Plugin(_) => None,

--- a/crates/typst-library/src/foundations/int.rs
+++ b/crates/typst-library/src/foundations/int.rs
@@ -72,10 +72,12 @@ type i64;
 impl i64 {
     /// The maximum value that can be represented by a Typst integer: $2^63-1$,
     /// `{9223372036854775807}`, or `{0x7FFFFFFFFFFFFFFF}`.
+    #[constant(title = "Maximum integer", since = "forever")]
     const MAX: i64 = i64::MAX;
 
     /// The minimum value that can be represented by a Typst integer: $-(2^63)$,
     /// `{-9223372036854775808}`, or `{0x8000000000000000}`.
+    #[constant(title = "Minimum integer", since = "forever")]
     const MIN: i64 = i64::MIN;
 
     /// Converts a value to an integer. Raises an error if there is an attempt

--- a/crates/typst-library/src/foundations/int.rs
+++ b/crates/typst-library/src/foundations/int.rs
@@ -17,9 +17,7 @@ use crate::foundations::{
 ///
 /// Typst stores signed integers with the #wiki("Two%27s_complement")[two's
 /// complement] representation in 64 bits. This allows storing numbers up to
-/// $2^63-1$ or `{9223372036854775807}`, and down to $-2^63$ or
-/// `{-9223372036854775808}`. These values are accessible as `{int.max}` and
-/// `{int.min}`.
+/// $2^63-1$ (@int.max), and down to $-2^63$ (@int.min).
 ///
 /// Integers can also be specified as hexadecimal, octal, or binary by starting
 /// with the prefixes: `0x`, `0o`, or `0b`.
@@ -51,17 +49,16 @@ use crate::foundations::{
 ///
 /// Hexadecimal numbers use the letters a--f or A--F for the values 10--15.
 ///
-/// Typst will error if an integer is written that is larger than `int.max` or
-/// smaller than `int.min`. If this happens, you may want to use a
-/// @float[floating point number] instead by appending a period to the end of
-/// the number.
+/// Typst will error if an integer is written that is larger than @int.max. If
+/// this happens, you may want to use a @float[floating point number] instead by
+/// appending a period to the end of the number.
 ///
 /// Typst differs from some other programming languages by not treating negative
 /// integers as individual tokens in its syntax. Instead, input like `{-6}` is
 /// treated as the negation operator applied to the positive integer `6`. This
 /// may cause an issue when trying to write the minimum negative integer
 /// `{-9223372036854775808}`, as `{9223372036854775808}` is larger than
-/// `{int.max}`. To write the minimum negative integer, use `{int.min}` instead.
+/// @int.max. To write the minimum negative integer, use @int.min instead.
 ///
 /// This also means that if you want to embed a negative integer in markup, you
 /// will need to use parentheses to group the negation operator: `[#(-6)]`.
@@ -70,13 +67,25 @@ type i64;
 
 #[scope(ext)]
 impl i64 {
-    /// The maximum value that can be represented by a Typst integer: $2^63-1$,
-    /// `{9223372036854775807}`, or `{0x7FFFFFFFFFFFFFFF}`.
+    /// The maximum value that can be represented as a Typst integer: $2^63-1$.
+    ///
+    /// ```example
+    /// #int.max \
+    /// // In hexadecimal:
+    /// #0x7FFFFFFFFFFFFFFF
+    /// ```
     #[constant(title = "Maximum integer", since = "forever")]
     const MAX: i64 = i64::MAX;
 
-    /// The minimum value that can be represented by a Typst integer: $-(2^63)$,
-    /// `{-9223372036854775808}`, or `{0x8000000000000000}`.
+    /// The minimum value that can be represented as a Typst integer: $-2^63$.
+    ///
+    /// Trying to write this integer explicitly as `{-9223372036854775808}`
+    /// instead of using `{int.min}` will result in an error. For more
+    /// information, read the @int:syntax section.
+    ///
+    /// ```example
+    /// #int.min
+    /// ```
     #[constant(title = "Minimum integer", since = "forever")]
     const MIN: i64 = i64::MIN;
 

--- a/crates/typst-library/src/foundations/scope.rs
+++ b/crates/typst-library/src/foundations/scope.rs
@@ -6,11 +6,13 @@ use indexmap::IndexMap;
 use indexmap::map::Entry;
 use rustc_hash::FxBuildHasher;
 use typst_syntax::Span;
+use typst_utils::DefSite;
 
 use crate::diag::{HintedStrResult, HintedString, SourceDiagnostic, WarningSink, error};
 use crate::engine::Engine;
 use crate::foundations::{
-    Func, IntoValue, NativeElement, NativeFunc, NativeFuncData, NativeType, Value,
+    Element, Func, IntoValue, NativeElement, NativeFunc, NativeFuncData, NativeType,
+    NativeTypeData, Since, Value,
 };
 use crate::{Category, Feature, Features, Library, World};
 
@@ -167,10 +169,12 @@ impl Scope {
     }
 
     /// Define a native function through a Rust type that shadows the function.
+    ///
+    /// Copies documentation information from the native function data to the
+    /// binding.
     #[track_caller]
     pub fn define_func<T: NativeFunc>(&mut self) -> &mut Binding {
-        let data = T::data();
-        self.define(data.name, Func::from(data))
+        self.define_func_with_data(T::data())
     }
 
     /// Define a native function with raw function data.
@@ -180,20 +184,21 @@ impl Scope {
         data: &'static NativeFuncData,
     ) -> &mut Binding {
         self.define(data.name, Func::from(data))
+            .with_documentation(data.into())
     }
 
     /// Define a native type.
     #[track_caller]
     pub fn define_type<T: NativeType>(&mut self) -> &mut Binding {
         let ty = T::ty();
-        self.define(ty.short_name(), ty)
+        self.define(ty.short_name(), ty).with_documentation(T::data().into())
     }
 
     /// Define a native element.
     #[track_caller]
     pub fn define_elem<T: NativeElement>(&mut self) -> &mut Binding {
         let elem = T::ELEM;
-        self.define(elem.name(), elem)
+        self.define(elem.name(), elem).with_documentation(elem.into())
     }
 
     /// Define a built-in with compile-time known name and returns a mutable
@@ -347,6 +352,15 @@ impl Binding {
         self
     }
 
+    /// Sets documentation for this binding.
+    pub fn with_documentation(
+        &mut self,
+        documentation: BindingDocumentation,
+    ) -> &mut Self {
+        self.init_info().documentation = Some(documentation);
+        self
+    }
+
     fn init_info(&mut self) -> &mut BindingInfo {
         self.info.get_or_insert_default()
     }
@@ -438,6 +452,44 @@ impl Binding {
     pub fn deprecation(&self) -> Option<Deprecation> {
         self.info.as_ref()?.deprecation
     }
+
+    /// Whether the binding should be listed in the documentation.
+    pub fn is_documented(&self) -> bool {
+        self.info.as_ref().is_some_and(|info| info.documentation.is_some())
+    }
+
+    /// The name for the binding.
+    pub fn name(&self) -> Option<&'static str> {
+        Some(self.info.as_ref()?.documentation?.name)
+    }
+
+    /// The title for the binding.
+    pub fn title(&self) -> Option<&'static str> {
+        Some(self.info.as_ref()?.documentation?.title)
+    }
+
+    /// The documentation for the binding, if any.
+    pub fn docs(&self) -> Option<&'static str> {
+        Some(self.info.as_ref()?.documentation?.docs)
+    }
+
+    /// The version of Typst the binding was introduced in, if any.
+    pub fn since(&self) -> Option<Since> {
+        self.info.as_ref()?.documentation?.since
+    }
+
+    /// The keywords associated with this binding.
+    pub fn keywords(&self) -> &'static [&'static str] {
+        self.info
+            .as_ref()
+            .and_then(|info| Some(info.documentation?.keywords))
+            .unwrap_or_default()
+    }
+
+    /// Where this binding is defined in the source code.
+    pub fn def_site(&self) -> Option<DefSite> {
+        self.info.as_ref()?.documentation?.def_site
+    }
 }
 
 /// Infrequently accessed information related to a binding.
@@ -449,6 +501,8 @@ struct BindingInfo {
     feature: Option<Feature>,
     /// The deprecation information if this item is deprecated.
     deprecation: Option<Deprecation>,
+    /// Documentation for the binding.
+    documentation: Option<BindingDocumentation>,
 }
 
 impl BindingInfo {
@@ -456,6 +510,62 @@ impl BindingInfo {
     /// it when it's accessed.
     fn has_checked_access(self) -> bool {
         self.feature.is_some() || self.deprecation.is_some()
+    }
+}
+
+/// Documentation information for a binding.
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Hash)]
+pub struct BindingDocumentation {
+    /// The name for the binding.
+    pub name: &'static str,
+    /// The title for the binding.
+    pub title: &'static str,
+    /// The documentation for the binding as a Typst markup.
+    pub docs: &'static str,
+    /// The version of Typst the binding was introduced in.
+    pub since: Option<Since>,
+    /// The keywords associated with this binding.
+    pub keywords: &'static [&'static str],
+    /// Where the binding is defined in the source code.
+    pub def_site: Option<DefSite>,
+}
+
+impl From<&'static NativeFuncData> for BindingDocumentation {
+    fn from(data: &'static NativeFuncData) -> Self {
+        Self {
+            name: data.name,
+            title: data.title,
+            docs: data.docs,
+            since: data.since,
+            keywords: data.keywords,
+            def_site: data.def_site,
+        }
+    }
+}
+
+impl From<&'static NativeTypeData> for BindingDocumentation {
+    fn from(data: &'static NativeTypeData) -> Self {
+        Self {
+            name: data.name,
+            title: data.title,
+            docs: data.docs,
+            since: data.since,
+            keywords: data.keywords,
+            def_site: Some(data.def_site),
+        }
+    }
+}
+
+impl From<Element> for BindingDocumentation {
+    fn from(elem: Element) -> Self {
+        Self {
+            name: elem.name(),
+            title: elem.title(),
+            docs: elem.docs(),
+            since: elem.since(),
+            keywords: elem.keywords(),
+            def_site: Some(elem.def_site()),
+        }
     }
 }
 

--- a/crates/typst-library/src/foundations/sys.rs
+++ b/crates/typst-library/src/foundations/sys.rs
@@ -1,6 +1,6 @@
 //! System-related things.
 
-use crate::foundations::{Dict, Module, Scope, Version};
+use crate::foundations::{BindingDocumentation, Dict, Module, Scope, Since, Version};
 
 /// A module with system-related things.
 pub fn module(inputs: Dict) -> Module {
@@ -12,7 +12,40 @@ pub fn module(inputs: Dict) -> Module {
     ]);
 
     let mut scope = Scope::deduplicating();
-    scope.define("version", version);
-    scope.define("inputs", inputs);
+    scope
+        .define("version", version)
+        .with_documentation(BindingDocumentation {
+            name: "version",
+            title: "Compiler Version",
+            docs: "
+            The currently active Typst compiler version.
+
+            ```example
+            #sys.version
+            ```
+            ",
+            since: Some(Since::Version([0, 9, 0])),
+            keywords: &[],
+            def_site: None,
+        });
+    scope
+        .define("inputs", inputs)
+        .with_documentation(BindingDocumentation {
+            name: "inputs",
+            title: "CLI inputs",
+            docs: r#"
+            Makes external inputs available to the project.
+
+            An input specified in the command line as `--input key=value` becomes
+            available under `{sys.inputs.key}` as `{"value"}`. To include spaces in
+            the value, it may be enclosed with single or double quotes.
+
+            The value is always of type @str[string]. More complex data may be
+            parsed manually using functions like @json.
+            "#,
+            since: Some(Since::Version([0, 11, 0])),
+            keywords: &[],
+            def_site: None,
+        });
     Module::new("sys", scope)
 }

--- a/crates/typst-library/src/foundations/ty.rs
+++ b/crates/typst-library/src/foundations/ty.rs
@@ -88,7 +88,7 @@ impl Type {
 
     /// The version of Typst this type was introduced in.
     pub fn since(&self) -> Option<Since> {
-        self.0.since.clone()
+        self.0.since
     }
 
     /// Documentation for the type (as Markdown).

--- a/crates/typst-library/src/foundations/version.rs
+++ b/crates/typst-library/src/foundations/version.rs
@@ -216,7 +216,7 @@ cast! {
 }
 
 /// When a feature was introduced.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum Since {
     /// The feature was introduced before Typst 0.1.0.
     Forever,

--- a/crates/typst-library/src/foundations/version.rs
+++ b/crates/typst-library/src/foundations/version.rs
@@ -18,7 +18,7 @@ use crate::foundations::{Repr, cast, func, repr, scope, ty};
 /// special case, the empty version (that has no components at all) is the same
 /// as `0`, `0.0`, `0.0.0`, and so on.
 ///
-/// The current version of the Typst compiler is available as `sys.version`.
+/// The current version of the Typst compiler is available as @sys.version.
 ///
 /// You can convert a version to an array of explicitly given components using
 /// the @array constructor.
@@ -75,8 +75,8 @@ impl Version {
     ///   ```
     /// )
     ///
-    /// As a practical use case, this allows comparing the current version
-    /// (@version[`{sys.version}`]) to a specific one.
+    /// As a practical use case, this allows comparing the current compiler
+    /// version (available as @sys.version) to a specific one.
     ///
     /// #example(
     ///   title: "Comparing with the current version",

--- a/crates/typst-library/src/layout/align.rs
+++ b/crates/typst-library/src/layout/align.rs
@@ -175,13 +175,21 @@ impl Alignment {
 
 #[scope]
 impl Alignment {
+    #[constant(since = "forever")]
     pub const START: Self = Alignment::H(HAlignment::Start);
-    pub const LEFT: Self = Alignment::H(HAlignment::Left);
-    pub const CENTER: Self = Alignment::H(HAlignment::Center);
-    pub const RIGHT: Self = Alignment::H(HAlignment::Right);
+    #[constant(since = "forever")]
     pub const END: Self = Alignment::H(HAlignment::End);
+    #[constant(since = "forever")]
+    pub const LEFT: Self = Alignment::H(HAlignment::Left);
+    #[constant(since = "forever")]
+    pub const CENTER: Self = Alignment::H(HAlignment::Center);
+    #[constant(since = "forever")]
+    pub const RIGHT: Self = Alignment::H(HAlignment::Right);
+    #[constant(since = "forever")]
     pub const TOP: Self = Alignment::V(VAlignment::Top);
+    #[constant(since = "forever")]
     pub const HORIZON: Self = Alignment::V(VAlignment::Horizon);
+    #[constant(since = "forever")]
     pub const BOTTOM: Self = Alignment::V(VAlignment::Bottom);
 
     /// The axis this alignment belongs to.

--- a/crates/typst-library/src/layout/align.rs
+++ b/crates/typst-library/src/layout/align.rs
@@ -102,15 +102,12 @@ pub struct AlignElem {
 /// Where to align something along an axis.
 ///
 /// Possible values are:
-/// - `start`: Aligns at the @direction.start[start] of the
-///   @text.dir[text direction].
-/// - `end`: Aligns at the @direction.end[end] of the @text.dir[text direction].
-/// - `left`: Align at the left.
-/// - `center`: Aligns in the middle, horizontally.
-/// - `right`: Aligns at the right.
-/// - `top`: Aligns at the top.
-/// - `horizon`: Aligns in the middle, vertically.
-/// - `bottom`: Align at the bottom.
+/// - Horizontal alignments: @alignment.start[`start`], @alignment.end[`end`],
+///   @alignment.left[`left`], @alignment.center[`center`], and
+///   @alignment.right[`right`].
+/// - Vertical alignments: @alignment.top[`top`], @alignment.horizon[`horizon`],
+///   and @alignment.bottom[`bottom`].
+/// - @alignment:2d-alignments[2D alignments], like `{center + horizon}`.
 ///
 /// These values are available globally and also in the alignment type's scope,
 /// so you can write either of the following two:
@@ -122,8 +119,8 @@ pub struct AlignElem {
 ///
 /// = 2D alignments <2d-alignments>
 /// To align along both axes at the same time, add the two alignments using the
-/// `+` operator. For example, `top + right` aligns the content to the top right
-/// corner.
+/// `+` operator. For example, `{top + right}` aligns the content to the top
+/// right corner.
 ///
 /// ```example
 /// #set page(height: 3cm)
@@ -175,20 +172,80 @@ impl Alignment {
 
 #[scope]
 impl Alignment {
+    /// Horizontal alignment to the @direction.start[start] of the
+    /// @text.dir[text direction].
+    ///
+    /// ```example
+    /// #set text(dir: ltr)
+    /// #align(start, emoji.arrow.r)
+    ///
+    /// #set text(dir: rtl)
+    /// #align(start, emoji.arrow.l)
+    /// ```
     #[constant(since = "forever")]
     pub const START: Self = Alignment::H(HAlignment::Start);
+
+    /// Horizontal alignment to the @direction.end[end] of the
+    /// @text.dir[text direction].
+    ///
+    /// ```example
+    /// #set text(dir: ltr)
+    /// #align(end, emoji.arrow.r)
+    ///
+    /// #set text(dir: rtl)
+    /// #align(end, emoji.arrow.l)
+    /// ```
     #[constant(since = "forever")]
     pub const END: Self = Alignment::H(HAlignment::End);
+
+    /// Left horizontal alignment.
+    ///
+    /// ```example
+    /// #align(left)[Left]
+    /// ```
     #[constant(since = "forever")]
     pub const LEFT: Self = Alignment::H(HAlignment::Left);
+
+    /// Center horizontal alignment.
+    ///
+    /// ```example
+    /// #align(center)[Center]
+    /// ```
     #[constant(since = "forever")]
     pub const CENTER: Self = Alignment::H(HAlignment::Center);
+
+    /// Right horizontal alignment.
+    ///
+    /// ```example
+    /// #align(right)[Right]
+    /// ```
     #[constant(since = "forever")]
     pub const RIGHT: Self = Alignment::H(HAlignment::Right);
+
+    /// Top vertical alignment.
+    ///
+    /// ```example
+    /// #set page(height: 3cm)
+    /// #align(top)[Top]
+    /// ```
     #[constant(since = "forever")]
     pub const TOP: Self = Alignment::V(VAlignment::Top);
+
+    /// Middle vertical alignment.
+    ///
+    /// ```example
+    /// #set page(height: 3cm)
+    /// #align(horizon)[Horizon]
+    /// ```
     #[constant(since = "forever")]
     pub const HORIZON: Self = Alignment::V(VAlignment::Horizon);
+
+    /// Bottom vertical alignment.
+    ///
+    /// ```example
+    /// #set page(height: 3cm)
+    /// #align(bottom)[Bottom]
+    /// ```
     #[constant(since = "forever")]
     pub const BOTTOM: Self = Alignment::V(VAlignment::Bottom);
 

--- a/crates/typst-library/src/layout/dir.rs
+++ b/crates/typst-library/src/layout/dir.rs
@@ -5,11 +5,8 @@ use crate::layout::{Axis, Side};
 
 /// The four directions into which content can be laid out.
 ///
-/// Possible values are:
-/// - `{ltr}`: Left to right.
-/// - `{rtl}`: Right to left.
-/// - `{ttb}`: Top to bottom.
-/// - `{btt}`: Bottom to top.
+/// Possible values are: @direction.ltr[`ltr`], @direction.rtl[`rtl`],
+/// @direction.ttb[`ttb`], and @direction.btt[`btt`].
 ///
 /// These values are available globally and also in the direction type's scope,
 /// so you can write either of the following two:
@@ -45,12 +42,59 @@ impl Dir {
 
 #[scope]
 impl Dir {
+    /// Left to right.
+    ///
+    /// ```example
+    /// #stack(
+    ///   dir: ltr,
+    ///   spacing: 0.2cm,
+    ///   circle(),
+    ///   line(),
+    ///   square(),
+    /// )
+    /// ```
     #[constant(title = "Left to right", since = "forever")]
     pub const LTR: Self = Self::LTR;
+
+    /// Right to left.
+    ///
+    /// ```example
+    /// #stack(
+    ///   dir: rtl,
+    ///   spacing: 0.2cm,
+    ///   circle(),
+    ///   line(),
+    ///   square(),
+    /// )
+    /// ```
     #[constant(title = "Right to left", since = "forever")]
     pub const RTL: Self = Self::RTL;
+
+    /// Top to bottom.
+    ///
+    /// ```example
+    /// #stack(
+    ///   dir: ttb,
+    ///   spacing: 0.2cm,
+    ///   circle(),
+    ///   line(),
+    ///   square(),
+    /// )
+    /// ```
     #[constant(title = "Top to bottom", since = "forever")]
     pub const TTB: Self = Self::TTB;
+
+    /// Bottom to top.
+    ///
+    /// ```example
+    /// #stack(
+    ///   dir: btt,
+    ///   spacing: 0.2cm,
+    ///   circle(),
+    ///   line(),
+    ///   square(),
+    /// )
+    /// ```
     #[constant(title = "Bottom to top", since = "forever")]
     pub const BTT: Self = Self::BTT;
 

--- a/crates/typst-library/src/layout/dir.rs
+++ b/crates/typst-library/src/layout/dir.rs
@@ -45,9 +45,13 @@ impl Dir {
 
 #[scope]
 impl Dir {
+    #[constant(title = "Left to right", since = "forever")]
     pub const LTR: Self = Self::LTR;
+    #[constant(title = "Right to left", since = "forever")]
     pub const RTL: Self = Self::RTL;
+    #[constant(title = "Top to bottom", since = "forever")]
     pub const TTB: Self = Self::TTB;
+    #[constant(title = "Bottom to top", since = "forever")]
     pub const BTT: Self = Self::BTT;
 
     /// Returns a direction from a starting point.

--- a/crates/typst-library/src/math/mod.rs
+++ b/crates/typst-library/src/math/mod.rs
@@ -28,7 +28,9 @@ pub use self::underover::*;
 use typst_utils::singleton;
 use unicode_math_class::MathClass;
 
-use crate::foundations::{Content, Module, NativeElement, Scope, StyleChain, elem};
+use crate::foundations::{
+    BindingDocumentation, Content, Module, NativeElement, Scope, Since, StyleChain, elem,
+};
 use crate::layout::{Em, HElem};
 use crate::text::{FontFamily, TextElem};
 
@@ -95,11 +97,94 @@ pub fn module() -> Module {
     op::define(&mut math);
 
     // Spacings.
-    math.define("thin", HElem::new(THIN.into()).pack());
-    math.define("med", HElem::new(MEDIUM.into()).pack());
-    math.define("thick", HElem::new(THICK.into()).pack());
-    math.define("quad", HElem::new(QUAD.into()).pack());
-    math.define("wide", HElem::new(WIDE.into()).pack());
+    math.define("thin", HElem::new(THIN.into()).pack())
+        .with_documentation(BindingDocumentation {
+            name: "thin",
+            title: "Thin space",
+            docs: r"
+            A mathematical space of width one sixth of an em.
+
+            ```example
+            $
+              x y \
+              x thin y
+            $
+            ```
+            ",
+            since: Some(Since::Forever),
+            keywords: &[],
+            def_site: None,
+        });
+    math.define("med", HElem::new(MEDIUM.into()).pack())
+        .with_documentation(BindingDocumentation {
+            name: "med",
+            title: "Medium space",
+            docs: "
+            A mathematical space of width two ninths of an em.
+
+            ```example
+            $ (lambda x. x) med y $
+            ```
+            ",
+            since: Some(Since::Forever),
+            keywords: &[],
+            def_site: None,
+        });
+    math.define("thick", HElem::new(THICK.into()).pack())
+        .with_documentation(BindingDocumentation {
+            name: "thick",
+            title: "Thick space",
+            docs: "
+            A mathematical space of width five eighteenths of an em.
+
+            ```example
+            $ x thick y $
+            ```
+            ",
+            since: Some(Since::Forever),
+            keywords: &[],
+            def_site: None,
+        });
+    math.define("quad", HElem::new(QUAD.into()).pack())
+        .with_documentation(BindingDocumentation {
+            name: "quad",
+            title: "Quad space",
+            docs: r#"
+            A one-em wide mathematical space.
+
+            ```example
+            $
+              f(x) = cases(
+                1/x quad &"if" x != 0,
+                0 quad &"otherwise",
+              )
+            $
+            ```
+            "#,
+            since: Some(Since::Forever),
+            keywords: &[],
+            def_site: None,
+        });
+    math.define("wide", HElem::new(WIDE.into()).pack())
+        .with_documentation(BindingDocumentation {
+            name: "wide",
+            title: "Wide space",
+            docs: r#"
+            A two-em wide mathematical space.
+
+            ```example
+            $
+              f(x) = cases(
+                1/x wide &"if" x != 0,
+                0 wide &"otherwise",
+              )
+            $
+            ```
+            "#,
+            since: Some(Since::Forever),
+            keywords: &[],
+            def_site: None,
+        });
 
     // Symbols.
     crate::symbols::define_math(&mut math);

--- a/crates/typst-library/src/visualize/color.rs
+++ b/crates/typst-library/src/visualize/color.rs
@@ -288,40 +288,59 @@ pub enum Color {
 
 #[scope]
 impl Color {
+    #[constant(since = "forever")]
     pub const BLACK: Self = Self::Process(ProcessColor::Luma(Luma::new(0.0, 1.0)));
+    #[constant(since = "forever")]
     pub const GRAY: Self = Self::Process(ProcessColor::Luma(Luma::new(0.6666666, 1.0)));
+    #[constant(since = "forever")]
     pub const WHITE: Self = Self::Process(ProcessColor::Luma(Luma::new(1.0, 1.0)));
+    #[constant(since = "forever")]
     pub const SILVER: Self = Self::Process(ProcessColor::Luma(Luma::new(0.8666667, 1.0)));
+    #[constant(since = "forever")]
     pub const NAVY: Self =
         Self::Process(ProcessColor::Rgb(Rgb::new(0.0, 0.121569, 0.247059, 1.0)));
+    #[constant(since = "forever")]
     pub const BLUE: Self =
         Self::Process(ProcessColor::Rgb(Rgb::new(0.0, 0.454902, 0.85098, 1.0)));
+    #[constant(since = "forever")]
     pub const AQUA: Self =
         Self::Process(ProcessColor::Rgb(Rgb::new(0.4980392, 0.858823, 1.0, 1.0)));
+    #[constant(since = "forever")]
     pub const TEAL: Self =
         Self::Process(ProcessColor::Rgb(Rgb::new(0.223529, 0.8, 0.8, 1.0)));
+    #[constant(since = "forever")]
     pub const EASTERN: Self =
         Self::Process(ProcessColor::Rgb(Rgb::new(0.13725, 0.615686, 0.678431, 1.0)));
+    #[constant(since = "forever")]
     pub const PURPLE: Self =
         Self::Process(ProcessColor::Rgb(Rgb::new(0.694118, 0.050980, 0.788235, 1.0)));
+    #[constant(since = "forever")]
     pub const FUCHSIA: Self =
         Self::Process(ProcessColor::Rgb(Rgb::new(0.941177, 0.070588, 0.745098, 1.0)));
+    #[constant(since = "forever")]
     pub const MAROON: Self =
         Self::Process(ProcessColor::Rgb(Rgb::new(0.521569, 0.078431, 0.294118, 1.0)));
+    #[constant(since = "forever")]
     pub const RED: Self =
         Self::Process(ProcessColor::Rgb(Rgb::new(1.0, 0.254902, 0.211765, 1.0)));
+    #[constant(since = "forever")]
     pub const ORANGE: Self =
         Self::Process(ProcessColor::Rgb(Rgb::new(1.0, 0.521569, 0.105882, 1.0)));
+    #[constant(since = "forever")]
     pub const YELLOW: Self =
         Self::Process(ProcessColor::Rgb(Rgb::new(1.0, 0.8627451, 0.0, 1.0)));
+    #[constant(since = "forever")]
     pub const OLIVE: Self =
         Self::Process(ProcessColor::Rgb(Rgb::new(0.239216, 0.6, 0.4392157, 1.0)));
+    #[constant(since = "forever")]
     pub const GREEN: Self =
         Self::Process(ProcessColor::Rgb(Rgb::new(0.1803922, 0.8, 0.2509804, 1.0)));
+    #[constant(since = "forever")]
     pub const LIME: Self =
         Self::Process(ProcessColor::Rgb(Rgb::new(0.0039216, 1.0, 0.4392157, 1.0)));
 
     /// The module of preset color maps.
+    #[constant(title = "Predefined color maps", since = "0.9.0")]
     pub const MAP: fn() -> Module = || typst_utils::singleton!(Module, map()).clone();
 
     /// Create a grayscale color.

--- a/crates/typst-library/src/visualize/color.rs
+++ b/crates/typst-library/src/visualize/color.rs
@@ -171,112 +171,6 @@ static TO_SRGB: LazyLock<Arc<moxcms::Transform8BitExecutor>> = LazyLock::new(|| 
 /// )
 /// ```
 ///
-/// = Predefined color maps <predefined-color-maps>
-/// Typst also includes a number of preset color maps that can be used for
-/// @gradient:stops[gradients]. These are simply arrays of colors defined in the
-/// module `color.map`.
-///
-/// ```example
-/// #circle(fill: gradient.linear(..color.map.crest))
-/// ```
-///
-/// #docs-table(
-///   table.header[Map][Details],
-///
-///   [`turbo`],
-///   [
-///     A perceptually uniform rainbow-like color map. Read
-///     #link("https://ai.googleblog.com/2019/08/turbo-improved-rainbow-colormap-for.html")[this blog post]
-///     for more details.
-///   ],
-///
-///   [`cividis`],
-///   [
-///     A blue to gray to yellow color map. See
-///     #link("https://bids.github.io/colormap/")[this blog post] for more
-///     details.
-///   ],
-///
-///   [`rainbow`],
-///   [
-///     Cycles through the full color spectrum. This color map is best used by
-///     setting the interpolation color space to @color.hsl[HSL]. The rainbow
-///     gradient is *not suitable* for data visualization because it is not
-///     perceptually uniform, so the differences between values become unclear
-///     to your readers. It should only be used for decorative purposes.
-///   ],
-///
-///   [`spectral`],
-///   [Red to yellow to blue color map.],
-///
-///   [`viridis`],
-///   [A purple to teal to yellow color map.],
-///
-///   [`inferno`],
-///   [A black to red to yellow color map.],
-///
-///   [`magma`],
-///   [A black to purple to yellow color map.],
-///
-///   [`plasma`],
-///   [A purple to pink to yellow color map.],
-///
-///   [`rocket`],
-///   [A black to red to white color map.],
-///
-///   [`mako`],
-///   [A black to teal to white color map.],
-///
-///   [`coolwarm`],
-///   [A blue to white to red color map with smooth transitions.],
-///
-///   [`vlag`],
-///   [A light blue to white to red color map.],
-///
-///   [`icefire`],
-///   [A light teal to black to orange color map.],
-///
-///   [`flare`],
-///   [A orange to purple color map that is perceptually uniform.],
-///
-///   [`crest`],
-///   [A light green to blue color map.],
-/// )
-///
-/// Some popular presets are not included because they are not available under a
-/// free licence. Others, like
-/// #link("https://jakevdp.github.io/blog/2014/10/16/how-bad-is-your-colormap/")[Jet],
-/// are not included because they are not color blind friendly. Feel free to use
-/// or create a package with other presets that are useful to you!
-///
-/// ```preview
-/// #set page(width: auto, height: auto)
-/// #set text(font: "PT Sans", size: 8pt)
-///
-/// #let maps = (
-///   "turbo", "cividis", "rainbow", "spectral",
-///   "viridis", "inferno", "magma", "plasma",
-///   "rocket", "mako", "coolwarm", "vlag",
-///   "icefire", "flare", "crest",
-/// )
-///
-/// #stack(dir: ltr, spacing: 3pt, ..maps.map((name) => {
-///   let map = eval("color.map." + name)
-///   stack(
-///     dir: ttb,
-///     block(
-///       width: 15pt,
-///       height: 100pt,
-///       fill: gradient.linear(..map, angle: 90deg),
-///     ),
-///     block(
-///       width: 15pt,
-///       height: 32pt,
-///       move(dy: 8pt, rotate(90deg, name)),
-///     ),
-///   )
-/// }))
-/// ```
 #[ty(scope, cast, since = "forever")]
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum Color {
@@ -339,7 +233,111 @@ impl Color {
     pub const LIME: Self =
         Self::Process(ProcessColor::Rgb(Rgb::new(0.0039216, 1.0, 0.4392157, 1.0)));
 
-    /// The module of preset color maps.
+    /// A collection of preset color maps that can be used for
+    /// @gradient:stops[gradients]. These are simply arrays of colors.
+    ///
+    /// ```example
+    /// #circle(fill: gradient.linear(..color.map.crest))
+    /// ```
+    ///
+    /// #docs-table(
+    ///   table.header[Map][Details],
+    ///
+    ///   [`turbo`],
+    ///   [
+    ///     A perceptually uniform rainbow-like color map. Read
+    ///     #link("https://ai.googleblog.com/2019/08/turbo-improved-rainbow-colormap-for.html")[this blog post]
+    ///     for more details.
+    ///   ],
+    ///
+    ///   [`cividis`],
+    ///   [
+    ///     A blue to gray to yellow color map. See
+    ///     #link("https://bids.github.io/colormap/")[this blog post] for more
+    ///     details.
+    ///   ],
+    ///
+    ///   [`rainbow`],
+    ///   [
+    ///     Cycles through the full color spectrum. This color map is best used
+    ///     by setting the interpolation color space to @color.hsl[HSL]. The
+    ///     rainbow gradient is *not suitable* for data visualization because it
+    ///     is not perceptually uniform, so the differences between values
+    ///     become unclear to your readers. It should only be used for
+    ///     decorative purposes.
+    ///   ],
+    ///
+    ///   [`spectral`],
+    ///   [Red to yellow to blue color map.],
+    ///
+    ///   [`viridis`],
+    ///   [A purple to teal to yellow color map.],
+    ///
+    ///   [`inferno`],
+    ///   [A black to red to yellow color map.],
+    ///
+    ///   [`magma`],
+    ///   [A black to purple to yellow color map.],
+    ///
+    ///   [`plasma`],
+    ///   [A purple to pink to yellow color map.],
+    ///
+    ///   [`rocket`],
+    ///   [A black to red to white color map.],
+    ///
+    ///   [`mako`],
+    ///   [A black to teal to white color map.],
+    ///
+    ///   [`coolwarm`],
+    ///   [A blue to white to red color map with smooth transitions.],
+    ///
+    ///   [`vlag`],
+    ///   [A light blue to white to red color map.],
+    ///
+    ///   [`icefire`],
+    ///   [A light teal to black to orange color map.],
+    ///
+    ///   [`flare`],
+    ///   [A orange to purple color map that is perceptually uniform.],
+    ///
+    ///   [`crest`],
+    ///   [A light green to blue color map.],
+    /// )
+    ///
+    /// Some popular presets are not included because they are not available
+    /// under a free licence. Others, like
+    /// #link("https://jakevdp.github.io/blog/2014/10/16/how-bad-is-your-colormap/")[Jet],
+    /// are not included because they are not color blind friendly. Feel free to
+    /// use or create a package with other presets that are useful to you!
+    ///
+    /// ```preview
+    /// #set page(width: auto, height: auto)
+    /// #set text(font: "PT Sans", size: 8pt)
+    ///
+    /// #let maps = (
+    ///   "turbo", "cividis", "rainbow", "spectral",
+    ///   "viridis", "inferno", "magma", "plasma",
+    ///   "rocket", "mako", "coolwarm", "vlag",
+    ///   "icefire", "flare", "crest",
+    /// )
+    ///
+    /// #stack(dir: ltr, spacing: 3pt, ..maps.map((name) => {
+    ///   let map = eval("color.map." + name)
+    ///   stack(
+    ///     dir: ttb,
+    ///     block(
+    ///       width: 15pt,
+    ///       height: 100pt,
+    ///       fill: gradient.linear(..map, angle: 90deg),
+    ///     ),
+    ///     block(
+    ///       width: 15pt,
+    ///       height: 32pt,
+    ///       move(dy: 8pt, rotate(90deg, name)),
+    ///     ),
+    ///   )
+    /// }))
+    /// ```
     #[constant(title = "Predefined color maps", since = "0.9.0")]
     pub const MAP: fn() -> Module = || typst_utils::singleton!(Module, map()).clone();
 

--- a/crates/typst-library/src/visualize/gradient.rs
+++ b/crates/typst-library/src/visualize/gradient.rs
@@ -117,8 +117,7 @@ use crate::visualize::{
 /// )
 /// ```
 ///
-/// Typst predefines color maps that you can use as stops. See the
-/// @color:predefined-color-maps[`color`] documentation for more details.
+/// Typst predefines color maps that you can use as stops in @color.map.
 ///
 /// = Relativeness <relativeness>
 /// The location of the `{0%}` and `{100%}` stops depends on the dimensions of a

--- a/crates/typst-macros/src/elem.rs
+++ b/crates/typst-macros/src/elem.rs
@@ -8,7 +8,7 @@ use syn::{Ident, Result, Token};
 use crate::util::{
     BlockWithReturn, Since, determine_name_and_title, documentation, foundations,
     has_attr, kw, oneliner, parse_attr, parse_flag, parse_key_value, parse_string,
-    parse_string_array, validate_attrs,
+    parse_string_array, quote_option, validate_attrs,
 };
 
 /// Expand the `#[elem]` macro.
@@ -388,11 +388,7 @@ fn create_native_elem_impl(element: &Elem) -> Result<TokenStream> {
     } = element;
     let def_site_key = ident.to_string();
 
-    let since = if let Some(since) = since {
-        quote! { Some(#since) }
-    } else {
-        quote! { None }
-    };
+    let since = quote_option(since);
 
     let fields = element.fields.iter().filter(|field| !field.internal).map(|field| {
         let i = field.i;

--- a/crates/typst-macros/src/func.rs
+++ b/crates/typst-macros/src/func.rs
@@ -334,11 +334,7 @@ fn create_func_data(func: &Func) -> TokenStream {
         quote! { #name }
     };
 
-    let since = if let Some(since) = since {
-        quote! { Some(#since) }
-    } else {
-        quote! { None }
-    };
+    let since = quote_option(since);
 
     quote! {
         #foundations::NativeFuncData {

--- a/crates/typst-macros/src/lib.rs
+++ b/crates/typst-macros/src/lib.rs
@@ -235,6 +235,7 @@ pub fn elem(stream: BoundaryStream, item: BoundaryStream) -> BoundaryStream {
 /// #[scope]
 /// impl name {
 ///     /// A simple constant.
+///     #[constant(title = "Value")]
 ///     const VAL: u32 = 0;
 ///
 ///     /// A function.

--- a/crates/typst-macros/src/scope.rs
+++ b/crates/typst-macros/src/scope.rs
@@ -1,11 +1,14 @@
-use heck::ToKebabCase;
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::{MetaNameValue, Result, Token, parse_quote};
 
-use crate::util::{BareType, foundations, kw, parse_flag};
+use crate::util::{
+    BareType, Since, determine_name_and_title, documentation, foundations, kw,
+    parse_flag, parse_key_value, parse_string, parse_string_array, quote_option,
+    remove_attrs, take_attr,
+};
 
 /// Expand the `#[scope]` macro.
 pub fn scope(stream: TokenStream, item: syn::Item) -> Result<TokenStream> {
@@ -36,7 +39,7 @@ pub fn scope(stream: TokenStream, item: syn::Item) -> Result<TokenStream> {
         let bare: BareType;
         let (mut def, attrs) = match child {
             syn::ImplItem::Const(item) => {
-                (handle_const(&self_ty_expr, item)?, &item.attrs)
+                (handle_const(&self_ty_expr, self_ty, item)?, &item.attrs)
             }
             syn::ImplItem::Fn(item) => (
                 match handle_fn(self_ty, item)? {
@@ -137,10 +140,50 @@ impl Parse for Meta {
 }
 
 /// Process a const item and returns its definition.
-fn handle_const(self_ty: &TokenStream, item: &syn::ImplItemConst) -> Result<TokenStream> {
+fn handle_const(
+    self_ty: &TokenStream,
+    parent: &syn::Type,
+    item: &mut syn::ImplItemConst,
+) -> Result<TokenStream> {
     let ident = &item.ident;
-    let name = ident.to_string().to_kebab_case();
-    Ok(quote! { scope.define(#name, #self_ty::#ident) })
+
+    let Some(attr) = take_attr(&mut item.attrs, "constant") else {
+        bail!(item, "scope constant is missing #[constant] attribute");
+    };
+
+    let meta = match &attr.meta {
+        syn::Meta::Path(_) => ConstantMeta::default(),
+        syn::Meta::List(list) => syn::parse2(list.tokens.clone())?,
+        syn::Meta::NameValue(_) => bail!(attr.meta, "invalid #[constant] attribute"),
+    };
+
+    let docs = documentation(&item.attrs);
+    remove_attrs(&mut item.attrs, "doc");
+
+    let (name, title) = determine_name_and_title(meta.name, meta.title, ident, None)?;
+    let since = quote_option(&meta.since);
+    let keywords = meta.keywords;
+
+    let def_site_key = if let syn::Type::Path(path) = parent
+        && let Some(parent) = path.path.get_ident()
+    {
+        format!("{parent}::{ident}")
+    } else {
+        ident.to_string()
+    };
+
+    Ok(quote! {
+        scope
+            .define(#name, #self_ty::#ident)
+            .with_documentation(::typst_library::foundations::BindingDocumentation {
+                name: #name,
+                title: #title,
+                docs: #docs,
+                since: #since,
+                keywords: &[#(#keywords),*],
+                def_site: Some(::typst_utils::DefSite { path: file!(), key: #def_site_key }),
+            })
+    })
 }
 
 /// Process a type item.
@@ -176,7 +219,7 @@ fn handle_fn(self_ty: &syn::Type, item: &mut syn::ImplItemFn) -> Result<FnKind> 
                 return Ok(FnKind::Constructor(quote! { Some(#self_ty::#ident_data()) }));
             }
         }
-        syn::Meta::NameValue(_) => bail!(attr.meta, "invalid func attribute"),
+        syn::Meta::NameValue(_) => bail!(attr.meta, "invalid #[func] attribute"),
     }
 
     Ok(FnKind::Member(quote! { scope.define_func_with_data(#self_ty::#ident_data()) }))
@@ -231,5 +274,29 @@ fn rewrite_primitive_base(item: &syn::ItemImpl, ident_ext: &syn::Ident) -> Token
         impl #ident_ext for #self_ty {
             #(#items)*
         }
+    }
+}
+
+/// The `..` in `#[constant(..)]`.
+#[derive(Default)]
+struct ConstantMeta {
+    /// The function's name as exposed to Typst.
+    name: Option<String>,
+    /// The function's title case name.
+    title: Option<String>,
+    /// The version of Typst the function was introduced in.
+    since: Option<Since>,
+    /// A list of alternate search terms for this function.
+    keywords: Vec<String>,
+}
+
+impl Parse for ConstantMeta {
+    fn parse(input: ParseStream) -> Result<Self> {
+        Ok(Self {
+            name: parse_string::<kw::name>(input)?,
+            title: parse_string::<kw::title>(input)?,
+            since: parse_key_value::<kw::since, Since>(input)?,
+            keywords: parse_string_array::<kw::keywords>(input)?,
+        })
     }
 }

--- a/crates/typst-macros/src/ty.rs
+++ b/crates/typst-macros/src/ty.rs
@@ -5,7 +5,7 @@ use syn::{Attribute, Ident, Result};
 
 use crate::util::{
     BareType, Since, determine_name_and_title, documentation, foundations, kw, oneliner,
-    parse_flag, parse_key_value, parse_string, parse_string_array,
+    parse_flag, parse_key_value, parse_string, parse_string_array, quote_option,
 };
 
 /// Expand the `#[ty]` macro.
@@ -81,11 +81,7 @@ fn create(ty: &Type, item: Option<&syn::Item>) -> TokenStream {
     let Meta { keywords, .. } = meta;
     let def_site_key = ident.to_string();
     let oneliner = oneliner(docs);
-    let since = if let Some(since) = &meta.since {
-        quote! { Some(#since) }
-    } else {
-        quote! { None }
-    };
+    let since = quote_option(&meta.since);
 
     let constructor = if meta.scope {
         quote! { <#ident as #foundations::NativeScope>::constructor() }

--- a/crates/typst-macros/src/ty.rs
+++ b/crates/typst-macros/src/ty.rs
@@ -6,6 +6,7 @@ use syn::{Attribute, Ident, Result};
 use crate::util::{
     BareType, Since, determine_name_and_title, documentation, foundations, kw, oneliner,
     parse_flag, parse_key_value, parse_string, parse_string_array, quote_option,
+    remove_attrs,
 };
 
 /// Expand the `#[ty]` macro.
@@ -23,7 +24,7 @@ pub fn ty(stream: TokenStream, mut item: syn::Item) -> Result<TokenStream> {
         _ => bail!(item, "invalid type item"),
     };
     let ty = parse(meta, ident.clone(), attrs)?;
-    attrs.retain(|attr| !attr.path().is_ident("doc"));
+    remove_attrs(attrs, "doc");
     Ok(create(&ty, keep.then_some(&item)))
 }
 

--- a/crates/typst-macros/src/util.rs
+++ b/crates/typst-macros/src/util.rs
@@ -90,6 +90,11 @@ pub fn take_attr(
         .map(|i| attrs.remove(i))
 }
 
+/// Removes all attributes of a specific type.
+pub fn remove_attrs(attrs: &mut Vec<syn::Attribute>, target: &str) {
+    attrs.retain(|attr| !attr.path().is_ident(target));
+}
+
 /// Ensure that no unrecognized attributes remain.
 pub fn validate_attrs(attrs: &[syn::Attribute]) -> Result<()> {
     for attr in attrs {

--- a/crates/typst-macros/src/util.rs
+++ b/crates/typst-macros/src/util.rs
@@ -79,7 +79,7 @@ pub fn parse_attr<T: Parse>(
         .transpose()
 }
 
-/// Whether an attribute list has a specified attribute.
+/// Extracts a specific attribute.
 pub fn take_attr(
     attrs: &mut Vec<syn::Attribute>,
     target: &str,

--- a/crates/typst-utils/src/lib.rs
+++ b/crates/typst-utils/src/lib.rs
@@ -464,7 +464,7 @@ pub fn defer<T, F: FnOnce(&mut T)>(
 /// to find the element. Identifiers of a semantical parent may also be used in
 /// this key. This has the added benefit that we can reliably find the
 /// definition site in the presence of edits (for hot reload).
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct DefSite {
     /// The path to the file as returned by the `file!()` macro.
     ///

--- a/docs/components/base.typ
+++ b/docs/components/base.typ
@@ -223,10 +223,17 @@
 }
 
 // Displays binding information, if any, such as:
+// - An introducing version
 // - A deprecation
 // - A feature gate
 #let definition-info(info) = {
   if info == none { return }
+
+  // The only items that don't have a `since` are symbol functions.
+  if info.since != none {
+    text(0.75em, small[Since: #info.since])
+    if target() == "paged" { h(0.5em, weak: true) }
+  }
 
   let item(size, name, alt, body) = {
     context if target() == "paged" {

--- a/docs/components/category.typ
+++ b/docs/components/category.typ
@@ -287,6 +287,24 @@
   }
 }
 
+// Displays additional details about a constant.
+#let const-subtitle(value, binding-info) = context {
+  let gap = if target() == "paged" { h(0.5em, weak: true) }
+  {
+    show: it => if target() == "paged" {
+      h(1em)
+      it
+    } else {
+      html.div(class: "additional-info", it)
+    }
+    ty-pill(type(value))
+    gap
+    definition-info(binding-info)
+  }
+
+  sources-link(binding-info)
+}
+
 // Displays additional details about a function.
 //
 // When the labels are changed here, `docs/content/reference/index.typ` needs to
@@ -307,13 +325,6 @@
       Contextual functions can only be used when the context is known.
     ])
   }
-  if info.since != none {
-    set text(0.75em)
-    gap
-    small[Since: #info.since]
-  } else {
-    panic("missing `since` for function " + info.def-site.key + " (" + stdx.str-from-path(info.def-site.path) + ")")
-  }
   gap
   definition-info(binding-info)
   sources-link(info)
@@ -321,16 +332,64 @@
 
 // Displays additional details about a type.
 #let ty-subtitle(ty-info, binding-info) = context {
-  let gap = if target() == "paged" { h(0.5em, weak: true) }
-  if ty-info.since != none {
-    set text(0.75em)
-    gap
-    small[Since: #ty-info.since]
-  } else {
-    panic("missing `since` for type " + ty-info.def-site.key + " (" + stdx.str-from-path(ty-info.def-site.path) + ")")
-  }
+  if target() == "paged" { h(0.5em, weak: true) }
   definition-info(binding-info)
   sources-link(ty-info)
+}
+
+// Renders documentation for a constant as part of a large documentation
+// section.
+#let const-member(
+  value,
+  parent: none,
+  base-label: none,
+  binding-info: none,
+) = {
+  assert.ne(binding-info, none, message: "binding-info is required")
+
+  let base-label = label(str(base-label) + "-" + binding-info.name)
+
+  let canonical-name = {
+    if parent != none {
+      parent + "."
+    }
+    binding-info.name
+  }
+
+  {
+    show heading: it => {
+      register-def(label(canonical-name), it.location())
+      register-index-item(
+        kind: stdx.describe(type(value)).title,
+        title: binding-info.title,
+        dest: it.location(),
+        keywords: binding-info.keywords,
+      )
+      if target() == "paged" {
+        it
+      } else {
+        html-heading-n(
+          it.level + 1,
+          class: classnames(
+            "scoped-definition",
+            deprecated: binding-info.deprecation != none,
+          ),
+          it.body,
+        )
+      }
+    }
+    let title = short-or-long(
+      binding-info.title,
+      raw(binding-info.name) + const-subtitle(value, binding-info),
+    )
+    labelled(heading(depth: 2, title), base-label)
+  }
+
+  show raw.where(lang: "example"): example.with(folding: true, open: true)
+  prose-styling(
+    live-docs(binding-info.docs, binding-info.def-site),
+    base-target: value,
+  )
 }
 
 // Renders documentation for a function as part of a large documentation
@@ -543,6 +602,14 @@
         binding-info: nested-binding(scope, name),
         definitions-section: definitions-section,
       )
+    } else if type(value) != color {
+      // We don't document named colors.
+      const-member(
+        value,
+        parent: parent,
+        base-label: base-label,
+        binding-info: nested-binding(scope, name),
+      )
     }
   }
 }
@@ -650,10 +717,32 @@
 
   prose-styling(info.docs, base-target: def-target)
 
-  if info.items.len() > 0 {
+  let is-function(value) = {
+    // We don't document symbols individually, so when we encounter an
+    // individual symbol to document, that must mean it is a callable symbol
+    // whose underlying function should be documented.
+    type(value) in (function, symbol)
+  }
+
+  let constants = info.definitions.filter(v => not is-function(v))
+  if constants.len() > 0 {
+    let base-label = <constants>
+    labelled(heading[Constants], base-label)
+    for (key, value) in constants {
+      const-member(
+        value,
+        parent: std-path-of(info.scope.mod),
+        base-label: base-label,
+        binding-info: nested-binding(info.scope, key),
+      )
+    }
+  }
+
+  let functions = info.definitions.filter(is-function)
+  if functions.len() > 0 {
     let base-label = <functions>
     labelled(heading[Functions], base-label)
-    for (key, value) in info.items {
+    for (key, value) in functions {
       func-member(
         value,
         base-label: base-label,
@@ -784,7 +873,10 @@
 
   let definitions = {
     // Non-grouped definitions from the scope.
-    let skip = groups.map(g => g.items.map(((k, v)) => v)).flatten()
+    let skip = groups
+      .map(g => g.definitions.values())
+      .filter(v => type(v) != function)
+      .flatten()
     scope
       .dict
       .pairs()

--- a/docs/content/changelog/0.12.0.typ
+++ b/docs/content/changelog/0.12.0.typ
@@ -157,7 +157,7 @@
 - Added @int.from-bytes, @int.to-bytes, @float.from-bytes, and @float.to-bytes
 - Added proper support for negative values of the `digits` parameter of @calc.round (the behaviour existed before but was subtly broken)
 - Conversions from @int to @float will now error instead of saturating if the float is too large *(Minor breaking change)*
-- Added `float.nan` and `float.inf`, removed `calc.nan` *(Minor breaking change)*
+- Added @float.nan and @float.inf, removed `{calc.nan}` *(Minor breaking change)*
 - Certain symbols are now generally callable like functions and not only specifically in math. Examples are accents or @math.floor[`floor`] and @math.ceil[`ceil`].
 - Improved @repr of relative values, sequences, infinities, NaN, `{type(none)}` and `{type(auto)}`
 - Fixed crash on whole packages (rather than just files) cyclically importing each other

--- a/docs/content/changelog/0.15.0.typ
+++ b/docs/content/changelog/0.15.0.typ
@@ -166,7 +166,7 @@ This section documents all changes to the Typst language and compiler between Ty
   - Added @tiling.constructor.offset[`offset` parameter] for shifting the starting position of a tiling #pr(7506)
   - Fixed parent-relative placement for @stack and @polygon #pr(8324)
 - Gradients
-  - Added @color:predefined-color-maps[`color.map.coolwarm`] for use with gradients #pr(7489)
+  - Added @color.map[`color.map.coolwarm`] for use with gradients #pr(7489)
   - Fixed interpolation of gradient @gradient.stops[stops] in Oklab color space #pr(7326)
   - Fixed gradient @gradient.angle[angle] handling for negative-size shapes #pr(7826)
   - Fixed gradient strokes for @line[lines] and @curve[curves] #pr(7863)

--- a/docs/content/changelog/0.8.0.typ
+++ b/docs/content/changelog/0.8.0.typ
@@ -18,7 +18,7 @@
 - Added encoding and decoding functions from and to bytes for data formats: `json.decode`, @json.encode, and similar functions for other formats
 - Added @array.intersperse function
 - Added @str.rev function
-- Added `calc.tau` constant
+- Added @calc.tau constant
 - Made @bytes[bytes] joinable and addable
 - Made @array.zip function variadic
 - Fixed bug with @eval when the `mode` was set to `{"math"}`

--- a/docs/content/changelog/0.9.0.typ
+++ b/docs/content/changelog/0.9.0.typ
@@ -17,7 +17,7 @@
   - Supports linear, radial, and conic gradients
   - Added support for defining colors in more color spaces, including @color.oklab[Oklab], @color.linear-rgb[Linear RGB(A)], @color.hsl[HSL], and @color.hsv[HSV]
   - Added @color.saturate[`saturate`], @color.desaturate[`desaturate`], and @color.rotate[`rotate`] functions on colors
-  - Added @color:predefined-color-maps[`color.map`] module with predefined color maps that can be used with gradients
+  - Added @color.map module with predefined color maps that can be used with gradients
   - Rename `kind` function on colors to @color.space[`space`]
   - Removed `to-rgba`, `to-cmyk`, and `to-luma` functions in favor of a new @color.components[`components`] function
 - Improved rendering of @rect[rectangles] with corner radius and varying stroke widths
@@ -104,7 +104,7 @@
 - Now only regenerates images for changed pages when using `typst watch` with PNG or SVG export
 
 = Miscellaneous Improvements <miscellaneous-improvements>
-- Added @version type and `sys.version` constant specifying the current compiler version. Can be used to gracefully support multiple versions.
+- Added @version type and @sys.version constant specifying the current compiler version. Can be used to gracefully support multiple versions.
 - The U+2212 MINUS SIGN is now used when displaying a numeric value, in the @repr of any numeric value and to replace a normal hyphen in text mode when before a digit. This improves, in particular, how negative integer values are displayed in math mode.
 - Added support for specifying a default value instead of failing for `remove` function in @array.remove[array] and @dictionary.remove[dictionary]
 - Simplified Page Setup Guide examples

--- a/docs/content/reference/export/html.typ
+++ b/docs/content/reference/export/html.typ
@@ -9,10 +9,9 @@
     (
       name: "typed",
       title: "Typed HTML",
-      items: {
+      definitions: {
         dictionary(html)
-          .pairs()
-          .filter(((_, val)) => {
+          .filter(val => {
             let info = stdx.describe(val)
             info != none and "typed-html" in info.keywords
           })

--- a/docs/content/reference/library/foundations.typ
+++ b/docs/content/reference/library/foundations.typ
@@ -14,19 +14,19 @@
       def-target: calc,
       title: "Calculation",
       scope: scope(std, "calc"),
-      items: dictionary(calc).pairs().filter(((k, v)) => type(v) == function),
+      definitions: dictionary(calc),
       description: "Documentation for the `calc` module, which contains definitions for mathematical computation.",
       docs: [
         Module for calculations and processing of numeric values.
 
-        These definitions are part of the `calc` module and not imported by default. In addition to the functions listed below, the `calc` module also defines the constants `pi`, `tau`, `e`, and `inf`.
+        These definitions are part of the `calc` module and not imported by default.
       ],
     ),
     (
       name: "std",
       def-target: std,
       title: "Standard Library",
-      items: (),
+      definitions: (:),
       description: "Documentation for the `std` module, which contains all globally accessible items.",
       docs: [
         A module that contains all globally accessible items.
@@ -51,7 +51,7 @@
         = Conditional access <conditional-access>
         You can also use this in combination with the @dictionary.constructor[dictionary constructor] to conditionally access global definitions. This can, for instance, be useful to use new or experimental functionality when it is available, while falling back to an alternative implementation if used on an older Typst version. In particular, this allows us to create #link("https://en.wikipedia.org/wiki/Polyfill_(programming)")[polyfills].
 
-        This can be as simple as creating an alias to prevent warning messages, for example, conditionally using `pattern` in Typst version 0.12, but using @tiling in newer versions. Since the parameters accepted by the `tiling` function match those of the older `pattern` function, using the `tiling` function when available and falling back to `pattern` otherwise will unify the usage across all versions. Note that, when creating a polyfill, @sys[`sys.version`] can also be very useful.
+        This can be as simple as creating an alias to prevent warning messages, for example, conditionally using `pattern` in Typst version 0.12, but using @tiling in newer versions. Since the parameters accepted by the `tiling` function match those of the older `pattern` function, using the `tiling` function when available and falling back to `pattern` otherwise will unify the usage across all versions. Note that, when creating a polyfill, @sys.version can also be very useful.
 
         ```typ
         #let tiling = if "tiling" in std { tiling } else { pattern }
@@ -64,18 +64,11 @@
       name: "sys",
       def-target: sys,
       title: "System",
-      items: (),
-      description: "Documentation for the `sys` module.",
+      scope: scope(std, "sys"),
+      definitions: dictionary(sys),
+      description: "Documentation for the `sys` module for system interactions.",
       docs: [
         Module for system interactions.
-
-        This module defines the following items:
-
-        - The `sys.version` constant (of type @version) that specifies the currently active Typst compiler version.
-
-        - The `sys.inputs` @dictionary[dictionary], which makes external inputs available to the project. An input specified in the command line as `--input key=value` becomes available under `sys.inputs.key` as `{"value"}`. To include spaces in the value, it may be enclosed with single or double quotes.
-
-          The value is always of type @str[string]. More complex data may be parsed manually using functions like @json.
       ],
     ),
   ),

--- a/docs/content/reference/library/math.typ
+++ b/docs/content/reference/library/math.typ
@@ -2,7 +2,7 @@
 
 #let math-definitions = dictionary(math)
 #let math-items(..keys) = {
-  keys.pos().map(k => (k, math-definitions.at(k)))
+  keys.pos().map(k => (k, math-definitions.at(k))).to-dict()
 }
 
 #show: docs-category.with(
@@ -14,7 +14,7 @@
     (
       name: "variants",
       title: "Variants",
-      items: math-items("serif", "sans", "frak", "mono", "bb", "cal", "scr"),
+      definitions: math-items("serif", "sans", "frak", "mono", "bb", "cal", "scr"),
       description: "Documentation for functions which allow switching to alternative math typefaces.",
       docs: [
         Alternate typefaces within formulas.
@@ -25,7 +25,7 @@
     (
       name: "styles",
       title: "Styles",
-      items: math-items("upright", "italic", "bold"),
+      definitions: math-items("upright", "italic", "bold"),
       description: "Documentation for functions which allow switching to alternative math letterforms.",
       docs: [
         Alternate letterforms within formulas.
@@ -36,7 +36,7 @@
     (
       name: "sizes",
       title: "Sizes",
-      items: math-items("display", "inline", "script", "sscript"),
+      definitions: math-items("display", "inline", "script", "sscript"),
       description: "Documentation for functions which allow switching to alternative math text sizes.",
       docs: [
         Forced size styles for expressions within formulas.
@@ -47,7 +47,7 @@
     (
       name: "underover",
       title: "Under/Over",
-      items: math-items(
+      definitions: math-items(
         "underline",
         "overline",
         "underbrace",
@@ -69,7 +69,7 @@
     (
       name: "roots",
       title: "Roots",
-      items: math-items("root", "sqrt"),
+      definitions: math-items("root", "sqrt"),
       description: "Documentation for functions that typeset mathematical roots.",
       docs: [
         Square and non-square roots.
@@ -84,7 +84,7 @@
     (
       name: "attach",
       title: "Attach",
-      items: math-items("attach", "scripts", "limits"),
+      definitions: math-items("attach", "scripts", "limits"),
       description: "Documentation for functions that allows to precisely attach sub-, superscripts, and limits to parts of an equation.",
       docs: [
         Subscript, superscripts, and limits.
@@ -105,7 +105,7 @@
     (
       name: "lr",
       title: "Left/Right",
-      items: math-items("lr", "mid", "abs", "norm", "floor", "ceil", "round"),
+      definitions: math-items("lr", "mid", "abs", "norm", "floor", "ceil", "round"),
       description: "Documentation for functions that enable typesetting of matched, potentially scaled, delimiters.",
       docs: [
         Delimiter matching.
@@ -123,6 +123,15 @@
         #set math.lr(size: 1em)
         $ { (a / b), a, b in (0; 1/2] } $
         ```
+      ],
+    ),
+    (
+      name: "spaces",
+      title: "Spaces",
+      definitions: math-items("thin", "med", "thick", "quad", "wide"),
+      description: "Documentation for math spaces.",
+      docs: [
+        Predefined mathematical spaces of various widths.
       ],
     ),
   ),

--- a/docs/src/live.rs
+++ b/docs/src/live.rs
@@ -72,15 +72,20 @@ impl LiveVisitor {
                     && let Some(parent) = path.path.get_ident()
                 {
                     for item in &i.items {
-                        if let syn::ImplItem::Fn(item) = item
-                            && has_attr(&item.attrs, "func")
-                        {
-                            self.visit_func(
-                                item.span(),
-                                &item.attrs,
-                                &item.sig,
-                                Some(parent),
-                            );
+                        match item {
+                            syn::ImplItem::Const(c) if has_attr(&c.attrs, "constant") => {
+                                let key = format!("{parent}::{}", c.ident);
+                                self.save_docs(key, c.span(), &c.attrs);
+                            }
+                            syn::ImplItem::Fn(item) if has_attr(&item.attrs, "func") => {
+                                self.visit_func(
+                                    item.span(),
+                                    &item.attrs,
+                                    &item.sig,
+                                    Some(parent),
+                                );
+                            }
+                            _ => {}
                         }
                     }
                 }

--- a/docs/src/reflect.rs
+++ b/docs/src/reflect.rs
@@ -36,7 +36,13 @@ pub fn binding(module: Module, name: EcoString) -> Option<Dict> {
         "deprecation" => binding.deprecation().map(|d| dict! {
             "message" => d.message(),
             "until" => d.until(),
-        })
+        }),
+        "name" => binding.name(),
+        "title" => binding.title(),
+        "docs" => binding.docs(),
+        "since" => binding.since(),
+        "keywords" => binding.keywords(),
+        "def-site" => binding.def_site().map(describe_def_site),
     })
 }
 


### PR DESCRIPTION
Closes https://github.com/typst/typst/issues/8355.

This PR adds infrastructure to support documentation for associated constants in the documentation, and adds documentation for almost all associated constants.

AFAIK, the only constants that still aren't documented are `math.dif` and `math.Dif` because I could not find a right place to put them. Note that `math.dif` is currently only documented on the General Symbols list, and `math.Dif` not documented at all. I also excluded individual color definitions from the `color` type, because they are better documented together in the "Predefined colors" section. On the other hand, the "Predefined color maps" section has been moved to the documentation for the `color.map` module, which is documented as a constant.

Documentation for constants are stored in `BindingInfo`, as part of a new `BindingDocumentation` structure, which ensures that a binding cannot have only partial documentation information. When creating a binding from a function, type or element, its documentation is copied to the binding. There is AFAIK a single exception: symbol functions, for which the binding does not have any documentation information (which makes sense, because the binding is for the symbol, not the function).

I would argue that this closes https://github.com/typst/typst/issues/6567 by making `sys.version` a searchable item in the documentation, such that searching for "version" yields the result "Compiler Version".

<details>
<summary>A few screenshots showing some newly-documented constants.</summary>
<img width="997" height="1925" alt="A documentation page for all mathematical spaces, with examples." src="https://github.com/user-attachments/assets/d8c68735-2ff5-481b-955a-913ca2eab95f" />
<img width="970" height="1685" alt="A documentation section for constants from the `calc` module." src="https://github.com/user-attachments/assets/770e7c3c-f2a8-4452-9094-a4e9f058f7a2" />
<img width="970" height="841" alt="The documentation page for the `sys` module, where `sys.version` and `sys.inputs` are documented individually." src="https://github.com/user-attachments/assets/64a37a28-5e3b-4b02-b6a0-dfe15ae7be99" />
</details>