### PR TITLE
Add PDF document version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1498,7 +1498,7 @@ dependencies = [
 [[package]]
 name = "krilla"
 version = "0.8.2"
-source = "git+https://github.com/LaurenzV/krilla?rev=7772dbe#7772dbee5ba576b7b7afe2c59cbe4c2fefe7ce9c"
+source = "git+https://github.com/LaurenzV/krilla?rev=fb07499#fb07499278a2d2524dda38c41f338dec28bd0e48"
 dependencies = [
  "base64",
  "bumpalo",
@@ -1529,7 +1529,7 @@ dependencies = [
 [[package]]
 name = "krilla-svg"
 version = "0.8.1"
-source = "git+https://github.com/LaurenzV/krilla?rev=7772dbe#7772dbee5ba576b7b7afe2c59cbe4c2fefe7ce9c"
+source = "git+https://github.com/LaurenzV/krilla?rev=fb07499#fb07499278a2d2524dda38c41f338dec28bd0e48"
 dependencies = [
  "flate2",
  "fontdb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,8 +77,8 @@ indexmap = { version = "2", features = ["serde", "rayon"] }
 infer = { version = "0.19.0", default-features = false }
 itoa = "1"
 kamadak-exif = "0.6"
-krilla = { git = "https://github.com/LaurenzV/krilla", rev = "7772dbe", default-features = false, features = ["raster-images", "comemo", "rayon", "pdf"] }
-krilla-svg = { git = "https://github.com/LaurenzV/krilla", rev = "7772dbe" }
+krilla = { git = "https://github.com/LaurenzV/krilla", rev = "fb07499", default-features = false, features = ["raster-images", "comemo", "rayon", "pdf"] }
+krilla-svg = { git = "https://github.com/LaurenzV/krilla", rev = "fb07499" }
 kurbo = "0.13"
 libfuzzer-sys = "0.4"
 libm = "0.2.11"

--- a/crates/typst-library/src/model/document.rs
+++ b/crates/typst-library/src/model/document.rs
@@ -165,6 +165,9 @@ pub struct DocumentElem {
     /// The document's keywords.
     pub keywords: OneOrMultiple<EcoString>,
 
+    /// The document's version.
+    pub version: Option<EcoString>,
+
     /// The document's creation date.
     ///
     /// If this is `{auto}` (default), Typst uses the current date and time.
@@ -245,6 +248,7 @@ impl ShowSet for Packed<DocumentElem> {
         self.author.copy_into(&mut styles);
         self.description.copy_into(&mut styles);
         self.keywords.copy_into(&mut styles);
+        self.version.copy_into(&mut styles);
         self.date.copy_into(&mut styles);
         styles
     }
@@ -336,6 +340,8 @@ pub struct DocumentInfo {
     pub description: Option<EcoString>,
     /// The document's keywords.
     pub keywords: Vec<EcoString>,
+    /// The document's version.
+    pub version: Option<EcoString>,
     /// The document's creation date.
     pub date: Smart<Option<Datetime>>,
     /// The document's language, set from the first top-level set rule, e.g.
@@ -368,6 +374,9 @@ impl DocumentInfo {
         }
         if styles.has(DocumentElem::keywords) {
             self.keywords = styles.get_cloned(DocumentElem::keywords).0;
+        }
+        if styles.has(DocumentElem::version) {
+            self.version = styles.get_cloned(DocumentElem::version);
         }
         if styles.has(DocumentElem::date) {
             self.date = styles.get(DocumentElem::date);

--- a/crates/typst-library/src/model/document.rs
+++ b/crates/typst-library/src/model/document.rs
@@ -1,10 +1,12 @@
 use ecow::EcoString;
+use std::fmt::{self, Display, Formatter};
+
 use typst_syntax::VirtualPath;
 
 use crate::diag::{HintedStrResult, bail, error};
 use crate::foundations::{
     Array, BundlePath, Cast, Content, Datetime, OneOrMultiple, Packed, ShowFn, ShowSet,
-    Smart, StyleChain, Styles, Target, Value, cast, elem,
+    Smart, StyleChain, Styles, Target, Value, Version, cast, elem,
 };
 use crate::text::{Locale, TextElem};
 
@@ -166,7 +168,7 @@ pub struct DocumentElem {
     pub keywords: OneOrMultiple<EcoString>,
 
     /// The document's version.
-    pub version: Option<EcoString>,
+    pub version: Option<DocumentVersion>,
 
     /// The document's creation date.
     ///
@@ -323,6 +325,34 @@ cast! {
     v: Array => Self(v.into_iter().map(Value::cast).collect::<HintedStrResult<_>>()?),
 }
 
+/// A document version.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum DocumentVersion {
+    /// An arbitrary version string.
+    String(EcoString),
+    /// A structured version.
+    Version(Version),
+}
+
+impl Display for DocumentVersion {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Self::String(version) => Display::fmt(version, f),
+            Self::Version(version) => Display::fmt(version, f),
+        }
+    }
+}
+
+cast! {
+    DocumentVersion,
+    self => match self {
+        Self::String(version) => version.into_value(),
+        Self::Version(version) => version.into_value(),
+    },
+    v: EcoString => Self::String(v),
+    v: Version => Self::Version(v),
+}
+
 /// A document resulting from compilation.
 pub trait Document {
     /// Get the document's metadata.
@@ -341,7 +371,7 @@ pub struct DocumentInfo {
     /// The document's keywords.
     pub keywords: Vec<EcoString>,
     /// The document's version.
-    pub version: Option<EcoString>,
+    pub version: Option<DocumentVersion>,
     /// The document's creation date.
     pub date: Smart<Option<Datetime>>,
     /// The document's language, set from the first top-level set rule, e.g.

--- a/crates/typst-pdf/src/metadata.rs
+++ b/crates/typst-pdf/src/metadata.rs
@@ -39,6 +39,10 @@ pub(crate) fn build_metadata(gc: &GlobalContext, doc_lang: Option<Locale>) -> Me
         metadata = metadata.description(description.to_string());
     }
 
+    if let Some(version) = &gc.document.info().version {
+        metadata = metadata.version_id(version.to_string());
+    }
+
     if let Smart::Custom(ident) = gc.options.ident.clone() {
         metadata = metadata.document_id(ident);
     }

--- a/tests/ref/pdftags/hashes.txt
+++ b/tests/ref/pdftags/hashes.txt
@@ -20,6 +20,7 @@ a435ca208442488e4e2aabe6e6099ba0 disable-tags-artifact
 3aac7b296f56f38b0fcc052600ee7f4e disable-tags-partially-hidden-list
 43634e3eaf8b049944de5d91b422d4f4 disable-tags-tiling
 98a66b0fbf18213150385bd502c454e7 document-set-version
+230f0601992eacf952005dac54b153e5 document-set-version-string
 859ace8e2c8a260057c11b2977712425 enum-number-override-nested
 e3af0bddd6bcdbad33943109d3c79fcb figure-basic
 cb9571403237411f8d62aa142f1f5c80 figure-tags-additional-caption-inside-body

--- a/tests/ref/pdftags/hashes.txt
+++ b/tests/ref/pdftags/hashes.txt
@@ -19,6 +19,7 @@ a435ca208442488e4e2aabe6e6099ba0 disable-tags-artifact
 5d6260377cd49d4dea5f6e9657c23990 disable-tags-hide
 3aac7b296f56f38b0fcc052600ee7f4e disable-tags-partially-hidden-list
 43634e3eaf8b049944de5d91b422d4f4 disable-tags-tiling
+98a66b0fbf18213150385bd502c454e7 document-set-version
 859ace8e2c8a260057c11b2977712425 enum-number-override-nested
 e3af0bddd6bcdbad33943109d3c79fcb figure-basic
 cb9571403237411f8d62aa142f1f5c80 figure-tags-additional-caption-inside-body

--- a/tests/src/pdftags.rs
+++ b/tests/src/pdftags.rs
@@ -165,6 +165,11 @@ fn format_xmp_metadata(f: &mut Formatter, stream: Stream) -> StrResult<()> {
     let rdf = child(&xmpmeta, "RDF").ok_or("missing rdf:RDF")?;
     let description = child(&rdf, "Description").ok_or("missing rdf:Description")?;
 
+    if let Some(version_id) = child(&description, "VersionID") {
+        let version_id = version_id.text().ok_or("missing text")?;
+        writeln!(f, "version: {version_id:?}").ok();
+    }
+
     if let Some(dc_lang) = child(&description, "language") {
         let bag = child(&dc_lang, "Bag").ok_or("missing rdf:Bag")?;
         let item = bag.first_element_child().ok_or("missing rdf:li")?;

--- a/tests/suite/model/document.typ
+++ b/tests/suite/model/document.typ
@@ -7,6 +7,9 @@ What's up?
 --- document-set-author-date paged empty ---
 #set document(author: ("A", "B"), date: datetime.today())
 
+--- document-set-version pdftags ---
+#set document(version: "1.2.3")
+
 --- document-date-bad eval ---
 // Error: 21-28 expected datetime, none, or auto, found string
 #set document(date: "today")
@@ -165,6 +168,7 @@ world
   author: "Test Author",
   description: [Test description],
   keywords: ("a", "b"),
+  version: "1.2.3",
 )[
   #title()
   // Testing all properties separately because, in the current implementation,
@@ -175,6 +179,7 @@ world
     test(document.author, ("Test Author",))
     test(document.description, [Test description])
     test(document.keywords, ("a", "b"))
+    test(document.version, "1.2.3")
     test(document.date, auto)
   }
 ]

--- a/tests/suite/model/document.typ
+++ b/tests/suite/model/document.typ
@@ -8,7 +8,10 @@ What's up?
 #set document(author: ("A", "B"), date: datetime.today())
 
 --- document-set-version pdftags ---
-#set document(version: "1.2.3")
+#set document(version: version(1, 2, 3))
+
+--- document-set-version-string pdftags ---
+#set document(version: "v1.2.3-beta")
 
 --- document-date-bad eval ---
 // Error: 21-28 expected datetime, none, or auto, found string
@@ -168,7 +171,7 @@ world
   author: "Test Author",
   description: [Test description],
   keywords: ("a", "b"),
-  version: "1.2.3",
+  version: version(1, 2, 3),
 )[
   #title()
   // Testing all properties separately because, in the current implementation,
@@ -179,7 +182,7 @@ world
     test(document.author, ("Test Author",))
     test(document.description, [Test description])
     test(document.keywords, ("a", "b"))
-    test(document.version, "1.2.3")
+    test(document.version, version(1, 2, 3))
     test(document.date, auto)
   }
 ]


### PR DESCRIPTION
Solves #7595 thanks to https://github.com/LaurenzV/krilla/pull/424 (reference update).

This is only for PDF. HTML, SVG and PNG aren't considered, as well as EPUB as it isn't implemented. Mostly because they don't have the same specification formality as PDF had it (to what I could find), it could possibly be embedded with meta tags in HTML or iTXt chunks in PNG, but I don't find it relevant.