### PR TITLE
Improve line breaks for the list of raw syntaxes in PDF docs

### DIFF
--- a/crates/typst-library/src/text/raw.rs
+++ b/crates/typst-library/src/text/raw.rs
@@ -340,7 +340,12 @@ pub struct RawElem {
     ///     table.header[Name][Tags],
     ///     ..stdx.raw-langs.map(((name, tokens)) => (
     ///       name,
-    ///       tokens.map(raw).join[, ],
+    ///       // Some tokens start with `.`. For example, `.env`. The Unicode
+    ///       // Line Breaking Algorithm forbids breaking before `.`, even after
+    ///       // spaces. Therefore, we add zero-width spaces to provide
+    ///       // additional break opportunities. Note that https://github.com/typst/typst/issues/5317
+    ///       // might change the situation.
+    ///       tokens.map(raw).join[, #sym.zws],
     ///     )).flatten()
     ///   )
     /// )

--- a/crates/typst-library/src/text/raw.rs
+++ b/crates/typst-library/src/text/raw.rs
@@ -343,8 +343,9 @@ pub struct RawElem {
     ///       // Some tokens start with `.`. For example, `.env`. The Unicode
     ///       // Line Breaking Algorithm forbids breaking before `.`, even after
     ///       // spaces. Therefore, we add zero-width spaces to provide
-    ///       // additional break opportunities. Note that https://github.com/typst/typst/issues/5317
-    ///       // might change the situation.
+    ///       // additional break opportunities. Note that
+    ///       // https://github.com/typst/typst/issues/5317 might change the
+    ///       // situation.
     ///       tokens.map(raw).join[, #sym.zws],
     ///     )).flatten()
     ///   )


### PR DESCRIPTION
#8624 added the list of supported `raw.lang` to docs.

However, in the PDF version, some lines overflow because of subtleties of the line breaking algorithm.
This PR adds additional break opportunities to avoid that.

| Before | After |
|--|--|
| <img width="400" alt="图片" src="https://github.com/user-attachments/assets/2955cd6b-2edc-45c7-89ff-624967bc5354" /> | <img width="400" alt="图片" src="https://github.com/user-attachments/assets/48a856e0-2fb4-4e5f-9c27-a2402bda28d3" /> |



## Further Details

Some tokens start with `.`. For example, `.env`, `.env.local`, `.bash_aliases`, etc.

[Rule LB15d in UAX `#14`: Unicode Line Breaking Algorithm](https://www.unicode.org/reports/tr14/#LB15d) specifies:

> …do not break before `;`, `,`, or `.`, even after spaces.

Therefore, the space in `.env, .env.local` does not provide a break opportunity.
You can verify that by pasting the following text to [Unicode Utilities: Breaks (Segmentation)](https://util.unicode.org/UnicodeJsps/breaks.jsp) and changing _Word_ to _Line_. You'll see that there're very few opportunities for line breaks (the red vertical lines).

> sh, bash, zsh, ash, .bash_aliases, .bash_completions, .bash_functions, .bash_login, .bash_logout, .bash_profile, .bash_variables, .bashrc, .profile, .textmate_init, .zlogin, .zlogout, .zprofile, .zshenv, .zshrc, PKGBUILD, ebuild, eclass
<img width="940" height="157" alt="图片" src="https://github.com/user-attachments/assets/9c53d0c5-85ec-4a58-a0aa-6237ab5e1f78" />

To fix that, we can add a zero-width space after the space.

[ZW: Zero Width Space in UAX `#14`](https://www.unicode.org/reports/tr14/#ZW):

> 200B 	ZERO WIDTH SPACE (ZWSP)
>
> This character is used to enable additional (invisible) break opportunities wherever SPACE cannot be used. As its name implies, it normally has no width. However, its presence between two characters does not prevent increased letter spacing in justification.

I guess the experts from Unicode have good reasons for LB15d, but they didn't expect `.env, .env.local`. It's easier that we tweak the algorithm manually.
