### PR TITLE
Upload typst-documentation.pdf in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,13 @@ jobs:
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
       - run: cargo docit compile --format website --deny-warnings
       - run: cargo docit compile --format pdf --deny-warnings
+      - name: Rename documentation file
+        run: mv docs/dist/docs.pdf typst-documentation.pdf
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: typst-documentation.pdf
+          path: typst-documentation.pdf
+          compression-level: 9
 
   min-version:
     name: Check minimum Rust version


### PR DESCRIPTION
Currently, `cargo docit` is resource-intensive and rather slow.
Uploading `typst-documentation.pdf` will make it easier to review docs PRs.

The problem fixed by #8750 is an example. If someone had checked the PDF for #8624, it would have been very easy to notice the problem.

I rename the file to be consistent with `release.yml`.

## Previous dicussions
[Discord 2026-07-19](https://discord.com/channels/1054443721975922748/1399326777540608041/1528423945873658061)

> Could ci.yml upload typst-documentation.pdf so that people can download the docs for each commit?
> cargo docit compile is already included in ci.yml. It's trivial to add actions/upload-artifact.
> Are there any particular concerns? 

> It'll probably be fine, since its not part of the repo it's just an artifact on gh

> would be cool 👀

> I wonder how much this would actually be used. This feels like a thing that only a handful of people would actually know or care about. 
