### PR TITLE
List Debian packages in the Linux install options

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ Typst's CLI is available from different sources:
   - Linux:
       - View [Typst on Repology][repology]
       - View [Typst's Snap][snap]
+      - [Debian packages](https://apt.pkg.haus) for stable, testing, and unstable (amd64, arm64)
+        - Add the repository: see https://pkg.haus for setup instructions
+        - Install: `sudo apt install typst`
   - macOS: `brew install typst`
   - Windows: `winget install --id Typst.Typst`
 


### PR DESCRIPTION
[pkg.haus](https://pkg.haus) is a signed APT archive carrying typst for Debian stable, testing and unstable (amd64/arm64), built from source at upstream release tags (typst-cli with default features, dynamic system OpenSSL). This adds it to the Linux options next to Repology and Snap.