### PR TITLE
Pin Docker base layers to specific tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
-FROM --platform=$BUILDPLATFORM rust:alpine AS build
+FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.9.0 AS xx
+FROM --platform=$BUILDPLATFORM rust:1.95.0-alpine3.23 AS build
 
 COPY --from=xx / /
 
@@ -24,7 +24,7 @@ RUN --mount=type=cache,target=/root/.cargo/git/db \
     cp target/$(xx-cargo --print-target-triple)/release/typst target/release/typst && \
     xx-verify target/release/typst
 
-FROM alpine:latest
+FROM alpine:3.23
 ARG CREATED
 ARG REVISION
 


### PR DESCRIPTION
In the production Dockerfile, we previously did not pin the Rust toolchain to a specific version or `tonistiigi/xx` to any version at all.

I have now pinned both: `xx` to the latest numbered version and Rust to 1.95.0, which we use most for `dtolnay/rust-toolchain` in our actions and the latest Alpine available there. For the final image, I used the matching Alpine minor (even though a newer minor version is available).

During this PR, I noticed a few things:

- We are using SHA hashes in CI but tags in Docker. Like in Git, Docker tags are mutable. Should we unify this?
- Do we need a note to update this alongside the workflow Rust toolchains? At any rate, checking this needs to go in the release checklist
- We ship no `.dockerignore` file, leading to things like the `target` and `.git` folders being included in the context transferred to Docker. This has no impact on the final image due to the staged build, but leads to cache invalidation both locally and in CI. In both environments, a `.git` folder is present and transferred to the first stage even if there were no other changes. Should I create a follow-up PR or an issue?