### PR TITLE
Let `cargo testit` use forward slashes for symlinks on Windows

### DIFF
--- a/tests/src/collect.rs
+++ b/tests/src/collect.rs
@@ -359,7 +359,9 @@ impl TestOutput {
     /// The path at which the live output will be stored.
     pub fn hash_path(self, hash: HashedRef, name: &str) -> PathBuf {
         let ext = self.live_extension();
-        PathBuf::from(format!("{STORE_PATH}/by-hash/{hash}_{name}.{ext}"))
+        [STORE_PATH, "by-hash", format!("{hash}_{name}.{ext}").as_ref()]
+            .iter()
+            .collect()
     }
 
     /// The path at which a symlink to the [`Self::hash_path`] will be created


### PR DESCRIPTION
`cargo testit` creates symlinks in `tests/store/`. For example, `tests/store/html/title.html` → `tests/store/by-hash/ef8ad75bfd126f2bd21b319bf594f001_title.html`.

On Windows, this symlink file contains `..\by-hash/ef8ad75bfd126f2bd21b319bf594f001_title.html` (backslash + forward slash). However, only `..\by-hash\ef8ad75bfd126f2bd21b319bf594f001_title.html` (all backslashes) is recognized.
(Note that this doesn't fail `cargo testit`. It's just that Windows users can't open `tests/store/html/title.html` directly.)

This PR fixes that by replacing `format!("{…}/{…}")` with a proper creation of `PathBuf`.

## Supplementary info

In fact, most parts of Windows today support both forward and backward slashes. Symlink is an exception.

You can verify the behaviour on Windows with the following steps.

1. Save the following as `src/main.rs` and execute `cargo run`.

```rust
use std::fs;
use std::io::prelude::*;

fn main() -> std::io::Result<()> {
    let mut file = fs::File::create("a.txt")?;
    file.write_all(b"There are only two kinds of operating systems: POSIX and others.")?;

    fs::create_dir_all("foo")?;
    std::os::windows::fs::symlink_file(r"..\a.txt", "foo/good.link")?;
    std::os::windows::fs::symlink_file(r"../a.txt", "foo/bad.link")?;

    Ok(())
}
```

2. Execute the following commands in PowerShell.

```pwsh
> Get-Content foo/good.link
There are only two kinds of operating systems: POSIX and others.

> Get-Content foo/bad.link
Get-Content: 文件名、目录名或卷标语法不正确。 : 'C:\path\to\project\foo\bad.link'.

> Get-ChildItem ./foo/

    Directory: C:\path\to\project\foo

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
la---           2026/8/17    17:26              0 bad.link -> ../a.txt
la---           2026/8/17    17:26              0 good.link -> ..\a.txt
```

(By the way, [uutils coreutils' `ln`](https://uutils.org/coreutils/docs/utils/ln.html) also has this problem.)
