### PR TITLE
Use `<meta name="author">` for authors in HTML output

### DIFF
--- a/crates/typst-html/src/document.rs
+++ b/crates/typst-html/src/document.rs
@@ -340,11 +340,11 @@ fn head_element(info: &DocumentInfo) -> HtmlElement {
         );
     }
 
-    if !info.author.is_empty() {
+    for author in &info.author {
         children.push(
             HtmlElement::new(tag::meta)
-                .with_attr(attr::name, "authors")
-                .with_attr(attr::content, info.author.join(", "))
+                .with_attr(attr::name, "author")
+                .with_attr(attr::content, author)
                 .into(),
         );
     }

--- a/tests/ref/bundle/document-properties-in-bundle.txt
+++ b/tests/ref/bundle/document-properties-in-bundle.txt
@@ -1,1 +1,1 @@
-4416a5e8d5e907f109b38ff116c8d7a4 hi.html
+da77501b2056df22ed5cfba32aab3043 hi.html

--- a/tests/ref/html/hashes.txt
+++ b/tests/ref/html/hashes.txt
@@ -41,6 +41,8 @@ ffa25d90e2baac1e02b03a60cae89720 block-html-block
 e87734ba4dba7fed32967be69484478c col-gutter-table
 e87734ba4dba7fed32967be69484478c col-row-gutter-table
 c3adb00220cf56685a91e1bd4d93f3b4 divider-html
+51bc0feb18dfc54b51463fa6374d9a21 document-multiple-authors-html
+ec72df663ab6b4fe6aedaec1ab3f2165 document-multiple-keywords-html
 4131a1789df95f853768971f54e850a9 enum-par
 013e6642f1140f60b83d7ca64ca77c87 enum-start
 dfd6054882467753666c1ebe54b81a0d footnote-basic
@@ -53,8 +55,6 @@ f05d21fa2b913016803bf5476a1b6826 footnote-ref-multiple
 238cfb7578ecfc0e457b2e2bb2dbba44 footnote-space-collapsing
 173d20de89ff8a56303aa8357ec2c323 heading-html-basic
 3779fea930339d8b6b37305dee2f7d1d html-deco
-51bc0feb18dfc54b51463fa6374d9a21 html-document-multiple-authors
-ec72df663ab6b4fe6aedaec1ab3f2165 html-document-multiple-keywords
 eeecf9598691783d361c20acf47a8775 html-elem-alone-context
 e34ea44e32ada9e0685b72d6e82ecfd5 html-elem-attrs-fold
 2ea76ccf8bdc8f8a39f586aab6ed80c9 html-elem-custom

--- a/tests/ref/html/hashes.txt
+++ b/tests/ref/html/hashes.txt
@@ -53,6 +53,8 @@ f05d21fa2b913016803bf5476a1b6826 footnote-ref-multiple
 238cfb7578ecfc0e457b2e2bb2dbba44 footnote-space-collapsing
 173d20de89ff8a56303aa8357ec2c323 heading-html-basic
 3779fea930339d8b6b37305dee2f7d1d html-deco
+51bc0feb18dfc54b51463fa6374d9a21 html-document-multiple-authors
+ec72df663ab6b4fe6aedaec1ab3f2165 html-document-multiple-keywords
 eeecf9598691783d361c20acf47a8775 html-elem-alone-context
 e34ea44e32ada9e0685b72d6e82ecfd5 html-elem-attrs-fold
 2ea76ccf8bdc8f8a39f586aab6ed80c9 html-elem-custom

--- a/tests/suite/html/document.typ
+++ b/tests/suite/html/document.typ
@@ -1,0 +1,7 @@
+--- html-document-multiple-authors html ---
+// Should emit multiple <meta> tags.
+#set document(author: ("John Doe", "Jane Doe"))
+
+--- html-document-multiple-keywords html ---
+// Should emit a single <meta> tag.
+#set document(keywords: ("foo", "bar"))

--- a/tests/suite/html/document.typ
+++ b/tests/suite/html/document.typ
@@ -1,7 +1,0 @@
---- html-document-multiple-authors html ---
-// Should emit multiple <meta> tags.
-#set document(author: ("John Doe", "Jane Doe"))
-
---- html-document-multiple-keywords html ---
-// Should emit a single <meta> tag.
-#set document(keywords: ("foo", "bar"))

--- a/tests/suite/model/document.typ
+++ b/tests/suite/model/document.typ
@@ -41,6 +41,14 @@ Hello
 // Error: 11-15 path `".."` would escape the bundle root
 #document("..", format: "pdf")[Root?]
 
+--- document-multiple-authors-html html ---
+// Should emit multiple `<meta>` tags.
+#set document(author: ("John Doe", "Jane Doe"))
+
+--- document-multiple-keywords-html html ---
+// Should emit a single `<meta>` tag.
+#set document(keywords: ("foo", "bar"))
+
 --- document-weird-extension bundle ---
 // The hashes of both files should match.
 #document("normal.pdf")[A PDF]


### PR DESCRIPTION
Previously, all authors were comma-separated into an `authors` meta element (note the plural form) which doesn't seem to exist in the HTML spec. With this commit, instead each author gets their own [`author`](https://html.spec.whatwg.org/#meta-author) meta element. From what I can tell, it is legal for this to occur multiple times in the case of multiple authors.