### PR TITLE
Improve type safety in flow layout

### DIFF
--- a/crates/typst-layout/src/flow/compose.rs
+++ b/crates/typst-layout/src/flow/compose.rs
@@ -1,6 +1,8 @@
+use std::convert::Infallible;
 use std::num::NonZeroUsize;
 
-use typst_library::diag::SourceResult;
+use ecow::EcoVec;
+use typst_library::diag::{SourceDiagnostic, SourceResult};
 use typst_library::engine::Engine;
 use typst_library::foundations::{Content, NativeElement, Packed, Resolve, Smart};
 use typst_library::introspection::{
@@ -18,9 +20,123 @@ use typst_library::model::{
 use typst_syntax::Span;
 use typst_utils::{NonZeroExt, Numeric};
 
-use super::{
-    Config, FlowMode, FlowResult, LineNumberConfig, PlacedChild, Stop, Work, distribute,
-};
+use super::distribute::distribute;
+use super::{Config, FlowMode, LineNumberConfig, PlacedChild, Work};
+
+/// The result type for page composition.
+type PageResult<T> = Result<T, PageStop>;
+
+/// A control flow event during page composition.
+enum PageStop {
+    /// Indicates that the parent region should be relayouted.
+    Relayout,
+    /// A fatal error.
+    Error(EcoVec<SourceDiagnostic>),
+}
+
+impl From<EcoVec<SourceDiagnostic>> for PageStop {
+    fn from(error: EcoVec<SourceDiagnostic>) -> Self {
+        Self::Error(error)
+    }
+}
+
+/// The result type for layout that may request a relayout.
+pub(super) type RelayoutResult<T> = Result<T, RelayoutStop>;
+
+/// A control flow event after layout during relayout.
+pub(super) enum RelayoutStop {
+    /// Indicates that the given scope should be relayouted.
+    Relayout(PlacementScope),
+    /// A fatal error.
+    Error(EcoVec<SourceDiagnostic>),
+}
+
+/// A control flow event while handling an insertion.
+///
+/// The type parameter `R` describes the requested relayout. The type parameter
+/// `M` controls the [`MigrateOrigin`](Self::MigrateOrigin) variant. When
+/// `M = Infallible`, the variant is empty.
+pub(super) enum InsertionStop<R, M = ()> {
+    /// The insertion changed the available space.
+    Relayout(R),
+    /// The footnote did not fit with its origin frame.
+    MigrateOrigin(M),
+    /// A fatal error.
+    Error(EcoVec<SourceDiagnostic>),
+}
+
+impl<R, M> From<EcoVec<SourceDiagnostic>> for InsertionStop<R, M> {
+    fn from(error: EcoVec<SourceDiagnostic>) -> Self {
+        Self::Error(error)
+    }
+}
+
+/// A control flow event during footnote handling.
+pub(super) type FootnoteStop<M = ()> = InsertionStop<(), M>;
+
+/// A control flow event during float handling.
+pub(super) type FloatStop<M = ()> = InsertionStop<PlacementScope, M>;
+
+impl<M> From<FootnoteStop<M>> for FloatStop<M> {
+    fn from(stop: FootnoteStop<M>) -> Self {
+        match stop {
+            FootnoteStop::Relayout(()) => Self::Relayout(PlacementScope::Column),
+            FootnoteStop::MigrateOrigin(migration) => Self::MigrateOrigin(migration),
+            FootnoteStop::Error(error) => Self::Error(error),
+        }
+    }
+}
+
+impl From<FootnoteStop<Infallible>> for RelayoutStop {
+    fn from(stop: FootnoteStop<Infallible>) -> Self {
+        match stop {
+            FootnoteStop::Relayout(()) => Self::Relayout(PlacementScope::Column),
+            FootnoteStop::MigrateOrigin(never) => match never {},
+            FootnoteStop::Error(error) => Self::Error(error),
+        }
+    }
+}
+
+impl From<FloatStop<Infallible>> for RelayoutStop {
+    fn from(stop: FloatStop<Infallible>) -> Self {
+        match stop {
+            FloatStop::Relayout(scope) => Self::Relayout(scope),
+            FloatStop::MigrateOrigin(never) => match never {},
+            FloatStop::Error(error) => Self::Error(error),
+        }
+    }
+}
+
+/// Whether a footnote's origin frame may migrate to the next region.
+#[derive(Clone, Copy)]
+pub(super) struct Migration<M>(Option<M>);
+
+impl Migration<()> {
+    /// Allow the origin frame to migrate.
+    pub(super) const ALLOW: Self = Self(Some(()));
+}
+
+impl Migration<Infallible> {
+    /// Forbid the origin frame from migrating.
+    const FORBID: Self = Self(None);
+}
+
+impl<M> Migration<M> {
+    /// Forbid the origin frame from migrating.
+    fn forbid(&mut self) {
+        self.0 = None;
+    }
+
+    /// Disable migration and return the previous setting.
+    fn take(&mut self) -> Self {
+        Self(self.0.take())
+    }
+
+    /// Extract the inner value, if migration is allowed.
+    fn into_inner(self) -> Option<M> {
+        self.0
+    }
+}
 
 /// Composes the contents of a single page/region. A region can have multiple
 /// columns/subregions.
@@ -83,7 +199,7 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
     /// Lay out a container/page region, including container/page insertions.
     fn page(mut self, locator: Locator, regions: Regions) -> SourceResult<Frame> {
         // This loop can restart region layout when requested to do so by a
-        // `Stop`. This happens when there is a parent-scoped float.
+        // `PageStop::Relayout`. This happens when there is a parent-scoped float.
         let checkpoint = self.work.clone();
         let output = loop {
             // Shrink the available space by the space used by page
@@ -93,12 +209,8 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
 
             match self.page_contents(locator.relayout(), pod) {
                 Ok(frame) => break frame,
-                Err(Stop::Finish(_)) => unreachable!(),
-                Err(Stop::Relayout(PlacementScope::Column)) => unreachable!(),
-                Err(Stop::Relayout(PlacementScope::Parent)) => {
-                    *self.work = checkpoint.clone();
-                }
-                Err(Stop::Error(err)) => return Err(err),
+                Err(PageStop::Relayout) => *self.work = checkpoint.clone(),
+                Err(PageStop::Error(err)) => return Err(err),
             }
         };
         drop(checkpoint);
@@ -107,7 +219,7 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
     }
 
     /// Lay out the inner contents of a container/page.
-    fn page_contents(&mut self, locator: Locator, regions: Regions) -> FlowResult<Frame> {
+    fn page_contents(&mut self, locator: Locator, regions: Regions) -> PageResult<Frame> {
         // No point in create column regions, if there's just one!
         if self.config.columns.count == 1 {
             return self.column(locator, regions).map(|(frame, ..)| frame);
@@ -206,7 +318,7 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
             let height = total_used_height / self.config.columns.count as f64;
             if self.column_balancing_height.is_none_or(|h| h < height) {
                 self.column_balancing_height = Some(height);
-                return Err(Stop::Relayout(PlacementScope::Parent));
+                return Err(PageStop::Relayout);
             }
         }
 
@@ -215,7 +327,7 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
 
     /// Lay out a column, including column insertions.
     ///
-    /// Returns a `FlowResult` containing a tuple of
+    /// Returns a `PageResult` containing a tuple of
     /// - `0`: The laid out frame.
     /// - `1`: The height actually used by the inner contents (used for column
     ///   balancing logic).
@@ -224,7 +336,7 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
         &mut self,
         locator: Locator,
         regions: Regions,
-    ) -> FlowResult<(Frame, Abs, Abs)> {
+    ) -> PageResult<(Frame, Abs, Abs)> {
         // Reset column insertion when starting a new column.
         self.column_insertions = Insertions::default();
 
@@ -234,7 +346,7 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
         }
 
         // This loop can restart column layout when requested to do so by a
-        // `Stop`. This happens when there is a column-scoped float.
+        // `RelayoutStop`. This happens when there is a column-scoped float.
         let checkpoint = self.work.clone();
         let (inner, used_height) = loop {
             // Shrink the available space by the space used by column
@@ -252,11 +364,13 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
 
             match self.column_contents(pod, balancing_target) {
                 Ok((frame, used_height)) => break (frame, used_height + float_height),
-                Err(Stop::Finish(_)) => unreachable!(),
-                Err(Stop::Relayout(PlacementScope::Column)) => {
+                Err(RelayoutStop::Relayout(PlacementScope::Column)) => {
                     *self.work = checkpoint.clone();
                 }
-                Err(err) => return Err(err),
+                Err(RelayoutStop::Relayout(PlacementScope::Parent)) => {
+                    return Err(PageStop::Relayout);
+                }
+                Err(RelayoutStop::Error(error)) => return Err(PageStop::Error(error)),
             }
         };
         drop(checkpoint);
@@ -302,21 +416,21 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
     /// however, we forbid footnote migration (moving the frame containing the
     /// footnote reference if the corresponding entry doesn't fit), allowing
     /// the footnote invariant to be broken, as it would require handling a
-    /// [`Stop::Finish`] at this point, but that is exclusively handled by the
-    /// distributor.
+    /// [`FootnoteStop::MigrateOrigin`] at this point, but that is exclusively
+    /// handled by the distributor.
     fn column_contents(
         &mut self,
         regions: Regions,
         balancing_target: Option<Abs>,
-    ) -> FlowResult<(Frame, Abs)> {
+    ) -> RelayoutResult<(Frame, Abs)> {
         // Process pending footnotes.
         for note in std::mem::take(&mut self.work.footnotes) {
-            self.footnote(note, &mut regions.clone(), Abs::zero(), false)?;
+            self.footnote(note, &mut regions.clone(), Abs::zero(), Migration::FORBID)?;
         }
 
         // Process pending floats.
         for placed in std::mem::take(&mut self.work.floats) {
-            self.float(placed, &regions, false, false)?;
+            self.float(placed, &regions, false, Migration::FORBID)?;
         }
 
         distribute(self, regions, balancing_target)
@@ -325,27 +439,27 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
     /// Lays out an item with floating placement.
     ///
     /// This is called from within [`distribute()`]. When the float fits, this
-    /// returns an `Err(Stop::Relayout(..))`, which bubbles all the way through
-    /// distribution and is handled in [`Self::page`] or [`Self::column`]
-    /// (depending on `placed.scope`).
+    /// returns an `Err(FloatStop::Relayout(..))`, which bubbles all the way
+    /// through distribution and is handled in [`Self::page`] or
+    /// [`Self::column`] (depending on `placed.scope`).
     ///
     /// When the float does not fit, it is queued into `work.floats`. The
     /// value of `clearance` indicates that between the float and flow content
     /// is needed --- it is set if there are already distributed items.
     ///
-    /// The value of `migratable` determines whether footnotes within the float
+    /// The value of `migration` determines whether footnotes within the float
     /// should be allowed to prompt its migration if they don't fit in order to
     /// respect the footnote invariant (entries in the same page as the
-    /// references), triggering [`Stop::Finish`]. This is usually `true` within
-    /// the distributor, as it can handle that particular flow event, and
-    /// `false` elsewhere.
-    pub fn float(
+    /// references), triggering [`FloatStop::MigrateOrigin`]. This is usually
+    /// [`Migration::ALLOW`] within the distributor, as it can handle that
+    /// particular flow event, and [`Migration::FORBID`] elsewhere.
+    pub fn float<M: Copy>(
         &mut self,
         placed: &'b PlacedChild<'a>,
         regions: &Regions,
         clearance: bool,
-        migratable: bool,
-    ) -> FlowResult<()> {
+        migration: Migration<M>,
+    ) -> Result<(), FloatStop<M>> {
         // If the float is already processed, skip it.
         let loc = placed.location();
         if self.skipped(loc) {
@@ -393,7 +507,7 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
         }
 
         // Handle footnotes in the float.
-        self.footnotes(regions, &frame, need, false, migratable)?;
+        self.footnotes(regions, &frame, need, false, migration)?;
 
         // Determine the float's vertical alignment. We can unwrap the inner
         // `Option` because `Custom(None)` is checked for during collection.
@@ -418,26 +532,27 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
         area.skips.push(loc);
 
         // Trigger relayout.
-        Err(Stop::Relayout(placed.scope))
+        Err(FloatStop::Relayout(placed.scope))
     }
 
     /// Lays out footnotes in the `frame` if this is the root flow and there are
     /// any. The value of `breakable` indicates whether the element that
     /// produced the frame is breakable. If not, the frame is treated as atomic.
     ///
-    /// The value of `migratable` indicates whether footnote migration should be
+    /// The value of `migration` indicates whether footnote migration should be
     /// possible (at least for the first footnote found in the frame, as it is
-    /// forbidden for the second footnote onwards). It is usually `true` within
-    /// the distributor and `false` elsewhere, as the distributor can handle
-    /// [`Stop::Finish`] which is returned when migration is requested.
-    pub fn footnotes(
+    /// forbidden for the second footnote onwards). It is usually
+    /// [`Migration::ALLOW`] within the distributor and [`Migration::FORBID`]
+    /// elsewhere, as the distributor can handle [`FootnoteStop::MigrateOrigin`]
+    /// which is returned when migration is requested.
+    pub fn footnotes<M: Copy>(
         &mut self,
         regions: &Regions,
         frame: &Frame,
         flow_need: Abs,
         breakable: bool,
-        migratable: bool,
-    ) -> FlowResult<()> {
+        mut migration: Migration<M>,
+    ) -> Result<(), FootnoteStop<M>> {
         // Footnotes are only supported at the root level.
         if self.config.mode != FlowMode::Root {
             return Ok(());
@@ -461,7 +576,9 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
         // The first footnote's origin frame should be migratable if the region
         // may progress (already checked by the footnote function) and if the
         // origin frame isn't breakable (checked here).
-        let mut migratable = migratable && !breakable;
+        if breakable {
+            migration.forbid();
+        }
 
         for (y, elem) in notes {
             // The amount of space used by the in-flow content that contains the
@@ -469,41 +586,42 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
             // the marker. For an unbreakable frame, it's the full height.
             let flow_need = if breakable { y } else { flow_need };
 
+            // We only migrate the origin frame if the first footnote's first
+            // line didn't fit.
+            let migration = migration.take();
+
             // Process the footnote.
-            match self.footnote(elem, &mut regions, flow_need, migratable) {
+            match self.footnote(elem, &mut regions, flow_need, migration) {
                 // The footnote was already processed or queued.
                 Ok(()) => {}
                 // First handle more footnotes before relayouting.
-                Err(Stop::Relayout(_)) => relayout = true,
+                Err(FootnoteStop::Relayout(())) => relayout = true,
                 // Either of
-                // - A `Stop::Finish` indicating that the frame's origin element
-                //   should migrate to uphold the footnote invariant.
+                // - A `FootnoteStop::MigrateOrigin` indicating that the frame's
+                //   origin element should migrate to uphold the footnote
+                //   invariant.
                 // - A fatal error.
                 err => return err,
             }
-
-            // We only migrate the origin frame if the first footnote's first
-            // line didn't fit.
-            migratable = false;
         }
 
         // If this is set, we laid out at least one footnote, so we need a
         // relayout.
         if relayout {
-            return Err(Stop::Relayout(PlacementScope::Column));
+            return Err(FootnoteStop::Relayout(()));
         }
 
         Ok(())
     }
 
     /// Handles a single footnote.
-    fn footnote(
+    fn footnote<M: Copy>(
         &mut self,
         elem: Packed<FootnoteElem>,
         regions: &mut Regions,
         flow_need: Abs,
-        migratable: bool,
-    ) -> FlowResult<()> {
+        migration: Migration<M>,
+    ) -> Result<(), FootnoteStop<M>> {
         // Ignore reference footnotes and already processed ones.
         let loc = elem.location().unwrap();
         if elem.is_ref() || self.skipped(loc) {
@@ -577,8 +695,10 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
         // `regions.may_progress()` must still be checked separately for
         // migration, regardless of the presence of flow need.
         if first.is_empty() && exist_non_empty_frame {
-            if migratable && regions.may_progress() {
-                return Err(Stop::Finish(false));
+            if let Some(m) = migration.into_inner()
+                && regions.may_progress()
+            {
+                return Err(FootnoteStop::MigrateOrigin(m));
             } else if regions.may_progress() || !flow_need.is_zero() {
                 self.footnote_queue.push(elem);
                 return Ok(());
@@ -603,24 +723,25 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
 
         // Lay out nested footnotes.
         for (_, note) in nested {
-            match self.footnote(note, regions, flow_need, migratable) {
+            match self.footnote(note, regions, flow_need, migration) {
                 // This footnote was already processed or queued.
                 Ok(()) => {}
                 // Footnotes always request a relayout when processed for the
                 // first time, so we ignore a relayout request since we're
                 // about to do so afterwards. Without this check, the first
                 // inner footnote interrupts processing of the following ones.
-                Err(Stop::Relayout(_)) => {}
+                Err(FootnoteStop::Relayout(())) => {}
                 // Either of
-                // - A `Stop::Finish` indicating that the frame's origin element
-                //   should migrate to uphold the footnote invariant.
+                // - A `FootnoteStop::MigrateOrigin` indicating that the frame's
+                //   origin element should migrate to uphold the footnote
+                //   invariant.
                 // - A fatal error.
                 err => return err,
             }
         }
 
         // Since we laid out a footnote, we need a relayout.
-        Err(Stop::Relayout(PlacementScope::Column))
+        Err(FootnoteStop::Relayout(()))
     }
 
     /// Handles spillover from a footnote.

--- a/crates/typst-layout/src/flow/compose.rs
+++ b/crates/typst-layout/src/flow/compose.rs
@@ -23,33 +23,45 @@ use typst_utils::{NonZeroExt, Numeric};
 use super::distribute::distribute;
 use super::{Config, FlowMode, LineNumberConfig, PlacedChild, Work};
 
-/// The result type for page composition.
-type PageResult<T> = Result<T, PageStop>;
-
-/// A control flow event during page composition.
-enum PageStop {
-    /// Indicates that the parent region should be relayouted.
-    Relayout,
+/// A control flow event during layout.
+///
+/// The type parameter `R` describes the requested relayout.
+pub(super) enum RelayoutStop<R = PlacementScope> {
+    /// Indicates that the given scope should be relayouted.
+    Relayout(R),
     /// A fatal error.
     Error(EcoVec<SourceDiagnostic>),
 }
 
-impl From<EcoVec<SourceDiagnostic>> for PageStop {
+impl<R> From<EcoVec<SourceDiagnostic>> for RelayoutStop<R> {
     fn from(error: EcoVec<SourceDiagnostic>) -> Self {
         Self::Error(error)
     }
 }
 
-/// The result type for layout that may request a relayout.
-pub(super) type RelayoutResult<T> = Result<T, RelayoutStop>;
+/// A version of [`PlacementScope`] that is known to be `Parent`.
+pub struct ParentScope;
 
-/// A control flow event after layout during relayout.
-pub(super) enum RelayoutStop {
-    /// Indicates that the given scope should be relayouted.
-    Relayout(PlacementScope),
-    /// A fatal error.
-    Error(EcoVec<SourceDiagnostic>),
+impl From<ParentScope> for PlacementScope {
+    fn from(_: ParentScope) -> Self {
+        PlacementScope::Parent
+    }
 }
+
+/// A version of [`PlacementScope`] that is known to be `Column`.
+pub struct ColumnScope;
+
+impl From<ColumnScope> for PlacementScope {
+    fn from(_: ColumnScope) -> Self {
+        PlacementScope::Column
+    }
+}
+
+/// A control flow event during footnote handling.
+pub(super) type FootnoteStop<M = ()> = InsertionStop<ColumnScope, M>;
+
+/// A control flow event during float handling.
+pub(super) type FloatStop<M = ()> = InsertionStop<PlacementScope, M>;
 
 /// A control flow event while handling an insertion.
 ///
@@ -65,45 +77,32 @@ pub(super) enum InsertionStop<R, M = ()> {
     Error(EcoVec<SourceDiagnostic>),
 }
 
-impl<R, M> From<EcoVec<SourceDiagnostic>> for InsertionStop<R, M> {
-    fn from(error: EcoVec<SourceDiagnostic>) -> Self {
-        Self::Error(error)
-    }
-}
-
-/// A control flow event during footnote handling.
-pub(super) type FootnoteStop<M = ()> = InsertionStop<(), M>;
-
-/// A control flow event during float handling.
-pub(super) type FloatStop<M = ()> = InsertionStop<PlacementScope, M>;
-
 impl<M> From<FootnoteStop<M>> for FloatStop<M> {
     fn from(stop: FootnoteStop<M>) -> Self {
         match stop {
-            FootnoteStop::Relayout(()) => Self::Relayout(PlacementScope::Column),
+            FootnoteStop::Relayout(ColumnScope) => Self::Relayout(PlacementScope::Column),
             FootnoteStop::MigrateOrigin(migration) => Self::MigrateOrigin(migration),
             FootnoteStop::Error(error) => Self::Error(error),
         }
     }
 }
 
-impl From<FootnoteStop<Infallible>> for RelayoutStop {
-    fn from(stop: FootnoteStop<Infallible>) -> Self {
+impl<R> From<InsertionStop<R, Infallible>> for RelayoutStop
+where
+    R: Into<PlacementScope>,
+{
+    fn from(stop: InsertionStop<R, Infallible>) -> Self {
         match stop {
-            FootnoteStop::Relayout(()) => Self::Relayout(PlacementScope::Column),
-            FootnoteStop::MigrateOrigin(never) => match never {},
-            FootnoteStop::Error(error) => Self::Error(error),
+            InsertionStop::Relayout(r) => Self::Relayout(r.into()),
+            InsertionStop::MigrateOrigin(never) => match never {},
+            InsertionStop::Error(error) => Self::Error(error),
         }
     }
 }
 
-impl From<FloatStop<Infallible>> for RelayoutStop {
-    fn from(stop: FloatStop<Infallible>) -> Self {
-        match stop {
-            FloatStop::Relayout(scope) => Self::Relayout(scope),
-            FloatStop::MigrateOrigin(never) => match never {},
-            FloatStop::Error(error) => Self::Error(error),
-        }
+impl<R, M> From<EcoVec<SourceDiagnostic>> for InsertionStop<R, M> {
+    fn from(error: EcoVec<SourceDiagnostic>) -> Self {
+        Self::Error(error)
     }
 }
 
@@ -199,7 +198,7 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
     /// Lay out a container/page region, including container/page insertions.
     fn page(mut self, locator: Locator, regions: Regions) -> SourceResult<Frame> {
         // This loop can restart region layout when requested to do so by a
-        // `PageStop::Relayout`. This happens when there is a parent-scoped float.
+        // `RelayoutStop::Relayout`. This happens when there is a parent-scoped float.
         let checkpoint = self.work.clone();
         let output = loop {
             // Shrink the available space by the space used by page
@@ -209,8 +208,10 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
 
             match self.page_contents(locator.relayout(), pod) {
                 Ok(frame) => break frame,
-                Err(PageStop::Relayout) => *self.work = checkpoint.clone(),
-                Err(PageStop::Error(err)) => return Err(err),
+                Err(RelayoutStop::Relayout(ParentScope)) => {
+                    *self.work = checkpoint.clone();
+                }
+                Err(RelayoutStop::Error(err)) => return Err(err),
             }
         };
         drop(checkpoint);
@@ -219,7 +220,11 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
     }
 
     /// Lay out the inner contents of a container/page.
-    fn page_contents(&mut self, locator: Locator, regions: Regions) -> PageResult<Frame> {
+    fn page_contents(
+        &mut self,
+        locator: Locator,
+        regions: Regions,
+    ) -> Result<Frame, RelayoutStop<ParentScope>> {
         // No point in create column regions, if there's just one!
         if self.config.columns.count == 1 {
             return self.column(locator, regions).map(|(frame, ..)| frame);
@@ -318,7 +323,7 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
             let height = total_used_height / self.config.columns.count as f64;
             if self.column_balancing_height.is_none_or(|h| h < height) {
                 self.column_balancing_height = Some(height);
-                return Err(PageStop::Relayout);
+                return Err(RelayoutStop::Relayout(ParentScope));
             }
         }
 
@@ -336,7 +341,7 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
         &mut self,
         locator: Locator,
         regions: Regions,
-    ) -> PageResult<(Frame, Abs, Abs)> {
+    ) -> Result<(Frame, Abs, Abs), RelayoutStop<ParentScope>> {
         // Reset column insertion when starting a new column.
         self.column_insertions = Insertions::default();
 
@@ -368,9 +373,11 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
                     *self.work = checkpoint.clone();
                 }
                 Err(RelayoutStop::Relayout(PlacementScope::Parent)) => {
-                    return Err(PageStop::Relayout);
+                    return Err(RelayoutStop::Relayout(ParentScope));
                 }
-                Err(RelayoutStop::Error(error)) => return Err(PageStop::Error(error)),
+                Err(RelayoutStop::Error(error)) => {
+                    return Err(RelayoutStop::Error(error));
+                }
             }
         };
         drop(checkpoint);
@@ -422,7 +429,7 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
         &mut self,
         regions: Regions,
         balancing_target: Option<Abs>,
-    ) -> RelayoutResult<(Frame, Abs)> {
+    ) -> Result<(Frame, Abs), RelayoutStop> {
         // Process pending footnotes.
         for note in std::mem::take(&mut self.work.footnotes) {
             self.footnote(note, &mut regions.clone(), Abs::zero(), Migration::FORBID)?;
@@ -595,7 +602,7 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
                 // The footnote was already processed or queued.
                 Ok(()) => {}
                 // First handle more footnotes before relayouting.
-                Err(FootnoteStop::Relayout(())) => relayout = true,
+                Err(FootnoteStop::Relayout(ColumnScope)) => relayout = true,
                 // Either of
                 // - A `FootnoteStop::MigrateOrigin` indicating that the frame's
                 //   origin element should migrate to uphold the footnote
@@ -608,7 +615,7 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
         // If this is set, we laid out at least one footnote, so we need a
         // relayout.
         if relayout {
-            return Err(FootnoteStop::Relayout(()));
+            return Err(FootnoteStop::Relayout(ColumnScope));
         }
 
         Ok(())
@@ -730,7 +737,7 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
                 // first time, so we ignore a relayout request since we're
                 // about to do so afterwards. Without this check, the first
                 // inner footnote interrupts processing of the following ones.
-                Err(FootnoteStop::Relayout(())) => {}
+                Err(FootnoteStop::Relayout(ColumnScope)) => {}
                 // Either of
                 // - A `FootnoteStop::MigrateOrigin` indicating that the frame's
                 //   origin element should migrate to uphold the footnote
@@ -741,7 +748,7 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
         }
 
         // Since we laid out a footnote, we need a relayout.
-        Err(FootnoteStop::Relayout(()))
+        Err(FootnoteStop::Relayout(ColumnScope))
     }
 
     /// Handles spillover from a footnote.

--- a/crates/typst-layout/src/flow/compose.rs
+++ b/crates/typst-layout/src/flow/compose.rs
@@ -141,9 +141,9 @@ impl<M> Migration<M> {
 /// columns/subregions.
 ///
 /// The composer is primarily concerned with layout of out-of-flow insertions
-/// (floats and footnotes).  It does this in per-page and per-column loops that
-/// rerun when a new float is added (since it affects the regions available to
-/// the distributor).
+/// (floats and footnotes). It does this in per-page and per-column loops that
+/// rerun when an insertion affects the regions available to the distributor,
+/// or when balancing columns.
 ///
 /// To lay out the in-flow contents of individual subregions, the composer
 /// invokes [distribution](distribute()).
@@ -198,7 +198,8 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
     /// Lay out a container/page region, including container/page insertions.
     fn page(mut self, locator: Locator, regions: Regions) -> SourceResult<Frame> {
         // This loop can restart region layout when requested to do so by a
-        // `RelayoutStop::Relayout`. This happens when there is a parent-scoped float.
+        // `RelayoutStop::Relayout(ParentScope)`. This happens when there is a
+        // parent-scoped float or when balancing columns.
         let checkpoint = self.work.clone();
         let output = loop {
             // Shrink the available space by the space used by page
@@ -332,7 +333,7 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
 
     /// Lay out a column, including column insertions.
     ///
-    /// Returns a `PageResult` containing a tuple of
+    /// On success, returns a tuple of
     /// - `0`: The laid out frame.
     /// - `1`: The height actually used by the inner contents (used for column
     ///   balancing logic).
@@ -351,7 +352,8 @@ impl<'a, 'b> Composer<'a, 'b, '_, '_> {
         }
 
         // This loop can restart column layout when requested to do so by a
-        // `RelayoutStop`. This happens when there is a column-scoped float.
+        // `RelayoutStop::Relayout(PlacementScope::Column)`. This happens when a
+        // column-scoped float or footnote is added.
         let checkpoint = self.work.clone();
         let (inner, used_height) = loop {
             // Shrink the available space by the space used by column

--- a/crates/typst-layout/src/flow/distribute.rs
+++ b/crates/typst-layout/src/flow/distribute.rs
@@ -7,16 +7,8 @@ use typst_library::layout::{
 };
 use typst_utils::Numeric;
 
-use super::compose::{
-    Composer, FloatStop, FootnoteStop, Migration, RelayoutResult, RelayoutStop,
-};
+use super::compose::{Composer, InsertionStop, Migration, RelayoutStop};
 use super::{Child, LineChild, MultiChild, MultiSpill, PlacedChild, SingleChild, Work};
-
-/// The result type for internal distributor control flow.
-///
-/// The `Err(_)` variant incorporate control flow events for finishing and
-/// relayouting regions.
-type FlowResult<T> = Result<T, Stop>;
 
 /// A control flow event during distribution.
 enum Stop {
@@ -36,29 +28,22 @@ enum Finish {
     Forced,
 }
 
+impl<R> From<InsertionStop<R, ()>> for Stop
+where
+    R: Into<PlacementScope>,
+{
+    fn from(stop: InsertionStop<R, ()>) -> Self {
+        match stop {
+            InsertionStop::Relayout(r) => Self::Relayout(r.into()),
+            InsertionStop::MigrateOrigin(()) => Self::Finish(Finish::Soft),
+            InsertionStop::Error(error) => Self::Error(error),
+        }
+    }
+}
+
 impl From<EcoVec<SourceDiagnostic>> for Stop {
     fn from(error: EcoVec<SourceDiagnostic>) -> Self {
         Self::Error(error)
-    }
-}
-
-impl From<FootnoteStop> for Stop {
-    fn from(stop: FootnoteStop) -> Self {
-        match stop {
-            FootnoteStop::Relayout(()) => Self::Relayout(PlacementScope::Column),
-            FootnoteStop::MigrateOrigin(()) => Self::Finish(Finish::Soft),
-            FootnoteStop::Error(error) => Self::Error(error),
-        }
-    }
-}
-
-impl From<FloatStop> for Stop {
-    fn from(stop: FloatStop) -> Self {
-        match stop {
-            FloatStop::Relayout(scope) => Self::Relayout(scope),
-            FloatStop::MigrateOrigin(()) => Self::Finish(Finish::Soft),
-            FloatStop::Error(error) => Self::Error(error),
-        }
     }
 }
 
@@ -69,7 +54,7 @@ pub fn distribute(
     composer: &mut Composer,
     regions: Regions,
     balancing_target: Option<Abs>,
-) -> RelayoutResult<(Frame, Abs)> {
+) -> Result<(Frame, Abs), RelayoutStop> {
     let mut distributor = Distributor {
         composer,
         regions,
@@ -83,12 +68,8 @@ pub fn distribute(
     let forced = match distributor.run() {
         Ok(()) => distributor.composer.work.done(),
         Err(Stop::Finish(finish)) => matches!(finish, Finish::Forced),
-        Err(Stop::Relayout(scope)) => {
-            return Err(RelayoutStop::Relayout(scope));
-        }
-        Err(Stop::Error(error)) => {
-            return Err(RelayoutStop::Error(error));
-        }
+        Err(Stop::Relayout(scope)) => return Err(RelayoutStop::Relayout(scope)),
+        Err(Stop::Error(error)) => return Err(RelayoutStop::Error(error)),
     };
     let region = Region::new(regions.size, regions.expand);
     distributor
@@ -176,7 +157,7 @@ impl Item<'_, '_> {
 
 impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
     /// Distributes content into the region.
-    fn run(&mut self) -> FlowResult<()> {
+    fn run(&mut self) -> Result<(), Stop> {
         // First, handle spill of a breakable block.
         if let Some(spill) = self.composer.work.spill.take() {
             self.multi_spill(spill)?;
@@ -199,7 +180,7 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
     /// - Returns `Err(Stop::Relayout(_))` if the region needs to be relayouted
     ///   due to an insertion (float/footnote).
     /// - Returns `Err(Stop::Error(_))` if there was a fatal error.
-    fn child(&mut self, child: &'b Child<'a>) -> FlowResult<()> {
+    fn child(&mut self, child: &'b Child<'a>) -> Result<(), Stop> {
         match child {
             Child::Tag(tag) => self.tag(tag),
             Child::Rel(amount, weakness) => self.rel(*amount, *weakness),
@@ -360,7 +341,7 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
     }
 
     /// Processes a line of a paragraph.
-    fn line(&mut self, line: &'b LineChild) -> FlowResult<()> {
+    fn line(&mut self, line: &'b LineChild) -> Result<(), Stop> {
         // If the line doesn't fit and a followup region may improve things,
         // finish the region.
         if !self.fits(line.frame.height()) && self.regions.may_progress() {
@@ -385,7 +366,7 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
     }
 
     /// Processes an unbreakable block.
-    fn single(&mut self, single: &'b SingleChild<'a>) -> FlowResult<()> {
+    fn single(&mut self, single: &'b SingleChild<'a>) -> Result<(), Stop> {
         // Lay out the block.
         let frame = single.layout(
             self.composer.engine,
@@ -416,7 +397,7 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
     }
 
     /// Processes a breakable block.
-    fn multi(&mut self, multi: &'b MultiChild<'a>) -> FlowResult<()> {
+    fn multi(&mut self, multi: &'b MultiChild<'a>) -> Result<(), Stop> {
         let mut pod = self.regions;
 
         // For column balancing, reduce the region size for layout.
@@ -457,7 +438,7 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
     }
 
     /// Processes spillover from a breakable block.
-    fn multi_spill(&mut self, spill: MultiSpill<'a, 'b>) -> FlowResult<()> {
+    fn multi_spill(&mut self, spill: MultiSpill<'a, 'b>) -> Result<(), Stop> {
         let mut pod = self.regions;
 
         // For column balancing, reduce the region size for layout.
@@ -494,7 +475,7 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
         align: Axes<FixedAlignment>,
         sticky: bool,
         breakable: bool,
-    ) -> FlowResult<()> {
+    ) -> Result<(), Stop> {
         // If the frame is sticky and we haven't remembered a preceding sticky
         // element, make a checkpoint which we can restore should we end on
         // this sticky element.
@@ -550,7 +531,7 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
     }
 
     /// Processes an absolutely or floatingly placed child.
-    fn placed(&mut self, placed: &'b PlacedChild<'a>) -> FlowResult<()> {
+    fn placed(&mut self, placed: &'b PlacedChild<'a>) -> Result<(), Stop> {
         if placed.float {
             // If the element is floatingly placed, let the composer handle it.
             // It might require relayout because the area available for
@@ -582,7 +563,7 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
     }
 
     /// Processes a float flush.
-    fn flush(&mut self) -> FlowResult<()> {
+    fn flush(&mut self) -> Result<(), Stop> {
         // If there are still pending floats, finish the region instead of
         // adding more content to it.
         if !self.composer.work.floats.is_empty() {
@@ -592,7 +573,7 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
     }
 
     /// Processes a column break.
-    fn break_(&mut self, weak: bool) -> FlowResult<()> {
+    fn break_(&mut self, weak: bool) -> Result<(), Stop> {
         // If there is a region to break into, break into it.
         if (!weak || !self.items.is_empty())
             && (!self.regions.backlog.is_empty() || self.regions.last.is_some())

--- a/crates/typst-layout/src/flow/distribute.rs
+++ b/crates/typst-layout/src/flow/distribute.rs
@@ -1,13 +1,66 @@
+use ecow::EcoVec;
+use typst_library::diag::{SourceDiagnostic, SourceResult};
 use typst_library::introspection::Tag;
 use typst_library::layout::{
-    Abs, Axes, FixedAlignment, Fr, Frame, FrameItem, Point, Region, Regions, Rel, Size,
+    Abs, Axes, FixedAlignment, Fr, Frame, FrameItem, PlacementScope, Point, Region,
+    Regions, Rel, Size,
 };
 use typst_utils::Numeric;
 
-use super::{
-    Child, Composer, FlowResult, LineChild, MultiChild, MultiSpill, PlacedChild,
-    SingleChild, Stop, Work,
+use super::compose::{
+    Composer, FloatStop, FootnoteStop, Migration, RelayoutResult, RelayoutStop,
 };
+use super::{Child, LineChild, MultiChild, MultiSpill, PlacedChild, SingleChild, Work};
+
+/// The result type for internal distributor control flow.
+///
+/// The `Err(_)` variant incorporate control flow events for finishing and
+/// relayouting regions.
+type FlowResult<T> = Result<T, Stop>;
+
+/// A control flow event during distribution.
+enum Stop {
+    /// Indicates that the current subregion should be finished.
+    Finish(Finish),
+    /// Indicates that the given scope should be relayouted.
+    Relayout(PlacementScope),
+    /// A fatal error.
+    Error(EcoVec<SourceDiagnostic>),
+}
+
+/// The reason why the current region should finish.
+enum Finish {
+    /// A lack of space.
+    Soft,
+    /// An explicit break.
+    Forced,
+}
+
+impl From<EcoVec<SourceDiagnostic>> for Stop {
+    fn from(error: EcoVec<SourceDiagnostic>) -> Self {
+        Self::Error(error)
+    }
+}
+
+impl From<FootnoteStop> for Stop {
+    fn from(stop: FootnoteStop) -> Self {
+        match stop {
+            FootnoteStop::Relayout(()) => Self::Relayout(PlacementScope::Column),
+            FootnoteStop::MigrateOrigin(()) => Self::Finish(Finish::Soft),
+            FootnoteStop::Error(error) => Self::Error(error),
+        }
+    }
+}
+
+impl From<FloatStop> for Stop {
+    fn from(stop: FloatStop) -> Self {
+        match stop {
+            FloatStop::Relayout(scope) => Self::Relayout(scope),
+            FloatStop::MigrateOrigin(()) => Self::Finish(Finish::Soft),
+            FloatStop::Error(error) => Self::Error(error),
+        }
+    }
+}
 
 /// Distributes as many children as fit from `composer.work` into the first
 /// region and returns the resulting frame and the height actually used
@@ -16,7 +69,7 @@ pub fn distribute(
     composer: &mut Composer,
     regions: Regions,
     balancing_target: Option<Abs>,
-) -> FlowResult<(Frame, Abs)> {
+) -> RelayoutResult<(Frame, Abs)> {
     let mut distributor = Distributor {
         composer,
         regions,
@@ -29,11 +82,18 @@ pub fn distribute(
     let init = distributor.snapshot();
     let forced = match distributor.run() {
         Ok(()) => distributor.composer.work.done(),
-        Err(Stop::Finish(forced)) => forced,
-        Err(err) => return Err(err),
+        Err(Stop::Finish(finish)) => matches!(finish, Finish::Forced),
+        Err(Stop::Relayout(scope)) => {
+            return Err(RelayoutStop::Relayout(scope));
+        }
+        Err(Stop::Error(error)) => {
+            return Err(RelayoutStop::Error(error));
+        }
     };
     let region = Region::new(regions.size, regions.expand);
-    distributor.finalize(region, init, forced)
+    distributor
+        .finalize(region, init, forced)
+        .map_err(RelayoutStop::Error)
 }
 
 /// State for distribution.
@@ -304,7 +364,7 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
         // If the line doesn't fit and a followup region may improve things,
         // finish the region.
         if !self.fits(line.frame.height()) && self.regions.may_progress() {
-            return Err(Stop::Finish(false));
+            return Err(Stop::Finish(Finish::Soft));
         }
 
         // If the line's need, which includes its own height and that of
@@ -318,7 +378,7 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
                 .nth(1)
                 .is_some_and(|region| region.y.fits(line.need))
         {
-            return Err(Stop::Finish(false));
+            return Err(Stop::Finish(Finish::Soft));
         }
 
         self.frame(line.frame.clone(), line.align, false, false)
@@ -334,8 +394,13 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
 
         // Handle fractionally sized blocks.
         if let Some(fr) = single.fr {
-            self.composer
-                .footnotes(&self.regions, &frame, Abs::zero(), false, true)?;
+            self.composer.footnotes(
+                &self.regions,
+                &frame,
+                Abs::zero(),
+                false,
+                Migration::ALLOW,
+            )?;
             self.flush_tags();
             self.items.push(Item::Fr(fr, 0, Some(single)));
             return Ok(());
@@ -344,7 +409,7 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
         // If the block doesn't fit and a followup region may improve things,
         // finish the region.
         if !self.fits(frame.height()) && self.regions.may_progress() {
-            return Err(Stop::Finish(false));
+            return Err(Stop::Finish(Finish::Soft));
         }
 
         self.frame(frame, single.align, single.sticky, false)
@@ -363,7 +428,7 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
         // Skip directly if the region is already (over)full. `line` and
         // `single` implicitly do this through their `fits` checks.
         if pod.is_full() {
-            return Err(Stop::Finish(false));
+            return Err(Stop::Finish(Finish::Soft));
         }
 
         // Lay out the block.
@@ -375,7 +440,7 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
             // If the first frame is empty, but there are non-empty frames in
             // the spill, the whole child should be put in the next region to
             // avoid any invisible orphans at the end of this region.
-            return Err(Stop::Finish(false));
+            return Err(Stop::Finish(Finish::Soft));
         }
 
         self.frame(frame, multi.align, multi.sticky, true)?;
@@ -385,7 +450,7 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
         if let Some(spill) = spill {
             self.composer.work.spill = Some(spill);
             self.composer.work.advance();
-            return Err(Stop::Finish(false));
+            return Err(Stop::Finish(Finish::Soft));
         }
 
         Ok(())
@@ -404,7 +469,7 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
         // Skip directly if the region is already (over)full.
         if pod.is_full() {
             self.composer.work.spill = Some(spill);
-            return Err(Stop::Finish(false));
+            return Err(Stop::Finish(Finish::Soft));
         }
 
         // Lay out the spilled remains.
@@ -416,7 +481,7 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
         // region.
         if let Some(spill) = spill {
             self.composer.work.spill = Some(spill);
-            return Err(Stop::Finish(false));
+            return Err(Stop::Finish(Finish::Soft));
         }
 
         Ok(())
@@ -465,7 +530,7 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
             &frame,
             frame.height(),
             breakable,
-            true,
+            Migration::ALLOW,
         )?;
 
         if !sticky && !frame.is_empty() {
@@ -498,13 +563,18 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
                 placed,
                 &self.regions,
                 self.items.iter().any(|item| matches!(item, Item::Frame(..))),
-                true,
+                Migration::ALLOW,
             )?;
             self.use_height(weak_spacing);
         } else {
             let frame = placed.layout(self.composer.engine, self.regions.base())?;
-            self.composer
-                .footnotes(&self.regions, &frame, Abs::zero(), true, true)?;
+            self.composer.footnotes(
+                &self.regions,
+                &frame,
+                Abs::zero(),
+                true,
+                Migration::ALLOW,
+            )?;
             self.flush_tags();
             self.items.push(Item::Placed(frame, placed));
         }
@@ -516,7 +586,7 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
         // If there are still pending floats, finish the region instead of
         // adding more content to it.
         if !self.composer.work.floats.is_empty() {
-            return Err(Stop::Finish(false));
+            return Err(Stop::Finish(Finish::Soft));
         }
         Ok(())
     }
@@ -528,7 +598,7 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
             && (!self.regions.backlog.is_empty() || self.regions.last.is_some())
         {
             self.composer.work.advance();
-            return Err(Stop::Finish(true));
+            return Err(Stop::Finish(Finish::Forced));
         }
         Ok(())
     }
@@ -541,7 +611,7 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
         region: Region,
         init: DistributionSnapshot<'a, 'b>,
         forced: bool,
-    ) -> FlowResult<(Frame, Abs)> {
+    ) -> SourceResult<(Frame, Abs)> {
         if forced {
             // If this is the very end of the flow, flush pending tags.
             self.flush_tags();

--- a/crates/typst-layout/src/flow/distribute.rs
+++ b/crates/typst-layout/src/flow/distribute.rs
@@ -176,7 +176,7 @@ impl<'a, 'b> Distributor<'a, 'b, '_, '_, '_> {
     /// Processes a single child.
     ///
     /// - Returns `Ok(())` if the child was successfully processed.
-    /// - Returns `Err(Stop::Finish)` if a region break should be triggered.
+    /// - Returns `Err(Stop::Finish(_))` if a region break should be triggered.
     /// - Returns `Err(Stop::Relayout(_))` if the region needs to be relayouted
     ///   due to an insertion (float/footnote).
     /// - Returns `Err(Stop::Error(_))` if there was a fatal error.

--- a/crates/typst-layout/src/flow/mod.rs
+++ b/crates/typst-layout/src/flow/mod.rs
@@ -14,15 +14,15 @@ use bumpalo::Bump;
 use comemo::{Track, Tracked, TrackedMut};
 use ecow::EcoVec;
 use rustc_hash::FxHashSet;
-use typst_library::diag::{At, SourceDiagnostic, SourceResult, bail};
+use typst_library::diag::{At, SourceResult, bail};
 use typst_library::engine::{Engine, Route, Sink, Traced};
 use typst_library::foundations::{Content, Packed, Resolve, StyleChain};
 use typst_library::introspection::{
     Introspector, Location, Locator, LocatorLink, SplitLocator, Tag,
 };
 use typst_library::layout::{
-    Abs, Angle, ColumnsElem, Dir, Em, Fragment, Frame, HAlignment, PageElem,
-    PlacementScope, Region, Regions, Rel, Size, VAlignment,
+    Abs, Angle, ColumnsElem, Dir, Em, Fragment, Frame, HAlignment, PageElem, Region,
+    Regions, Rel, Size, VAlignment,
 };
 use typst_library::model::{
     ArtifactKind, FootnoteElem, FootnoteEntry, LineNumberingScope, ParLine,
@@ -37,8 +37,7 @@ use self::block::{layout_multi_block, layout_single_block};
 use self::collect::{
     Child, LineChild, MultiChild, MultiSpill, PlacedChild, SingleChild, collect,
 };
-use self::compose::{Composer, compose};
-use self::distribute::distribute;
+use self::compose::compose;
 
 /// Lays out content into a single region, producing a single frame.
 pub fn layout_frame(
@@ -443,27 +442,4 @@ struct LineNumberConfig {
     /// value is a percentage of the page width clamped between `0.75em` and
     /// `2.5em`.
     default_clearance: Abs,
-}
-
-/// The result type for flow layout.
-///
-/// The `Err(_)` variant incorporate control flow events for finishing and
-/// relayouting regions.
-type FlowResult<T> = Result<T, Stop>;
-
-/// A control flow event during flow layout.
-enum Stop {
-    /// Indicates that the current subregion should be finished. Can be caused
-    /// by a lack of space (`false`) or an explicit column break (`true`).
-    Finish(bool),
-    /// Indicates that the given scope should be relayouted.
-    Relayout(PlacementScope),
-    /// A fatal error.
-    Error(EcoVec<SourceDiagnostic>),
-}
-
-impl From<EcoVec<SourceDiagnostic>> for Stop {
-    fn from(error: EcoVec<SourceDiagnostic>) -> Self {
-        Stop::Error(error)
-    }
 }


### PR DESCRIPTION
This grew out of #8602 after I was looking at flow layout a lot. The main motivation is to get rid of any `unreachable!()` statements by using the type system. I discussed this briefly with Laurenz a couple of weeks ago and have finally gotten around to opening a PR.