### PR TITLE
Require `=` when passing a viewer to `--open`

### DIFF
--- a/crates/typst-cli/src/args.rs
+++ b/crates/typst-cli/src/args.rs
@@ -381,7 +381,10 @@ pub struct CompileArgs {
 
     /// Opens the output file with the default viewer or a specific program
     /// after compilation. Ignored if output is stdout.
-    #[arg(long = "open", value_name = "VIEWER")]
+    ///
+    /// When passing a specific program, the name must be attached with
+    /// an equals sign (`--open=VIEWER`).
+    #[arg(long = "open", value_name = "VIEWER", require_equals = true)]
     pub open: Option<Option<String>>,
 
     /// Produces performance timings of the compilation process. (experimental)


### PR DESCRIPTION
@joshtriplett asked in #8734 that `--open` shouldn't take any argument and to create an `--open-with` option.
@saecki then suggested that `--open` could require `=` to pass the optional viewer.

So I added: `require_equals = true` to the `pub open: Option<Option<String>>` argument:

```diff
- #[arg(long = "open", value_name = "VIEWER")]
+ #[arg(long = "open", value_name = "VIEWER", require_equals = true)]
```

> [!CAUTION]
> It's a breaking change: `--open <VIEWER>` with a space stops working

| Invocation | Before | After |
| --- | --- | --- |
| `typst compile --open doc.typ` | `doc.typ` taken as the viewer | works, opens with the default viewer |
| `typst compile --open=echo doc.typ` | works | works |
| `typst compile doc.typ --open` | works | works |
| `typst compile doc.typ --open=echo` | works | works |
| `typst compile --open echo doc.typ` | works | `echo` becomes the input, errors out |
| `typst compile doc.typ --open echo` | works | `echo` becomes the output, errors out |

Closes https://github.com/typst/typst/issues/8734.