### PR TITLE
Add zh-HK translations so heading references use Traditional Chinese

### DIFF
--- a/crates/typst-library/src/text/lang.rs
+++ b/crates/typst-library/src/text/lang.rs
@@ -114,6 +114,7 @@ const TRANSLATIONS: &[(&str, &str)] = &[
     translation!("ur"),
     translation!("vi"),
     translation!("zh"),
+    translation!("zh-HK"),
     translation!("zh-TW"),
 ];
 
@@ -759,5 +760,11 @@ mod tests {
             TRANSLATIONS.is_sorted_by_key(|(lang, _)| lang),
             "TRANSLATIONS should be sorted"
         );
+    }
+
+    #[test]
+    fn test_zh_hk_heading_is_traditional() {
+        let name = localized_str(Lang::CHINESE, Some(Region(*b"HK")), "heading");
+        assert_eq!(name, "小節");
     }
 }

--- a/crates/typst-library/src/text/lang.rs
+++ b/crates/typst-library/src/text/lang.rs
@@ -761,5 +761,4 @@ mod tests {
             "TRANSLATIONS should be sorted"
         );
     }
-
 }

--- a/crates/typst-library/src/text/lang.rs
+++ b/crates/typst-library/src/text/lang.rs
@@ -762,9 +762,4 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_zh_hk_heading_is_traditional() {
-        let name = localized_str(Lang::CHINESE, Some(Region(*b"HK")), "heading");
-        assert_eq!(name, "小節");
-    }
 }

--- a/crates/typst-library/translations/zh-HK.txt
+++ b/crates/typst-library/translations/zh-HK.txt
@@ -1,0 +1,11 @@
+figure = 圖
+table = 表
+equation = 式
+bibliography = 書目
+heading = 小節
+outline = 目錄
+raw = 程式
+page = 頁
+footnote = 註腳
+email = 電子郵件
+telephone = 電話

--- a/tests/suite/model/heading.typ
+++ b/tests/suite/model/heading.typ
@@ -134,6 +134,16 @@ comment spans lines
 Not in heading
 =Nope
 
+--- issue-8756-heading-ref-zh-hk paged empty ---
+// Heading references must use Traditional Chinese for zh-HK.
+#set text(lang: "zh", region: "HK")
+#set heading(numbering: "1.")
+#show heading: none
+#show ref: none
+= 序言 <prelude>
+@prelude
+#context test(query(<prelude>).first().supplement, [小節])
+
 --- heading-numbering-hint paged ---
 = Heading <intro>
 


### PR DESCRIPTION
Heading references with `lang: \"zh\", region: \"HK\"` fell back to the `zh` bundle (Simplified `小节`) because there was no `zh-HK` translation file.

Add `zh-HK.txt` (Traditional forms, including `heading = 小節`) and register it in `TRANSLATIONS`.

Fixes #8756