### PR TITLE
Fix spacing for single-argument functions in docs

### DIFF
--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -1416,15 +1416,7 @@ h4 .additional-info .pill + .pill {
 }
 
 .single-arg .arguments .overview-param {
-  display: inline-flex;
-  align-items: baseline;
-  flex-wrap: wrap;
-  gap: 4px;
-  margin-inline: 2px;
-}
-
-.single-arg .arguments .pill + .pill {
-  margin-inline-start: 0px;
+  display: inline;
 }
 
 .arguments {


### PR DESCRIPTION
Fixes https://github.com/typst/typst/issues/8691.

The solution was to remove a few CSS rules. The `.single-arg .arguments .pill + .pill` block was removed because the `4px` spacing between pills is now handled by the generic `.pill + .pill` block.