### PR TITLE
Update correct tag tree jump progressions when splitting outer group

### DIFF
--- a/crates/typst-pdf/src/tags/tree/build.rs
+++ b/crates/typst-pdf/src/tags/tree/build.rs
@@ -772,7 +772,7 @@ fn split_outer_group(
         }
 
         // Update progressions to jump into the inner entry instead.
-        let prev = tree.progressions[entry.prog_idx as usize];
+        let prev = entry.id;
         for prog in &mut tree.progressions[entry.prog_idx as usize..] {
             if *prog == prev {
                 *prog = nested;

--- a/tests/ref/pdftags/hashes.txt
+++ b/tests/ref/pdftags/hashes.txt
@@ -59,6 +59,7 @@ cae4c2653cf68f0c43c1619afea2c424 link-basic
 5c6b8b980f727c417326686acb7f854c link-tags-contact-prefix
 319c50f5b21c31ff13569f4b5903b7d6 link-tags-heading-with-numbering
 8a18e918e15ed8260bef7a4aee86e3a4 link-tags-heading-without-numbering
+091cb4a5621d1ce40d1b351458142384 link-tags-nesting-across-pars
 1cd0843343eaeee4d8429b29e04e298f link-tags-non-refable-location
 ceff1a5f851fa3bc1763a37a2931dcce link-tags-position
 a63593f98e18612ca4f9ac1515f6833c link-tags-with-parbreak

--- a/tests/suite/pdftags/link.typ
+++ b/tests/suite/pdftags/link.typ
@@ -77,3 +77,9 @@ Look #link("https://github.com/typst/typst")[this #parbreak() thing].
 // of the next line, which can cause issues with links in PDF.
 #set text(lang: "cs", hyphenate: true)
 #block(width: 0.9cm)[#link("x")[test-]ing]
+
+--- link-tags-nesting-across-pars pdftags ---
+This #link("https://outer.org")[is a split
+#link("https://inner.org")[ multi paragraph link.
+
+Thanks for the] multi attention.] Okay!


### PR DESCRIPTION
The issue was that this would look up the previous ID of the jump progression in the list, intstead of just using the ID of the stack entry. That jump progression in the list could have already been updated by a previous splitting of groups. Thus jump progressions of a nested group were updated instead of the one that we actually care about.

Here is an illustration of what happens with the two nested links in the added test.

= 1. Initial break
After encountering the following tags:
```
start par-1
    start link-1
        start link-2
end par-1
```

We have the following intermediate tree:
```
- par-1
    - link-1
        - link-2
- link-1 (weak)
    - link-2 (weak) <- here
```

= 2. New paragraph
Now we find the start tag of the second paragraph:
```
start par-2
```

It's naively inserted into the current tree
```
- par-1
    - link-1
        - link-2
- link-1 (weak)
    - link-2 (weak)
        - par-2 <- here
```

= 3. Break of inner link group (link-2)
Now we find the end tag of the inner link:
```
end link-2
```

The paragraph is moved out of the inner link, and a new link is added to it instead. This somewhat transposes the nesting order, but in the end it will all make sense. Because the newly added link was just closed, we're still inside the paragraph group.
```
- par-1
    - link-1
        - link-2
- link-1 (weak)
    - link-2 (weak)
    - par-2 <- here
        - link-2 (weak)
```
While doing this tree transformation we update the previous jump progressions that jumped into the `par-2` of the previous tree structure, to jump into the newly added `link-2` instead. Thus updating the group id in the progression list, but not the group id of the stack entry, that's still active.

= 4. Break of outer link group (link-1)
Now we find the end tag of the outer link:
```
end link-1
```

We move `par-2` out of the closed outer link (`link-1`) with a similar transformation and add the nested `link-1`. All immediate children of `par-2` will be moved into `link-1` instead. To make the transformation complete we need to update the jump progressions that previously jumped into `par-2` to jump into the newly added `link-1` instead.
```
- par-1
    - link-1
        - link-2
- link-1 (weak)
    - link-2 (weak)
- par-2 <- here
    - link-1 (weak)
        - link-2 (weak)
```
This is were the bug came into place. The indirect lookup of the ID would resolve the ID of the inner `link-2` instead.
```rs
let prev = tree.progressions[entry.prog_idx as usize];
```
The wrong progresssions were updated, and our newly added `link-1` would never be visited by the progression list, because the progression still jumped into `par-2`.

= 5. Link ancestor
Because we never visited the last `link-1` group, the link annotation couldn't find its ancestor and would generate an internal error.

<!--
Thanks for your interest in landing a change in Typst! Before opening the PR, please review our contribution guidelines: https://github.com/typst/typst/blob/main/CONTRIBUTING.md

In particular, please keep in mind that we do not accept contributions implemented by an AI model. We would also ask you to refrain from using AI to write your pull request description. Summarizing your work helps organizing your thoughts as much as it helps us with seeing the human thought process behind a particular change.
-->
