### PR TITLE
Add support for `delim` positional argument to `binom`

### DIFF
--- a/crates/typst-library/src/math/frac.rs
+++ b/crates/typst-library/src/math/frac.rs
@@ -139,8 +139,8 @@ pub struct BinomElem {
     /// left and a right delimiter.
     ///
     /// ```example
-    /// #set math.vec(delim: "[")
-    /// $ vec(1, 2) $
+    /// #set math.binom(delim: "[")
+    /// $ binom(1, 2) $
     /// ```
     #[default(DelimiterPair::PAREN)]
     pub delim: DelimiterPair,

--- a/crates/typst-library/src/math/frac.rs
+++ b/crates/typst-library/src/math/frac.rs
@@ -3,7 +3,7 @@ use typst_syntax::Spanned;
 use crate::diag::bail;
 use crate::foundations::{Cast, Content, Value, elem};
 use crate::layout::Em;
-use crate::math::Mathy;
+use crate::math::{DelimiterPair, Mathy};
 
 /// How much padding to add around each side of a fraction.
 pub const FRAC_PADDING: Em = Em::new(0.1);
@@ -132,6 +132,19 @@ pub enum FracStyle {
 /// ```
 #[elem(title = "Binomial", since = "forever", Mathy)]
 pub struct BinomElem {
+    /// The delimiter to use.
+    ///
+    /// Can be a single character specifying the left delimiter, in which case
+    /// the right delimiter is inferred. Otherwise, can be an array containing a
+    /// left and a right delimiter.
+    ///
+    /// ```example
+    /// #set math.vec(delim: "[")
+    /// $ vec(1, 2) $
+    /// ```
+    #[default(DelimiterPair::PAREN)]
+    pub delim: DelimiterPair,
+
     /// The binomial's upper index.
     #[required]
     pub upper: Content,

--- a/crates/typst-library/src/math/ir/resolve.rs
+++ b/crates/typst-library/src/math/ir/resolve.rs
@@ -705,7 +705,8 @@ fn resolve_frac<'a>(
             styles,
             &elem.num,
             std::slice::from_ref(&elem.denom),
-            false,
+            true,
+            None,
             elem.span(),
         ),
     }
@@ -717,7 +718,15 @@ fn resolve_binom<'a>(
     ctx: &mut MathResolver<'a, '_, '_>,
     styles: StyleChain<'a>,
 ) -> SourceResult<()> {
-    resolve_vertical_frac_like(ctx, styles, &elem.upper, &elem.lower, true, elem.span())
+    resolve_vertical_frac_like(
+        ctx,
+        styles,
+        &elem.upper,
+        &elem.lower,
+        false,
+        Some(elem.delim.get(styles)),
+        elem.span(),
+    )
 }
 
 /// Resolve a vertical fraction or binomial.
@@ -726,7 +735,8 @@ fn resolve_vertical_frac_like<'a>(
     styles: StyleChain<'a>,
     num: &'a Content,
     denom: &[Content],
-    binom: bool,
+    line: bool,
+    delim: Option<DelimiterPair>,
     span: Span,
 ) -> SourceResult<()> {
     let num_style = ctx.store_styles(style_for_numerator(styles));
@@ -747,22 +757,32 @@ fn resolve_vertical_frac_like<'a>(
     )?;
 
     let frac =
-        FractionItem::create(numerator, denominator, !binom, FRAC_PADDING, styles, span);
+        FractionItem::create(numerator, denominator, line, FRAC_PADDING, styles, span);
 
-    if binom {
+    if let Some(delim) = delim {
         let stretch =
             Stretch::new().with_y(StretchInfo::new(Rel::one(), DELIM_SHORT_FALL));
-        let open = ctx.resolve_into_item(
-            ctx.store(SymbolElem::packed('(').spanned(span)),
-            styles,
-        )?;
-        open.set_stretch(stretch);
-        let close = ctx.resolve_into_item(
-            ctx.store(SymbolElem::packed(')').spanned(span)),
-            styles,
-        )?;
-        close.set_stretch(stretch);
-        ctx.push(FencedItem::create(Some(open), Some(close), frac, false, styles, span));
+        let open = delim
+            .open()
+            .map(|c| {
+                ctx.resolve_into_item(
+                    ctx.store(SymbolElem::packed(c).spanned(span)),
+                    styles,
+                )
+            })
+            .transpose()?
+            .inspect(|x| x.set_stretch(stretch));
+        let close = delim
+            .close()
+            .map(|c| {
+                ctx.resolve_into_item(
+                    ctx.store(SymbolElem::packed(c).spanned(span)),
+                    styles,
+                )
+            })
+            .transpose()?
+            .inspect(|x| x.set_stretch(stretch));
+        ctx.push(FencedItem::create(open, close, frac, false, styles, span));
     } else {
         ctx.push(frac);
     }

--- a/crates/typst-library/src/math/matrix.rs
+++ b/crates/typst-library/src/math/matrix.rs
@@ -348,7 +348,7 @@ cast! {
 }
 
 impl DelimiterPair {
-    const PAREN: Self = Self {
+    pub const PAREN: Self = Self {
         open: Delimiter(Some('(')),
         close: Delimiter(Some(')')),
     };


### PR DESCRIPTION
Add support for the `delim` positional argument to `binom`, allowing to write other common operations such as Stirling numbers of the first and second kind and Eulerian numbers of the first and second order (in that order in the picture), by using `delim` in the same way that would be done for `vec`, but getting the height of the brackets like in the usual `binom` (as well as allowing multinomial-style notation with other brackets, though i'm unaware of such notation existing)

<img width="89" height="530" alt="image" src="https://github.com/user-attachments/assets/073ad482-21b6-4616-be8d-2bfe61fd499e" />

I changed `binom: bool` to two arguments `line: bool` and `delim: Option<DelimiterPair>` in `resolve_vertical_frac_like`; while for the purposes of the implemented changes `line == delim.is_none()` is true in both calls to the function, it would allow for both `frac(line: false)` or similar (as in #7686) and `binom(line: true)` for writing Legendre symbols; I wasn't sure whether to add the latter to this PR.

`DelimiterPair::PAREN` is defined in `matrix.rs` since it had only been used by `VecElem` and `MatElem` from the same file; I had to make it `pub` to access it for `BinomElem` (which is in `frac.rs`). Is that okay?