### PR TITLE
Don't update PDF figure tag bounding boxes inside artifacts

### DIFF
--- a/crates/typst-pdf/src/tags/mod.rs
+++ b/crates/typst-pdf/src/tags/mod.rs
@@ -206,11 +206,11 @@ pub fn text<'a, 'b>(
         return TagHandle { surface, started: false };
     }
 
-    update_bbox(gc, fc, || text.bbox());
-
     if gc.tags.tree.parent_artifact().is_some() {
         return TagHandle { surface, started: false };
     }
+
+    update_bbox(gc, fc, || text.bbox());
 
     let attrs = tree::resolve_text_attrs(&mut gc.tags.tree, gc.options, text);
 
@@ -238,11 +238,11 @@ pub fn image<'a, 'b>(
         return TagHandle { surface, started: false };
     }
 
-    update_bbox(gc, fc, || Rect::from_pos_size(Point::zero(), size));
-
     if gc.tags.tree.parent_artifact().is_some() {
         return TagHandle { surface, started: false };
     }
+
+    update_bbox(gc, fc, || Rect::from_pos_size(Point::zero(), size));
 
     let content = ContentTag::Span(SpanTag::empty().with_alt_text(image.alt()));
     let id = surface.start_tagged(content);
@@ -262,11 +262,11 @@ pub fn shape<'a, 'b>(
         return TagHandle { surface, started: false };
     }
 
-    update_bbox(gc, fc, || shape.bbox(true));
-
     if gc.tags.tree.parent_artifact().is_some() {
         return TagHandle { surface, started: false };
     }
+
+    update_bbox(gc, fc, || shape.bbox(true));
 
     surface.start_tagged(ContentTag::Artifact(Artifact::with_kind(
         if gc.options.standards.config.version() == PdfVersion::Pdf17

--- a/tests/ref/pdftags/hashes.txt
+++ b/tests/ref/pdftags/hashes.txt
@@ -52,7 +52,7 @@ f5f3604f1588538567ec71405654998a issue-7301-link-tags-empty-link-body-linebreak
 c224c9b9de88cc28465647ad99ac5c01 issue-7777-missing-link-parent
 45c9cfe17a8402f6c0869fd5267dce5e issue-7777-missing-link-parent-repeated-hyphen
 4c9538b1955e189fda33054d5f5fc50a issue-7789-list-tags-breaking
-90657e69b78fab7c6f1b2d5318177791 issue-8703-single-page-figure-without-bbox
+e125dd464c92efd53afe5c5cbfd356ae issue-8703-single-page-figure-without-bbox
 a82a398895d6aa9fbf754e9bccf1fc73 lang-tags-pars-basic
 1d4724e9204407592d0ed20eeb376b51 lang-tags-propagation
 f3dffe7d5f7f86d4ac3d7a2f181602f0 layout-tags-placement-float

--- a/tests/ref/pdftags/hashes.txt
+++ b/tests/ref/pdftags/hashes.txt
@@ -52,6 +52,7 @@ f5f3604f1588538567ec71405654998a issue-7301-link-tags-empty-link-body-linebreak
 c224c9b9de88cc28465647ad99ac5c01 issue-7777-missing-link-parent
 45c9cfe17a8402f6c0869fd5267dce5e issue-7777-missing-link-parent-repeated-hyphen
 4c9538b1955e189fda33054d5f5fc50a issue-7789-list-tags-breaking
+90657e69b78fab7c6f1b2d5318177791 issue-8703-single-page-figure-without-bbox
 a82a398895d6aa9fbf754e9bccf1fc73 lang-tags-pars-basic
 1d4724e9204407592d0ed20eeb376b51 lang-tags-propagation
 f3dffe7d5f7f86d4ac3d7a2f181602f0 layout-tags-placement-float

--- a/tests/suite/pdftags/figure.typ
+++ b/tests/suite/pdftags/figure.typ
@@ -110,3 +110,14 @@ Ein Paragraph.
   alt: "A square with a red stroke",
   square(size: 60pt, stroke: 10pt + red)
 )
+
+--- issue-8703-single-page-figure-without-bbox pdftags pdfstandard(ua-1) ---
+#set page(height: 100pt)
+#set page(header: [hi])
+
+#figure(
+  alt: "A rect",
+  rect(width: 80pt, height: 80pt),
+)
+
+Hi


### PR DESCRIPTION
Fixes #8703, by only updating the bounding box of figures when not inside of an artifact. The problem was that the page header is considered to be inside the figure, which can't really be circumvented, because although the page header is an artifact, it still has to go somewhere in the frame tree.