### PR TITLE
Join consecutive inline links

### DIFF
--- a/crates/typst-layout/src/inline/collect.rs
+++ b/crates/typst-layout/src/inline/collect.rs
@@ -1,10 +1,10 @@
 use typst_library::diag::warning;
-use typst_library::foundations::{NativeElement, Packed, Resolve, Style};
-use typst_library::introspection::{SplitLocator, Tag, TagElem};
+use typst_library::foundations::{Packed, Resolve};
+use typst_library::introspection::{Location, SplitLocator, Tag, TagElem};
 use typst_library::layout::{
     Abs, BoxElem, Dir, Fr, Frame, HElem, InlineElem, InlineItem, Sizing, Spacing,
 };
-use typst_library::model::{Destination, LinkElem};
+use typst_library::model::{Destination, LinkElem, LinkMarker};
 use typst_library::routines::Pair;
 use typst_library::text::{
     LinebreakElem, SmartQuoteElem, SmartQuoter, SmartQuotes, SpaceElem, TextElem,
@@ -44,6 +44,9 @@ pub enum Item<'a> {
     /// An item that is invisible and needs to be skipped, e.g. a Unicode
     /// isolate.
     Skip(&'static str),
+    /// An event for a secondary effect on the paragraph, such as a link start
+    /// or end.
+    Event(Event),
 }
 
 impl<'a> Item<'a> {
@@ -68,7 +71,7 @@ impl<'a> Item<'a> {
     pub fn is_skippable(&self) -> bool {
         match self {
             Self::Text(text) => text.glyphs.is_empty(),
-            Self::Tag(_) => true,
+            Self::Tag(_) | Self::Event(_) => true,
             Self::Skip(_) => true,
             _ => false,
         }
@@ -81,7 +84,7 @@ impl<'a> Item<'a> {
             Self::Text(shaped) => shaped.text,
             Self::Absolute(_, _) | Self::Fractional(_, _) => SPACING_REPLACE,
             Self::Frame(_) => OBJ_REPLACE,
-            Self::Tag(_) => "",
+            Self::Tag(_) | Self::Event(_) => "",
             Self::Skip(s) => s,
         }
     }
@@ -97,7 +100,7 @@ impl<'a> Item<'a> {
             Self::Text(shaped) => shaped.width(),
             Self::Absolute(v, _) => *v,
             Self::Frame(frame) => frame.width(),
-            Self::Fractional(_, _) | Self::Tag(_) => Abs::zero(),
+            Self::Fractional(_, _) | Self::Tag(_) | Self::Event(_) => Abs::zero(),
             Self::Skip(_) => Abs::zero(),
         }
     }
@@ -158,65 +161,18 @@ pub fn collect<'a>(
         collector.spans.push(1, Span::detached());
     }
 
-    let prev_styles = None;
-    let mut active_links: Vec<(Destination, &[LazyHash<Style>])> = vec![];
+    let mut initial_link = None;
+    let mut active_links: Vec<(Destination, Location)> = vec![];
+    let mut checked_initial_link_tags = false;
+    let mut added_initial_link = false;
     for &(child, styles) in children {
         let prev_len = collector.full.len();
-
-        // 1. End active links.
-        let mut hit = false;
-        for style in styles.links() {
-            if let Some(link_pos) =
-                active_links.iter().position(|(_, s)| std::ptr::eq(*s, style))
-            {
-                for (link, _) in active_links.drain(link_pos + 1..).rev() {
-                    collector.push_event(Event::EndLink(link));
-                }
-                hit = true;
-                break;
-            }
+        if !added_initial_link {
+            added_initial_link = true;
+            initial_link = styles.get_cloned(LinkElem::current);
         }
 
-        // All links are gone!!
-        if !hit {
-            for (link, style) in active_links.drain(..) {
-                println!("Bye {link:?} {:p}!", style);
-                collector.push_event(Event::EndLink(link));
-            }
-        }
-
-        // 2. Append new links.
-        let common_styles =
-            prev_styles.and_then(|prev| StyleChain::trunk([prev, styles]));
-        let first_common_entry = common_styles.and_then(|c| c.links().next());
-        for new_entry in styles.links()
-        // .skip_while(|&s| first_common_entry.is_some_and(|c| !std::ptr::eq(c, s)))
-        {
-            if first_common_entry.is_some_and(|c| std::ptr::eq(c, new_entry)) {
-                break;
-            }
-            if active_links.last().is_some_and(|(_, s)| std::ptr::eq(*s, new_entry)) {
-                continue;
-            }
-
-            if new_entry.iter().any(|s| {
-                s.property()
-                    .is_some_and(|p| p.is(LinkElem::ELEM, LinkElem::current.index()))
-            }) {
-                let link = styles.get_cloned(LinkElem::current);
-                if let Some(link) = link {
-                    println!("Hi {link:?} {:p}!", new_entry);
-                    collector.push_event(Event::StartLink(link.clone()));
-                    active_links.push((link, new_entry));
-                } else {
-                    // What to do if setting link to none? probably nothing? or
-                    // maybe add end and later start event again for the same
-                    // link?
-                    break;
-                }
-            }
-        }
-
+        let mut was_link_tag = false;
         if child.is::<SpaceElem>() {
             collector.push_text(" ", styles);
         } else if let Some(elem) = child.to_packed::<TextElem>() {
@@ -307,6 +263,24 @@ pub fn collect<'a>(
             }
         } else if let Some(elem) = child.to_packed::<TagElem>() {
             collector.push_item(Item::Tag(&elem.tag));
+
+            match &elem.tag {
+                Tag::Start(content, _) => {
+                    if let Some(link_marker) = content.to_packed::<LinkMarker>() {
+                        was_link_tag = true;
+                        let link = link_marker.dest.clone();
+                        collector.push_event(Event::StartLink(link.clone()));
+                        active_links.push((link, elem.tag.location()));
+                    }
+                }
+                Tag::End(location, _, _) => {
+                    if let Some((link, _)) =
+                        active_links.pop_if(|(_, loc)| loc == location)
+                    {
+                        collector.push_event(Event::EndLink(link));
+                    }
+                }
+            }
         } else {
             // Non-paragraph inline layout should never trigger this since it
             // only won't be triggered if we see any non-inline content.
@@ -317,72 +291,14 @@ pub fn collect<'a>(
             ));
         }
 
+        checked_initial_link_tags |= !was_link_tag;
+
         let len = collector.full.len() - prev_len;
         collector.spans.push(len, child.span());
     }
 
     Ok((collector.full, collector.segments, collector.spans))
 }
-//
-//   BB
-//  AAAAA
-// -------
-//  |
-//  A
-//  S
-// active_links: [] --> [A,]
-// common_styles: -
-// style_diff: A- \ - = A
-//
-//   BB
-//  AAAAA
-// -------
-//   |
-//  AB
-//  SS
-// active_links: [A,] --> [A, B]
-// common_styles: A-
-// style_diff: BA- \ A- = B
-//
-//   BB
-//  AAAAA
-// -------
-//    |
-//  AB
-//  SS
-// active_links: [A, B]
-// common_styles: BA-
-// style_diff: BA- \ BA- = 0
-//
-//   BB
-//  AAAAA
-// -------
-//     |
-//  AB B
-//  SS E
-// active_links: [A, B] --> [A, ] (check if top is still in the style)
-// common_styles: A-
-// style_diff: A- \ A- = 0
-//
-//   BB
-//  AAAAA
-// -------
-//      |
-//  AB B
-//  SS E
-// active_links: [A, ]
-// common_styles: A-
-// style_diff: A- \ A- = 0
-//
-//   BB
-//  AAAAA*
-// -------
-//       |
-//  AB B A
-//  SS E E
-// active_links: [A, ] --> []
-// common_styles: -
-// style_diff: *- \ - = * (not a link, okay)
 
 /// Collects segments.
 struct Collector<'a> {

--- a/crates/typst-layout/src/inline/collect.rs
+++ b/crates/typst-layout/src/inline/collect.rs
@@ -262,10 +262,11 @@ pub fn collect<'a>(
                 collector.push_item(Item::Frame(frame));
             }
         } else if let Some(elem) = child.to_packed::<TagElem>() {
-            collector.push_item(Item::Tag(&elem.tag));
-
+            // Push tag before a corresponding start event, and after an end
+            // event, so that PDF tags can be generated with correct nesting.
             match &elem.tag {
                 Tag::Start(content, _) => {
+                    collector.push_item(Item::Tag(&elem.tag));
                     if let Some(link_marker) = content.to_packed::<LinkMarker>() {
                         let link = link_marker.dest.clone();
                         let location = elem.tag.location();
@@ -294,6 +295,8 @@ pub fn collect<'a>(
                         initial_events.push(Event::StartLink(link.clone()));
                         collector.push_event(Event::EndLink(link.clone()));
                     }
+
+                    collector.push_item(Item::Tag(&elem.tag));
                 }
             }
         } else {

--- a/crates/typst-layout/src/inline/collect.rs
+++ b/crates/typst-layout/src/inline/collect.rs
@@ -1,9 +1,10 @@
 use typst_library::diag::warning;
-use typst_library::foundations::{Packed, Resolve};
+use typst_library::foundations::{NativeElement, Packed, Resolve, Style};
 use typst_library::introspection::{SplitLocator, Tag, TagElem};
 use typst_library::layout::{
     Abs, BoxElem, Dir, Fr, Frame, HElem, InlineElem, InlineItem, Sizing, Spacing,
 };
+use typst_library::model::{Destination, LinkElem};
 use typst_library::routines::Pair;
 use typst_library::text::{
     LinebreakElem, SmartQuoteElem, SmartQuoter, SmartQuotes, SpaceElem, TextElem,
@@ -13,7 +14,7 @@ use typst_syntax::Span;
 use typst_utils::Numeric;
 
 use super::*;
-use crate::modifiers::{FrameModifiers, FrameModify, layout_and_modify};
+use crate::modifiers::{FrameModifiers, FrameModify, layout_and_reset_modifications};
 
 // The characters by which spacing, inline content and pins are replaced in the
 // full text.
@@ -157,8 +158,64 @@ pub fn collect<'a>(
         collector.spans.push(1, Span::detached());
     }
 
+    let prev_styles = None;
+    let mut active_links: Vec<(Destination, &[LazyHash<Style>])> = vec![];
     for &(child, styles) in children {
         let prev_len = collector.full.len();
+
+        // 1. End active links.
+        let mut hit = false;
+        for style in styles.links() {
+            if let Some(link_pos) =
+                active_links.iter().position(|(_, s)| std::ptr::eq(*s, style))
+            {
+                for (link, _) in active_links.drain(link_pos + 1..).rev() {
+                    collector.push_event(Event::EndLink(link));
+                }
+                hit = true;
+                break;
+            }
+        }
+
+        // All links are gone!!
+        if !hit {
+            for (link, style) in active_links.drain(..) {
+                println!("Bye {link:?} {:p}!", style);
+                collector.push_event(Event::EndLink(link));
+            }
+        }
+
+        // 2. Append new links.
+        let common_styles =
+            prev_styles.and_then(|prev| StyleChain::trunk([prev, styles]));
+        let first_common_entry = common_styles.and_then(|c| c.links().next());
+        for new_entry in styles.links()
+        // .skip_while(|&s| first_common_entry.is_some_and(|c| !std::ptr::eq(c, s)))
+        {
+            if first_common_entry.is_some_and(|c| std::ptr::eq(c, new_entry)) {
+                break;
+            }
+            if active_links.last().is_some_and(|(_, s)| std::ptr::eq(*s, new_entry)) {
+                continue;
+            }
+
+            if new_entry.iter().any(|s| {
+                s.property()
+                    .is_some_and(|p| p.is(LinkElem::ELEM, LinkElem::current.index()))
+            }) {
+                let link = styles.get_cloned(LinkElem::current);
+                if let Some(link) = link {
+                    println!("Hi {link:?} {:p}!", new_entry);
+                    collector.push_event(Event::StartLink(link.clone()));
+                    active_links.push((link, new_entry));
+                } else {
+                    // What to do if setting link to none? probably nothing? or
+                    // maybe add end and later start event again for the same
+                    // link?
+                    break;
+                }
+            }
+        }
 
         if child.is::<SpaceElem>() {
             collector.push_text(" ", styles);
@@ -240,9 +297,11 @@ pub fn collect<'a>(
             if let Sizing::Fr(v) = elem.width.get(styles) {
                 collector.push_item(Item::Fractional(v, Some((elem, loc, styles))));
             } else {
-                let mut frame = layout_and_modify(styles, |styles| {
-                    layout_box(elem, engine, loc, styles, region)
-                })?;
+                let (_modifiers, mut frame) =
+                    layout_and_reset_modifications(styles, |styles| {
+                        layout_box(elem, engine, loc, styles, region)
+                    })?;
+
                 apply_shift(&engine.world, &mut frame, styles);
                 collector.push_item(Item::Frame(frame));
             }
@@ -264,6 +323,66 @@ pub fn collect<'a>(
 
     Ok((collector.full, collector.segments, collector.spans))
 }
+//
+//   BB
+//  AAAAA
+// -------
+//  |
+//  A
+//  S
+// active_links: [] --> [A,]
+// common_styles: -
+// style_diff: A- \ - = A
+//
+//   BB
+//  AAAAA
+// -------
+//   |
+//  AB
+//  SS
+// active_links: [A,] --> [A, B]
+// common_styles: A-
+// style_diff: BA- \ A- = B
+//
+//   BB
+//  AAAAA
+// -------
+//    |
+//  AB
+//  SS
+// active_links: [A, B]
+// common_styles: BA-
+// style_diff: BA- \ BA- = 0
+//
+//   BB
+//  AAAAA
+// -------
+//     |
+//  AB B
+//  SS E
+// active_links: [A, B] --> [A, ] (check if top is still in the style)
+// common_styles: A-
+// style_diff: A- \ A- = 0
+//
+//   BB
+//  AAAAA
+// -------
+//      |
+//  AB B
+//  SS E
+// active_links: [A, ]
+// common_styles: A-
+// style_diff: A- \ A- = 0
+//
+//   BB
+//  AAAAA*
+// -------
+//       |
+//  AB B A
+//  SS E E
+// active_links: [A, ] --> []
+// common_styles: -
+// style_diff: *- \ - = * (not a link, okay)
 
 /// Collects segments.
 struct Collector<'a> {

--- a/crates/typst-layout/src/inline/collect.rs
+++ b/crates/typst-layout/src/inline/collect.rs
@@ -14,7 +14,7 @@ use typst_syntax::Span;
 use typst_utils::Numeric;
 
 use super::*;
-use crate::modifiers::{FrameModifiers, FrameModify, layout_and_reset_modifications};
+use crate::modifiers::{FrameModifiers, FrameModify, layout_and_modify_without_links};
 
 // The characters by which spacing, inline content and pins are replaced in the
 // full text.
@@ -254,10 +254,9 @@ pub fn collect<'a>(
             if let Sizing::Fr(v) = elem.width.get(styles) {
                 collector.push_item(Item::Fractional(v, Some((elem, loc, styles))));
             } else {
-                let (_modifiers, mut frame) =
-                    layout_and_reset_modifications(styles, |styles| {
-                        layout_box(elem, engine, loc, styles, region)
-                    })?;
+                let mut frame = layout_and_modify_without_links(styles, |styles| {
+                    layout_box(elem, engine, loc, styles, region)
+                })?;
 
                 apply_shift(&engine.world, &mut frame, styles);
                 collector.push_item(Item::Frame(frame));

--- a/crates/typst-layout/src/inline/collect.rs
+++ b/crates/typst-layout/src/inline/collect.rs
@@ -102,6 +102,12 @@ impl<'a> Item<'a> {
     }
 }
 
+#[derive(Debug)]
+pub enum Event {
+    StartLink(Destination),
+    EndLink(Destination),
+}
+
 /// An item or not-yet shaped text. We can't shape text until we have collected
 /// all items because only then we can compute BiDi, and we need to split shape
 /// runs at level boundaries.
@@ -112,6 +118,8 @@ pub enum Segment<'a> {
     Text(usize, StyleChain<'a>),
     /// An already prepared item.
     Item(Item<'a>),
+    /// An event.
+    Event(Event),
 }
 
 impl Segment<'_> {
@@ -120,6 +128,7 @@ impl Segment<'_> {
         match self {
             Self::Text(len, _) => *len,
             Self::Item(item) => item.textual_len(),
+            Self::Event(_) => 0,
         }
     }
 }
@@ -310,6 +319,10 @@ impl<'a> Collector<'a> {
                 self.segments.push(Segment::Item(item));
             }
         }
+    }
+
+    fn push_event(&mut self, event: Event) {
+        self.segments.push(Segment::Event(event));
     }
 }
 

--- a/crates/typst-layout/src/inline/collect.rs
+++ b/crates/typst-layout/src/inline/collect.rs
@@ -161,6 +161,12 @@ pub fn collect<'a>(
         collector.spans.push(1, Span::detached());
     }
 
+    // Paragraph-wide link, according to the flow layouter.
+    // Normally, this link is applied at the very end of the paragraph, unless
+    // the whole paragraph is a #link[...], in which case we must not apply it
+    // again.
+    let mut shared_link = config.link.as_ref();
+
     let mut initial_events = vec![];
     let mut prev_link: Option<&(Destination, Location)> = None;
     let mut active_links: Vec<(Destination, Location)> = vec![];
@@ -263,8 +269,17 @@ pub fn collect<'a>(
                 Tag::Start(content, _) => {
                     if let Some(link_marker) = content.to_packed::<LinkMarker>() {
                         let link = link_marker.dest.clone();
+                        let location = elem.tag.location();
                         collector.push_event(Event::StartLink(link.clone()));
-                        active_links.push((link, elem.tag.location()));
+                        active_links.push((link, location));
+
+                        if let Some((_, loc)) = shared_link
+                            && loc == &location
+                        {
+                            // Link spanning the entire paragraph starts and
+                            // ends within it, so don't apply it twice.
+                            shared_link = None;
+                        }
                     }
                 }
                 Tag::End(location, _, _) => {
@@ -296,6 +311,12 @@ pub fn collect<'a>(
 
         let len = collector.full.len() - prev_len;
         collector.spans.push(len, child.span());
+    }
+
+    // Apply flow-level link.
+    if let Some((link, _)) = shared_link {
+        initial_events.push(Event::StartLink(link.clone()));
+        collector.push_event(Event::EndLink(link.clone()));
     }
 
     if !initial_events.is_empty() {

--- a/crates/typst-layout/src/inline/collect.rs
+++ b/crates/typst-layout/src/inline/collect.rs
@@ -161,18 +161,13 @@ pub fn collect<'a>(
         collector.spans.push(1, Span::detached());
     }
 
-    let mut initial_link = None;
+    let mut initial_events = vec![];
+    let mut prev_link: Option<&(Destination, Location)> = None;
     let mut active_links: Vec<(Destination, Location)> = vec![];
-    let mut checked_initial_link_tags = false;
-    let mut added_initial_link = false;
     for &(child, styles) in children {
         let prev_len = collector.full.len();
-        if !added_initial_link {
-            added_initial_link = true;
-            initial_link = styles.get_cloned(LinkElem::current);
-        }
+        let current_link = styles.get_ref(LinkElem::current);
 
-        let mut was_link_tag = false;
         if child.is::<SpaceElem>() {
             collector.push_text(" ", styles);
         } else if let Some(elem) = child.to_packed::<TextElem>() {
@@ -267,7 +262,6 @@ pub fn collect<'a>(
             match &elem.tag {
                 Tag::Start(content, _) => {
                     if let Some(link_marker) = content.to_packed::<LinkMarker>() {
-                        was_link_tag = true;
                         let link = link_marker.dest.clone();
                         collector.push_event(Event::StartLink(link.clone()));
                         active_links.push((link, elem.tag.location()));
@@ -278,6 +272,13 @@ pub fn collect<'a>(
                         active_links.pop_if(|(_, loc)| loc == location)
                     {
                         collector.push_event(Event::EndLink(link));
+                    // Experimentally, the link style is already reverted at the
+                    // end tag, so we check the previous link style.
+                    } else if let Some((link, loc)) = prev_link
+                        && loc == location
+                    {
+                        initial_events.push(Event::StartLink(link.clone()));
+                        collector.push_event(Event::EndLink(link.clone()));
                     }
                 }
             }
@@ -291,12 +292,21 @@ pub fn collect<'a>(
             ));
         }
 
-        checked_initial_link_tags |= !was_link_tag;
+        prev_link = current_link.as_ref();
 
         let len = collector.full.len() - prev_len;
         collector.spans.push(len, child.span());
     }
 
+    if !initial_events.is_empty() {
+        // TODO: could be more efficient by returning initial events directly
+        collector.segments = initial_events
+            .into_iter()
+            .rev()
+            .map(Segment::Event)
+            .chain(collector.segments)
+            .collect();
+    }
     Ok((collector.full, collector.segments, collector.spans))
 }
 

--- a/crates/typst-layout/src/inline/finalize.rs
+++ b/crates/typst-layout/src/inline/finalize.rs
@@ -27,9 +27,12 @@ pub fn finalize(
     };
 
     // Stack the lines into one frame per region.
+    // Keep track of active links across lines, as some links might span
+    // multiple lines.
+    let mut active_links = Vec::new();
     lines
         .iter()
-        .map(|line| commit(engine, p, line, width, region.y, locator))
+        .map(|line| commit(engine, p, line, width, region.y, locator, &mut active_links))
         .collect::<SourceResult<_>>()
         .map(Fragment::frames)
 }

--- a/crates/typst-layout/src/inline/line.rs
+++ b/crates/typst-layout/src/inline/line.rs
@@ -3,16 +3,18 @@ use std::ops::{Deref, DerefMut};
 
 use ecow::EcoVec;
 use typst_library::engine::Engine;
-use typst_library::introspection::{SplitLocator, Tag, TagFlags};
-use typst_library::layout::{Abs, Dir, Em, Fr, Frame, FrameItem, Point};
-use typst_library::model::ParLineMarker;
+use typst_library::foundations::Styles;
+use typst_library::introspection::{Location, SplitLocator, Tag, TagFlags};
+use typst_library::layout::{Abs, Dir, Em, Fr, Frame, FrameItem, FrameKind, Point};
+use typst_library::model::{Destination, LinkElem, ParLineMarker};
 use typst_library::text::{FontInstance, Lang, TextElem, families, variant};
 use typst_utils::Numeric;
 
 use super::*;
+use crate::inline::collect::Event;
 use crate::inline::linebreak::Trim;
 use crate::inline::shaping::{Adjustability, ShapedGlyph};
-use crate::modifiers::layout_and_modify;
+use crate::modifiers::{FrameModifiers, FrameModify, layout_and_modify};
 
 const SHY: char = '\u{ad}';
 const HYPHEN: char = '-';
@@ -485,13 +487,14 @@ pub fn apply_shift<'a>(
 }
 
 /// Commit to a line and build its frame.
-pub fn commit(
+pub fn commit<'l>(
     engine: &mut Engine,
     p: &Preparation,
-    line: &Line,
+    line: &'l Line,
     width: Abs,
     full: Abs,
     locator: &mut SplitLocator<'_>,
+    active_links: &mut Vec<&'l Destination>,
 ) -> SourceResult<Frame> {
     let mut remaining = width - line.width - p.config.hanging_indent;
     let mut offset = Abs::zero();
@@ -556,6 +559,13 @@ pub fn commit(
         }
     }
 
+    // Keep track of items spanned by each link, including the destination, the
+    // horizontal offset where it starts, and the offset where it ends - this
+    // starts as `None` and becomes `Some()` if the link ends at this line, or
+    // ends as `None` if it spans the whole line.
+    let mut link_spans: Vec<(&Destination, Abs, Option<Abs>)> =
+        active_links.iter().map(|&l| (l, Abs::zero(), None)).collect();
+
     let mut top = Abs::zero();
     let mut bottom = Abs::zero();
 
@@ -605,6 +615,25 @@ pub fn commit(
                 frames.push((offset, frame, idx));
             }
             Item::Skip(_) => {}
+            Item::Event(Event::StartLink(dest)) => {
+                active_links.push(dest);
+                link_spans.push((dest, offset, None));
+            }
+            Item::Event(Event::EndLink(dest)) => {
+                if active_links.is_empty() {
+                    // External links should have been handled before...
+                    todo!()
+                } else {
+                    debug_assert_eq!(active_links.last(), Some(&dest));
+                    debug_assert_eq!(link_spans.last().map(|(l, _, _)| l), Some(&dest));
+                    debug_assert_eq!(
+                        link_spans.last().map(|(_, _, end)| end),
+                        Some(&None)
+                    );
+                    active_links.pop();
+                    link_spans.last_mut().unwrap().2 = Some(offset);
+                }
+            }
         }
     }
 
@@ -630,6 +659,27 @@ pub fn commit(
     for (offset, frame, _) in frames {
         let x = offset + p.config.align.position(remaining);
         let y = top - frame.baseline();
+        output.push_frame(Point::new(x, y), frame);
+    }
+
+    // Construct link frames.
+    for (dest, offset, end) in link_spans {
+        let x = offset + p.config.align.position(remaining);
+        let y = bottom;
+        dbg!(x);
+        dbg!(y);
+        let width = match end {
+            Some(end) => dbg!(end - offset),
+            None => dbg!(width),
+        };
+        dbg!(width);
+        let height = dbg!(top) - dbg!(bottom);
+        dbg!(height);
+        let mut styles = Styles::new();
+        styles.set(LinkElem::current, Some((dest.clone(), Location::new(0))));
+
+        let frame = Frame::new(Size::new(width, height), FrameKind::Soft)
+            .modified(&FrameModifiers::get_in(StyleChain::new(&styles)));
         output.push_frame(Point::new(x, y), frame);
     }
 

--- a/crates/typst-layout/src/inline/line.rs
+++ b/crates/typst-layout/src/inline/line.rs
@@ -14,7 +14,7 @@ use super::*;
 use crate::inline::collect::Event;
 use crate::inline::linebreak::Trim;
 use crate::inline::shaping::{Adjustability, ShapedGlyph};
-use crate::modifiers::{FrameModifiers, FrameModify, layout_and_modify};
+use crate::modifiers::{FrameModifiers, FrameModify, FrameModifyText, layout_and_modify};
 
 const SHY: char = '\u{ad}';
 const HYPHEN: char = '-';
@@ -677,8 +677,9 @@ pub fn commit<'l>(
         let mut styles = Styles::new();
         styles.set(LinkElem::current, Some((dest.clone(), Location::new(0))));
 
-        let frame = Frame::new(Size::new(width, height), FrameKind::Soft)
-            .modified(&FrameModifiers::get_in(StyleChain::new(&styles)));
+        // TODO: a single modify call, calculating the height needed in real-time when going over text...
+        let mut frame = Frame::new(Size::new(width, height), FrameKind::Soft);
+        frame.modify_text_with_link(StyleChain::new(&styles));
         output.push_frame(Point::new(x, y), frame);
     }
 

--- a/crates/typst-layout/src/inline/line.rs
+++ b/crates/typst-layout/src/inline/line.rs
@@ -486,6 +486,20 @@ pub fn apply_shift<'a>(
     frame.translate(Point::new(compensation, baseline));
 }
 
+#[derive(Default)]
+struct LinkRenderInfo {
+    spans_text: bool,
+    height: Abs,
+    start: Abs,
+    y: Abs,
+}
+
+impl LinkRenderInfo {
+    fn with_start(start: Abs) -> Self {
+        Self { start, ..Default::default() }
+    }
+}
+
 /// Commit to a line and build its frame.
 pub fn commit<'l>(
     engine: &mut Engine,
@@ -559,12 +573,12 @@ pub fn commit<'l>(
         }
     }
 
-    // Keep track of items spanned by each link, including the destination, the
-    // horizontal offset where it starts, and (for finished links) the offset
-    // where it ends.
-    let mut link_stack: Vec<(&Destination, Abs)> =
-        active_links.iter().map(|&l| (l, Abs::zero())).collect();
-    let mut finished_links: Vec<(&Destination, Abs, Abs)> = vec![];
+    // Keep track of items spanned by each link, including the destination,
+    // whether a text was spanned, the height, the horizontal offset where it
+    // starts, and (for finished links) the offset where it ends.
+    let mut link_stack: Vec<(&Destination, LinkRenderInfo)> =
+        active_links.iter().map(|&l| (l, LinkRenderInfo::default())).collect();
+    let mut finished_links: Vec<(&Destination, LinkRenderInfo, Abs)> = vec![];
 
     // Horizontal offset after the last frame in the line.
     let mut last_frame_end = Abs::zero();
@@ -577,8 +591,16 @@ pub fn commit<'l>(
     for &(idx, ref item) in line.items.iter_indexed() {
         let mut push = |offset: &mut Abs, frame: Frame, idx: LogicalIndex| {
             let width = frame.width();
+            let frame_bottom = frame.size().y - frame.baseline();
             top.set_max(frame.baseline());
-            bottom.set_max(frame.size().y - frame.baseline());
+            bottom.set_max(frame_bottom);
+
+            for (_, link_info) in &mut link_stack {
+                // Ensure link covers this frame.
+                link_info.height.set_max(frame.height());
+                link_info.y.set_max(frame_bottom);
+            }
+
             frames.push((*offset, frame, idx));
             *offset += width;
             last_frame_end = *offset;
@@ -609,6 +631,10 @@ pub fn commit<'l>(
                     extra_justification,
                 );
                 push(&mut offset, frame, idx);
+
+                for (_, link_info) in &mut link_stack {
+                    link_info.spans_text = true;
+                }
             }
             Item::Frame(frame) => {
                 push(&mut offset, frame.clone(), idx);
@@ -621,23 +647,26 @@ pub fn commit<'l>(
             Item::Skip(_) => {}
             Item::Event(Event::StartLink(dest)) => {
                 active_links.push(dest);
-                link_stack.push((dest, offset));
+                link_stack.push((dest, LinkRenderInfo::with_start(offset)));
             }
             Item::Event(Event::EndLink(dest)) => {
                 debug_assert_eq!(active_links.last(), Some(&dest));
                 debug_assert_eq!(link_stack.last().map(|(l, _)| l), Some(&dest));
-                let (dest, start) = link_stack.pop().unwrap();
+                let (dest, link_info) = link_stack.pop().unwrap();
                 // Any external links should have been handled before.
                 active_links.pop().unwrap();
-                finished_links.push((dest, start, offset));
+                finished_links.push((dest, link_info, offset));
             }
         }
     }
 
     // Any unfinished links extend towards the very end of the last visible item
     // in the line.
-    finished_links
-        .extend(link_stack.into_iter().map(|(l, start)| (l, start, last_frame_end)));
+    finished_links.extend(
+        link_stack
+            .into_iter()
+            .map(|(l, link_info)| (l, link_info, last_frame_end)),
+    );
 
     // Remaining space is distributed now.
     if !fr.is_zero() {
@@ -665,15 +694,11 @@ pub fn commit<'l>(
     }
 
     // Construct link frames.
-    for (dest, offset, end) in finished_links {
-        let x = offset + p.config.align.position(remaining);
-        let y = bottom;
-        dbg!(x);
-        dbg!(y);
-        let width = dbg!(end) - dbg!(offset);
-        dbg!(width);
-        let height = dbg!(top) - dbg!(bottom);
-        dbg!(height);
+    for (dest, link_info, end) in finished_links {
+        let x = link_info.start + p.config.align.position(remaining);
+        let y = top - link_info.height;
+        let width = end - link_info.start;
+        let height = link_info.height;
         let mut styles = Styles::new();
         styles.set(LinkElem::current, Some((dest.clone(), Location::new(0))));
 

--- a/crates/typst-layout/src/inline/line.rs
+++ b/crates/typst-layout/src/inline/line.rs
@@ -560,11 +560,14 @@ pub fn commit<'l>(
     }
 
     // Keep track of items spanned by each link, including the destination, the
-    // horizontal offset where it starts, and the offset where it ends - this
-    // starts as `None` and becomes `Some()` if the link ends at this line, or
-    // ends as `None` if it spans the whole line.
-    let mut link_spans: Vec<(&Destination, Abs, Option<Abs>)> =
-        active_links.iter().map(|&l| (l, Abs::zero(), None)).collect();
+    // horizontal offset where it starts, and (for finished links) the offset
+    // where it ends.
+    let mut link_stack: Vec<(&Destination, Abs)> =
+        active_links.iter().map(|&l| (l, Abs::zero())).collect();
+    let mut finished_links: Vec<(&Destination, Abs, Abs)> = vec![];
+
+    // Horizontal offset after the last frame in the line.
+    let mut last_frame_end = Abs::zero();
 
     let mut top = Abs::zero();
     let mut bottom = Abs::zero();
@@ -578,6 +581,7 @@ pub fn commit<'l>(
             bottom.set_max(frame.size().y - frame.baseline());
             frames.push((*offset, frame, idx));
             *offset += width;
+            last_frame_end = *offset;
         };
 
         match &**item {
@@ -617,25 +621,23 @@ pub fn commit<'l>(
             Item::Skip(_) => {}
             Item::Event(Event::StartLink(dest)) => {
                 active_links.push(dest);
-                link_spans.push((dest, offset, None));
+                link_stack.push((dest, offset));
             }
             Item::Event(Event::EndLink(dest)) => {
-                if active_links.is_empty() {
-                    // External links should have been handled before...
-                    todo!()
-                } else {
-                    debug_assert_eq!(active_links.last(), Some(&dest));
-                    debug_assert_eq!(link_spans.last().map(|(l, _, _)| l), Some(&dest));
-                    debug_assert_eq!(
-                        link_spans.last().map(|(_, _, end)| end),
-                        Some(&None)
-                    );
-                    active_links.pop();
-                    link_spans.last_mut().unwrap().2 = Some(offset);
-                }
+                debug_assert_eq!(active_links.last(), Some(&dest));
+                debug_assert_eq!(link_stack.last().map(|(l, _)| l), Some(&dest));
+                let (dest, start) = link_stack.pop().unwrap();
+                // Any external links should have been handled before.
+                active_links.pop().unwrap();
+                finished_links.push((dest, start, offset));
             }
         }
     }
+
+    // Any unfinished links extend towards the very end of the last visible item
+    // in the line.
+    finished_links
+        .extend(link_stack.into_iter().map(|(l, start)| (l, start, last_frame_end)));
 
     // Remaining space is distributed now.
     if !fr.is_zero() {
@@ -663,15 +665,12 @@ pub fn commit<'l>(
     }
 
     // Construct link frames.
-    for (dest, offset, end) in link_spans {
+    for (dest, offset, end) in finished_links {
         let x = offset + p.config.align.position(remaining);
         let y = bottom;
         dbg!(x);
         dbg!(y);
-        let width = match end {
-            Some(end) => dbg!(end - offset),
-            None => dbg!(width),
-        };
+        let width = dbg!(end) - dbg!(offset);
         dbg!(width);
         let height = dbg!(top) - dbg!(bottom);
         dbg!(height);

--- a/crates/typst-layout/src/inline/line.rs
+++ b/crates/typst-layout/src/inline/line.rs
@@ -603,7 +603,7 @@ pub fn commit<'l>(
                 link_info.y.set_max(frame_bottom);
             }
 
-            frames.push((*offset, frame, idx));
+            frames.push((*offset, frame, idx, None));
             *offset += width;
             last_frame_end = *offset;
         };
@@ -644,7 +644,7 @@ pub fn commit<'l>(
             Item::Tag(tag) => {
                 let mut frame = Frame::soft(Size::zero());
                 frame.push(Point::zero(), FrameItem::Tag((*tag).clone()));
-                frames.push((offset, frame, idx));
+                frames.push((offset, frame, idx, None));
             }
             Item::Skip(_) => {}
             Item::Event(Event::StartLink(dest)) => {
@@ -657,7 +657,27 @@ pub fn commit<'l>(
                 let (dest, link_info) = link_stack.pop().unwrap();
                 // Any external links should have been handled before.
                 active_links.pop().unwrap();
-                finished_links.push((dest, link_info, offset));
+
+                let end = offset;
+
+                let x = link_info.start;
+                let y = link_info.height;
+                let width = end - link_info.start;
+                let height = link_info.height;
+                let mut styles = Styles::new();
+                styles.set(LinkElem::current, Some((dest.clone(), Location::new(0))));
+
+                // TODO: a single modify call, calculating the height needed in real-time when going over text...
+                let mut frame = Frame::new(Size::new(width, height), FrameKind::Soft);
+                let stylechain = StyleChain::new(&styles);
+                if link_info.spans_text {
+                    frame.modify_text(stylechain);
+                } else {
+                    // Don't add padding; restrict the link to the box.
+                    // TODO: also need to consider equations...
+                    frame.modify(&FrameModifiers::get_in(stylechain));
+                }
+                frames.push((offset, frame, idx, Some(Point::new(x, y))));
             }
         }
     }
@@ -686,16 +706,18 @@ pub fn commit<'l>(
     // Ensure that the final frame's items are in logical order rather than in
     // visual order. This is important because it affects the order of elements
     // during introspection and thus things like counters.
-    frames.sort_unstable_by_key(|(_, _, idx)| *idx);
+    frames.sort_unstable_by_key(|(_, _, idx, _)| *idx);
 
     // Construct the line's frame.
-    for (offset, frame, _) in frames {
-        let x = offset + p.config.align.position(remaining);
-        let y = top - frame.baseline();
+    for (offset, frame, _, point) in frames {
+        let Point { x, y } =
+            point.unwrap_or_else(|| Point::new(offset, frame.baseline()));
+        let x = x + p.config.align.position(remaining);
+        let y = top - y;
         output.push_frame(Point::new(x, y), frame);
     }
 
-    // Construct link frames.
+    // Construct unfinished link frames.
     for (dest, link_info, end) in finished_links {
         let x = link_info.start + p.config.align.position(remaining);
         let y = top - link_info.height;

--- a/crates/typst-layout/src/inline/line.rs
+++ b/crates/typst-layout/src/inline/line.rs
@@ -488,17 +488,19 @@ pub fn apply_shift<'a>(
     frame.translate(Point::new(compensation, baseline));
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 struct LinkRenderInfo {
     spans_text: bool,
     height: Abs,
     start: Abs,
     y: Abs,
+    last_index: Option<usize>,
+    last_end: Abs,
 }
 
 impl LinkRenderInfo {
     fn with_start(start: Abs) -> Self {
-        Self { start, ..Default::default() }
+        Self { start, last_end: start, ..Default::default() }
     }
 }
 
@@ -580,7 +582,6 @@ pub fn commit<'l>(
     // starts, and (for finished links) the offset where it ends.
     let mut link_stack: Vec<(&Destination, LinkRenderInfo)> =
         active_links.iter().map(|&l| (l, LinkRenderInfo::default())).collect();
-    let mut finished_links: Vec<(&Destination, LinkRenderInfo, Abs)> = vec![];
 
     // Horizontal offset after the last frame in the line.
     let mut last_frame_end = Abs::zero();
@@ -593,17 +594,10 @@ pub fn commit<'l>(
     for &(idx, ref item) in line.items.iter_indexed() {
         let mut push = |offset: &mut Abs, frame: Frame, idx: LogicalIndex| {
             let width = frame.width();
-            let frame_bottom = frame.size().y - frame.baseline();
             top.set_max(frame.baseline());
-            bottom.set_max(frame_bottom);
+            bottom.set_max(frame.size().y - frame.baseline());
 
-            for (_, link_info) in &mut link_stack {
-                // Ensure link covers this frame.
-                link_info.height.set_max(frame.height());
-                link_info.y.set_max(frame_bottom);
-            }
-
-            frames.push((*offset, frame, idx, None));
+            frames.push((*offset, Some(frame), idx, frames.len(), item));
             *offset += width;
             last_frame_end = *offset;
         };
@@ -633,10 +627,6 @@ pub fn commit<'l>(
                     extra_justification,
                 );
                 push(&mut offset, frame, idx);
-
-                for (_, link_info) in &mut link_stack {
-                    link_info.spans_text = true;
-                }
             }
             Item::Frame(frame) => {
                 push(&mut offset, frame.clone(), idx);
@@ -644,51 +634,17 @@ pub fn commit<'l>(
             Item::Tag(tag) => {
                 let mut frame = Frame::soft(Size::zero());
                 frame.push(Point::zero(), FrameItem::Tag((*tag).clone()));
-                frames.push((offset, frame, idx, None));
+                frames.push((offset, Some(frame), idx, frames.len(), item));
             }
             Item::Skip(_) => {}
-            Item::Event(Event::StartLink(dest)) => {
-                active_links.push(dest);
-                link_stack.push((dest, LinkRenderInfo::with_start(offset)));
+            Item::Event(Event::StartLink(_)) => {
+                frames.push((offset, None, idx, frames.len(), item));
             }
-            Item::Event(Event::EndLink(dest)) => {
-                debug_assert_eq!(active_links.last(), Some(&dest));
-                debug_assert_eq!(link_stack.last().map(|(l, _)| l), Some(&dest));
-                let (dest, link_info) = link_stack.pop().unwrap();
-                // Any external links should have been handled before.
-                active_links.pop().unwrap();
-
-                let end = offset;
-
-                let x = link_info.start;
-                let y = link_info.height;
-                let width = end - link_info.start;
-                let height = link_info.height;
-                let mut styles = Styles::new();
-                styles.set(LinkElem::current, Some((dest.clone(), Location::new(0))));
-
-                // TODO: a single modify call, calculating the height needed in real-time when going over text...
-                let mut frame = Frame::new(Size::new(width, height), FrameKind::Soft);
-                let stylechain = StyleChain::new(&styles);
-                if link_info.spans_text {
-                    frame.modify_text(stylechain);
-                } else {
-                    // Don't add padding; restrict the link to the box.
-                    // TODO: also need to consider equations...
-                    frame.modify(&FrameModifiers::get_in(stylechain));
-                }
-                frames.push((offset, frame, idx, Some(Point::new(x, y))));
+            Item::Event(Event::EndLink(_)) => {
+                frames.push((offset, None, idx, frames.len(), item));
             }
         }
     }
-
-    // Any unfinished links extend towards the very end of the last visible item
-    // in the line.
-    finished_links.extend(
-        link_stack
-            .into_iter()
-            .map(|(l, link_info)| (l, link_info, last_frame_end)),
-    );
 
     // Remaining space is distributed now.
     if !fr.is_zero() {
@@ -706,19 +662,9 @@ pub fn commit<'l>(
     // Ensure that the final frame's items are in logical order rather than in
     // visual order. This is important because it affects the order of elements
     // during introspection and thus things like counters.
-    frames.sort_unstable_by_key(|(_, _, idx, _)| *idx);
+    frames.sort_unstable_by_key(|(_, _, idx, _, _)| *idx);
 
-    // Construct the line's frame.
-    for (offset, frame, _, point) in frames {
-        let Point { x, y } =
-            point.unwrap_or_else(|| Point::new(offset, frame.baseline()));
-        let x = x + p.config.align.position(remaining);
-        let y = top - y;
-        output.push_frame(Point::new(x, y), frame);
-    }
-
-    // Construct unfinished link frames.
-    for (dest, link_info, end) in finished_links {
+    let prepare_link = |dest: &Destination, link_info: &LinkRenderInfo, end: Abs| {
         let x = link_info.start + p.config.align.position(remaining);
         let y = top - link_info.height;
         let width = end - link_info.start;
@@ -736,7 +682,88 @@ pub fn commit<'l>(
             // TODO: also need to consider equations...
             frame.modify(&FrameModifiers::get_in(stylechain));
         }
-        output.push_frame(Point::new(x, y), frame);
+
+        (Point::new(x, y), frame)
+    };
+
+    // Construct the line's frame.
+    for (offset, frame, _, frame_index, item) in frames {
+        let mut frame_width = Abs::zero();
+        let mut frame_height = Abs::zero();
+        let mut frame_bottom = Abs::zero();
+
+        if let Some(frame) = frame {
+            let x = offset + p.config.align.position(remaining);
+            let y = top - frame.baseline();
+
+            frame_width = frame.width();
+            frame_height = frame.height();
+            frame_bottom = frame.size().y - frame.baseline();
+
+            output.push_frame(Point::new(x, y), frame);
+        }
+
+        for (dest, link_info) in &mut link_stack {
+            // Check if link items are discontinuous, i.e. if despite the two
+            // being adjacent in the source code (consecutive logical indices),
+            // they are not adjacent in the resulting line (non-consecutive
+            // frame indices) due to RTL reordering.
+            if let Some(last_index) = link_info.last_index {
+                if frame_index + 1 == last_index {
+                    // RTL (items reversed), so just move the link backwards
+                    // instead of forwards.
+                    link_info.start.set_min(offset);
+                } else if frame_index != last_index + 1 {
+                    let (pos, frame) = prepare_link(dest, link_info, link_info.last_end);
+                    output.push_frame(pos, frame);
+
+                    // Items are discontinuous; break and begin a new link
+                    // bounding box.
+                    *link_info = LinkRenderInfo::with_start(offset);
+                }
+            }
+
+            // Ensure link spans at least this frame as well.
+            link_info.height.set_max(frame_height);
+            link_info.y.set_max(frame_bottom);
+            link_info.last_end.set_max(offset + frame_width);
+            link_info.last_index = Some(frame_index);
+
+            if matches!(**item, Item::Text(_)) {
+                link_info.spans_text = true;
+            }
+        }
+
+        match &**item {
+            Item::Event(Event::StartLink(dest)) => {
+                active_links.push(dest);
+                link_stack.push((dest, LinkRenderInfo::with_start(offset)));
+            }
+            Item::Event(Event::EndLink(dest)) => {
+                debug_assert_eq!(active_links.last(), Some(&dest));
+                debug_assert_eq!(link_stack.last().map(|(l, _)| l), Some(&dest));
+
+                let (dest, link_info) = link_stack.pop().unwrap();
+                // Any external links should have been handled before.
+                active_links.pop().unwrap();
+
+                // Place a link all the way to the end of the rightmost one.
+                // Ignore the offset of the end event itself as it might
+                // (visually) be at the start rather than the end of the link
+                // due to RTL reversal.
+                let (pos, frame) = prepare_link(dest, &link_info, link_info.last_end);
+                output.push_frame(pos, frame);
+            }
+            _ => {}
+        }
+    }
+
+    // Construct unfinished link frames.
+    for (dest, link_info) in link_stack {
+        // Any unfinished links extend towards the very end of the last visible
+        // item in the line.
+        let (pos, frame) = prepare_link(dest, &link_info, last_frame_end);
+        output.push_frame(pos, frame);
     }
 
     Ok(output)

--- a/crates/typst-layout/src/inline/line.rs
+++ b/crates/typst-layout/src/inline/line.rs
@@ -14,7 +14,9 @@ use super::*;
 use crate::inline::collect::Event;
 use crate::inline::linebreak::Trim;
 use crate::inline::shaping::{Adjustability, ShapedGlyph};
-use crate::modifiers::{FrameModifyText, layout_and_modify_without_links};
+use crate::modifiers::{
+    FrameModifiers, FrameModify, FrameModifyText, layout_and_modify_without_links,
+};
 
 const SHY: char = '\u{ad}';
 const HYPHEN: char = '-';
@@ -704,7 +706,14 @@ pub fn commit<'l>(
 
         // TODO: a single modify call, calculating the height needed in real-time when going over text...
         let mut frame = Frame::new(Size::new(width, height), FrameKind::Soft);
-        frame.modify_text(StyleChain::new(&styles));
+        let stylechain = StyleChain::new(&styles);
+        if link_info.spans_text {
+            frame.modify_text(stylechain);
+        } else {
+            // Don't add padding; restrict the link to the box.
+            // TODO: also need to consider equations...
+            frame.modify(&FrameModifiers::get_in(stylechain));
+        }
         output.push_frame(Point::new(x, y), frame);
     }
 

--- a/crates/typst-layout/src/inline/line.rs
+++ b/crates/typst-layout/src/inline/line.rs
@@ -14,7 +14,7 @@ use super::*;
 use crate::inline::collect::Event;
 use crate::inline::linebreak::Trim;
 use crate::inline::shaping::{Adjustability, ShapedGlyph};
-use crate::modifiers::{FrameModifiers, FrameModify, FrameModifyText, layout_and_modify};
+use crate::modifiers::{FrameModifyText, layout_and_modify_without_links};
 
 const SHY: char = '\u{ad}';
 const HYPHEN: char = '-';
@@ -592,7 +592,7 @@ pub fn commit<'l>(
                 let amount = v.share(fr, remaining);
                 if let Some((elem, loc, styles)) = elem {
                     let region = Size::new(amount, full);
-                    let mut frame = layout_and_modify(*styles, |styles| {
+                    let mut frame = layout_and_modify_without_links(*styles, |styles| {
                         layout_box(elem, engine, loc.relayout(), styles, region)
                     })?;
                     apply_shift(&engine.world, &mut frame, *styles);
@@ -679,7 +679,7 @@ pub fn commit<'l>(
 
         // TODO: a single modify call, calculating the height needed in real-time when going over text...
         let mut frame = Frame::new(Size::new(width, height), FrameKind::Soft);
-        frame.modify_text_with_link(StyleChain::new(&styles));
+        frame.modify_text(StyleChain::new(&styles));
         output.push_frame(Point::new(x, y), frame);
     }
 

--- a/crates/typst-layout/src/inline/line.rs
+++ b/crates/typst-layout/src/inline/line.rs
@@ -7,7 +7,7 @@ use typst_library::foundations::Styles;
 use typst_library::introspection::{Location, SplitLocator, Tag, TagFlags};
 use typst_library::layout::{Abs, Dir, Em, Fr, Frame, FrameItem, FrameKind, Point};
 use typst_library::model::{Destination, LinkElem, ParLineMarker};
-use typst_library::text::{FontInstance, Lang, TextElem, families, variant};
+use typst_library::text::{FontInstance, Lang, TextElem, TextSize, families, variant};
 use typst_utils::Numeric;
 
 use super::*;
@@ -669,8 +669,13 @@ pub fn commit<'l>(
         let y = top - link_info.height;
         let width = end - link_info.start;
         let height = link_info.height;
+
+        // TODO: pass relative leading directly to 'modify_text' instead of ad-hoc stylechain modifications?
+        // - also consider per-text run font size.
         let mut styles = Styles::new();
         styles.set(LinkElem::current, Some((dest.clone(), Location::new(0))));
+        styles.set(ParElem::leading, p.config.leading);
+        styles.set(TextElem::size, TextSize(Length::from(p.config.font_size)));
 
         // TODO: a single modify call, calculating the height needed in real-time when going over text...
         let mut frame = Frame::new(Size::new(width, height), FrameKind::Soft);

--- a/crates/typst-layout/src/inline/mod.rs
+++ b/crates/typst-layout/src/inline/mod.rs
@@ -15,11 +15,13 @@ use comemo::{Track, Tracked, TrackedMut};
 use typst_library::diag::SourceResult;
 use typst_library::engine::{Engine, Route, Sink, Traced};
 use typst_library::foundations::{Packed, Smart, StyleChain};
-use typst_library::introspection::{Introspector, Locator, LocatorLink, SplitLocator};
+use typst_library::introspection::{
+    Introspector, Location, Locator, LocatorLink, SplitLocator,
+};
 use typst_library::layout::{Abs, AlignElem, Dir, FixedAlignment, Fragment, Size};
 use typst_library::model::{
-    EnumElem, FirstLineIndent, JustificationLimits, Linebreaks, ListElem, ParElem,
-    ParLine, ParLineMarker, TermsElem,
+    Destination, EnumElem, FirstLineIndent, JustificationLimits, Linebreaks, LinkElem,
+    ListElem, ParElem, ParLine, ParLineMarker, TermsElem,
 };
 use typst_library::routines::{Arenas, Pair, RealizationKind};
 use typst_library::text::{Costs, Lang, TextElem};
@@ -187,6 +189,7 @@ fn configuration(
     let justify = base.justify;
     let font_size = shared.resolve(TextElem::size);
     let dir = shared.resolve(TextElem::dir);
+    let link = shared.get_cloned(LinkElem::current);
 
     Config {
         justify,
@@ -238,6 +241,7 @@ fn configuration(
         fallback: shared.get(TextElem::fallback),
         cjk_latin_spacing: shared.get(TextElem::cjk_latin_spacing).is_auto(),
         costs: shared.get(TextElem::costs),
+        link,
     }
 }
 
@@ -297,6 +301,8 @@ struct Config {
     cjk_latin_spacing: bool,
     /// Costs for various layout decisions.
     costs: Costs,
+    /// The link active throughout the whole paragraph.
+    link: Option<(Destination, Location)>,
 }
 
 /// Get a style property, but only if it is the same for all of the children.

--- a/crates/typst-layout/src/inline/mod.rs
+++ b/crates/typst-layout/src/inline/mod.rs
@@ -18,7 +18,9 @@ use typst_library::foundations::{Packed, Smart, StyleChain};
 use typst_library::introspection::{
     Introspector, Location, Locator, LocatorLink, SplitLocator,
 };
-use typst_library::layout::{Abs, AlignElem, Dir, FixedAlignment, Fragment, Size};
+use typst_library::layout::{
+    Abs, AlignElem, Dir, FixedAlignment, Fragment, Length, Size,
+};
 use typst_library::model::{
     Destination, EnumElem, FirstLineIndent, JustificationLimits, Linebreaks, LinkElem,
     ListElem, ParElem, ParLine, ParLineMarker, TermsElem,
@@ -242,6 +244,7 @@ fn configuration(
         cjk_latin_spacing: shared.get(TextElem::cjk_latin_spacing).is_auto(),
         costs: shared.get(TextElem::costs),
         link,
+        leading: shared.get(ParElem::leading),
     }
 }
 
@@ -303,6 +306,8 @@ struct Config {
     costs: Costs,
     /// The link active throughout the whole paragraph.
     link: Option<(Destination, Location)>,
+    /// Paragraph leading.
+    leading: Length,
 }
 
 /// Get a style property, but only if it is the same for all of the children.

--- a/crates/typst-layout/src/inline/prepare.rs
+++ b/crates/typst-layout/src/inline/prepare.rs
@@ -95,6 +95,9 @@ pub fn prepare<'a>(
                 shape_range(&mut items, engine, text, &bidi, range, styles);
             }
             Segment::Item(item) => items.push((range, item)),
+            Segment::Event(event) => {
+                println!("{event:?}");
+            }
         }
 
         cursor = end;

--- a/crates/typst-layout/src/inline/prepare.rs
+++ b/crates/typst-layout/src/inline/prepare.rs
@@ -83,6 +83,7 @@ pub fn prepare<'a>(
 
     let mut cursor = 0;
     let mut items = Vec::with_capacity(segments.len());
+    let mut events = Vec::new();
 
     // Shape the text to finalize the items.
     for segment in segments {
@@ -96,7 +97,8 @@ pub fn prepare<'a>(
             }
             Segment::Item(item) => items.push((range, item)),
             Segment::Event(event) => {
-                println!("{event:?}");
+                events.push(items.len());
+                items.push((range, Item::Event(event)));
             }
         }
 

--- a/crates/typst-layout/src/inline/shaping.rs
+++ b/crates/typst-layout/src/inline/shaping.rs
@@ -22,8 +22,9 @@ use typst_utils::SliceExt;
 use unicode_bidi::{BidiInfo, Level as BidiLevel};
 use unicode_script::{Script, UnicodeScript};
 
-use super::{Item, Range, SpanMapper, decorate};
 use crate::modifiers::FrameModifyText;
+
+use super::{Item, Range, SpanMapper, decorate};
 
 const SHY: char = '\u{ad}';
 const SHY_STR: &str = "\u{ad}";
@@ -459,7 +460,7 @@ impl<'a> ShapedText<'a> {
             offset += width;
         }
 
-        frame.modify_text(self.styles);
+        frame.modify_text_without_links(self.styles);
         frame
     }
 

--- a/crates/typst-layout/src/modifiers.rs
+++ b/crates/typst-layout/src/modifiers.rs
@@ -79,10 +79,18 @@ where
 pub trait FrameModifyText {
     /// Resolve and apply [`FrameModifiers`] for this text frame.
     fn modify_text(&mut self, styles: StyleChain);
+
+    /// Resolve and apply [`FrameModifiers`] for this text frame, including links.
+    fn modify_text_with_link(&mut self, styles: StyleChain);
 }
 
 impl FrameModifyText for Frame {
     fn modify_text(&mut self, styles: StyleChain) {
+        let modifiers = FrameModifiers::get_in(styles);
+        modify_frame_non_link(self, &modifiers);
+    }
+
+    fn modify_text_with_link(&mut self, styles: StyleChain) {
         let modifiers = FrameModifiers::get_in(styles);
         let expand_y = 0.5 * styles.resolve(ParElem::leading);
         let outset = Sides::new(Abs::zero(), expand_y, Abs::zero(), expand_y);
@@ -90,7 +98,13 @@ impl FrameModifyText for Frame {
     }
 }
 
-fn modify_frame(
+fn modify_frame_non_link(frame: &mut Frame, modifiers: &FrameModifiers) {
+    if modifiers.hidden {
+        frame.hide();
+    }
+}
+
+pub(super) fn modify_frame(
     frame: &mut Frame,
     modifiers: &FrameModifiers,
     link_box_outset: Option<Sides<Abs>>,

--- a/crates/typst-layout/src/modifiers.rs
+++ b/crates/typst-layout/src/modifiers.rs
@@ -29,7 +29,7 @@ impl FrameModifiers {
     /// Retrieve all modifications that should be applied per-frame.
     pub fn get_in(styles: StyleChain) -> Self {
         Self {
-            dest: styles.get_cloned(LinkElem::current),
+            dest: styles.get_cloned(LinkElem::current).map(|(dest, _)| dest),
             hidden: styles.get(HideElem::hidden),
         }
     }

--- a/crates/typst-layout/src/modifiers.rs
+++ b/crates/typst-layout/src/modifiers.rs
@@ -1,3 +1,4 @@
+use typst_library::diag::SourceResult;
 use typst_library::foundations::StyleChain;
 use typst_library::layout::{Abs, Fragment, Frame, FrameItem, HideElem, Point, Sides};
 use typst_library::model::{Destination, LinkElem, ParElem};
@@ -108,6 +109,38 @@ fn modify_frame(
     if modifiers.hidden {
         frame.hide();
     }
+}
+
+/// Performs layout, while resetting modifications as they are about to be done,
+/// but not applying them just yet to allow other similar modifications to be
+/// collected and merged first.
+///
+/// This just runs `layout(styles)`, but with the additional step that redundant
+/// modifiers (which are already applied here) are removed from the `styles`
+/// passed to `layout`. This is used in inline layout for elements such as text,
+/// boxes and equations.
+pub fn layout_and_reset_modifications<F, R>(
+    styles: StyleChain<'_>,
+    layout: F,
+) -> SourceResult<(FrameModifiers, R)>
+where
+    F: FnOnce(StyleChain) -> SourceResult<R>,
+    R: FrameModify,
+{
+    let modifiers = FrameModifiers::get_in(styles);
+
+    // Disable the current link internally since it's already applied at this
+    // level of layout. This means we don't generate redundant nested links,
+    // which may bloat the output considerably.
+    let reset;
+    let outer = styles;
+    let mut styles = styles;
+    if modifiers.dest.is_some() {
+        reset = LinkElem::current.set(None).wrap();
+        styles = outer.chain(&reset);
+    }
+
+    Ok((modifiers, layout(styles)?))
 }
 
 /// Performs layout and modification in one step.

--- a/crates/typst-layout/src/modifiers.rs
+++ b/crates/typst-layout/src/modifiers.rs
@@ -1,4 +1,3 @@
-use typst_library::diag::SourceResult;
 use typst_library::foundations::StyleChain;
 use typst_library::layout::{Abs, Fragment, Frame, FrameItem, HideElem, Point, Sides};
 use typst_library::model::{Destination, LinkElem, ParElem};
@@ -80,27 +79,24 @@ pub trait FrameModifyText {
     /// Resolve and apply [`FrameModifiers`] for this text frame.
     fn modify_text(&mut self, styles: StyleChain);
 
-    /// Resolve and apply [`FrameModifiers`] for this text frame, including links.
-    fn modify_text_with_link(&mut self, styles: StyleChain);
+    /// Resolve and apply [`FrameModifiers`] for this text frame, except for
+    /// the current link (which is handled by the paragraph itself).
+    fn modify_text_without_links(&mut self, styles: StyleChain);
 }
 
 impl FrameModifyText for Frame {
     fn modify_text(&mut self, styles: StyleChain) {
         let modifiers = FrameModifiers::get_in(styles);
-        modify_frame_non_link(self, &modifiers);
-    }
-
-    fn modify_text_with_link(&mut self, styles: StyleChain) {
-        let modifiers = FrameModifiers::get_in(styles);
         let expand_y = 0.5 * styles.resolve(ParElem::leading);
         let outset = Sides::new(Abs::zero(), expand_y, Abs::zero(), expand_y);
         modify_frame(self, &modifiers, Some(outset));
     }
-}
 
-fn modify_frame_non_link(frame: &mut Frame, modifiers: &FrameModifiers) {
-    if modifiers.hidden {
-        frame.hide();
+    fn modify_text_without_links(&mut self, styles: StyleChain) {
+        let modifiers = FrameModifiers { dest: None, ..FrameModifiers::get_in(styles) };
+        let expand_y = 0.5 * styles.resolve(ParElem::leading);
+        let outset = Sides::new(Abs::zero(), expand_y, Abs::zero(), expand_y);
+        modify_frame(self, &modifiers, Some(outset));
     }
 }
 
@@ -125,38 +121,6 @@ pub(super) fn modify_frame(
     }
 }
 
-/// Performs layout, while resetting modifications as they are about to be done,
-/// but not applying them just yet to allow other similar modifications to be
-/// collected and merged first.
-///
-/// This just runs `layout(styles)`, but with the additional step that redundant
-/// modifiers (which are already applied here) are removed from the `styles`
-/// passed to `layout`. This is used in inline layout for elements such as text,
-/// boxes and equations.
-pub fn layout_and_reset_modifications<F, R>(
-    styles: StyleChain<'_>,
-    layout: F,
-) -> SourceResult<(FrameModifiers, R)>
-where
-    F: FnOnce(StyleChain) -> SourceResult<R>,
-    R: FrameModify,
-{
-    let modifiers = FrameModifiers::get_in(styles);
-
-    // Disable the current link internally since it's already applied at this
-    // level of layout. This means we don't generate redundant nested links,
-    // which may bloat the output considerably.
-    let reset;
-    let outer = styles;
-    let mut styles = styles;
-    if modifiers.dest.is_some() {
-        reset = LinkElem::current.set(None).wrap();
-        styles = outer.chain(&reset);
-    }
-
-    Ok((modifiers, layout(styles)?))
-}
-
 /// Performs layout and modification in one step.
 ///
 /// This just runs `layout(styles).modified(&FrameModifiers::get_in(styles))`,
@@ -169,7 +133,33 @@ where
     R: FrameModify,
 {
     let modifiers = FrameModifiers::get_in(styles);
+    layout_and_modify_internal(modifiers, styles, layout, true)
+}
 
+/// Performs layout and modification in one step, except for links, which are handled by other parts of layout.
+pub fn layout_and_modify_without_links<F, R>(styles: StyleChain<'_>, layout: F) -> R
+where
+    F: FnOnce(StyleChain) -> R,
+    R: FrameModify,
+{
+    let modifiers = FrameModifiers::get_in(styles);
+
+    // While we could set 'modifiers.dest = None' directly here, a boolean
+    // argument is used so the function remembers to reset the link in the
+    // stylechain before removing it from modifiers.
+    layout_and_modify_internal(modifiers, styles, layout, false)
+}
+
+fn layout_and_modify_internal<F, R>(
+    mut modifiers: FrameModifiers,
+    styles: StyleChain,
+    layout: F,
+    allow_links: bool,
+) -> R
+where
+    F: FnOnce(StyleChain) -> R,
+    R: FrameModify,
+{
     // Disable the current link internally since it's already applied at this
     // level of layout. This means we don't generate redundant nested links,
     // which may bloat the output considerably.
@@ -179,6 +169,10 @@ where
     if modifiers.dest.is_some() {
         reset = LinkElem::current.set(None).wrap();
         styles = outer.chain(&reset);
+    }
+
+    if !allow_links {
+        modifiers.dest = None;
     }
 
     layout(styles).modified(&modifiers)

--- a/crates/typst-layout/src/rules.rs
+++ b/crates/typst-layout/src/rules.rs
@@ -226,10 +226,7 @@ const LINK_RULE: ShowFn<LinkElem> = |elem, engine, styles| {
     let alt = dest.alt_text(engine, styles, span)?;
     // Manually construct link marker that spans the whole link elem, not just
     // the body.
-    Ok(LinkMarker::new(body, Some(alt))
-        .pack()
-        .spanned(span)
-        .set(LinkElem::current, Some(dest)))
+    Ok(LinkMarker::new(body, Some(alt), dest).pack().spanned(span))
 };
 
 const DIRECT_LINK_RULE: ShowFn<DirectLinkElem> = |elem, _, _| {

--- a/crates/typst-library/src/foundations/content/mod.rs
+++ b/crates/typst-library/src/foundations/content/mod.rs
@@ -31,7 +31,7 @@ use crate::foundations::{
 };
 use crate::introspection::Location;
 use crate::layout::{AlignElem, Alignment, Axes, Length, MoveElem, PadElem, Rel, Sides};
-use crate::model::{Destination, EmphElem, LinkElem, LinkMarker, StrongElem};
+use crate::model::{Destination, EmphElem, LinkMarker, StrongElem};
 use crate::pdf::{ArtifactElem, ArtifactKind};
 use crate::text::UnderlineElem;
 
@@ -482,10 +482,7 @@ impl Content {
     /// Link the content somewhere.
     pub fn linked(self, dest: Destination, alt: Option<EcoString>) -> Self {
         let span = self.span();
-        LinkMarker::new(self, alt)
-            .pack()
-            .spanned(span)
-            .set(LinkElem::current, Some(dest))
+        LinkMarker::new(self, alt, dest).pack().spanned(span)
     }
 
     /// Set alignments for this content.

--- a/crates/typst-library/src/model/link.rs
+++ b/crates/typst-library/src/model/link.rs
@@ -213,10 +213,11 @@ pub struct LinkElem {
     })]
     pub body: Content,
 
-    /// A destination style that should be applied to elements.
+    /// A destination style that should be applied to elements, including the location
+    /// of the [`LinkMarker`] that applied this change.
     #[internal]
     #[ghost]
-    pub current: Option<Destination>,
+    pub current: Option<(Destination, Location)>,
 }
 
 impl LinkElem {
@@ -477,7 +478,7 @@ impl Construct for DirectLinkElem {
 }
 
 /// An element that wraps all content that is @Content::linked to a destination.
-#[elem(Tagged, Construct)]
+#[elem(Tagged, Construct, ShowSet)]
 pub struct LinkMarker {
     /// The content.
     #[internal]
@@ -486,11 +487,22 @@ pub struct LinkMarker {
     #[internal]
     #[required]
     pub alt: Option<EcoString>,
+    #[internal]
+    #[required]
+    pub dest: Destination,
 }
 
 impl Construct for LinkMarker {
     fn construct(_: &mut Engine, args: &mut Args) -> SourceResult<Content> {
         bail!(args.span, "cannot be constructed manually");
+    }
+}
+
+impl ShowSet for Packed<LinkMarker> {
+    fn show_set(&self, _: StyleChain) -> Styles {
+        let mut out = Styles::new();
+        out.set(LinkElem::current, Some((self.dest.clone(), self.location().unwrap())));
+        out
     }
 }
 


### PR DESCRIPTION
This PR essentially transfers responsibility of making text links clickable from each piece of text to the paragraph's line layout. This allows joining consecutive link bounding boxes together in a single line, ensuring a single `#link` call generates a single clickable area _(for each line)_.

(Notably, this does not address #6248, as each line will still produce a different link bounding box, but could definitely be a step forward in that direction.)

By introducing the necessary infrastructure to detect changes in styles mid-paragraph (particularly link styles), this PR is thus the first step before moving decoration handling to paragraphs as well, in order to fix various issues under #7802.

I've attempted to cleanup commit history a bit (not fully), so checking commit-by-commit should be possible if that's desirable.

## TODO

- [ ] Verify minor changes in link bounding box tests
- [x] Support for RTL text
- [x] Fix `#hide`
- [ ] Address any remaining tests