### PR TITLE
Expose baseline through `measure`

### DIFF
--- a/crates/typst-library/src/layout/measure.rs
+++ b/crates/typst-library/src/layout/measure.rs
@@ -42,7 +42,8 @@ use crate::layout::{Abs, Axes, Length, Region, Size};
 /// ```
 ///
 /// The measure function returns a dictionary with the entries `width` and
-/// `height`, both of type @length.
+/// `height`, both of type @length. When `baseline` is `{true}`, the dictionary
+/// additionally contains the `baseline` entry.
 #[func(contextual, since = "forever")]
 pub fn measure(
     engine: &mut Engine,
@@ -71,6 +72,12 @@ pub fn measure(
     #[named]
     #[default(Smart::Auto)]
     height: Smart<Length>,
+    /// Whether to include the content's baseline in the returned dictionary.
+    ///
+    /// The baseline is measured from the top of the content.
+    #[named]
+    #[default(false)]
+    baseline: bool,
     /// The content whose size to measure.
     content: Content,
 ) -> SourceResult<Dict> {
@@ -101,5 +108,16 @@ pub fn measure(
         pod,
     )?;
     let Size { x, y } = frame.size();
-    Ok(dict! { "width" => x, "height" => y })
+    Ok(if baseline {
+        dict! {
+            "width" => x,
+            "height" => y,
+            "baseline" => frame.baseline(),
+        }
+    } else {
+        dict! {
+            "width" => x,
+            "height" => y,
+        }
+    })
 }

--- a/tests/suite/layout/measure.typ
+++ b/tests/suite/layout/measure.typ
@@ -8,6 +8,37 @@
 #text(10pt, f(6pt, 8pt))
 #text(20pt, f(13pt, 14pt))
 
+--- measure-baseline paged empty ---
+// Test that `measure` exposes the baseline of content.
+#context {
+  let rect = rect(width: 10pt, height: 20pt)
+  test("baseline" in measure(rect), false)
+
+  let baseline-less = measure(baseline: true, rect)
+  test(baseline-less.baseline, baseline-less.height)
+
+  let shifted = measure(
+    baseline: true,
+    box(
+      width: 10pt,
+      height: 20pt,
+      baseline: (at: bottom, shift: 5pt),
+    ),
+  )
+  test(shifted.baseline, 15pt)
+
+  let text = measure(baseline: true)[Hello]
+  let boxed-text = measure(baseline: true, box[Hello])
+  assert(text.baseline > 0pt)
+  test(boxed-text.baseline, text.baseline)
+
+  let math = measure(baseline: true, $sum_(i=1)^n i$)
+  let boxed-math = measure(baseline: true, box($sum_(i=1)^n i$))
+  assert(math.baseline > 0pt)
+  assert(math.baseline < math.height)
+  test(boxed-math.baseline, math.baseline)
+}
+
 --- measure-given-area paged empty ---
 // Test `measure` given an area.
 #let text = lorem(100)
@@ -129,4 +160,7 @@
   let (width, height) = measure(image("/assets/images/monkey.svg"))
   test(width, 36pt)
   test(height, 36pt)
+
+  let measured = measure(baseline: true, image("/assets/images/monkey.svg"))
+  test(measured.baseline, height)
 }


### PR DESCRIPTION
Adds an opt-in `baseline` parameter to `measure()`.

When `baseline: true` is set, the returned dictionary includes the content's baseline offset measured from its top edge. The `baseline` parameter is set to `false` by default, so existing results are unchanged.

---

Update: Following maintainer feedback, the PR now always includes `baseline` in the
returned dictionary.

Closes #8798.
