### PR TITLE
Make PDF image support optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,16 +20,16 @@ typst = { path = "crates/typst", version = "0.15.1" }
 typst-bundle = { path = "crates/typst-bundle", version = "0.15.1" }
 typst-cli = { path = "crates/typst-cli", version = "0.15.1" }
 typst-eval = { path = "crates/typst-eval", version = "0.15.1" }
-typst-html = { path = "crates/typst-html", version = "0.15.1" }
+typst-html = { path = "crates/typst-html", version = "0.15.1", default-features = false }
 typst-ide = { path = "crates/typst-ide", version = "0.15.1" }
 typst-kit = { path = "crates/typst-kit", version = "0.15.1", default-features = false }
 typst-layout = { path = "crates/typst-layout", version = "0.15.1" }
-typst-library = { path = "crates/typst-library", version = "0.15.1" }
+typst-library = { path = "crates/typst-library", version = "0.15.1", default-features = false }
 typst-macros = { path = "crates/typst-macros", version = "0.15.1" }
-typst-pdf = { path = "crates/typst-pdf", version = "0.15.1" }
+typst-pdf = { path = "crates/typst-pdf", version = "0.15.1", default-features = false }
 typst-realize = { path = "crates/typst-realize", version = "0.15.1" }
-typst-render = { path = "crates/typst-render", version = "0.15.1" }
-typst-svg = { path = "crates/typst-svg", version = "0.15.1" }
+typst-render = { path = "crates/typst-render", version = "0.15.1", default-features = false }
+typst-svg = { path = "crates/typst-svg", version = "0.15.1", default-features = false }
 typst-syntax = { path = "crates/typst-syntax", version = "0.15.1" }
 typst-timing = { path = "crates/typst-timing", version = "0.15.1" }
 typst-utils = { path = "crates/typst-utils", version = "0.15.1" }

--- a/crates/typst-bundle/Cargo.toml
+++ b/crates/typst-bundle/Cargo.toml
@@ -30,5 +30,15 @@ indexmap = { workspace = true }
 rayon = { workspace = true }
 rustc-hash = { workspace = true }
 
+[features]
+default = ["pdf-images"]
+pdf-images = [
+    "typst-html/pdf-images",
+    "typst-library/pdf-images",
+    "typst-pdf/pdf-images",
+    "typst-render/pdf-images",
+    "typst-svg/pdf-images",
+]
+
 [lints]
 workspace = true

--- a/crates/typst-html/Cargo.toml
+++ b/crates/typst-html/Cargo.toml
@@ -29,5 +29,9 @@ rustc-hash = { workspace = true }
 time = { workspace = true }
 unicode-math-class = { workspace = true }
 
+[features]
+default = ["pdf-images"]
+pdf-images = ["typst-library/pdf-images", "typst-svg/pdf-images"]
+
 [lints]
 workspace = true

--- a/crates/typst-library/Cargo.toml
+++ b/crates/typst-library/Cargo.toml
@@ -32,7 +32,7 @@ flate2 = { workspace = true }
 fontdb = { workspace = true }
 glidesort = { workspace = true }
 hayagriva = { workspace = true }
-hayro-syntax = { workspace = true }
+hayro-syntax = { workspace = true, optional = true }
 icu_collator = { workspace = true }
 icu_properties = { workspace = true }
 image = { workspace = true }
@@ -76,6 +76,10 @@ xmlwriter = { workspace = true }
 
 [dev-dependencies]
 typst-dev-assets = { workspace = true }
+
+[features]
+default = ["pdf-images"]
+pdf-images = ["dep:hayro-syntax"]
 
 [lints]
 workspace = true

--- a/crates/typst-library/src/visualize/image/mod.rs
+++ b/crates/typst-library/src/visualize/image/mod.rs
@@ -1,9 +1,11 @@
 //! Image handling.
 
+#[cfg(feature = "pdf-images")]
 mod pdf;
 mod raster;
 mod svg;
 
+#[cfg(feature = "pdf-images")]
 pub use self::pdf::PdfImage;
 pub use self::raster::{
     ExchangeFormat, PixelEncoding, PixelFormat, RasterFormat, RasterImage,
@@ -14,12 +16,17 @@ use std::fmt::{self, Debug, Formatter};
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
-use ecow::{EcoString, eco_format};
+use ecow::EcoString;
+#[cfg(feature = "pdf-images")]
+use ecow::eco_format;
+#[cfg(feature = "pdf-images")]
 use hayro_syntax::LoadPdfError;
 use typst_syntax::{Spanned, VirtualPath};
 use typst_utils::{LazyHash, NonZeroExt};
 
-use crate::diag::{At, LoadError, LoadedWithin, SourceResult, StrResult, bail, warning};
+use crate::diag::{At, LoadedWithin, SourceResult, StrResult, warning};
+#[cfg(feature = "pdf-images")]
+use crate::diag::{LoadError, bail};
 use crate::engine::Engine;
 use crate::foundations::{
     Bytes, Cast, Derived, Packed, Smart, StyleChain, Synthesize, cast, elem,
@@ -28,6 +35,7 @@ use crate::layout::{Length, Rel, Sizing};
 use crate::loading::{DataSource, Load, Loaded};
 use crate::model::Figurable;
 use crate::text::{LocalName, Locale, families};
+#[cfg(feature = "pdf-images")]
 use crate::visualize::image::pdf::PdfDocument;
 
 /// A raster or vector graphic.
@@ -284,6 +292,7 @@ impl Packed<ImageElem> {
                     .within(loaded)?,
                 )
             }
+            #[cfg(feature = "pdf-images")]
             ImageFormat::Vector(VectorFormat::Pdf) => {
                 let document = match PdfDocument::new(loaded.data.clone()) {
                     Ok(doc) => doc,
@@ -380,6 +389,7 @@ fn determine_format_from_path(path: &VirtualPath) -> Option<ImageFormat> {
         "webp" => Some(ExchangeFormat::Webp.into()),
         // Vector formats
         "svg" | "svgz" => Some(VectorFormat::Svg.into()),
+        #[cfg(feature = "pdf-images")]
         "pdf" => Some(VectorFormat::Pdf.into()),
         _ => None,
     }
@@ -463,6 +473,7 @@ impl Image {
         match &self.0.kind {
             ImageKind::Raster(raster) => raster.format().into(),
             ImageKind::Svg(_) => VectorFormat::Svg.into(),
+            #[cfg(feature = "pdf-images")]
             ImageKind::Pdf(_) => VectorFormat::Pdf.into(),
         }
     }
@@ -472,6 +483,7 @@ impl Image {
         match &self.0.kind {
             ImageKind::Raster(raster) => raster.width() as f64,
             ImageKind::Svg(svg) => svg.width(),
+            #[cfg(feature = "pdf-images")]
             ImageKind::Pdf(pdf) => pdf.width() as f64,
         }
     }
@@ -481,6 +493,7 @@ impl Image {
         match &self.0.kind {
             ImageKind::Raster(raster) => raster.height() as f64,
             ImageKind::Svg(svg) => svg.height(),
+            #[cfg(feature = "pdf-images")]
             ImageKind::Pdf(pdf) => pdf.height() as f64,
         }
     }
@@ -490,6 +503,7 @@ impl Image {
         match &self.0.kind {
             ImageKind::Raster(raster) => raster.dpi(),
             ImageKind::Svg(_) => Some(Image::USVG_DEFAULT_DPI),
+            #[cfg(feature = "pdf-images")]
             ImageKind::Pdf(_) => Some(Image::DEFAULT_DPI),
         }
     }
@@ -530,6 +544,7 @@ pub enum ImageKind {
     /// An SVG image.
     Svg(SvgImage),
     /// A PDF image.
+    #[cfg(feature = "pdf-images")]
     Pdf(PdfImage),
 }
 
@@ -565,6 +580,7 @@ impl ImageFormat {
             return Some(Self::Vector(VectorFormat::Svg));
         }
 
+        #[cfg(feature = "pdf-images")]
         if is_pdf(data) {
             return Some(Self::Vector(VectorFormat::Pdf));
         }
@@ -574,6 +590,7 @@ impl ImageFormat {
 }
 
 /// Checks whether the data looks like a PDF file.
+#[cfg(feature = "pdf-images")]
 fn is_pdf(data: &[u8]) -> bool {
     let head = &data[..data.len().min(2048)];
     memchr::memmem::find(head, b"%PDF-").is_some()
@@ -601,6 +618,7 @@ pub enum VectorFormat {
     Svg,
     /// High-fidelity document and graphics format, with focus on exact
     /// reproduction in print.
+    #[cfg(feature = "pdf-images")]
     Pdf,
 }
 
@@ -610,6 +628,21 @@ where
 {
     fn from(format: R) -> Self {
         Self::Raster(format.into())
+    }
+}
+
+#[cfg(all(test, not(feature = "pdf-images")))]
+mod tests {
+    use typst_syntax::VirtualPath;
+
+    use super::{ImageFormat, determine_format_from_path};
+
+    #[test]
+    fn pdf_is_unsupported_without_pdf_images() {
+        assert_eq!(ImageFormat::detect(b"%PDF-1.7"), None);
+
+        let path = VirtualPath::new("image.pdf").unwrap();
+        assert_eq!(determine_format_from_path(&path), None);
     }
 }
 

--- a/crates/typst-library/src/visualize/image/svg.rs
+++ b/crates/typst-library/src/visualize/image/svg.rs
@@ -398,6 +398,7 @@ impl<'a> ImageResolver<'a> {
                         VectorFormat::Svg => {
                             Err("SVG images are not supported yet".into())
                         }
+                        #[cfg(feature = "pdf-images")]
                         VectorFormat::Pdf => {
                             Err("PDF documents are not supported".into())
                         }

--- a/crates/typst-pdf/Cargo.toml
+++ b/crates/typst-pdf/Cargo.toml
@@ -35,5 +35,9 @@ rustc-hash = { workspace = true }
 serde = { workspace = true }
 smallvec = { workspace = true }
 
+[features]
+default = ["pdf-images"]
+pdf-images = ["typst-library/pdf-images"]
+
 [lints]
 workspace = true

--- a/crates/typst-pdf/src/image.rs
+++ b/crates/typst-pdf/src/image.rs
@@ -4,14 +4,17 @@ use std::sync::{Arc, OnceLock};
 use ecow::eco_format;
 use image::{DynamicImage, EncodableLayout, GenericImageView, Rgba};
 use krilla::image::{BitsPerComponent, CustomImage, ImageColorspace};
+#[cfg(feature = "pdf-images")]
 use krilla::pdf::PdfDocument;
 use krilla::surface::Surface;
 use krilla_svg::{SurfaceExt, SvgSettings};
 use typst_library::diag::{At, SourceResult};
 use typst_library::foundations::Smart;
 use typst_library::layout::{Abs, Angle, Ratio, Size, Transform};
+#[cfg(feature = "pdf-images")]
+use typst_library::visualize::PdfImage;
 use typst_library::visualize::{
-    ExchangeFormat, Image, ImageKind, ImageScaling, PdfImage, RasterFormat, RasterImage,
+    ExchangeFormat, Image, ImageKind, ImageScaling, RasterFormat, RasterImage,
 };
 use typst_syntax::Span;
 use typst_utils::defer;
@@ -70,6 +73,7 @@ pub(crate) fn handle_image(
                 );
             }
         }
+        #[cfg(feature = "pdf-images")]
         ImageKind::Pdf(pdf) => {
             if let Some(size) = size.to_krilla() {
                 surface.draw_pdf_page(&convert_pdf(pdf), size, pdf.page_index());
@@ -211,6 +215,7 @@ fn convert_raster(
 }
 
 #[comemo::memoize]
+#[cfg(feature = "pdf-images")]
 fn convert_pdf(pdf: &PdfImage) -> PdfDocument {
     PdfDocument::new(pdf.document().pdf().clone())
 }

--- a/crates/typst-render/Cargo.toml
+++ b/crates/typst-render/Cargo.toml
@@ -13,7 +13,7 @@ keywords = { workspace = true }
 readme = { workspace = true }
 
 [dependencies]
-typst-assets = { workspace = true }
+typst-assets = { workspace = true, optional = true }
 typst-layout = { workspace = true }
 typst-library = { workspace = true }
 typst-macros = { workspace = true }
@@ -21,13 +21,17 @@ typst-timing = { workspace = true }
 typst-utils = { workspace = true }
 bytemuck = { workspace = true }
 comemo = { workspace = true }
-hayro = { workspace = true }
+hayro = { workspace = true, optional = true }
 image = { workspace = true }
 libm = { workspace = true }
 pixglyph = { workspace = true }
 resvg = { workspace = true }
 tiny-skia = { workspace = true }
 ttf-parser = { workspace = true }
+
+[features]
+default = ["pdf-images"]
+pdf-images = ["dep:hayro", "dep:typst-assets", "typst-library/pdf-images"]
 
 [lints]
 workspace = true

--- a/crates/typst-render/src/image.rs
+++ b/crates/typst-render/src/image.rs
@@ -1,16 +1,24 @@
+#[cfg(feature = "pdf-images")]
 use hayro::RenderCache;
+#[cfg(feature = "pdf-images")]
 use hayro::RenderSettings;
+#[cfg(feature = "pdf-images")]
 use hayro::hayro_interpret::InterpreterSettings;
+#[cfg(feature = "pdf-images")]
 use hayro::hayro_interpret::font::{FontData, FontQuery, StandardFont};
+#[cfg(feature = "pdf-images")]
 use hayro::vello_cpu::color::palette::css::TRANSPARENT;
 use image::imageops::FilterType;
 use image::{GenericImageView, Rgba};
 use std::sync::Arc;
 use tiny_skia as sk;
+#[cfg(feature = "pdf-images")]
 use tiny_skia::IntSize;
 use typst_library::foundations::Smart;
 use typst_library::layout::Size;
-use typst_library::visualize::{Image, ImageKind, ImageScaling, PdfImage};
+#[cfg(feature = "pdf-images")]
+use typst_library::visualize::PdfImage;
+use typst_library::visualize::{Image, ImageKind, ImageScaling};
 
 use crate::{AbsExt, State};
 
@@ -106,6 +114,7 @@ fn build_texture(image: &Image, w: u32, h: u32) -> Option<Arc<sk::Pixmap>> {
             resvg::render(tree, ts, &mut texture.as_mut());
             texture
         }
+        #[cfg(feature = "pdf-images")]
         ImageKind::Pdf(pdf) => build_pdf_texture(pdf, w, h)?,
     };
 
@@ -113,6 +122,7 @@ fn build_texture(image: &Image, w: u32, h: u32) -> Option<Arc<sk::Pixmap>> {
 }
 
 // Keep this in sync with `typst-svg`!
+#[cfg(feature = "pdf-images")]
 fn build_pdf_texture(pdf: &PdfImage, w: u32, h: u32) -> Option<sk::Pixmap> {
     let select_standard_font = move |font: StandardFont| -> Option<(FontData, u32)> {
         let bytes = match font {

--- a/crates/typst-svg/Cargo.toml
+++ b/crates/typst-svg/Cargo.toml
@@ -13,7 +13,7 @@ keywords = { workspace = true }
 readme = { workspace = true }
 
 [dependencies]
-typst-assets = { workspace = true }
+typst-assets = { workspace = true, optional = true }
 typst-layout = { workspace = true }
 typst-library = { workspace = true }
 typst-macros = { workspace = true }
@@ -23,8 +23,8 @@ base64 = { workspace = true }
 comemo = { workspace = true }
 ecow = { workspace = true }
 flate2 = { workspace = true }
-hayro = { workspace = true }
-hayro-svg = { workspace = true }
+hayro = { workspace = true, optional = true }
+hayro-svg = { workspace = true, optional = true }
 image = { workspace = true }
 indexmap = { workspace = true }
 itoa = { workspace = true }
@@ -32,6 +32,15 @@ rustc-hash = { workspace = true }
 ryu = { workspace = true }
 ttf-parser = { workspace = true }
 xmlwriter = { workspace = true }
+
+[features]
+default = ["pdf-images"]
+pdf-images = [
+    "dep:hayro",
+    "dep:hayro-svg",
+    "dep:typst-assets",
+    "typst-library/pdf-images",
+]
 
 [lints]
 workspace = true

--- a/crates/typst-svg/src/image.rs
+++ b/crates/typst-svg/src/image.rs
@@ -1,15 +1,21 @@
+#[cfg(feature = "pdf-images")]
 use std::sync::Arc;
 
 use base64::Engine;
 use ecow::{EcoString, eco_format};
+#[cfg(feature = "pdf-images")]
 use hayro::hayro_interpret::InterpreterSettings;
+#[cfg(feature = "pdf-images")]
 use hayro::hayro_interpret::font::{FontData, FontQuery, StandardFont};
+#[cfg(feature = "pdf-images")]
 use hayro_svg::{RenderCache, SvgRenderSettings};
 use image::{ImageEncoder, codecs::png::PngEncoder};
 use typst_library::foundations::{Bytes, Smart};
 use typst_library::layout::{Abs, Axes};
+#[cfg(feature = "pdf-images")]
+use typst_library::visualize::PdfImage;
 use typst_library::visualize::{
-    ExchangeFormat, Image, ImageKind, ImageScaling, PdfImage, RasterFormat,
+    ExchangeFormat, Image, ImageKind, ImageScaling, RasterFormat,
 };
 
 use crate::write::{SvgElem, SvgTransform, SvgWrite};
@@ -123,6 +129,7 @@ impl WebImage {
                 }),
             },
             ImageKind::Svg(svg) => (WebImageFormat::Svg, svg.data().clone()),
+            #[cfg(feature = "pdf-images")]
             ImageKind::Pdf(pdf) => {
                 (WebImageFormat::Svg, Bytes::from_string(pdf_to_svg(pdf)))
             }
@@ -143,6 +150,7 @@ impl WebImage {
 }
 
 // Keep this in sync with `typst-png`!
+#[cfg(feature = "pdf-images")]
 fn pdf_to_svg(pdf: &PdfImage) -> String {
     let select_standard_font = move |font: StandardFont| -> Option<(FontData, u32)> {
         let bytes = match font {

--- a/crates/typst/Cargo.toml
+++ b/crates/typst/Cargo.toml
@@ -27,5 +27,9 @@ comemo = { workspace = true }
 ecow = { workspace = true }
 rustc-hash = { workspace = true }
 
+[features]
+default = ["pdf-images"]
+pdf-images = ["typst-html/pdf-images", "typst-library/pdf-images"]
+
 [lints]
 workspace = true

--- a/tests/fuzz/Cargo.toml
+++ b/tests/fuzz/Cargo.toml
@@ -10,11 +10,11 @@ cargo-fuzz = true
 [dependencies]
 typst = { workspace = true }
 typst-assets = { workspace = true, features = ["fonts"] }
-typst-pdf = { workspace = true }
+typst-pdf = { workspace = true, features = ["pdf-images"] }
 typst-svg = { workspace = true }
 typst-layout = { workspace = true }
 typst-html = { workspace = true }
-typst-render = { workspace = true }
+typst-render = { workspace = true, features = ["pdf-images"] }
 typst-syntax = { workspace = true }
 comemo = { workspace = true }
 libfuzzer-sys = { workspace = true }


### PR DESCRIPTION
The crates.io backend uses Typst as a library (see https://github.com/rust-lang/crates_io_og_image) but only needs a small subset of its functionality. We are trying to reduce the number of dependencies pulled into the backend to limit its security and supply-chain exposure.

PDF image support is a relatively self-contained capability with a meaningful dependency cost. This PR adds a default-enabled `pdf-images` feature across `typst-library` and the relevant exporters, preserving existing behavior while allowing library users to exclude the PDF parsing and rendering paths.

With the feature disabled, a fixture roughly matching crates.io's Typst dependencies decreases from 370 to 341 unique packages :)