### PR TITLE
Add Standard Zhuang translations

### DIFF
--- a/crates/typst-library/src/text/lang.rs
+++ b/crates/typst-library/src/text/lang.rs
@@ -113,6 +113,7 @@ const TRANSLATIONS: &[(&str, &str)] = &[
     translation!("uk"),
     translation!("ur"),
     translation!("vi"),
+    translation!("za"),
     translation!("zh"),
     translation!("zh-TW"),
 ];

--- a/crates/typst-library/translations/za.txt
+++ b/crates/typst-library/translations/za.txt
@@ -1,0 +1,11 @@
+figure = Doz
+table = Biuj
+equation = Daengjsik
+bibliography = Vwnzyen Doiqciuq
+heading = Ciet
+outline = Moegloeg
+raw = Daihmax
+page = yieb
+footnote = Gejnaeuz
+email = E-mail
+telephone = Denva


### PR DESCRIPTION
Adding translation file for [Standard Zhuang](https://en.wikipedia.org/wiki/Standard_Zhuang) (`za`).

Note:
* For `raw` (code) there is [daimaj](https://en.wiktionary.org/wiki/daimaj#Zhuang) and [daihmax](https://en.wiktionary.org/wiki/daihmax#Zhuang); we choose the [standardized](https://www.guangximinzubao.cn/sy/jxzw/412847.html) one.
* `heading = Ciet` means section
* `footnote = Gejnaeuz` means "explanation" -- publications usually uses this word for notes marked with superscript numbers.