### PR TITLE
Add flags `--all-targets` and `--all-features` to minimum Rust version check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: dtolnay/rust-toolchain@87eb139fed4b08a67bd1fa429a21d1f5d523e03e # 1.92.0
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
-      - run: cargo check --workspace
+      - run: cargo check --workspace --all-targets --all-features
 
   fuzz:
     name: Check fuzzers


### PR DESCRIPTION
<!--
Thanks for your interest in landing a change in Typst! Before opening the PR, please review our contribution guidelines: https://github.com/typst/typst/blob/main/CONTRIBUTING.md

In particular, please keep in mind that we do not accept contributions implemented by an AI model. We would also ask you to refrain from using AI to write your pull request description. Summarizing your work helps organizing your thoughts as much as it helps us with seeing the human thought process behind a particular change.
-->

The flags `--all-targets` and `--all-features` were missing for the minimal supported Rust version check, as noted by @laurmaedje (https://github.com/typst/hayagriva/pull/521#discussion_r3895307750), making the check unsound.

This PR adds the flags.
