### PR TITLE
Improve documentation for `text.body` and `text.text`

### DIFF
--- a/crates/typst-library/src/foundations/content/field.rs
+++ b/crates/typst-library/src/foundations/content/field.rs
@@ -213,7 +213,7 @@ impl<E: ExternalField<I>, const I: u8> ExternalFieldData<E, I> {
     }
 
     /// Creates type-erased metadata and routines for an `#[external]` field.
-    pub const fn vtable() -> FieldVtable<Packed<E>>
+    pub const fn vtable(positional: bool, required: bool) -> FieldVtable<Packed<E>>
     where
         E: ExternalField<I>,
         E::Type: Reflect + IntoValue,
@@ -222,8 +222,8 @@ impl<E: ExternalField<I>, const I: u8> ExternalFieldData<E, I> {
             name: E::FIELD.name,
             docs: E::FIELD.docs,
             def_site: E::FIELD.def_site,
-            positional: false,
-            required: false,
+            positional,
+            required,
             variadic: false,
             settable: false,
             synthesized: false,

--- a/crates/typst-library/src/text/mod.rs
+++ b/crates/typst-library/src/text/mod.rs
@@ -850,11 +850,31 @@ pub struct TextElem {
     pub variations: FontVariations,
 
     /// Content in which all text is styled according to the other arguments.
+    ///
+    /// This parameter is only available on the `text` constructor (and not on
+    /// existing `text` elements) because the `text` constructor does not
+    /// necessarily construct a single `text` element, but instead applies style
+    /// to all the text elements within the passed body.
+    ///
+    /// ```example
+    /// #text(red)[
+    ///   The `body` can be _arbitrary_
+    ///   #underline[content].
+    /// ]
+    /// ```
     #[external]
     #[required]
     pub body: Content,
 
-    /// The text.
+    /// The text contained in a `text` element.
+    ///
+    /// This parameter is not available on the constructor. Instead, you can
+    /// access it on an existing `text` element. This is because the `text`
+    /// constructor accepts arbitrary content as its body (see @text.body).
+    ///
+    /// ```example
+    /// #repr([This is just text].text)
+    /// ```
     #[required]
     pub text: EcoString,
 

--- a/crates/typst-macros/src/elem.rs
+++ b/crates/typst-macros/src/elem.rs
@@ -397,7 +397,9 @@ fn create_native_elem_impl(element: &Elem) -> Result<TokenStream> {
     let fields = element.fields.iter().filter(|field| !field.internal).map(|field| {
         let i = field.i;
         if field.external {
-            quote! { #foundations::ExternalFieldData::<#ident, #i>::vtable() }
+            let positional = field.positional;
+            let required = field.required;
+            quote! { #foundations::ExternalFieldData::<#ident, #i>::vtable(#positional, #required) }
         } else if field.variadic {
             quote! { #foundations::RequiredFieldData::<#ident, #i>::vtable_variadic() }
         } else if field.required {


### PR DESCRIPTION
The documentation for `text.body` and `text.text` is quite bad right now. This PR aims to improve this. In addition, it fixes https://github.com/typst/typst/issues/7580 by properly documenting `text.body` (and `page.body`) as required and positional.

I am wondering whether `text.text` should be documented at all, especially knowing that peeking into content is not really intended. If we document it, it shouldn't be marked as required, nor positional, but this seems a bit harder to change so I won't do it in this PR. For reference, this issue is tracked as part of https://github.com/typst/typst/issues/6286.