### PR TITLE
/claim #8823: Propagate figure(alt:) to HTML export (set aria-label)

### DIFF
--- a/crates/typst-html/src/rules.rs
+++ b/crates/typst-html/src/rules.rs
@@ -277,6 +277,7 @@ const FIGURE_RULE: ShowFn<FigureElem> = |elem, _, styles| {
 
     Ok(BlockElem::packed(
         HtmlElem::new(tag::figure)
+            .with_optional_attr(attr::aria_label, elem.alt.get_cloned(styles))
             .with_body(Some(realized))
             .pack()
             .spanned(elem.span()),
@@ -712,8 +713,9 @@ const OVERLINE_RULE: ShowFn<OverlineElem> = |elem, _, _| {
 const STRIKE_RULE: ShowFn<StrikeElem> =
     |elem, _, _| Ok(HtmlElem::new(tag::s).with_body(Some(elem.body.clone())).pack());
 
-const HIGHLIGHT_RULE: ShowFn<HighlightElem> =
-    |elem, _, _| Ok(HtmlElem::new(tag::mark).with_body(Some(elem.body.clone())).pack());
+const HIGHLIGHT_RULE: ShowFn<HighlightElem> = |elem, _, _| {
+    Ok(HtmlElem::new(tag::mark).with_body(Some(elem.body.clone())).pack())
+};
 
 const SMALLCAPS_RULE: ShowFn<SmallcapsElem> = |elem, _, styles| {
     let variant = if elem.all.get(styles) { "all-small-caps" } else { "small-caps" };
@@ -755,7 +757,6 @@ const RAW_RULE: ShowFn<RawElem> = |elem, _, styles| {
 };
 
 /// This is used by `RawElem::synthesize` through a routine.
-///
 /// It's a temporary workaround until `TextElem::fill` is supported in HTML
 /// export.
 #[doc(hidden)]


### PR DESCRIPTION
Closes #8823

Summary
- Map FigureElem.alt to the HTML <figure> element's aria-label when exporting to HTML.
- Changes made in crates/typst-html/src/rules.rs (FIGURE_RULE).
- Ensures parity between PDF and HTML accessibility behavior for figures.

Verification (how to test locally)
1. Build Typst with HTML feature:
   cargo build --features html -p typst

2. Create a minimal test.typ with the example from the issue:

   #set page(width: 300pt, height: auto, margin: 20pt)

   #figure(
     rect(width: 100pt, height: 60pt, fill: blue),
     alt: "A blue rectangle.",
   )

3. Export to HTML:
   typst compile --features html --format html test.typ test.html

4. Inspect test.html and confirm the figure contains aria-label:
   <figure aria-label="A blue rectangle."> ... </figure>

Notes
- This change is minimal and restricted to the HTML show rule for FigureElem. It does not alter PDF export.
- If additional ARIA semantics are desired (e.g. role mapping) we can extend this in a follow-up, but this patch addresses the specific issue of alt not being propagated to HTML.


Closes #8823