### PR TITLE
Error in case of unsupported use of `stringify!`

### DIFF
--- a/crates/typst-macros/src/cast.rs
+++ b/crates/typst-macros/src/cast.rs
@@ -32,7 +32,7 @@ pub fn derive_cast(item: DeriveInput) -> Result<TokenStream> {
         variants.push(Variant {
             ident: variant.ident.clone(),
             string,
-            docs: documentation(&variant.attrs),
+            docs: documentation(&variant.attrs)?,
         });
     }
 
@@ -72,7 +72,7 @@ pub fn cast(stream: TokenStream) -> Result<TokenStream> {
     let input: CastInput = syn::parse2(stream)?;
     let ty = &input.ty;
     let castable_body = create_castable_body(&input);
-    let input_body = create_input_body(&input);
+    let input_body = create_input_body(&input)?;
     let output_body = create_output_body(&input);
     let into_value_body = create_into_value_body(&input);
     let from_value_body = create_from_value_body(&input);
@@ -239,11 +239,11 @@ fn create_castable_body(input: &CastInput) -> TokenStream {
     }
 }
 
-fn create_input_body(input: &CastInput) -> TokenStream {
+fn create_input_body(input: &CastInput) -> Result<TokenStream> {
     let mut infos = vec![];
 
     for cast in &input.from_value {
-        let docs = documentation(&cast.attrs);
+        let docs = documentation(&cast.attrs)?;
         infos.push(match &cast.pattern {
             Pattern::Str(lit) => {
                 quote! {
@@ -265,9 +265,9 @@ fn create_input_body(input: &CastInput) -> TokenStream {
         });
     }
 
-    quote! {
+    Ok(quote! {
         #(#infos)+*
-    }
+    })
 }
 
 fn create_output_body(input: &CastInput) -> TokenStream {

--- a/crates/typst-macros/src/elem.rs
+++ b/crates/typst-macros/src/elem.rs
@@ -161,7 +161,7 @@ fn parse(stream: TokenStream, body: &syn::ItemStruct) -> Result<Elem> {
         Some(|base| base.trim_end_matches("Elem")),
     )?;
 
-    let docs = documentation(&body.attrs);
+    let docs = documentation(&body.attrs)?;
 
     let syn::Fields::Named(named) = &body.fields else {
         bail!(body, "expected named fields");
@@ -217,7 +217,7 @@ fn parse_field(field: &syn::Field) -> Result<Field> {
         vis: field.vis.clone(),
         ty: field.ty.clone(),
         name: ident.to_string().to_kebab_case(),
-        docs: documentation(&attrs),
+        docs: documentation(&attrs)?,
         positional,
         required,
         variadic,

--- a/crates/typst-macros/src/func.rs
+++ b/crates/typst-macros/src/func.rs
@@ -141,7 +141,7 @@ fn parse(stream: TokenStream, item: &syn::ItemFn) -> Result<Func> {
     let (name, title) =
         determine_name_and_title(meta.name, meta.title, &item.sig.ident, None)?;
 
-    let docs = documentation(&item.attrs);
+    let docs = documentation(&item.attrs)?;
 
     let mut special = SpecialParams::default();
     let mut params = vec![];
@@ -202,7 +202,7 @@ fn parse_param(
                     None => bail!(recv, "explicit parent type required"),
                 },
                 name: "self".into(),
-                docs: documentation(&recv.attrs),
+                docs: documentation(&recv.attrs)?,
                 named: false,
                 variadic: false,
                 external: false,
@@ -231,7 +231,7 @@ fn parse_param(
                 ident: ident.clone(),
                 ty: (*typed.ty).clone(),
                 name: ident.to_string().to_kebab_case(),
-                docs: documentation(&attrs),
+                docs: documentation(&attrs)?,
                 named: has_attr(&mut attrs, "named"),
                 variadic: has_attr(&mut attrs, "variadic"),
                 external: has_attr(&mut attrs, "external"),

--- a/crates/typst-macros/src/ty.rs
+++ b/crates/typst-macros/src/ty.rs
@@ -68,7 +68,7 @@ impl Parse for Meta {
 
 /// Parse details about the type from its definition.
 fn parse(meta: Meta, ident: Ident, attrs: &[Attribute]) -> Result<Type> {
-    let docs = documentation(attrs);
+    let docs = documentation(attrs)?;
     let (name, title) =
         determine_name_and_title(meta.name.clone(), meta.title.clone(), &ident, None)?;
     let long = title.to_lowercase();

--- a/crates/typst-macros/src/util.rs
+++ b/crates/typst-macros/src/util.rs
@@ -3,8 +3,9 @@ use proc_macro2::TokenStream;
 use quote::{ToTokens, quote};
 use std::str::FromStr;
 use syn::parse::{Parse, ParseStream};
+use syn::spanned::Spanned;
 use syn::token::Token;
-use syn::{Attribute, Ident, Result, Token};
+use syn::{Attribute, Error, Ident, Result, Token};
 
 /// Return an error at the given item.
 macro_rules! bail {
@@ -22,8 +23,22 @@ macro_rules! bail {
     };
 }
 
+/// A basic reimplementation of the `stringify!` macro.
+///
+/// The `stringify!` macro does not expand eagerly so we have
+/// some very basic support for int and float expressions here.
+/// This is e.g. used for paper sizes.
+fn stringify(tokens: TokenStream) -> Option<String> {
+    let lit = syn::parse2::<syn::Lit>(tokens).ok()?;
+    match lit {
+        syn::Lit::Int(int) => Some(int.base10_digits().to_owned()),
+        syn::Lit::Float(float) => Some(float.base10_digits().to_owned()),
+        _ => None,
+    }
+}
+
 /// Extract documentation comments from an attribute list.
-pub fn documentation(attrs: &[syn::Attribute]) -> String {
+pub fn documentation(attrs: &[syn::Attribute]) -> Result<String> {
     let mut doc = String::new();
 
     // Parse doc comments.
@@ -39,23 +54,21 @@ pub fn documentation(attrs: &[syn::Attribute]) -> String {
                 doc.push_str(line);
                 doc.push('\n');
             } else if let syn::Expr::Macro(expr) = &meta.value
-                // The `stringify!` macro does not expand eagerly so we have
-                // some very basic support for int and float expressions here.
-                // This is e.g. used for paper sizes.
                 && expr.mac.path.is_ident("stringify")
-                && let Ok(lit) = syn::parse2::<syn::Lit>(expr.mac.tokens.clone())
-                && let Some(value) = match &lit {
-                syn::Lit::Int(int) => Some(int.base10_digits()),
-                syn::Lit::Float(float) => Some(float.base10_digits()),
-                _ => None,
-            } {
-                doc.push_str(value);
+            {
+                let value = stringify(expr.mac.tokens.clone()).ok_or_else(|| {
+                    Error::new(
+                        expr.span(),
+                        "the `stringify!` macro is not fully supported in Typst documentation",
+                    )
+                })?;
+                doc.push_str(&value);
                 doc.push('\n');
             }
         }
     }
 
-    doc.trim().into()
+    Ok(doc.trim().into())
 }
 
 /// Whether an attribute list has a specified attribute.

--- a/crates/typst-macros/src/util.rs
+++ b/crates/typst-macros/src/util.rs
@@ -25,9 +25,9 @@ macro_rules! bail {
 
 /// A basic reimplementation of the `stringify!` macro.
 ///
-/// The `stringify!` macro does not expand eagerly so we have
-/// some very basic support for int and float expressions here.
-/// This is e.g. used for paper sizes.
+/// The `stringify!` macro does not expand eagerly so we have some very basic
+/// support for int and float expressions here. This is e.g. used for paper
+/// sizes.
 fn stringify(tokens: TokenStream) -> Option<String> {
     let lit = syn::parse2::<syn::Lit>(tokens).ok()?;
     match lit {
@@ -59,7 +59,8 @@ pub fn documentation(attrs: &[syn::Attribute]) -> Result<String> {
                 let value = stringify(expr.mac.tokens.clone()).ok_or_else(|| {
                     Error::new(
                         expr.span(),
-                        "the `stringify!` macro is not fully supported in Typst documentation",
+                        "the `stringify!` macro is not fully supported in \
+                         the Typst documentation",
                     )
                 })?;
                 doc.push_str(&value);


### PR DESCRIPTION
A while ago I couldn't figure out why `stringify!` worked for paper sized but not for the use-case I had. I recently discovered why that it is because `stringify!` is actually reimplemented manually.

This PR emits a compilation error when using `stringify!` in a way that is not supported, instead of silently failing.