### PR TITLE
 Make `location.position()` work inside `html.frame`

### DIFF
--- a/crates/typst-html/src/encode.rs
+++ b/crates/typst-html/src/encode.rs
@@ -53,6 +53,8 @@ fn html_impl(mut w: Writer, root: &HtmlElement) -> SourceResult<String> {
     w.buf.push_str("<!DOCTYPE html>");
     write_indent(&mut w);
     write_element(&mut w, root)?;
+    // Writes nothing unless the document has no `body` element.
+    write_defs(&mut w);
     if w.pretty {
         w.buf.push('\n');
     }
@@ -65,9 +67,10 @@ struct Writer<'a> {
     buf: String,
     /// The current indentation level
     level: usize,
-    /// Used to resolve links between the document and contained frames as well
-    /// as cross-document links in bundle export.
-    link_resolver: Tracked<'a, LateLinkResolver<'a>>,
+    /// The definitions shared by the frames, written at the end of the body.
+    /// Also holds what resolves links between the document and its frames as
+    /// well as cross-document links in bundle export.
+    defs: typst_svg::HtmlDefs<'a>,
     /// Whether pretty printing is enabled.
     pretty: bool,
 }
@@ -78,7 +81,7 @@ impl<'a> Writer<'a> {
         Self {
             buf: String::new(),
             level: 0,
-            link_resolver,
+            defs: typst_svg::HtmlDefs::new(link_resolver),
             pretty,
         }
     }
@@ -202,6 +205,12 @@ fn write_children(w: &mut Writer, element: &HtmlElement) -> SourceResult<()> {
         write_node(w, c, element.pre_span)?;
         indent = pretty_around;
     }
+
+    // The definitions shared by the frames are written at the end of the body.
+    if element.tag == tag::body {
+        write_defs(w);
+    }
+
     w.level -= 1;
 
     write_indent(w);
@@ -399,15 +408,27 @@ fn unencodable(c: char) -> EcoString {
 /// Encode a laid out frame into the writer.
 fn write_frame(w: &mut Writer, frame: &HtmlFrame) {
     let svg = typst_svg::svg_in_html(
+        &mut w.defs,
         &frame.inner,
         frame.text_size,
         w.pretty,
         frame.id.as_deref(),
         &eco_format!("{}", frame.css.to_inline()),
         &frame.anchors,
-        w.link_resolver,
     );
 
+    write_svg(w, &svg);
+}
+
+/// Encode the definitions shared by the frames into the writer.
+fn write_defs(w: &mut Writer) {
+    let Some(svg) = w.defs.take_svg(w.pretty) else { return };
+    write_indent(w);
+    write_svg(w, &svg);
+}
+
+/// Encode a generated SVG into the writer.
+fn write_svg(w: &mut Writer, svg: &str) {
     if w.pretty {
         // Indent the SVG after generation. This ensures the frame is cached no
         // matter the current indentation of the outer HTML.
@@ -418,6 +439,6 @@ fn write_frame(w: &mut Writer, frame: &HtmlFrame) {
             w.buf.push_str(line);
         }
     } else {
-        w.buf.push_str(&svg);
+        w.buf.push_str(svg);
     }
 }

--- a/crates/typst-library/src/introspection/location.rs
+++ b/crates/typst-library/src/introspection/location.rs
@@ -8,9 +8,11 @@ use typst_utils::NonZeroExt;
 
 use crate::diag::{SourceDiagnostic, warning};
 use crate::engine::Engine;
-use crate::foundations::{Content, IntoValue, Repr, Selector, func, repr, scope, ty};
+use crate::foundations::{
+    Content, Dict, IntoValue, Repr, Selector, func, repr, scope, ty,
+};
 use crate::introspection::{
-    DocumentPosition, History, Introspect, Introspector, PagedPosition,
+    DocumentPosition, History, InnerHtmlPosition, Introspect, Introspector, PagedPosition,
 };
 use crate::layout::Abs;
 use crate::model::Numbering;
@@ -104,9 +106,22 @@ impl Location {
     ///
     /// If you only need the page number, use `page()` instead as it allows
     /// Typst to skip unnecessary work.
+    ///
+    /// = HTML export <html>
+    /// The dictionary has the same keys in HTML export, but only the contents
+    /// of an @html.frame have a position: a frame is laid out by the same
+    /// engine that lays out a page, so `x` and `y` are the coordinates within
+    /// it, measured from its top-left corner. Everywhere else, positioning is
+    /// the browser's business and Typst cannot know where content will end up,
+    /// so `x` and `y` are `{none}`.
+    ///
+    /// An HTML document has no pages, so `page` is always `{1}`, just like the
+    /// result of `page()`. Note that each frame has its own coordinate system,
+    /// so positions from two different frames cannot be compared, just as
+    /// positions on two different pages cannot be.
     #[func(since = "forever")]
-    pub fn position(self, engine: &mut Engine, span: Span) -> PagedPosition {
-        engine.introspect(PositionIntrospection(self, span))
+    pub fn position(self, engine: &mut Engine, span: Span) -> Dict {
+        engine.introspect(PositionIntrospection(self, span)).into()
     }
 
     /// Returns the page numbering pattern of the page at this location. This
@@ -169,18 +184,17 @@ impl From<Location> for LocationKey {
 pub struct PositionIntrospection(pub Location, pub Span);
 
 impl Introspect for PositionIntrospection {
-    type Output = PagedPosition;
+    type Output = DocumentPosition;
 
     fn introspect(
         &self,
         _: &mut Engine,
         introspector: Tracked<dyn Introspector + '_>,
     ) -> Self::Output {
-        match introspector.position(self.0) {
-            Some(DocumentPosition::Paged(pos)) => pos,
-            // Maybe error here instead?
-            Some(DocumentPosition::Html(_)) | None => PagedPosition::ORIGIN,
-        }
+        // A location that is not part of the document has no position. This
+        // notably includes every location in the first iteration, before there
+        // is a document to introspect.
+        introspector.position(self.0).unwrap_or(PagedPosition::ORIGIN.into())
     }
 
     fn diagnose(&self, history: &History<Self::Output>) -> SourceDiagnostic {
@@ -192,12 +206,20 @@ impl Introspect for PositionIntrospection {
             |element| eco_format!("{element} position"),
             |pos| {
                 let coord = |v: Abs| repr::format_float(v.to_pt(), Some(0), false, "pt");
-                eco_format!(
-                    "page {} at ({}, {})",
-                    pos.page,
-                    coord(pos.point.x),
-                    coord(pos.point.y)
-                )
+                match pos {
+                    DocumentPosition::Paged(pos) => eco_format!(
+                        "page {} at ({}, {})",
+                        pos.page,
+                        coord(pos.point.x),
+                        coord(pos.point.y)
+                    ),
+                    DocumentPosition::Html(pos) => match pos.details() {
+                        Some(InnerHtmlPosition::Frame(point)) => {
+                            eco_format!("({}, {})", coord(point.x), coord(point.y))
+                        }
+                        _ => eco_format!("no position"),
+                    },
+                }
             },
         )
     }

--- a/crates/typst-library/src/introspection/position.rs
+++ b/crates/typst-library/src/introspection/position.rs
@@ -93,6 +93,30 @@ impl From<PagedPosition> for Dict {
     }
 }
 
+impl From<DocumentPosition> for Dict {
+    fn from(pos: DocumentPosition) -> Self {
+        match pos {
+            DocumentPosition::Paged(pos) => pos.into(),
+            // An HTML document has no pages, but the dictionary's shape should
+            // not depend on the target, so we report page one, just like
+            // `location.page()` does. Coordinates are only known within a
+            // frame, which is laid out just like a page. Elsewhere, positioning
+            // is the browser's business and we have nothing to report.
+            DocumentPosition::Html(pos) => {
+                let point = match pos.details() {
+                    Some(&InnerHtmlPosition::Frame(point)) => Some(point),
+                    Some(InnerHtmlPosition::Character(_)) | None => None,
+                };
+                dict! {
+                    "page" => NonZeroUsize::ONE,
+                    "x" => point.map(|point| point.x),
+                    "y" => point.map(|point| point.y),
+                }
+            }
+        }
+    }
+}
+
 /// A position in an HTML tree.
 #[derive(Clone, Debug, Hash)]
 pub struct HtmlPosition {

--- a/crates/typst-svg/src/lib.rs
+++ b/crates/typst-svg/src/lib.rs
@@ -77,21 +77,23 @@ pub fn svg_in_bundle(
 
 /// Export a frame into an SVG suitable for embedding into HTML.
 ///
+/// Glyphs, clip paths, gradients and tilings are collected into `defs` rather
+/// than written into the frame, so that frames which share them define them
+/// once.
+///
 /// Takes additional `anchor` locations that will be serialized as linkable
 /// points. This enables other documents in the bundle to link into the
-/// resulting SVG. Also takes a `link_resolver` for resolving links between the
-/// frame and remaining document.
+/// resulting SVG.
 #[typst_macros::time(name = "svg in html")]
 pub fn svg_in_html(
+    defs: &mut HtmlDefs,
     frame: &Frame,
     text_size: Abs,
     pretty: bool,
     id: Option<&str>,
     styles: &str,
     anchors: &[(Point, EcoString)],
-    link_resolver: Tracked<LateLinkResolver>,
 ) -> String {
-    let mut renderer = SVGRenderer::with_options(Some(link_resolver));
     let mut xml = XmlWriter::new(xml_options(pretty));
     let mut svg = svg_header_with_custom_attrs(&mut xml, frame.size(), |svg| {
         if let Some(id) = id {
@@ -112,14 +114,56 @@ pub fn svg_in_html(
     });
 
     let state = State::new(frame.size());
-    renderer.render_frame(&mut svg, &state, frame);
+    defs.renderer.render_frame(&mut svg, &state, frame);
 
     for (pos, id) in anchors {
-        renderer.render_anchor(&mut svg, *pos, id);
+        defs.renderer.render_anchor(&mut svg, *pos, id);
     }
 
-    renderer.finalize(svg);
+    drop(svg);
     xml.end_document()
+}
+
+/// The definitions shared by the frames of one HTML document.
+pub struct HtmlDefs<'a> {
+    renderer: SVGRenderer<'a>,
+}
+
+impl<'a> HtmlDefs<'a> {
+    /// Creates an empty set of definitions.
+    ///
+    /// The `link_resolver` resolves links between a frame and the rest of the
+    /// document.
+    pub fn new(link_resolver: Tracked<'a, LateLinkResolver<'a>>) -> Self {
+        Self {
+            renderer: SVGRenderer::with_options(Some(link_resolver)),
+        }
+    }
+
+    /// Takes what has been collected so far as an `<svg>` element, or `None` if
+    /// there is nothing to define.
+    ///
+    /// The frames reference it by ID, so it must end up in the same document.
+    pub fn take_svg(&mut self, pretty: bool) -> Option<String> {
+        if self.renderer.is_empty() {
+            return None;
+        }
+
+        let link_resolver = self.renderer.link_resolver;
+        let renderer = std::mem::replace(
+            &mut self.renderer,
+            SVGRenderer::with_options(link_resolver),
+        );
+
+        let mut xml = XmlWriter::new(xml_options(pretty));
+        let mut svg = SvgElem::new(&mut xml, "svg");
+        svg.attr("style", "position: absolute; width: 0; height: 0");
+        svg.attr("aria-hidden", "true");
+        svg.attr("xmlns", "http://www.w3.org/2000/svg");
+        svg.attr("xmlns:xlink", "http://www.w3.org/1999/xlink");
+        renderer.finalize(svg);
+        Some(xml.end_document())
+    }
 }
 
 /// Export a document with potentially multiple pages into a single SVG file.
@@ -419,6 +463,17 @@ impl<'a> SVGRenderer<'a> {
         svg.elem("g")
             .attr("id", id)
             .attr("transform", SvgTransform(Transform::translate(pos.x, pos.y)));
+    }
+
+    /// Whether anything that `finalize` would write has been collected.
+    fn is_empty(&self) -> bool {
+        self.glyphs.iter().all(|(_, glyph)| glyph.is_none())
+            && self.clip_paths.is_empty()
+            && self.gradients.is_empty()
+            && self.gradient_refs.is_empty()
+            && self.conic_subgradients.is_empty()
+            && self.tilings.is_empty()
+            && self.tiling_refs.is_empty()
     }
 
     /// Finalize the SVG file. This must be called after all rendering is done.

--- a/tests/ref/bundle/link-bundle-html-frame.txt
+++ b/tests/ref/bundle/link-bundle-html-frame.txt
@@ -1,2 +1,2 @@
 5caa14f2425347763746e46baed2a725 index.html
-1fe4c62d11dc09f78c89e735f7ce9f0c folder/a.html
+7b4c3cce01298d6b404b9de4f6b75cbd folder/a.html

--- a/tests/ref/html/hashes.txt
+++ b/tests/ref/html/hashes.txt
@@ -61,6 +61,7 @@ e34ea44e32ada9e0685b72d6e82ecfd5 html-elem-attrs-fold
 52de31c777d4b7b8d356b54138b5fe14 html-elem-metadata
 0a1d1443e72ef554d74d15ae49cd076c html-escapable-raw-text-contains-closing-tag
 41d47680056dc0777c4060cf3ecc8c6a html-frame
+73e6a075915195f77631a229ce6afe70 html-frame-position
 1e1005b4ac5db07bd074e5d12aa2162e html-pre-starting-with-newline
 9ddbaca4b63c936215a967cb76b0327a html-script
 de4b0b9e9a41128ffdb982bae7550178 html-space-collapsing

--- a/tests/ref/html/hashes.txt
+++ b/tests/ref/html/hashes.txt
@@ -62,6 +62,7 @@ e34ea44e32ada9e0685b72d6e82ecfd5 html-elem-attrs-fold
 0a1d1443e72ef554d74d15ae49cd076c html-escapable-raw-text-contains-closing-tag
 41d47680056dc0777c4060cf3ecc8c6a html-frame
 73e6a075915195f77631a229ce6afe70 html-frame-position
+467b6d133e16e258ebf5f0606e4ab20e html-frame-shared-defs
 1e1005b4ac5db07bd074e5d12aa2162e html-pre-starting-with-newline
 9ddbaca4b63c936215a967cb76b0327a html-script
 de4b0b9e9a41128ffdb982bae7550178 html-space-collapsing

--- a/tests/suite/html/frame.typ
+++ b/tests/suite/html/frame.typ
@@ -7,3 +7,12 @@ A rectangle:
 // actual paged export than for _nested_ HTML frames, which take the same code
 // path.
 #html.frame[A]
+
+--- html-frame-position html ---
+// Test that positions are available within a frame, but nowhere else.
+#context test(here().position(), (page: 1, x: none, y: none))
+#html.frame(box(width: 100pt, height: 50pt, {
+  place(top + left, dx: 30pt, dy: 20pt, context {
+    test(here().position(), (page: 1, x: 30pt, y: 20pt))
+  })
+}))

--- a/tests/suite/html/frame.typ
+++ b/tests/suite/html/frame.typ
@@ -16,3 +16,9 @@ A rectangle:
     test(here().position(), (page: 1, x: 30pt, y: 20pt))
   })
 }))
+
+--- html-frame-shared-defs html ---
+// Test that definitions shared by multiple frames (here, glyphs) are written
+// only once, at the end of the body.
+#html.frame[A]
+#html.frame[A]

--- a/tests/suite/introspection/locate.typ
+++ b/tests/suite/introspection/locate.typ
@@ -105,10 +105,12 @@ A
 
 --- locate-html html empty ---
 #metadata(none)
-// This is not optimal, it should probably rather error.
+// Outside of a frame, positioning is the browser's business, so there are no
+// coordinates to report. (For positions inside of a frame, see the
+// `html-frame-position` test.)
 #context test(
   locate(metadata).position(),
-  (page: 1, x: 0pt, y: 0pt),
+  (page: 1, x: none, y: none),
 )
 
 --- locate-bundle-top-level bundle ---


### PR DESCRIPTION
Fixes #8828

It exposes the position of an element inside an `html.frame` via `location.position()` which alway returns `(page:1, x:0, y:0)` before this PR.
