### PR TITLE
 Make `location.position()` work inside `html.frame`

### DIFF
--- a/crates/typst-library/src/introspection/location.rs
+++ b/crates/typst-library/src/introspection/location.rs
@@ -107,7 +107,7 @@ impl Location {
     /// If you only need the page number, use `page()` instead as it allows
     /// Typst to skip unnecessary work.
     ///
-    /// = HTML export <html>
+    /// = HTML export <html-export>
     /// The dictionary has the same keys in HTML export, but only the contents
     /// of an @html.frame have a position: a frame is laid out by the same
     /// engine that lays out a page, so `x` and `y` are the coordinates within
@@ -214,7 +214,7 @@ impl Introspect for PositionIntrospection {
                         coord(pos.point.y)
                     ),
                     DocumentPosition::Html(pos) => match pos.details() {
-                        Some(InnerHtmlPosition::Frame(point)) => {
+                        Some(&InnerHtmlPosition::Frame(point)) => {
                             eco_format!("({}, {})", coord(point.x), coord(point.y))
                         }
                         _ => eco_format!("no position"),

--- a/crates/typst-library/src/introspection/location.rs
+++ b/crates/typst-library/src/introspection/location.rs
@@ -8,9 +8,11 @@ use typst_utils::NonZeroExt;
 
 use crate::diag::{SourceDiagnostic, warning};
 use crate::engine::Engine;
-use crate::foundations::{Content, IntoValue, Repr, Selector, func, repr, scope, ty};
+use crate::foundations::{
+    Content, Dict, IntoValue, Repr, Selector, func, repr, scope, ty,
+};
 use crate::introspection::{
-    DocumentPosition, History, Introspect, Introspector, PagedPosition,
+    DocumentPosition, History, InnerHtmlPosition, Introspect, Introspector, PagedPosition,
 };
 use crate::layout::Abs;
 use crate::model::Numbering;
@@ -104,9 +106,22 @@ impl Location {
     ///
     /// If you only need the page number, use `page()` instead as it allows
     /// Typst to skip unnecessary work.
+    ///
+    /// = HTML export <html>
+    /// The dictionary has the same keys in HTML export, but only the contents
+    /// of an @html.frame have a position: a frame is laid out by the same
+    /// engine that lays out a page, so `x` and `y` are the coordinates within
+    /// it, measured from its top-left corner. Everywhere else, positioning is
+    /// the browser's business and Typst cannot know where content will end up,
+    /// so `x` and `y` are `{none}`.
+    ///
+    /// An HTML document has no pages, so `page` is always `{1}`, just like the
+    /// result of `page()`. Note that each frame has its own coordinate system,
+    /// so positions from two different frames cannot be compared, just as
+    /// positions on two different pages cannot be.
     #[func(since = "forever")]
-    pub fn position(self, engine: &mut Engine, span: Span) -> PagedPosition {
-        engine.introspect(PositionIntrospection(self, span))
+    pub fn position(self, engine: &mut Engine, span: Span) -> Dict {
+        engine.introspect(PositionIntrospection(self, span)).into()
     }
 
     /// Returns the page numbering pattern of the page at this location. This
@@ -169,18 +184,17 @@ impl From<Location> for LocationKey {
 pub struct PositionIntrospection(pub Location, pub Span);
 
 impl Introspect for PositionIntrospection {
-    type Output = PagedPosition;
+    type Output = DocumentPosition;
 
     fn introspect(
         &self,
         _: &mut Engine,
         introspector: Tracked<dyn Introspector + '_>,
     ) -> Self::Output {
-        match introspector.position(self.0) {
-            Some(DocumentPosition::Paged(pos)) => pos,
-            // Maybe error here instead?
-            Some(DocumentPosition::Html(_)) | None => PagedPosition::ORIGIN,
-        }
+        // A location that is not part of the document has no position. This
+        // notably includes every location in the first iteration, before there
+        // is a document to introspect.
+        introspector.position(self.0).unwrap_or(PagedPosition::ORIGIN.into())
     }
 
     fn diagnose(&self, history: &History<Self::Output>) -> SourceDiagnostic {
@@ -192,12 +206,20 @@ impl Introspect for PositionIntrospection {
             |element| eco_format!("{element} position"),
             |pos| {
                 let coord = |v: Abs| repr::format_float(v.to_pt(), Some(0), false, "pt");
-                eco_format!(
-                    "page {} at ({}, {})",
-                    pos.page,
-                    coord(pos.point.x),
-                    coord(pos.point.y)
-                )
+                match pos {
+                    DocumentPosition::Paged(pos) => eco_format!(
+                        "page {} at ({}, {})",
+                        pos.page,
+                        coord(pos.point.x),
+                        coord(pos.point.y)
+                    ),
+                    DocumentPosition::Html(pos) => match pos.details() {
+                        Some(InnerHtmlPosition::Frame(point)) => {
+                            eco_format!("({}, {})", coord(point.x), coord(point.y))
+                        }
+                        _ => eco_format!("no position"),
+                    },
+                }
             },
         )
     }

--- a/crates/typst-library/src/introspection/position.rs
+++ b/crates/typst-library/src/introspection/position.rs
@@ -97,11 +97,8 @@ impl From<DocumentPosition> for Dict {
     fn from(pos: DocumentPosition) -> Self {
         match pos {
             DocumentPosition::Paged(pos) => pos.into(),
-            // An HTML document has no pages, but the dictionary's shape should
-            // not depend on the target, so we report page one, just like
-            // `location.page()` does. Coordinates are only known within a
-            // frame, which is laid out just like a page. Elsewhere, positioning
-            // is the browser's business and we have nothing to report.
+            // HTML documents have no pages. Coordinates are only known inside
+            // frames, see `Location::position`.
             DocumentPosition::Html(pos) => {
                 let point = match pos.details() {
                     Some(&InnerHtmlPosition::Frame(point)) => Some(point),

--- a/crates/typst-library/src/introspection/position.rs
+++ b/crates/typst-library/src/introspection/position.rs
@@ -93,6 +93,30 @@ impl From<PagedPosition> for Dict {
     }
 }
 
+impl From<DocumentPosition> for Dict {
+    fn from(pos: DocumentPosition) -> Self {
+        match pos {
+            DocumentPosition::Paged(pos) => pos.into(),
+            // An HTML document has no pages, but the dictionary's shape should
+            // not depend on the target, so we report page one, just like
+            // `location.page()` does. Coordinates are only known within a
+            // frame, which is laid out just like a page. Elsewhere, positioning
+            // is the browser's business and we have nothing to report.
+            DocumentPosition::Html(pos) => {
+                let point = match pos.details() {
+                    Some(&InnerHtmlPosition::Frame(point)) => Some(point),
+                    Some(InnerHtmlPosition::Character(_)) | None => None,
+                };
+                dict! {
+                    "page" => NonZeroUsize::ONE,
+                    "x" => point.map(|point| point.x),
+                    "y" => point.map(|point| point.y),
+                }
+            }
+        }
+    }
+}
+
 /// A position in an HTML tree.
 #[derive(Clone, Debug, Hash)]
 pub struct HtmlPosition {

--- a/tests/ref/html/hashes.txt
+++ b/tests/ref/html/hashes.txt
@@ -61,6 +61,7 @@ e34ea44e32ada9e0685b72d6e82ecfd5 html-elem-attrs-fold
 52de31c777d4b7b8d356b54138b5fe14 html-elem-metadata
 0a1d1443e72ef554d74d15ae49cd076c html-escapable-raw-text-contains-closing-tag
 41d47680056dc0777c4060cf3ecc8c6a html-frame
+73e6a075915195f77631a229ce6afe70 html-frame-position
 1e1005b4ac5db07bd074e5d12aa2162e html-pre-starting-with-newline
 9ddbaca4b63c936215a967cb76b0327a html-script
 de4b0b9e9a41128ffdb982bae7550178 html-space-collapsing

--- a/tests/suite/html/frame.typ
+++ b/tests/suite/html/frame.typ
@@ -7,3 +7,12 @@ A rectangle:
 // actual paged export than for _nested_ HTML frames, which take the same code
 // path.
 #html.frame[A]
+
+--- html-frame-position html ---
+// Test that positions are available within a frame, but nowhere else.
+#context test(here().position(), (page: 1, x: none, y: none))
+#html.frame(box(width: 100pt, height: 50pt, {
+  place(top + left, dx: 30pt, dy: 20pt, context {
+    test(here().position(), (page: 1, x: 30pt, y: 20pt))
+  })
+}))

--- a/tests/suite/introspection/locate.typ
+++ b/tests/suite/introspection/locate.typ
@@ -105,10 +105,12 @@ A
 
 --- locate-html html empty ---
 #metadata(none)
-// This is not optimal, it should probably rather error.
+// Outside of a frame, positioning is the browser's business, so there are no
+// coordinates to report. (For positions inside of a frame, see the
+// `html-frame-position` test.)
 #context test(
   locate(metadata).position(),
-  (page: 1, x: 0pt, y: 0pt),
+  (page: 1, x: none, y: none),
 )
 
 --- locate-bundle-top-level bundle ---

--- a/tests/suite/introspection/locate.typ
+++ b/tests/suite/introspection/locate.typ
@@ -105,9 +105,7 @@ A
 
 --- locate-html html empty ---
 #metadata(none)
-// Outside of a frame, positioning is the browser's business, so there are no
-// coordinates to report. (For positions inside of a frame, see the
-// `html-frame-position` test.)
+// Outside of a frame, there are no coordinates. See `html-frame-position`.
 #context test(
   locate(metadata).position(),
   (page: 1, x: none, y: none),


### PR DESCRIPTION
Fixes #8828

It exposes the position of an element inside an `html.frame` via `location.position()` which alway returns `(page:1, x:0, y:0)` before this PR.
