### PR TITLE
Share SVG definitions across HTML frames

### DIFF
--- a/crates/typst-html/src/encode.rs
+++ b/crates/typst-html/src/encode.rs
@@ -53,6 +53,8 @@ fn html_impl(mut w: Writer, root: &HtmlElement) -> SourceResult<String> {
     w.buf.push_str("<!DOCTYPE html>");
     write_indent(&mut w);
     write_element(&mut w, root)?;
+    // Writes nothing unless the document has no `body` element.
+    write_defs(&mut w);
     if w.pretty {
         w.buf.push('\n');
     }
@@ -65,9 +67,10 @@ struct Writer<'a> {
     buf: String,
     /// The current indentation level
     level: usize,
-    /// Used to resolve links between the document and contained frames as well
-    /// as cross-document links in bundle export.
-    link_resolver: Tracked<'a, LateLinkResolver<'a>>,
+    /// The definitions shared by the frames, written at the end of the body.
+    /// Also holds what resolves links between the document and its frames as
+    /// well as cross-document links in bundle export.
+    defs: typst_svg::HtmlDefs<'a>,
     /// Whether pretty printing is enabled.
     pretty: bool,
 }
@@ -78,7 +81,7 @@ impl<'a> Writer<'a> {
         Self {
             buf: String::new(),
             level: 0,
-            link_resolver,
+            defs: typst_svg::HtmlDefs::new(link_resolver),
             pretty,
         }
     }
@@ -202,6 +205,12 @@ fn write_children(w: &mut Writer, element: &HtmlElement) -> SourceResult<()> {
         write_node(w, c, element.pre_span)?;
         indent = pretty_around;
     }
+
+    // The definitions shared by the frames are written at the end of the body.
+    if element.tag == tag::body {
+        write_defs(w);
+    }
+
     w.level -= 1;
 
     write_indent(w);
@@ -399,15 +408,27 @@ fn unencodable(c: char) -> EcoString {
 /// Encode a laid out frame into the writer.
 fn write_frame(w: &mut Writer, frame: &HtmlFrame) {
     let svg = typst_svg::svg_in_html(
+        &mut w.defs,
         &frame.inner,
         frame.text_size,
         w.pretty,
         frame.id.as_deref(),
         &eco_format!("{}", frame.css.to_inline()),
         &frame.anchors,
-        w.link_resolver,
     );
 
+    write_svg(w, &svg);
+}
+
+/// Encode the definitions shared by the frames into the writer.
+fn write_defs(w: &mut Writer) {
+    let Some(svg) = w.defs.take_svg(w.pretty) else { return };
+    write_indent(w);
+    write_svg(w, &svg);
+}
+
+/// Encode a generated SVG into the writer.
+fn write_svg(w: &mut Writer, svg: &str) {
     if w.pretty {
         // Indent the SVG after generation. This ensures the frame is cached no
         // matter the current indentation of the outer HTML.
@@ -418,6 +439,6 @@ fn write_frame(w: &mut Writer, frame: &HtmlFrame) {
             w.buf.push_str(line);
         }
     } else {
-        w.buf.push_str(&svg);
+        w.buf.push_str(svg);
     }
 }

--- a/crates/typst-html/src/encode.rs
+++ b/crates/typst-html/src/encode.rs
@@ -53,7 +53,7 @@ fn html_impl(mut w: Writer, root: &HtmlElement) -> SourceResult<String> {
     w.buf.push_str("<!DOCTYPE html>");
     write_indent(&mut w);
     write_element(&mut w, root)?;
-    // Writes nothing unless the document has no `body` element.
+    // Only writes if there is no `body` element.
     write_defs(&mut w);
     if w.pretty {
         w.buf.push('\n');
@@ -68,7 +68,7 @@ struct Writer<'a> {
     /// The current indentation level
     level: usize,
     /// The definitions shared by the frames, written at the end of the body.
-    /// Also holds what resolves links between the document and its frames as
+    /// Also owns the link resolver for the document and its frames as
     /// well as cross-document links in bundle export.
     defs: typst_svg::HtmlDefs<'a>,
     /// Whether pretty printing is enabled.

--- a/crates/typst-svg/src/lib.rs
+++ b/crates/typst-svg/src/lib.rs
@@ -77,9 +77,8 @@ pub fn svg_in_bundle(
 
 /// Export a frame into an SVG suitable for embedding into HTML.
 ///
-/// Glyphs, clip paths, gradients and tilings are collected into `defs` rather
-/// than written into the frame, so that frames which share them define them
-/// once.
+/// Glyphs, clip paths, gradients and tilings are collected into `<defs>` 
+/// rather than written into the frame.
 ///
 /// Takes additional `anchor` locations that will be serialized as linkable
 /// points. This enables other documents in the bundle to link into the

--- a/crates/typst-svg/src/lib.rs
+++ b/crates/typst-svg/src/lib.rs
@@ -77,7 +77,7 @@ pub fn svg_in_bundle(
 
 /// Export a frame into an SVG suitable for embedding into HTML.
 ///
-/// Glyphs, clip paths, gradients and tilings are collected into `<defs>` 
+/// Glyphs, clip paths, gradients and tilings are collected into `<defs>`
 /// rather than written into the frame.
 ///
 /// Takes additional `anchor` locations that will be serialized as linkable

--- a/crates/typst-svg/src/lib.rs
+++ b/crates/typst-svg/src/lib.rs
@@ -140,8 +140,8 @@ impl<'a> HtmlDefs<'a> {
         }
     }
 
-    /// Takes what has been collected so far as an `<svg>` element, or `None` if
-    /// there is nothing to define.
+    /// Takes the collected definitions as an `<svg>` element, or `None` if
+    /// there are none.
     ///
     /// The frames reference it by ID, so it must end up in the same document.
     pub fn take_svg(&mut self, pretty: bool) -> Option<String> {
@@ -467,7 +467,7 @@ impl<'a> SVGRenderer<'a> {
 
     /// Whether anything that `finalize` would write has been collected.
     fn is_empty(&self) -> bool {
-        self.glyphs.iter().all(|(_, glyph)| glyph.is_none())
+        !self.has_glyph_defs()
             && self.clip_paths.is_empty()
             && self.gradients.is_empty()
             && self.gradient_refs.is_empty()

--- a/crates/typst-svg/src/lib.rs
+++ b/crates/typst-svg/src/lib.rs
@@ -77,21 +77,23 @@ pub fn svg_in_bundle(
 
 /// Export a frame into an SVG suitable for embedding into HTML.
 ///
+/// Glyphs, clip paths, gradients and tilings are collected into `defs` rather
+/// than written into the frame, so that frames which share them define them
+/// once.
+///
 /// Takes additional `anchor` locations that will be serialized as linkable
 /// points. This enables other documents in the bundle to link into the
-/// resulting SVG. Also takes a `link_resolver` for resolving links between the
-/// frame and remaining document.
+/// resulting SVG.
 #[typst_macros::time(name = "svg in html")]
 pub fn svg_in_html(
+    defs: &mut HtmlDefs,
     frame: &Frame,
     text_size: Abs,
     pretty: bool,
     id: Option<&str>,
     styles: &str,
     anchors: &[(Point, EcoString)],
-    link_resolver: Tracked<LateLinkResolver>,
 ) -> String {
-    let mut renderer = SVGRenderer::with_options(Some(link_resolver));
     let mut xml = XmlWriter::new(xml_options(pretty));
     let mut svg = svg_header_with_custom_attrs(&mut xml, frame.size(), |svg| {
         if let Some(id) = id {
@@ -112,14 +114,56 @@ pub fn svg_in_html(
     });
 
     let state = State::new(frame.size());
-    renderer.render_frame(&mut svg, &state, frame);
+    defs.renderer.render_frame(&mut svg, &state, frame);
 
     for (pos, id) in anchors {
-        renderer.render_anchor(&mut svg, *pos, id);
+        defs.renderer.render_anchor(&mut svg, *pos, id);
     }
 
-    renderer.finalize(svg);
+    drop(svg);
     xml.end_document()
+}
+
+/// The definitions shared by the frames of one HTML document.
+pub struct HtmlDefs<'a> {
+    renderer: SVGRenderer<'a>,
+}
+
+impl<'a> HtmlDefs<'a> {
+    /// Creates an empty set of definitions.
+    ///
+    /// The `link_resolver` resolves links between a frame and the rest of the
+    /// document.
+    pub fn new(link_resolver: Tracked<'a, LateLinkResolver<'a>>) -> Self {
+        Self {
+            renderer: SVGRenderer::with_options(Some(link_resolver)),
+        }
+    }
+
+    /// Takes what has been collected so far as an `<svg>` element, or `None` if
+    /// there is nothing to define.
+    ///
+    /// The frames reference it by ID, so it must end up in the same document.
+    pub fn take_svg(&mut self, pretty: bool) -> Option<String> {
+        if self.renderer.is_empty() {
+            return None;
+        }
+
+        let link_resolver = self.renderer.link_resolver;
+        let renderer = std::mem::replace(
+            &mut self.renderer,
+            SVGRenderer::with_options(link_resolver),
+        );
+
+        let mut xml = XmlWriter::new(xml_options(pretty));
+        let mut svg = SvgElem::new(&mut xml, "svg");
+        svg.attr("style", "position: absolute; width: 0; height: 0");
+        svg.attr("aria-hidden", "true");
+        svg.attr("xmlns", "http://www.w3.org/2000/svg");
+        svg.attr("xmlns:xlink", "http://www.w3.org/1999/xlink");
+        renderer.finalize(svg);
+        Some(xml.end_document())
+    }
 }
 
 /// Export a document with potentially multiple pages into a single SVG file.
@@ -419,6 +463,17 @@ impl<'a> SVGRenderer<'a> {
         svg.elem("g")
             .attr("id", id)
             .attr("transform", SvgTransform(Transform::translate(pos.x, pos.y)));
+    }
+
+    /// Whether anything that `finalize` would write has been collected.
+    fn is_empty(&self) -> bool {
+        self.glyphs.iter().all(|(_, glyph)| glyph.is_none())
+            && self.clip_paths.is_empty()
+            && self.gradients.is_empty()
+            && self.gradient_refs.is_empty()
+            && self.conic_subgradients.is_empty()
+            && self.tilings.is_empty()
+            && self.tiling_refs.is_empty()
     }
 
     /// Finalize the SVG file. This must be called after all rendering is done.

--- a/crates/typst-svg/src/text.rs
+++ b/crates/typst-svg/src/text.rs
@@ -182,7 +182,7 @@ impl SVGRenderer<'_> {
 
     /// Build the glyph definitions.
     pub(super) fn write_glyph_defs(&mut self, svg: &mut SvgElem) {
-        if self.glyphs.iter().all(|(_, g)| g.is_none()) {
+        if !self.has_glyph_defs() {
             return;
         }
 
@@ -216,5 +216,10 @@ impl SVGRenderer<'_> {
         // The glyphs have been taken above, there shouldn't be any new glyphs
         // produced from writing the glyph definitions.
         assert!(self.glyphs.is_empty());
+    }
+
+    /// Whether any glyph definitions have been collected.
+    pub(super) fn has_glyph_defs(&self) -> bool {
+        self.glyphs.iter().any(|(_, glyph)| glyph.is_some())
     }
 }

--- a/tests/ref/bundle/link-bundle-html-frame.txt
+++ b/tests/ref/bundle/link-bundle-html-frame.txt
@@ -1,2 +1,2 @@
 5caa14f2425347763746e46baed2a725 index.html
-1fe4c62d11dc09f78c89e735f7ce9f0c folder/a.html
+7b4c3cce01298d6b404b9de4f6b75cbd folder/a.html

--- a/tests/ref/html/hashes.txt
+++ b/tests/ref/html/hashes.txt
@@ -61,7 +61,7 @@ e34ea44e32ada9e0685b72d6e82ecfd5 html-elem-attrs-fold
 52de31c777d4b7b8d356b54138b5fe14 html-elem-metadata
 0a1d1443e72ef554d74d15ae49cd076c html-escapable-raw-text-contains-closing-tag
 41d47680056dc0777c4060cf3ecc8c6a html-frame
-467b6d133e16e258ebf5f0606e4ab20e html-frame-shared-defs
+6e88f190fe39f00a9f92f2159c2ffc36 html-frame-shared-defs
 1e1005b4ac5db07bd074e5d12aa2162e html-pre-starting-with-newline
 9ddbaca4b63c936215a967cb76b0327a html-script
 de4b0b9e9a41128ffdb982bae7550178 html-space-collapsing

--- a/tests/ref/html/hashes.txt
+++ b/tests/ref/html/hashes.txt
@@ -61,6 +61,7 @@ e34ea44e32ada9e0685b72d6e82ecfd5 html-elem-attrs-fold
 52de31c777d4b7b8d356b54138b5fe14 html-elem-metadata
 0a1d1443e72ef554d74d15ae49cd076c html-escapable-raw-text-contains-closing-tag
 41d47680056dc0777c4060cf3ecc8c6a html-frame
+467b6d133e16e258ebf5f0606e4ab20e html-frame-shared-defs
 1e1005b4ac5db07bd074e5d12aa2162e html-pre-starting-with-newline
 9ddbaca4b63c936215a967cb76b0327a html-script
 de4b0b9e9a41128ffdb982bae7550178 html-space-collapsing

--- a/tests/suite/html/frame.typ
+++ b/tests/suite/html/frame.typ
@@ -9,7 +9,11 @@ A rectangle:
 #html.frame[A]
 
 --- html-frame-shared-defs html ---
-// Test that definitions shared by multiple frames (here, glyphs) are written
-// only once, at the end of the body.
-#html.frame[A]
-#html.frame[A]
+// Test that definitions shared by multiple frames are written only once, at
+// the end of the body.
+#let shared = {
+  box(clip: true, fill: gradient.linear(red, blue))[A]
+  box(fill: tiling(size: (4pt, 4pt), circle(radius: 1pt)))[B]
+}
+#html.frame(shared)
+#html.frame(shared)

--- a/tests/suite/html/frame.typ
+++ b/tests/suite/html/frame.typ
@@ -7,3 +7,9 @@ A rectangle:
 // actual paged export than for _nested_ HTML frames, which take the same code
 // path.
 #html.frame[A]
+
+--- html-frame-shared-defs html ---
+// Test that definitions shared by multiple frames (here, glyphs) are written
+// only once, at the end of the body.
+#html.frame[A]
+#html.frame[A]


### PR DESCRIPTION
Closes #8830

Glyph symbols, clip paths, gradients and tilings used by `html.frame` elements are now collected once per document and written into a single hidden `<svg>` before `</body>`, instead of being repeated inside every frame. Frames reference the shared definitions by ID.