### PR TITLE
Add more traces for functions called by the compiler

### DIFF
--- a/crates/typst-cli/tests/smoke.rs
+++ b/crates/typst-cli/tests/smoke.rs
@@ -310,9 +310,49 @@ fn test_tracepoints() {
         .must_contain(r#"include "chap" + "ter1.typ""#);
     output
         .stderr
+        .must_contain("while calling function")
+        .must_contain("main.typ:1:1")
+        .must_contain("show strong:");
+    output
+        .stderr
         .must_contain("while showing strong element at")
         .must_contain("main.typ:2:11")
         .must_contain("*Slightly unusual…*");
+}
+
+#[test]
+fn test_tracepoints_of_bare_show() {
+    let project = tempfs();
+    let main = project.write(
+        "main.typ",
+        "#let foo(body) = panic()
+         #show: foo",
+    );
+    let output = exec().arg("compile").arg(&main).must_fail();
+    output
+        .stderr
+        .must_contain("while calling `foo`")
+        .must_contain("main.typ:2:1")
+        .must_contain("show: foo");
+}
+
+#[test]
+fn test_tracepoints_of_panic_in_show_rule() {
+    let project = tempfs();
+    let main = project.write(
+        "main.typ",
+        "#show strong: _ => panic()
+         *strong*",
+    );
+    let output = exec().arg("compile").arg(&main).must_fail();
+    // The tracepoint is filtered out, because its span overlaps with the
+    // `panic()` call.
+    output.stderr.must_not_contain("while calling function");
+    output
+        .stderr
+        .must_contain("while showing strong element at")
+        .must_contain("main.typ:2:9")
+        .must_contain("*strong*");
 }
 
 #[test]
@@ -404,7 +444,13 @@ struct Stream<T = Vec<u8>>(T);
 impl<T: AsRef<[u8]>> Stream<T> {
     #[track_caller]
     fn must_contain(&self, data: impl Debug + AsRef<[u8]>) -> &Self {
-        assert!(self.contains(data.as_ref()), "{self:?} did not contain {data:?}",);
+        assert!(self.contains(data.as_ref()), "{self:?} did not contain {data:?}");
+        self
+    }
+
+    #[track_caller]
+    fn must_not_contain(&self, data: impl Debug + AsRef<[u8]>) -> &Self {
+        assert!(!self.contains(data.as_ref()), "{self:?} did contain {data:?}");
         self
     }
 

--- a/crates/typst-eval/src/access.rs
+++ b/crates/typst-eval/src/access.rs
@@ -63,7 +63,7 @@ impl Access for ast::FuncCall<'_> {
                 let args = self.args().eval(vm)?.spanned(span);
                 let value = access.target().access(vm)?;
                 let result = call_method_access(value, &method, args, span);
-                let point = || Tracepoint::Call(Some(method.get().clone()));
+                let point = || Tracepoint::call(method.get().clone());
                 return result.trace(world, point, span);
             }
         }

--- a/crates/typst-eval/src/call.rs
+++ b/crates/typst-eval/src/call.rs
@@ -201,7 +201,7 @@ fn maybe_resolve_mutating(
         // Only arrays and dictionaries have mutable methods.
         target @ (Value::Array(_) | Value::Dict(_)) => {
             let value = call_method_mut(target, &field, args, span);
-            let point = || Tracepoint::Call(Some(field.get().clone()));
+            let point = || Tracepoint::call(field.get().clone());
             Ok(Ok(value.trace(vm.world(), point, span)?))
         }
         target => Ok(Err((target.clone(), args))),

--- a/crates/typst-eval/src/call.rs
+++ b/crates/typst-eval/src/call.rs
@@ -166,11 +166,7 @@ fn eval_math_call(vm: &mut Vm, math_call: ast::MathCall) -> SourceResult<Value> 
 /// Call a function.
 fn call_func(vm: &mut Vm, func: Func, args: Args, span: Span) -> SourceResult<Value> {
     let func = func.spanned(span);
-    let point = || Tracepoint::Call(func.name().map(Into::into));
-    let f = || {
-        func.call(&mut vm.engine, vm.context, args)
-            .trace(vm.world(), point, span)
-    };
+    let f = || func.call_traced(&mut vm.engine, vm.context, args, span);
 
     // Stacker is broken on WASM.
     #[cfg(target_arch = "wasm32")]

--- a/crates/typst-eval/src/call.rs
+++ b/crates/typst-eval/src/call.rs
@@ -631,7 +631,7 @@ impl Eval for ast::Closure<'_> {
                 .count(),
         };
 
-        Ok(Value::Func(Func::from(closure).spanned(self.params().span())))
+        Ok(Value::Func(Func::from(closure).spanned(self.span())))
     }
 }
 

--- a/crates/typst-eval/src/markup.rs
+++ b/crates/typst-eval/src/markup.rs
@@ -9,6 +9,7 @@ use typst_library::model::{
 use typst_library::text::{
     LinebreakElem, RawContent, RawElem, SmartQuoteElem, SpaceElem, TextElem,
 };
+use typst_syntax::Spanned;
 use typst_syntax::ast::{self, AstNode};
 use typst_utils::PicoStr;
 
@@ -200,8 +201,10 @@ impl Eval for ast::Ref<'_> {
             .expect("unexpected empty reference");
         let mut elem = RefElem::new(target);
         if let Some(supplement) = self.supplement() {
-            elem.supplement
-                .set(Smart::Custom(Some(Supplement::Content(supplement.eval(vm)?))));
+            elem.supplement.set(Spanned::new(
+                Smart::Custom(Some(Supplement::Content(supplement.eval(vm)?))),
+                supplement.span(),
+            ));
         }
         Ok(elem.pack())
     }

--- a/crates/typst-ide/src/definition.rs
+++ b/crates/typst-ide/src/definition.rs
@@ -166,9 +166,7 @@ mod tests {
         let world = TestWorld::new("#import \"other.typ\"; #other.foo")
             .with_source("other.typ", "#let foo(x) = x + 1");
 
-        // The span is at the args here because that's what the function value's
-        // span is. Not ideal, but also not too big of a big deal.
-        test(&world, -2, Side::Before).must_be_at("other.typ", 8..11);
+        test(&world, -2, Side::Before).must_be_at("other.typ", 5..19);
     }
 
     #[test]

--- a/crates/typst-ide/src/docs.rs
+++ b/crates/typst-ide/src/docs.rs
@@ -17,12 +17,11 @@ pub fn find_value_docs(world: &dyn IdeWorld, value: &Value) -> Option<Docs> {
         && let span = func.span()
         && let Some(id) = span.id()
         && let Ok(source) = world.source(id)
-        && let Some(args) = source.find(span)
-        && let Some(parent) = args.parent()
-        && parent.kind() == SyntaxKind::Closure
-        && let Some(grand) = parent.parent()
-        && grand.kind() == SyntaxKind::LetBinding
-        && let Some(docs) = Docs::collect_doc_comment(grand.clone())
+        && let Some(node) = source.find(span)
+        && node.kind() == SyntaxKind::Closure
+        && let Some(parent) = node.parent()
+        && parent.kind() == SyntaxKind::LetBinding
+        && let Some(docs) = Docs::collect_doc_comment(parent.clone())
     {
         return Some(docs);
     }

--- a/crates/typst-layout/src/grid/lines.rs
+++ b/crates/typst-layout/src/grid/lines.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use typst_library::foundations::{AlternativeFold, Fold};
 use typst_library::layout::Abs;
 use typst_library::layout::grid::resolve::{CellGrid, Line, Repeatable};
+use typst_library::layout::resolve::GridStroke;
 use typst_library::visualize::Stroke;
 
 use super::RowPiece;
@@ -89,7 +90,7 @@ where
             &CellGrid,
             usize,
             usize,
-            Option<Option<Arc<Stroke<Abs>>>>,
+            GridStroke<Abs>,
         ) -> Option<(Arc<Stroke<Abs>>, StrokePriority)>
         + 'grid,
     I: IntoIterator<Item = (usize, Abs)>,
@@ -276,7 +277,7 @@ pub fn vline_stroke_at_row(
     grid: &CellGrid,
     x: usize,
     y: usize,
-    stroke: Option<Option<Arc<Stroke<Abs>>>>,
+    stroke: GridStroke<Abs>,
 ) -> Option<(Arc<Stroke<Abs>>, StrokePriority)> {
     // When the vline isn't at the border, we need to check if a colspan would
     // be present between columns 'x' and 'x-1' at row 'y', and thus overlap
@@ -401,7 +402,7 @@ pub fn hline_stroke_at_column(
     in_last_region: bool,
     y: usize,
     x: usize,
-    stroke: Option<Option<Arc<Stroke<Abs>>>>,
+    stroke: GridStroke<Abs>,
 ) -> Option<(Arc<Stroke<Abs>>, StrokePriority)> {
     // When the hline isn't at the border, we need to check if a rowspan
     // would be present between rows 'y' and 'y-1' at column 'x', and thus

--- a/crates/typst-layout/src/lists.rs
+++ b/crates/typst-layout/src/lists.rs
@@ -1,8 +1,10 @@
 use comemo::Track;
 use smallvec::smallvec;
-use typst_library::diag::SourceResult;
+use typst_library::diag::{SourceResult, Trace, Tracepoint};
 use typst_library::engine::Engine;
-use typst_library::foundations::{Content, Context, Depth, Packed, Resolve, StyleChain};
+use typst_library::foundations::{
+    Content, Context, Depth, NativeElement, Packed, Resolve, StyleChain,
+};
 use typst_library::introspection::Locator;
 use typst_library::layout::{
     Abs, Axes, Dir, Fragment, Frame, FrameItem, Length, Point, Region, Regions, Size,
@@ -38,10 +40,11 @@ pub fn layout_list(
     // avoids '#set align' interference with the list.
     let marker_align = elem.marker_align.get(styles);
     let baseline_align = marker_align.y().is_none();
-    let marker = elem
-        .marker
-        .get_ref(styles)
-        .resolve(engine, styles, depth)?
+    let marker = elem.marker.get_ref(styles);
+    let marker = marker
+        .v
+        .resolve(engine, styles, depth, marker.span)
+        .trace(engine.world, || Tracepoint::call(ListElem::ELEM.name()), elem.span())?
         .aligned(marker_align);
 
     let mut items = vec![];

--- a/crates/typst-layout/src/math/cancel.rs
+++ b/crates/typst-layout/src/math/cancel.rs
@@ -98,7 +98,12 @@ fn draw_cancel_line(
             CancelAngle::Angle(v) => *v,
             // This specifies a function that takes the default angle as input.
             CancelAngle::Func(func) => func
-                .call(engine, Context::new(None, Some(styles)).track(), [default])?
+                .call_traced(
+                    engine,
+                    Context::new(None, Some(styles)).track(),
+                    [default],
+                    span,
+                )?
                 .cast()
                 .at(span)?,
         },

--- a/crates/typst-layout/src/math/cancel.rs
+++ b/crates/typst-layout/src/math/cancel.rs
@@ -6,7 +6,7 @@ use typst_library::layout::{Abs, Angle, Frame, FrameItem, Point, Rel, Size, Tran
 use typst_library::math::CancelAngle;
 use typst_library::math::ir::{CancelItem, MathProperties};
 use typst_library::visualize::{FixedStroke, Geometry};
-use typst_syntax::Span;
+use typst_syntax::{Span, Spanned};
 
 use super::MathContext;
 use super::fragment::FrameFragment;
@@ -84,16 +84,16 @@ fn draw_cancel_line(
     length_scale: Rel<Abs>,
     stroke: FixedStroke,
     invert: bool,
-    angle: &Smart<CancelAngle>,
+    angle: &Spanned<Smart<CancelAngle>>,
     body_size: Size,
     styles: StyleChain,
     span: Span,
 ) -> SourceResult<Frame> {
     let default = default_angle(body_size);
-    let mut angle = match angle {
+    let mut angle = match &angle.v {
         // Non specified angle defaults to the diagonal
         Smart::Auto => default,
-        Smart::Custom(angle) => match angle {
+        Smart::Custom(a) => match a {
             // This specifies the absolute angle w.r.t y-axis clockwise.
             CancelAngle::Angle(v) => *v,
             // This specifies a function that takes the default angle as input.
@@ -102,7 +102,7 @@ fn draw_cancel_line(
                     engine,
                     Context::new(None, Some(styles)).track(),
                     [default],
-                    span,
+                    angle.span,
                 )?
                 .cast()
                 .at(span)?,

--- a/crates/typst-layout/src/rules.rs
+++ b/crates/typst-layout/src/rules.rs
@@ -754,9 +754,15 @@ const LAYOUT_RULE: ShowFn<LayoutElem> = |elem, _, _| {
             let Size { x, y } = regions.base();
             let loc = elem.location().unwrap();
             let context = Context::new(Some(loc), Some(styles));
+
             let result = elem
                 .func
-                .call(engine, context.track(), [dict! { "width" => x, "height" => y }])?
+                .call_traced(
+                    engine,
+                    context.track(),
+                    [dict! { "width" => x, "height" => y }],
+                    elem.span(),
+                )?
                 .display();
             crate::flow::layout_fragment(engine, &result, locator, styles, regions)
         },

--- a/crates/typst-layout/src/rules.rs
+++ b/crates/typst-layout/src/rules.rs
@@ -1,7 +1,7 @@
 use comemo::Track;
 use ecow::{EcoVec, eco_format};
 use smallvec::smallvec;
-use typst_library::diag::{At, SourceResult, bail};
+use typst_library::diag::{At, SourceResult, Trace, Tracepoint, bail};
 use typst_library::foundations::{
     Content, Context, NativeElement, NativeRuleMap, Packed, Resolve, ShowFn, Smart,
     StyleChain, Synthesize, Target, dict,
@@ -447,7 +447,9 @@ const OUTLINE_ENTRY_RULE: ShowFn<OutlineEntry> = |elem, engine, styles| {
         let body = prefix.unwrap_or_default() + inner;
         BlockElem::packed(body).spanned(span)
     } else {
-        elem.indented(engine, context, span, prefix, inner, Em::new(0.5).into())?
+        let point = || Tracepoint::call(OutlineEntry::indented_data().name);
+        elem.indented(engine, context, span, prefix, inner, Em::new(0.5).into())
+            .trace(engine.world, point, span)?
     };
 
     let loc = elem.element_location().at(span)?;

--- a/crates/typst-library/src/diag.rs
+++ b/crates/typst-library/src/diag.rs
@@ -548,6 +548,12 @@ pub enum Tracepoint {
     Include(EcoString),
 }
 
+impl Tracepoint {
+    pub fn call<T: Into<EcoString>>(name: T) -> Self {
+        Self::Call(Some(name.into()))
+    }
+}
+
 impl Display for Tracepoint {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {

--- a/crates/typst-library/src/diag.rs
+++ b/crates/typst-library/src/diag.rs
@@ -22,6 +22,8 @@ use typst_syntax::{
 };
 use utf8_iter::ErrorReportingUtf8Chars;
 
+use crate::engine::Engine;
+use crate::foundations::{Context, Func, IntoArgs, Value};
 use crate::loading::{LoadSource, Loaded};
 use crate::{World, WorldExt};
 
@@ -587,6 +589,28 @@ impl<T> Trace<T> for SourceResult<T> {
             }
             errors
         })
+    }
+}
+
+/// Conveniently call [`Func::call_traced`].
+pub trait CallTraced {
+    /// Convenience wrapper method for calling [`Func::call_traced`].
+    fn call_traced<A: IntoArgs>(
+        &self,
+        engine: &mut Engine,
+        context: Tracked<Context>,
+        args: A,
+    ) -> SourceResult<Value>;
+}
+
+impl CallTraced for Spanned<Func> {
+    fn call_traced<A: IntoArgs>(
+        &self,
+        engine: &mut Engine,
+        context: Tracked<Context>,
+        args: A,
+    ) -> SourceResult<Value> {
+        self.v.call_traced(engine, context, args, self.span)
     }
 }
 

--- a/crates/typst-library/src/foundations/args.rs
+++ b/crates/typst-library/src/foundations/args.rs
@@ -6,7 +6,9 @@ use comemo::Tracked;
 use ecow::{EcoString, EcoVec, eco_format, eco_vec};
 use typst_syntax::{Span, Spanned};
 
-use crate::diag::{At, SourceDiagnostic, SourceResult, StrResult, bail, error};
+use crate::diag::{
+    At, CallTraced, SourceDiagnostic, SourceResult, StrResult, bail, error,
+};
 use crate::engine::Engine;
 use crate::foundations::{
     Array, Context, Dict, FromValue, Func, IntoValue, Repr, Str, Value, cast, func, repr,
@@ -405,12 +407,12 @@ impl Args {
         engine: &mut Engine,
         context: Tracked<Context>,
         /// The function to apply to each value. Must return a boolean.
-        test: Func,
+        test: Spanned<Func>,
     ) -> SourceResult<Args> {
         let mut run_test = |v: &Value| {
-            test.call(engine, context, [v.clone()])?
+            test.call_traced(engine, context, [v.clone()])?
                 .cast::<bool>()
-                .at(test.span())
+                .at(test.span)
         };
         self.into_iter()
             .filter_map(|arg| {
@@ -434,11 +436,11 @@ impl Args {
         engine: &mut Engine,
         context: Tracked<Context>,
         /// The function to apply to each value.
-        mapper: Func,
+        mapper: Spanned<Func>,
     ) -> SourceResult<Args> {
         self.into_iter()
             .map(|arg| {
-                let mapped_value = mapper.call(engine, context, [arg.value.v])?;
+                let mapped_value = mapper.call_traced(engine, context, [arg.value.v])?;
                 Ok(Arg {
                     span: arg.span,
                     name: arg.name,

--- a/crates/typst-library/src/foundations/array.rs
+++ b/crates/typst-library/src/foundations/array.rs
@@ -10,7 +10,8 @@ use smallvec::SmallVec;
 use typst_syntax::{Span, Spanned};
 
 use crate::diag::{
-    At, HintedStrResult, HintedString, SourceDiagnostic, SourceResult, StrResult, bail,
+    At, CallTraced, HintedStrResult, HintedString, SourceDiagnostic, SourceResult,
+    StrResult, bail,
 };
 use crate::engine::Engine;
 use crate::foundations::{
@@ -320,13 +321,13 @@ impl Array {
         engine: &mut Engine,
         context: Tracked<Context>,
         /// The function to apply to each item. Must return a boolean.
-        searcher: Func,
+        searcher: Spanned<Func>,
     ) -> SourceResult<Option<Value>> {
         for item in self {
             if searcher
-                .call(engine, context, [item.clone()])?
+                .call_traced(engine, context, [item.clone()])?
                 .cast::<bool>()
-                .at(searcher.span())?
+                .at(searcher.span)?
             {
                 return Ok(Some(item.clone()));
             }
@@ -349,13 +350,13 @@ impl Array {
         /// // Or equivalently:
         /// #values.position(calc.even)
         /// ```
-        searcher: Func,
+        searcher: Spanned<Func>,
     ) -> SourceResult<Option<i64>> {
         for (i, item) in self.iter().enumerate() {
             if searcher
-                .call(engine, context, [item.clone()])?
+                .call_traced(engine, context, [item.clone()])?
                 .cast::<bool>()
-                .at(searcher.span())?
+                .at(searcher.span)?
             {
                 return Ok(Some(i as i64));
             }
@@ -450,14 +451,14 @@ impl Array {
         engine: &mut Engine,
         context: Tracked<Context>,
         /// The function to apply to each item. Must return a boolean.
-        test: Func,
+        test: Spanned<Func>,
     ) -> SourceResult<Array> {
         let mut kept = EcoVec::new();
         for item in self {
             if test
-                .call(engine, context, [item.clone()])?
+                .call_traced(engine, context, [item.clone()])?
                 .cast::<bool>()
-                .at(test.span())?
+                .at(test.span)?
             {
                 kept.push(item.clone());
             }
@@ -473,10 +474,10 @@ impl Array {
         engine: &mut Engine,
         context: Tracked<Context>,
         /// The function to apply to each item.
-        mapper: Func,
+        mapper: Spanned<Func>,
     ) -> SourceResult<Array> {
         self.into_iter()
-            .map(|item| mapper.call(engine, context, [item]))
+            .map(|item| mapper.call_traced(engine, context, [item]))
             .collect()
     }
 
@@ -627,11 +628,11 @@ impl Array {
         init: Value,
         /// The folding function. Must have two parameters: One for the
         /// accumulated value and one for an item.
-        folder: Func,
+        folder: Spanned<Func>,
     ) -> SourceResult<Value> {
         let mut acc = init;
         for item in self {
-            acc = folder.call(engine, context, [acc, item])?;
+            acc = folder.call_traced(engine, context, [acc, item])?;
         }
         Ok(acc)
     }
@@ -684,10 +685,14 @@ impl Array {
         engine: &mut Engine,
         context: Tracked<Context>,
         /// The function to apply to each item. Must return a boolean.
-        test: Func,
+        test: Spanned<Func>,
     ) -> SourceResult<bool> {
         for item in self {
-            if test.call(engine, context, [item])?.cast::<bool>().at(test.span())? {
+            if test
+                .call_traced(engine, context, [item])?
+                .cast::<bool>()
+                .at(test.span)?
+            {
                 return Ok(true);
             }
         }
@@ -702,10 +707,14 @@ impl Array {
         engine: &mut Engine,
         context: Tracked<Context>,
         /// The function to apply to each item. Must return a boolean.
-        test: Func,
+        test: Spanned<Func>,
     ) -> SourceResult<bool> {
         for item in self {
-            if !test.call(engine, context, [item])?.cast::<bool>().at(test.span())? {
+            if !test
+                .call_traced(engine, context, [item])?
+                .cast::<bool>()
+                .at(test.span)?
+            {
                 return Ok(false);
             }
         }
@@ -905,7 +914,7 @@ impl Array {
         /// If given, applies this function to each element in the array to
         /// determine the keys to sort by.
         #[named]
-        key: Option<Func>,
+        key: Option<Spanned<Func>>,
         /// If given, uses this function to compare every two elements in the
         /// array.
         ///
@@ -934,7 +943,7 @@ impl Array {
         /// )
         /// ```
         #[named]
-        by: Option<Func>,
+        by: Option<Spanned<Func>>,
     ) -> SourceResult<Array> {
         // We use `glidesort` instead of the standard library sorting algorithm
         // to prevent panics in case the comparison function does not define a
@@ -946,10 +955,10 @@ impl Array {
                     if let Some(f) = &key {
                         // We rely on `comemo`'s memoization of function
                         // evaluation to not excessively reevaluate the key.
-                        x = f.call(engine, context, [x])?;
-                        y = f.call(engine, context, [y])?;
+                        x = f.call_traced(engine, context, [x])?;
+                        y = f.call_traced(engine, context, [y])?;
                     }
-                    match by.call(engine, context, [x, y])? {
+                    match by.call_traced(engine, context, [x, y])? {
                         Value::Bool(b) => Ok(b),
                         x => {
                             bail!(
@@ -1012,7 +1021,7 @@ impl Array {
                 let mut key_of = |x: Value| match &key {
                     // We rely on `comemo`'s memoization of function evaluation
                     // to not excessively reevaluate the key.
-                    Some(f) => f.call(engine, context, [x]),
+                    Some(f) => f.call_traced(engine, context, [x]),
                     None => Ok(x),
                 };
 
@@ -1070,13 +1079,13 @@ impl Array {
         /// #("apple", "banana", " apple ").dedup(key: s => s.trim())
         /// ```
         #[named]
-        key: Option<Func>,
+        key: Option<Spanned<Func>>,
     ) -> SourceResult<Array> {
         let mut out = EcoVec::with_capacity(self.0.len());
         let mut key_of = |x: Value| match &key {
             // NOTE: We are relying on `comemo`'s memoization of function
             // evaluation to not excessively reevaluate the `key`.
-            Some(f) => f.call(engine, context, [x]),
+            Some(f) => f.call_traced(engine, context, [x]),
             None => Ok(x),
         };
 
@@ -1158,12 +1167,12 @@ impl Array {
         context: Tracked<Context>,
         /// The reducing function. Must have two parameters: One for the
         /// accumulated value and one for an item.
-        reducer: Func,
+        reducer: Spanned<Func>,
     ) -> SourceResult<Value> {
         let mut iter = self.into_iter();
         let mut acc = iter.next().unwrap_or_default();
         for item in iter {
-            acc = reducer.call(engine, context, [acc, item])?;
+            acc = reducer.call_traced(engine, context, [acc, item])?;
         }
         Ok(acc)
     }

--- a/crates/typst-library/src/foundations/context.rs
+++ b/crates/typst-library/src/foundations/context.rs
@@ -78,5 +78,8 @@ impl Construct for ContextElem {
 pub const CONTEXT_RULE: ShowFn<ContextElem> = |elem, engine, styles| {
     let loc = elem.location().unwrap();
     let context = Context::new(Some(loc), Some(styles));
-    Ok(elem.func.call::<[Value; 0]>(engine, context.track(), [])?.display())
+    Ok(elem
+        .func
+        .call_traced::<[Value; 0]>(engine, context.track(), [], elem.span())?
+        .display())
 };

--- a/crates/typst-library/src/foundations/dict.rs
+++ b/crates/typst-library/src/foundations/dict.rs
@@ -10,7 +10,7 @@ use rustc_hash::FxBuildHasher;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use typst_syntax::{Spanned, is_ident};
 
-use crate::diag::{At, Hint, HintedStrResult, SourceResult, StrResult};
+use crate::diag::{At, CallTraced, Hint, HintedStrResult, SourceResult, StrResult};
 use crate::engine::Engine;
 use crate::foundations::{
     Array, Context, Func, Module, Repr, Str, Value, WorldBindingExt, array, cast, func,
@@ -318,12 +318,12 @@ impl Dict {
         engine: &mut Engine,
         context: Tracked<Context>,
         /// The function to apply to each value. Must return a boolean.
-        test: Func,
+        test: Spanned<Func>,
     ) -> SourceResult<Dict> {
         let mut run_test = |v: &Value| {
-            test.call(engine, context, [v.clone()])?
+            test.call_traced(engine, context, [v.clone()])?
                 .cast::<bool>()
-                .at(test.span())
+                .at(test.span)
         };
         self.into_iter()
             .filter_map(|(k, v)| run_test(&v).map(|b| b.then_some((k, v))).transpose())
@@ -342,11 +342,11 @@ impl Dict {
         engine: &mut Engine,
         context: Tracked<Context>,
         /// The function to apply to each value.
-        mapper: Func,
+        mapper: Spanned<Func>,
     ) -> SourceResult<Dict> {
         self.into_iter()
             .map(|(k, v)| {
-                let mapped_value = mapper.call(engine, context, [v])?;
+                let mapped_value = mapper.call_traced(engine, context, [v])?;
                 Ok((k, mapped_value))
             })
             .collect()

--- a/crates/typst-library/src/foundations/func.rs
+++ b/crates/typst-library/src/foundations/func.rs
@@ -11,7 +11,9 @@ use either::Either;
 use typst_syntax::{Span, Spanned, SyntaxNode, ast};
 use typst_utils::{DefSite, LazyHash, Static, singleton};
 
-use crate::diag::{At, HintedStrResult, SourceResult, StrResult, bail};
+use crate::diag::{
+    At, HintedStrResult, SourceResult, StrResult, Trace, Tracepoint, bail,
+};
 use crate::engine::Engine;
 use crate::foundations::{
     Args, BindingAccess, BindingGuard, Bytes, CastInfo, Content, Context, Element,
@@ -320,6 +322,19 @@ impl Func {
             FuncInner::Plugin(func) => Some(func),
             _ => None,
         }
+    }
+
+    /// Call the function with the given context and arguments, adding a call
+    /// tracepoint at the span.
+    pub fn call_traced<A: IntoArgs>(
+        &self,
+        engine: &mut Engine,
+        context: Tracked<Context>,
+        args: A,
+        span: Span,
+    ) -> SourceResult<Value> {
+        let point = || Tracepoint::Call(self.name().map(Into::into));
+        self.call(engine, context, args).trace(engine.world, point, span)
     }
 
     /// Call the function with the given context and arguments.

--- a/crates/typst-library/src/foundations/func.rs
+++ b/crates/typst-library/src/foundations/func.rs
@@ -344,7 +344,7 @@ impl Func {
         context: Tracked<Context>,
         args: A,
     ) -> SourceResult<Value> {
-        self.call_impl(engine, context, args.into_args(self.span))
+        self.call_impl(engine, context, args.into_args(self.params_span()))
     }
 
     /// Non-generic implementation of `call`.
@@ -391,12 +391,28 @@ impl Func {
         }
     }
 
-    /// The function's span.
+    /// The span with which errors are reported when this function is called.
     pub fn span(&self) -> Span {
         self.span
     }
 
+    /// The span of the function parameters, falling back to the general report
+    /// span, if not available.
+    pub fn params_span(&self) -> Span {
+        let params_span = match &self.inner {
+            FuncInner::Native(_) => Span::detached(),
+            FuncInner::Element(_) => Span::detached(),
+            FuncInner::Closure(closure) => closure.node.params_span(),
+            FuncInner::Plugin(_) => Span::detached(),
+            FuncInner::With(with) => with.0.params_span(),
+        };
+        params_span.or(self.span)
+    }
+
     /// Attach a span to this function if it doesn't already have one.
+    ///
+    /// This is used to report errors of the return value of the closure, or
+    /// when the closure is used as a value.
     pub fn spanned(mut self, span: Span) -> Self {
         if self.span.is_detached() {
             self.span = span;
@@ -735,6 +751,20 @@ pub enum ClosureNode {
     /// Synthetic closure used for `context` expressions. Can be any `ast::Expr`
     /// and has no parameters.
     Context(SyntaxNode),
+}
+
+impl ClosureNode {
+    /// Returns the span of the closure parameters, if any.
+    pub fn params_span(&self) -> Span {
+        match self {
+            ClosureNode::Closure(node) => node
+                .cast::<ast::Closure>()
+                .expect("node to be an `ast::Closure`")
+                .params()
+                .span(),
+            ClosureNode::Context(_) => Span::detached(),
+        }
+    }
 }
 
 /// A user-defined closure.

--- a/crates/typst-library/src/foundations/str.rs
+++ b/crates/typst-library/src/foundations/str.rs
@@ -510,7 +510,7 @@ impl Str {
         ///
         /// The dictionary passed to the function has the same shape as the
         /// dictionary returned by @str.match[`match`].
-        replacement: Replacement,
+        replacement: Spanned<Replacement>,
         /// If given, only the first `count` matches of the pattern are
         /// replaced.
         #[named]
@@ -528,13 +528,13 @@ impl Str {
             last_match = range.end;
 
             // Determine and push the replacement.
-            match &replacement {
+            match &replacement.v {
                 Replacement::Str(s) => output.push_str(s),
                 Replacement::Func(func) => {
                     let piece = func
-                        .call(engine, context, [dict])?
+                        .call_traced(engine, context, [dict], replacement.span)?
                         .cast::<Str>()
-                        .at(func.span())?;
+                        .at(replacement.span)?;
                     output.push_str(&piece);
                 }
             }

--- a/crates/typst-library/src/foundations/styles.rs
+++ b/crates/typst-library/src/foundations/styles.rs
@@ -504,10 +504,17 @@ impl Recipe {
             Transformation::Content(content) => content.clone(),
             Transformation::Func(func) => {
                 let mut result = func.call(engine, context, [content.clone()]);
+
+                // Add the definition site of the show rule to the trace.
+                let point = || Tracepoint::Call(func.name().map(Into::into));
+                result = result.trace(engine.world, point, self.span);
+
+                // Add application site of the show rule to the trace.
                 if self.selector.is_some() {
                     let point = || Tracepoint::Show(content.func().name().into());
                     result = result.trace(engine.world, point, content.span());
                 }
+
                 result?.display()
             }
             Transformation::Style(styles) => content.styled_with_map(styles.clone()),

--- a/crates/typst-library/src/foundations/styles.rs
+++ b/crates/typst-library/src/foundations/styles.rs
@@ -503,11 +503,9 @@ impl Recipe {
         let mut content = match &self.transform {
             Transformation::Content(content) => content.clone(),
             Transformation::Func(func) => {
-                let mut result = func.call(engine, context, [content.clone()]);
-
                 // Add the definition site of the show rule to the trace.
-                let point = || Tracepoint::Call(func.name().map(Into::into));
-                result = result.trace(engine.world, point, self.span);
+                let mut result =
+                    func.call_traced(engine, context, [content.clone()], self.span);
 
                 // Add application site of the show rule to the trace.
                 if self.selector.is_some() {

--- a/crates/typst-library/src/foundations/styles.rs
+++ b/crates/typst-library/src/foundations/styles.rs
@@ -8,7 +8,7 @@ use ecow::{EcoString, EcoVec, eco_vec};
 use indexmap::IndexMap;
 use rustc_hash::FxBuildHasher;
 use smallvec::SmallVec;
-use typst_syntax::Span;
+use typst_syntax::{Span, Spanned};
 use typst_utils::LazyHash;
 
 use crate::diag::{SourceResult, Trace, Tracepoint};
@@ -885,6 +885,14 @@ impl<T: Resolve> Resolve for Option<T> {
     }
 }
 
+impl<T: Resolve> Resolve for Spanned<T> {
+    type Output = Spanned<T::Output>;
+
+    fn resolve(self, styles: StyleChain) -> Self::Output {
+        self.map(|v| v.resolve(styles))
+    }
+}
+
 /// A property that is folded to determine its final value.
 ///
 /// In the example below, the chain of stroke values is folded into a single
@@ -938,6 +946,12 @@ impl<T> Fold for OneOrMultiple<T> {
     fn fold(self, mut outer: Self) -> Self {
         outer.0.extend(self.0);
         outer
+    }
+}
+
+impl<T: Fold> Fold for Spanned<T> {
+    fn fold(self, outer: Self) -> Self {
+        Spanned::new(self.v.fold(outer.v), self.span.or(outer.span))
     }
 }
 

--- a/crates/typst-library/src/introspection/counter.rs
+++ b/crates/typst-library/src/introspection/counter.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use comemo::{Track, Tracked, TrackedMut};
 use ecow::{EcoString, EcoVec, eco_format, eco_vec};
 use smallvec::{SmallVec, smallvec};
-use typst_syntax::Span;
+use typst_syntax::{Span, Spanned};
 use typst_utils::{LazyHash, NonZeroExt, Protected};
 
 use crate::diag::{At, HintedStrResult, SourceDiagnostic, SourceResult, bail, warning};
@@ -584,7 +584,7 @@ cast! {
 /// Elements that have special counting behaviour.
 pub trait Count {
     /// Get the counter update for this element.
-    fn update(&self) -> Option<CounterUpdate>;
+    fn update(&self) -> Option<Spanned<CounterUpdate>>;
 }
 
 /// Counts through elements with different levels.
@@ -602,16 +602,21 @@ impl CounterState {
     pub fn update(
         &mut self,
         engine: &mut Engine,
-        update: CounterUpdate,
+        update: Spanned<CounterUpdate>,
     ) -> SourceResult<()> {
-        match update {
+        match update.v {
             CounterUpdate::Set(state) => *self = state,
             CounterUpdate::Step(level) => self.step(level, 1),
             CounterUpdate::Func(func) => {
                 *self = func
-                    .call(engine, Context::none().track(), self.0.iter().copied())?
+                    .call_traced(
+                        engine,
+                        Context::none().track(),
+                        self.0.iter().copied(),
+                        update.span,
+                    )?
                     .cast()
-                    .at(func.span())?;
+                    .at(update.span)?;
             }
         }
         Ok(())
@@ -676,8 +681,8 @@ impl Construct for CounterUpdateElem {
 }
 
 impl Count for Packed<CounterUpdateElem> {
-    fn update(&self) -> Option<CounterUpdate> {
-        Some(self.update.clone())
+    fn update(&self) -> Option<Spanned<CounterUpdate>> {
+        Some(Spanned::new(self.update.clone(), self.span()))
     }
 }
 
@@ -756,7 +761,10 @@ impl ManualPageCounter {
                     };
                     if elem.key == CounterKey::Page {
                         let mut state = CounterState(smallvec![self.logical]);
-                        state.update(engine, elem.update.clone())?;
+                        state.update(
+                            engine,
+                            Spanned::new(elem.update.clone(), elem.span()),
+                        )?;
                         self.logical = state.first();
                     }
                 }
@@ -950,7 +958,7 @@ fn sequence_impl(
 
         if let Some(update) = match elem.with::<dyn Count>() {
             Some(countable) => countable.update(),
-            None => Some(CounterUpdate::Step(NonZeroUsize::ONE)),
+            None => Some(Spanned::detached(CounterUpdate::Step(NonZeroUsize::ONE))),
         } {
             current.update(&mut engine, update)?;
         }

--- a/crates/typst-library/src/introspection/state.rs
+++ b/crates/typst-library/src/introspection/state.rs
@@ -500,7 +500,12 @@ fn sequence_impl(
         match &elem.update {
             StateUpdate::Set(value) => current = value.clone(),
             StateUpdate::Func(func) => {
-                current = func.call(&mut engine, Context::none().track(), [current])?;
+                current = func.call_traced(
+                    &mut engine,
+                    Context::none().track(),
+                    [current],
+                    elem.span(),
+                )?;
             }
         }
         stops.push(current.clone());

--- a/crates/typst-library/src/layout/grid/mod.rs
+++ b/crates/typst-library/src/layout/grid/mod.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use comemo::Track;
 use smallvec::{SmallVec, smallvec};
+use typst_syntax::{Span, Spanned};
 use typst_utils::NonZeroExt;
 
 use crate::diag::{At, HintedStrResult, HintedString, SourceResult, bail};
@@ -13,7 +14,7 @@ use crate::foundations::{
     Array, CastInfo, Content, Context, Fold, FromValue, Func, IntoValue, Packed, Reflect,
     Resolve, Smart, StyleChain, Synthesize, Value, cast, elem, scope,
 };
-use crate::layout::resolve::{CellGrid, grid_to_cellgrid};
+use crate::layout::resolve::{CellGrid, GridStroke, grid_to_cellgrid};
 use crate::layout::{
     Alignment, Length, OuterHAlignment, OuterVAlignment, Rel, Sides, Sizing,
 };
@@ -234,7 +235,7 @@ pub struct GridElem {
     ///
     /// In addition, you can find an example at the @table.inset parameter.
     #[fold]
-    pub inset: Celled<Sides<Option<Rel<Length>>>>,
+    pub inset: Spanned<Celled<Sides<Option<Rel<Length>>>>>,
 
     /// How to align the cells' content.
     ///
@@ -248,7 +249,7 @@ pub struct GridElem {
     /// See the @grid:styling[styling section] above for details.
     ///
     /// In addition, you can find an example at the @table.align parameter.
-    pub align: Celled<Smart<Alignment>>,
+    pub align: Spanned<Celled<Smart<Alignment>>>,
 
     /// How to fill the cells.
     ///
@@ -274,7 +275,7 @@ pub struct GridElem {
     ///   [O], [X], [O], [X],
     /// )
     /// ```
-    pub fill: Celled<Option<Paint>>,
+    pub fill: Spanned<Celled<Option<Paint>>>,
 
     /// How to @stroke[stroke] the cells.
     ///
@@ -405,7 +406,7 @@ pub struct GridElem {
     ///   ```
     /// )
     #[fold]
-    pub stroke: Celled<Sides<Option<Option<Arc<Stroke>>>>>,
+    pub stroke: Spanned<Celled<Sides<GridStroke>>>,
 
     #[internal]
     #[synthesized]
@@ -849,7 +850,7 @@ pub struct GridCell {
 
     /// The cell's @grid.stroke[stroke] override.
     #[fold]
-    pub stroke: Sides<Option<Option<Arc<Stroke>>>>,
+    pub stroke: Sides<GridStroke>,
 
     #[internal]
     #[parse(Some(false))]
@@ -905,13 +906,19 @@ impl<T: Default + Clone + FromValue> Celled<T> {
         styles: StyleChain,
         x: usize,
         y: usize,
+        span: Span,
     ) -> SourceResult<T> {
         Ok(match self {
             Self::Value(value) => value.clone(),
             Self::Func(func) => func
-                .call(engine, Context::new(None, Some(styles)).track(), [x, y])?
+                .call_traced(
+                    engine,
+                    Context::new(None, Some(styles)).track(),
+                    [x, y],
+                    span,
+                )?
                 .cast()
-                .at(func.span())?,
+                .at(span)?,
             Self::Array(array) => x
                 .checked_rem(array.len())
                 .and_then(|i| array.get(i))
@@ -1006,13 +1013,19 @@ where
         styles: StyleChain,
         x: usize,
         y: usize,
+        span: Span,
     ) -> SourceResult<T::Output> {
         Ok(match &self.0 {
             Celled::Value(value) => value.clone(),
             Celled::Func(func) => func
-                .call(engine, Context::new(None, Some(styles)).track(), [x, y])?
+                .call_traced(
+                    engine,
+                    Context::new(None, Some(styles)).track(),
+                    [x, y],
+                    span,
+                )?
                 .cast::<T>()
-                .at(func.span())?
+                .at(span)?
                 .resolve(styles),
             Celled::Array(array) => x
                 .checked_rem(array.len())

--- a/crates/typst-library/src/layout/grid/resolve.rs
+++ b/crates/typst-library/src/layout/grid/resolve.rs
@@ -17,9 +17,10 @@ use typst_library::model::{TableCell, TableChild, TableElem, TableItem};
 use typst_library::text::TextElem;
 use typst_library::visualize::{Paint, Stroke};
 
-use typst_syntax::Span;
+use typst_syntax::{Span, Spanned};
 use typst_utils::{NonZeroExt, SmallBitSet};
 
+use crate::foundations::NativeElement;
 use crate::model::{TableCellKind, TableHeaderScope};
 
 /// Convert a grid to a cell grid.
@@ -41,7 +42,6 @@ pub fn grid_to_cellgrid(
     let tracks = Axes::new(columns.0.as_slice(), rows.0.as_slice());
     let gutter = Axes::new(column_gutter.0.as_slice(), row_gutter.0.as_slice());
     // Use trace to link back to the grid when a specific cell errors
-    let tracepoint = || Tracepoint::Call(Some(eco_format!("grid")));
     let resolve_item = |item: &GridItem| grid_item_to_resolvable(item, styles);
     let children = elem.children.iter().map(|child| match child {
         GridChild::Header(header) => ResolvableGridChild::Header {
@@ -71,7 +71,7 @@ pub fn grid_to_cellgrid(
         styles,
         elem.span(),
     )
-    .trace(engine.world, tracepoint, elem.span())
+    .trace(engine.world, || Tracepoint::call(GridElem::ELEM.name()), elem.span())
 }
 
 /// Convert a table to a cell grid.
@@ -93,7 +93,6 @@ pub fn table_to_cellgrid(
     let tracks = Axes::new(columns.0.as_slice(), rows.0.as_slice());
     let gutter = Axes::new(column_gutter.0.as_slice(), row_gutter.0.as_slice());
     // Use trace to link back to the table when a specific cell errors
-    let tracepoint = || Tracepoint::Call(Some(eco_format!("table")));
     let resolve_item = |item: &TableItem| table_item_to_resolvable(item, styles);
     let children = elem.children.iter().map(|child| match child {
         TableChild::Header(header) => ResolvableGridChild::Header {
@@ -123,7 +122,7 @@ pub fn table_to_cellgrid(
         styles,
         elem.span(),
     )
-    .trace(engine.world, tracepoint, elem.span())
+    .trace(engine.world, || Tracepoint::call(TableElem::ELEM.name()), elem.span())
 }
 
 fn grid_item_to_resolvable(
@@ -208,7 +207,7 @@ impl ResolvableCell for Packed<TableCell> {
         fill: &Option<Paint>,
         align: Smart<Alignment>,
         inset: Sides<Option<Rel<Length>>>,
-        stroke: Sides<Option<Option<Arc<Stroke<Abs>>>>>,
+        stroke: Sides<GridStroke<Abs>>,
         breakable: bool,
         styles: StyleChain,
         kind: Smart<TableCellKind>,
@@ -305,7 +304,7 @@ impl ResolvableCell for Packed<GridCell> {
         fill: &Option<Paint>,
         align: Smart<Alignment>,
         inset: Sides<Option<Rel<Length>>>,
-        stroke: Sides<Option<Option<Arc<Stroke<Abs>>>>>,
+        stroke: Sides<GridStroke<Abs>>,
         breakable: bool,
         styles: StyleChain,
         _: Smart<TableCellKind>,
@@ -512,7 +511,7 @@ pub trait ResolvableCell {
         fill: &Option<Paint>,
         align: Smart<Alignment>,
         inset: Sides<Option<Rel<Length>>>,
-        stroke: Sides<Option<Option<Arc<Stroke<Abs>>>>>,
+        stroke: Sides<GridStroke<Abs>>,
         breakable: bool,
         styles: StyleChain,
         kind: Smart<TableCellKind>,
@@ -898,6 +897,9 @@ impl CellGrid {
     }
 }
 
+/// A stroke that can be folded with the cell and parent element values.
+pub type GridStroke<T = Length> = Option<Option<Arc<Stroke<T>>>>;
+
 /// Resolves and positions all cells in the grid before creating it.
 /// Allows them to keep track of their final properties and positions
 /// and adjust their fields accordingly.
@@ -909,10 +911,10 @@ pub fn resolve_cellgrid<'a, T, C, I>(
     tracks: Axes<&'a [Sizing]>,
     gutter: Axes<&'a [Sizing]>,
     children: C,
-    fill: &'a Celled<Option<Paint>>,
-    align: &'a Celled<Smart<Alignment>>,
-    inset: &'a Celled<Sides<Option<Rel<Length>>>>,
-    stroke: &'a ResolvedCelled<Sides<Option<Option<Arc<Stroke>>>>>,
+    fill: &'a Spanned<Celled<Option<Paint>>>,
+    align: &'a Spanned<Celled<Smart<Alignment>>>,
+    inset: &'a Spanned<Celled<Sides<Option<Rel<Length>>>>>,
+    stroke: &'a Spanned<ResolvedCelled<Sides<GridStroke>>>,
     engine: &'a mut Engine,
     styles: StyleChain<'a>,
     span: Span,
@@ -940,10 +942,10 @@ where
 struct CellGridResolver<'a, 'b> {
     tracks: Axes<&'a [Sizing]>,
     gutter: Axes<&'a [Sizing]>,
-    fill: &'a Celled<Option<Paint>>,
-    align: &'a Celled<Smart<Alignment>>,
-    inset: &'a Celled<Sides<Option<Rel<Length>>>>,
-    stroke: &'a ResolvedCelled<Sides<Option<Option<Arc<Stroke>>>>>,
+    fill: &'a Spanned<Celled<Option<Paint>>>,
+    align: &'a Spanned<Celled<Smart<Alignment>>>,
+    inset: &'a Spanned<Celled<Sides<Option<Rel<Length>>>>>,
+    stroke: &'a Spanned<ResolvedCelled<Sides<GridStroke>>>,
     engine: &'a mut Engine<'b>,
     styles: StyleChain<'a>,
     span: Span,
@@ -1978,10 +1980,10 @@ impl CellGridResolver<'_, '_> {
         Ok(cell.resolve_cell(
             x,
             y,
-            &self.fill.resolve(self.engine, self.styles, x, y)?,
-            self.align.resolve(self.engine, self.styles, x, y)?,
-            self.inset.resolve(self.engine, self.styles, x, y)?,
-            self.stroke.resolve(self.engine, self.styles, x, y)?,
+            &(self.fill.v).resolve(self.engine, self.styles, x, y, self.fill.span)?,
+            (self.align.v).resolve(self.engine, self.styles, x, y, self.align.span)?,
+            (self.inset.v).resolve(self.engine, self.styles, x, y, self.inset.span)?,
+            (self.stroke.v).resolve(self.engine, self.styles, x, y, self.stroke.span)?,
             breakable,
             self.styles,
             kind,

--- a/crates/typst-library/src/math/cancel.rs
+++ b/crates/typst-library/src/math/cancel.rs
@@ -1,3 +1,5 @@
+use typst_syntax::Spanned;
+
 use crate::foundations::{Content, Func, Smart, cast, elem};
 use crate::layout::{Angle, Em, Length, Ratio, Rel};
 use crate::math::Mathy;
@@ -73,7 +75,7 @@ pub struct CancelElem {
     ///   cancel(1/(1+x), angle: #(a => a + 45deg))
     ///   cancel(1/(1+x), angle: #(a => a + 90deg)) $
     /// ```
-    pub angle: Smart<CancelAngle>,
+    pub angle: Spanned<Smart<CancelAngle>>,
 
     /// How to @stroke[stroke] the cancel line.
     ///

--- a/crates/typst-library/src/math/equation.rs
+++ b/crates/typst-library/src/math/equation.rs
@@ -221,9 +221,9 @@ impl ShowSet for Packed<EquationElem> {
 }
 
 impl Count for Packed<EquationElem> {
-    fn update(&self) -> Option<CounterUpdate> {
+    fn update(&self) -> Option<Spanned<CounterUpdate>> {
         (self.block.get(StyleChain::default()) && self.numbering().is_some())
-            .then(|| CounterUpdate::Step(NonZeroUsize::ONE))
+            .then(|| Spanned::new(CounterUpdate::Step(NonZeroUsize::ONE), self.span()))
     }
 }
 

--- a/crates/typst-library/src/math/equation.rs
+++ b/crates/typst-library/src/math/equation.rs
@@ -2,9 +2,10 @@ use std::num::NonZeroUsize;
 
 use codex::styling::MathVariant;
 use ecow::EcoString;
+use typst_syntax::Spanned;
 use typst_utils::NonZeroExt;
 
-use crate::diag::SourceResult;
+use crate::diag::{SourceResult, Trace, Tracepoint};
 use crate::engine::Engine;
 use crate::foundations::{
     Content, NativeElement, Packed, ShowSet, Smart, StyleChain, Styles, Synthesize, elem,
@@ -107,7 +108,7 @@ pub struct EquationElem {
     /// With @ratio, we get:
     /// $ F_n = floor(1 / sqrt(5) phi.alt^n) $
     /// ```
-    pub supplement: Smart<Option<Supplement>>,
+    pub supplement: Spanned<Smart<Option<Supplement>>>,
 
     /// An alternative description of the mathematical equation.
     ///
@@ -176,16 +177,22 @@ impl Synthesize for Packed<EquationElem> {
         engine: &mut Engine,
         styles: StyleChain,
     ) -> SourceResult<()> {
-        let supplement = match self.as_ref().supplement.get_ref(styles) {
+        let sup = self.as_ref().supplement.get_ref(styles);
+        let supplement = match &sup.v {
             Smart::Auto => TextElem::packed(Self::local_name_in(styles)),
             Smart::Custom(None) => Content::empty(),
             Smart::Custom(Some(supplement)) => {
-                supplement.resolve(engine, styles, [self.clone().pack()])?
+                let point = || Tracepoint::call(EquationElem::ELEM.name());
+                supplement
+                    .resolve(engine, styles, [self.clone().pack()], sup.span)
+                    .trace(engine.world, point, self.span())?
             }
         };
 
-        self.supplement
-            .set(Smart::Custom(Some(Supplement::Content(supplement))));
+        self.supplement.set(Spanned {
+            span: supplement.span(),
+            v: Smart::Custom(Some(Supplement::Content(supplement))),
+        });
 
         self.locale = Some(Locale::get_in(styles));
 
@@ -227,7 +234,7 @@ impl LocalName for Packed<EquationElem> {
 impl Refable for Packed<EquationElem> {
     fn supplement(&self) -> Content {
         // After synthesis, this should always be custom content.
-        match self.supplement.get_cloned(StyleChain::default()) {
+        match self.supplement.get_cloned(StyleChain::default()).v {
             Smart::Custom(Some(Supplement::Content(content))) => content,
             _ => Content::empty(),
         }

--- a/crates/typst-library/src/math/ir/item.rs
+++ b/crates/typst-library/src/math/ir/item.rs
@@ -4,7 +4,7 @@ use std::ops::{Deref, MulAssign};
 use std::rc::Rc;
 
 use ecow::EcoString;
-use typst_syntax::Span;
+use typst_syntax::{Span, Spanned};
 use typst_utils::{Get, default_math_class};
 use unicode_math_class::MathClass;
 use unicode_segmentation::UnicodeSegmentation;
@@ -799,7 +799,7 @@ pub struct CancelItem<'a> {
     /// Whether to draw the line behind the main content.
     pub background: bool,
     /// The angle of the line.
-    pub angle: Smart<CancelAngle>,
+    pub angle: Spanned<Smart<CancelAngle>>,
 }
 
 impl<'a> CancelItem<'a> {
@@ -813,7 +813,7 @@ impl<'a> CancelItem<'a> {
         cross: bool,
         invert_first_line: bool,
         background: bool,
-        angle: Smart<CancelAngle>,
+        angle: Spanned<Smart<CancelAngle>>,
         styles: StyleChain<'a>,
         span: Span,
     ) -> MathItem<'a> {

--- a/crates/typst-library/src/model/figure.rs
+++ b/crates/typst-library/src/model/figure.rs
@@ -443,12 +443,12 @@ impl ShowSet for Packed<FigureElem> {
 }
 
 impl Count for Packed<FigureElem> {
-    fn update(&self) -> Option<CounterUpdate> {
+    fn update(&self) -> Option<Spanned<CounterUpdate>> {
         // If the figure is numbered, step the counter by one.
         // This steps the `counter(figure)` which is global to all numbered figures.
         self.numbering()
             .is_some()
-            .then(|| CounterUpdate::Step(NonZeroUsize::ONE))
+            .then(|| Spanned::new(CounterUpdate::Step(NonZeroUsize::ONE), self.span()))
     }
 }
 

--- a/crates/typst-library/src/model/figure.rs
+++ b/crates/typst-library/src/model/figure.rs
@@ -3,9 +3,10 @@ use std::num::NonZeroUsize;
 use std::str::FromStr;
 
 use ecow::EcoString;
+use typst_syntax::{Span, Spanned};
 use typst_utils::NonZeroExt;
 
-use crate::diag::{SourceResult, bail};
+use crate::diag::{SourceResult, Trace, Tracepoint, bail};
 use crate::engine::Engine;
 use crate::foundations::{
     Content, Element, NativeElement, Packed, Selector, ShowSet, Smart, StyleChain,
@@ -291,7 +292,7 @@ pub struct FigureElem {
     ///   kind: "foo",
     /// )
     /// ```
-    pub supplement: Smart<Option<Supplement>>,
+    pub supplement: Spanned<Smart<Option<Supplement>>>,
 
     /// How to number the figure. Accepts a
     /// @numbering[numbering pattern or function] taking a single number.
@@ -360,7 +361,8 @@ impl Synthesize for Packed<FigureElem> {
         });
 
         // Resolve the supplement.
-        let supplement = match elem.supplement.get_ref(styles).as_ref() {
+        let sup = elem.supplement.get_ref(styles).as_ref();
+        let supplement = match &sup.v {
             Smart::Auto => {
                 // Default to the local name for the kind, if available.
                 let name = match &kind {
@@ -392,7 +394,11 @@ impl Synthesize for Packed<FigureElem> {
                 };
 
                 let target = descendant.unwrap_or_else(|| Cow::Borrowed(&elem.body));
-                Some(supplement.resolve(engine, styles, [target])?)
+                Some(supplement.resolve(engine, styles, [target], sup.span).trace(
+                    engine.world,
+                    || Tracepoint::call(FigureElem::ELEM.name()),
+                    span,
+                )?)
             }
         };
 
@@ -413,8 +419,10 @@ impl Synthesize for Packed<FigureElem> {
         }
 
         elem.kind.set(Smart::Custom(kind));
-        elem.supplement
-            .set(Smart::Custom(supplement.map(Supplement::Content)));
+        elem.supplement.set(Spanned {
+            span: supplement.as_ref().map(Content::span).unwrap_or(Span::detached()),
+            v: Smart::Custom(supplement.map(Supplement::Content)),
+        });
         elem.counter = Some(Some(counter));
         elem.caption.set(caption);
         elem.locale = Some(Locale::get_in(styles));
@@ -447,7 +455,7 @@ impl Count for Packed<FigureElem> {
 impl Refable for Packed<FigureElem> {
     fn supplement(&self) -> Content {
         // After synthesis, this should always be custom content.
-        match self.supplement.get_cloned(StyleChain::default()) {
+        match self.supplement.get_cloned(StyleChain::default()).v {
             Smart::Custom(Some(Supplement::Content(content))) => content,
             _ => Content::empty(),
         }

--- a/crates/typst-library/src/model/footnote.rs
+++ b/crates/typst-library/src/model/footnote.rs
@@ -2,6 +2,7 @@ use std::num::NonZeroUsize;
 use std::str::FromStr;
 
 use ecow::{EcoString, eco_format};
+use typst_syntax::Spanned;
 use typst_utils::{NonZeroExt, singleton};
 
 use crate::diag::{At, SourceResult, StrResult, bail};
@@ -172,8 +173,9 @@ impl Packed<FootnoteElem> {
 }
 
 impl Count for Packed<FootnoteElem> {
-    fn update(&self) -> Option<CounterUpdate> {
-        (!self.is_ref()).then(|| CounterUpdate::Step(NonZeroUsize::ONE))
+    fn update(&self) -> Option<Spanned<CounterUpdate>> {
+        (!self.is_ref())
+            .then(|| Spanned::new(CounterUpdate::Step(NonZeroUsize::ONE), self.span()))
     }
 }
 

--- a/crates/typst-library/src/model/heading.rs
+++ b/crates/typst-library/src/model/heading.rs
@@ -1,9 +1,10 @@
 use std::num::NonZeroUsize;
 
 use ecow::EcoString;
+use typst_syntax::Spanned;
 use typst_utils::NonZeroExt;
 
-use crate::diag::SourceResult;
+use crate::diag::{SourceResult, Trace, Tracepoint};
 use crate::engine::Engine;
 use crate::foundations::{
     Content, NativeElement, Packed, ShowSet, Smart, StyleChain, Styles, Synthesize, elem,
@@ -171,7 +172,7 @@ pub struct HeadingElem {
     /// in @intro[Part], it is done
     /// manually.
     /// ```
-    pub supplement: Smart<Option<Supplement>>,
+    pub supplement: Spanned<Smart<Option<Supplement>>>,
 
     /// Whether the heading should appear in the @outline[outline].
     ///
@@ -251,11 +252,15 @@ impl Synthesize for Packed<HeadingElem> {
         engine: &mut Engine,
         styles: StyleChain,
     ) -> SourceResult<()> {
-        let supplement = match self.supplement.get_ref(styles) {
+        let sup = self.supplement.get_ref(styles);
+        let supplement = match &sup.v {
             Smart::Auto => TextElem::packed(Self::local_name_in(styles)),
             Smart::Custom(None) => Content::empty(),
             Smart::Custom(Some(supplement)) => {
-                supplement.resolve(engine, styles, [self.clone().pack()])?
+                let point = || Tracepoint::call(HeadingElem::ELEM.name());
+                supplement
+                    .resolve(engine, styles, [self.clone().pack()], sup.span)
+                    .trace(engine.world, point, self.span())?
             }
         };
 
@@ -279,8 +284,10 @@ impl Synthesize for Packed<HeadingElem> {
 
         let elem = self.as_mut();
         elem.level.set(Smart::Custom(elem.resolve_level(styles)));
-        elem.supplement
-            .set(Smart::Custom(Some(Supplement::Content(supplement))));
+        elem.supplement.set(Spanned {
+            span: supplement.span(),
+            v: Smart::Custom(Some(Supplement::Content(supplement))),
+        });
         Ok(())
     }
 }
@@ -320,7 +327,7 @@ impl Count for Packed<HeadingElem> {
 impl Refable for Packed<HeadingElem> {
     fn supplement(&self) -> Content {
         // After synthesis, this should always be custom content.
-        match self.supplement.get_cloned(StyleChain::default()) {
+        match self.supplement.get_cloned(StyleChain::default()).v {
             Smart::Custom(Some(Supplement::Content(content))) => content,
             _ => Content::empty(),
         }

--- a/crates/typst-library/src/model/heading.rs
+++ b/crates/typst-library/src/model/heading.rs
@@ -316,11 +316,13 @@ impl ShowSet for Packed<HeadingElem> {
 }
 
 impl Count for Packed<HeadingElem> {
-    fn update(&self) -> Option<CounterUpdate> {
-        self.numbering
-            .get_ref(StyleChain::default())
-            .is_some()
-            .then(|| CounterUpdate::Step(self.resolve_level(StyleChain::default())))
+    fn update(&self) -> Option<Spanned<CounterUpdate>> {
+        self.numbering.get_ref(StyleChain::default()).is_some().then(|| {
+            Spanned::new(
+                CounterUpdate::Step(self.resolve_level(StyleChain::default())),
+                self.span(),
+            )
+        })
     }
 }
 

--- a/crates/typst-library/src/model/list.rs
+++ b/crates/typst-library/src/model/list.rs
@@ -1,4 +1,5 @@
 use comemo::Track;
+use typst_syntax::{Span, Spanned};
 
 use crate::diag::{SourceResult, bail};
 use crate::engine::Engine;
@@ -84,15 +85,15 @@ pub struct ListElem {
     ///   - Items
     /// - Items
     /// ```
-    #[default(ListMarker::Content(vec![
+    #[default(Spanned::detached(ListMarker::Content(vec![
         // These are all available in the default font, vertically centered, and
         // roughly of the same size (with the last one having slightly lower
         // weight because it is not filled).
         TextElem::packed('\u{2022}'), // Bullet
         TextElem::packed('\u{2023}'), // Triangular Bullet
         TextElem::packed('\u{2013}'), // En-dash
-    ]))]
-    pub marker: ListMarker,
+    ])))]
+    pub marker: Spanned<ListMarker>,
 
     /// The indent of each item.
     pub indent: Length,
@@ -189,13 +190,19 @@ impl ListMarker {
         engine: &mut Engine,
         styles: StyleChain,
         depth: usize,
+        span: Span,
     ) -> SourceResult<Content> {
         Ok(match self {
             Self::Content(list) => {
                 list.get(depth % list.len()).cloned().unwrap_or_default()
             }
             Self::Func(func) => func
-                .call(engine, Context::new(None, Some(styles)).track(), [depth])?
+                .call_traced(
+                    engine,
+                    Context::new(None, Some(styles)).track(),
+                    [depth],
+                    span,
+                )?
                 .display(),
         })
     }

--- a/crates/typst-library/src/model/numbering.rs
+++ b/crates/typst-library/src/model/numbering.rs
@@ -116,7 +116,9 @@ impl Numbering {
             Self::Pattern(pattern) => {
                 Value::Str(pattern.apply(Some((engine, span)), numbers).at(span)?.into())
             }
-            Self::Func(func) => func.call(engine, context, numbers.iter().copied())?,
+            Self::Func(func) => {
+                func.call_traced(engine, context, numbers.iter().copied(), span)?
+            }
         })
     }
 

--- a/crates/typst-library/src/model/outline.rs
+++ b/crates/typst-library/src/model/outline.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 use comemo::Tracked;
 use smallvec::SmallVec;
-use typst_syntax::Span;
+use typst_syntax::{Span, Spanned};
 use typst_utils::{Get, NonZeroExt};
 
 use crate::diag::{At, HintedStrResult, SourceResult, StrResult, bail, error};
@@ -240,7 +240,7 @@ pub struct OutlineElem {
     /// = Designing software components
     /// = Testing and integration
     /// ```
-    pub indent: Smart<OutlineIndent>,
+    pub indent: Spanned<Smart<OutlineIndent>>,
 }
 
 #[scope]
@@ -433,7 +433,9 @@ impl OutlineIndent {
         let depth = level.get() - 1;
         match self {
             Self::Rel(length) => Ok(*length * depth as f64),
-            Self::Func(func) => func.call(engine, context, [depth])?.cast().at(span),
+            Self::Func(func) => {
+                func.call_traced(engine, context, [depth], span)?.cast().at(span)
+            }
         }
     }
 }
@@ -573,7 +575,7 @@ impl OutlineEntry {
         let prefix_inset = prefix_width.map(|w| w + gap.resolve(styles));
 
         let indent = outline.indent.get_ref(styles);
-        let (base_indent, hanging_indent) = match &indent {
+        let (base_indent, hanging_indent) = match &indent.v {
             Smart::Auto => compute_auto_indents(
                 engine,
                 outline_loc,
@@ -583,7 +585,7 @@ impl OutlineEntry {
                 span,
             ),
             Smart::Custom(amount) => {
-                let base = amount.resolve(engine, context, self.level, span)?;
+                let base = amount.resolve(engine, context, self.level, indent.span)?;
                 (base, prefix_inset)
             }
         };
@@ -599,7 +601,7 @@ impl OutlineEntry {
             // can query for (within `compute_auto_indent`) to align
             // themselves).
             let mut seq = Vec::with_capacity(5);
-            if indent.is_auto() {
+            if indent.v.is_auto() {
                 seq.push(PrefixInfo::new(outline_loc, self.level, prefix_inset).pack());
             }
 

--- a/crates/typst-library/src/model/par.rs
+++ b/crates/typst-library/src/model/par.rs
@@ -1,4 +1,5 @@
 use ecow::eco_format;
+use typst_syntax::Spanned;
 use typst_utils::singleton;
 
 use crate::diag::{HintedStrResult, SourceResult, StrResult, bail};
@@ -951,7 +952,7 @@ impl Construct for ParLineMarker {
 }
 
 impl Count for Packed<ParLineMarker> {
-    fn update(&self) -> Option<CounterUpdate> {
+    fn update(&self) -> Option<Spanned<CounterUpdate>> {
         // The line counter must be updated manually by the root flow.
         None
     }

--- a/crates/typst-library/src/model/reference.rs
+++ b/crates/typst-library/src/model/reference.rs
@@ -1,7 +1,8 @@
 use comemo::Track;
 use ecow::eco_format;
+use typst_syntax::{Span, Spanned};
 
-use crate::diag::{At, Hint, SourceResult, bail};
+use crate::diag::{At, Hint, SourceResult, Trace, Tracepoint, bail};
 use crate::engine::Engine;
 use crate::foundations::{
     Cast, Content, Context, Func, IntoValue, Label, NativeElement, Packed, Repr, Smart,
@@ -176,7 +177,7 @@ pub struct RefElem {
     /// in @intro[Part], it is done
     /// manually.
     /// ```
-    pub supplement: Smart<Option<Supplement>>,
+    pub supplement: Spanned<Smart<Option<Supplement>>>,
 
     /// The kind of reference to produce.
     ///
@@ -338,10 +339,13 @@ fn realize_reference(
     let loc = elem.location().unwrap();
     let numbers = counter.display_at(engine, loc, styles, &numbering.trimmed(), span)?;
 
-    let supplement = match reference.supplement.get_ref(styles) {
+    let sup = reference.supplement.get_ref(styles);
+    let supplement = match &sup.v {
         Smart::Auto => supplement,
         Smart::Custom(None) => Content::empty(),
-        Smart::Custom(Some(supplement)) => supplement.resolve(engine, styles, [elem])?,
+        Smart::Custom(Some(supplement)) => supplement
+            .resolve(engine, styles, [elem], sup.span)
+            .trace(engine.world, || Tracepoint::call(RefElem::ELEM.name()), span)?,
     };
 
     let alt = {
@@ -367,7 +371,7 @@ fn to_citation(
     styles: StyleChain,
 ) -> SourceResult<Packed<CiteElem>> {
     let mut elem = Packed::new(CiteElem::new(reference.target).with_supplement(
-        match reference.supplement.get_cloned(styles) {
+        match reference.supplement.get_cloned(styles).v {
             Smart::Custom(Some(Supplement::Content(content))) => Some(content),
             _ => None,
         },
@@ -392,11 +396,17 @@ impl Supplement {
         engine: &mut Engine,
         styles: StyleChain,
         args: impl IntoIterator<Item = T>,
+        span: Span,
     ) -> SourceResult<Content> {
         Ok(match self {
             Supplement::Content(content) => content.clone(),
             Supplement::Func(func) => func
-                .call(engine, Context::new(None, Some(styles)).track(), args)?
+                .call_traced(
+                    engine,
+                    Context::new(None, Some(styles)).track(),
+                    args,
+                    span,
+                )?
                 .display(),
         })
     }

--- a/crates/typst-library/src/model/table.rs
+++ b/crates/typst-library/src/model/table.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use ecow::EcoString;
 use typst_macros::Cast;
+use typst_syntax::Spanned;
 use typst_utils::NonZeroExt;
 
 use crate::diag::{HintedStrResult, HintedString, SourceResult, bail};
@@ -10,7 +11,7 @@ use crate::engine::Engine;
 use crate::foundations::{
     Content, Packed, Smart, StyleChain, Synthesize, cast, elem, scope,
 };
-use crate::layout::resolve::{CellGrid, table_to_cellgrid};
+use crate::layout::resolve::{CellGrid, GridStroke, table_to_cellgrid};
 use crate::layout::{
     Abs, Alignment, Celled, GridCell, GridFooter, GridHLine, GridHeader, GridVLine,
     Length, OuterHAlignment, OuterVAlignment, Rel, Sides, TrackSizings,
@@ -192,8 +193,8 @@ pub struct TableElem {
     /// )
     /// ```
     #[fold]
-    #[default(Celled::Value(Sides::splat(Some(Abs::pt(5.0).into()))))]
-    pub inset: Celled<Sides<Option<Rel<Length>>>>,
+    #[default(Spanned::detached(Celled::Value(Sides::splat(Some(Abs::pt(5.0).into())))))]
+    pub inset: Spanned<Celled<Sides<Option<Rel<Length>>>>>,
 
     /// How to align the cells' content.
     ///
@@ -215,7 +216,7 @@ pub struct TableElem {
     ///   [A], [B], [C],
     /// )
     /// ```
-    pub align: Celled<Smart<Alignment>>,
+    pub align: Spanned<Celled<Smart<Alignment>>>,
 
     /// How to fill the cells.
     ///
@@ -243,7 +244,7 @@ pub struct TableElem {
     ///   [Profit:], [500 €], [1000 €], [1500 €],
     /// )
     /// ```
-    pub fill: Celled<Option<Paint>>,
+    pub fill: Spanned<Celled<Option<Paint>>>,
 
     /// How to @stroke[stroke] the cells.
     ///
@@ -265,8 +266,10 @@ pub struct TableElem {
     ///
     /// See the @guides:tables:strokes[Table Guide] for more details.
     #[fold]
-    #[default(Celled::Value(Sides::splat(Some(Some(Arc::new(Stroke::default()))))))]
-    pub stroke: Celled<Sides<Option<Option<Arc<Stroke>>>>>,
+    #[default(Spanned::detached(Celled::Value(Sides::splat(Some(Some(
+        Arc::new(Stroke::default())
+    ))))))]
+    pub stroke: Spanned<Celled<Sides<GridStroke>>>,
 
     /// A summary of the purpose and structure of complex tables.
     ///
@@ -762,7 +765,7 @@ pub struct TableCell {
 
     /// The cell's @table.stroke[stroke] override.
     #[fold]
-    pub stroke: Sides<Option<Option<Arc<Stroke>>>>,
+    pub stroke: Sides<GridStroke>,
 
     /// Whether rows spanned by this cell can be placed in different pages. When
     /// equal to `{auto}`, a cell spanning only fixed-size rows is unbreakable,

--- a/crates/typst-syntax/src/span.rs
+++ b/crates/typst-syntax/src/span.rs
@@ -415,6 +415,12 @@ impl<T: Debug, S: Copy + SpanDetached> Debug for Spanned<T, S> {
     }
 }
 
+impl<T: Default, S: Copy + SpanDetached> Default for Spanned<T, S> {
+    fn default() -> Self {
+        Self { v: Default::default(), span: S::SPAN_DETACHED }
+    }
+}
+
 /// Allows generic access to the detached span. Only used to implement
 /// [`Spanned::detached`].
 trait SpanDetached {

--- a/tests/README.md
+++ b/tests/README.md
@@ -146,6 +146,7 @@ attributes are currently defined:
   sparingly.
 - `empty`: Indicates that a test shouldn't produce any non-trivial output. If it
   does anyway, it will fail.
+- `trace`: Check the trace points of errors using `// Trace:` notes.
 
 There are, broadly speaking, three kinds of tests:
 
@@ -177,14 +178,23 @@ There are, broadly speaking, three kinds of tests:
     ```
 
     These have inline annotations like `// Error: 2-7 thing was wrong`. An
-    annotation can start with either "Error", "Warning", or "Hint". The range
-    designates the code span the diagnostic message refers to in the _first
-    non-annotation line_ below. If the code span is in a line further below, you
-    can write ranges like `3:2-3:7` to indicate the 2-7 column in the 3rd
-    non-annotation line.
+    annotation can start with either "Error", "Warning", "Hint", or "Trace".
+    The range designates the code span the diagnostic message refers to in the
+    _first non-annotation line_ below. If the code span is in a line further
+    below, you can write ranges like `3:2-3:7` to indicate the 2-7 column in
+    the 3rd non-annotation line.
 
     Similarly to 1, these tests should have either the `eval` attribute or a
     pair like `paged empty` or `html empty`.
+
+    Using the `trace` attribute, the trace point of errors can be checked as
+    well. The position of a trace point in the list is prepended to the its
+    message as follows: `({n}) `, which will look like this:
+    ```
+    --- example-diagnostic-test eval ---
+    // Trace: 4-19 (3) while calling `func`
+    #func()
+    ```
 
 3. Tests that ensure certain **output is produced**:
     ```typ

--- a/tests/src/collect.rs
+++ b/tests/src/collect.rs
@@ -87,6 +87,7 @@ bitflags! {
     struct AttrFlags: u16 {
         const LARGE = 1 << 0;
         const EMPTY = 1 << 1;
+        const TRACE = 1 << 2;
     }
 }
 
@@ -95,6 +96,8 @@ bitflags! {
 pub struct Attrs {
     pub large: bool,
     pub empty: bool,
+    /// Whether to insert [`Tracepoint`]s as notes.
+    pub trace: bool,
     pub features: Option<Features>,
     /// Tolerance for image comparisons. Render tests are not 100% reproducible.
     /// By default, we allow a byte difference of 1, but in rare cases, we need
@@ -664,7 +667,7 @@ impl<'a> Parser<'a> {
             }
 
             let body = self.s.from(start);
-            let body = parse_test_body(pos, body, &mut self.collector.errors);
+            let body = parse_test_body(pos, &attrs, body, &mut self.collector.errors);
 
             self.collector.tests.push(Test { name, attrs, body });
         }
@@ -723,6 +726,7 @@ impl<'a> Parser<'a> {
                 "bundle" => self.set_attr(attr_name, &mut stages, TestStages::BUNDLE),
                 "large" => self.set_attr(attr_name, &mut flags, AttrFlags::LARGE),
                 "empty" => self.set_attr(attr_name, &mut flags, AttrFlags::EMPTY),
+                "trace" => self.set_attr(attr_name, &mut flags, AttrFlags::TRACE),
                 "features" => {
                     let Some(params) = attr_params.take() else {
                         self.error("expected parameter for `features`");
@@ -767,6 +771,7 @@ impl<'a> Parser<'a> {
         Attrs {
             large: flags.contains(AttrFlags::LARGE),
             empty: flags.contains(AttrFlags::EMPTY),
+            trace: flags.contains(AttrFlags::TRACE),
             features,
             stages,
             tolerance,

--- a/tests/src/notes.rs
+++ b/tests/src/notes.rs
@@ -8,7 +8,6 @@ use std::ops::Range;
 use std::path::Path;
 use std::sync::LazyLock;
 
-use ecow::EcoString;
 use regex::{Captures, Regex};
 use typst::diag::{StrResult, bail};
 use typst::foundations::Bytes;
@@ -20,7 +19,7 @@ use typst_syntax::{
 };
 use unscanny::Scanner;
 
-use crate::collect::{FilePos, TestParseError, TestStages};
+use crate::collect::{Attrs, FilePos, TestParseError, TestStages};
 use crate::world::{TestFiles, TestWorld};
 
 /// The body of a test.
@@ -196,6 +195,7 @@ pub enum NoteKind {
     Error,
     Warning,
     Hint,
+    Trace,
 }
 
 impl Display for NoteKind {
@@ -204,6 +204,7 @@ impl Display for NoteKind {
             Self::Error => "Error",
             Self::Warning => "Warning",
             Self::Hint => "Hint",
+            Self::Trace => "Trace",
         })
     }
 }
@@ -213,7 +214,7 @@ impl Note {
     pub fn emitted(
         kind: NoteKind,
         stage: TestStages,
-        message: &EcoString,
+        message: impl Into<String>,
         span: DiagSpan,
         world: &TestWorld,
     ) -> Self {
@@ -235,7 +236,7 @@ impl Note {
             NoteRange::None
         };
 
-        let mut message: String = message.into();
+        let mut message = message.into();
         if message.contains('\\') {
             // HACK: Replace backslashes in path sepators with slashes for cross
             // platform reproducible error messages.
@@ -424,6 +425,7 @@ impl Display for LineCol {
 /// Parse the body of a test.
 pub fn parse_test_body(
     pos: FilePos,
+    attrs: &Attrs,
     full_body: &str,
     errors: &mut Vec<TestParseError>,
 ) -> TestBody {
@@ -453,7 +455,16 @@ pub fn parse_test_body(
         let line = pos.line + i;
         let note_pos = FilePos { path: pos.path.clone(), line };
         match parse_note(note_pos, annotated_line, &mut s, kind, source.clone()) {
-            Ok(note) => notes.push(note),
+            Ok(note) => {
+                if !attrs.trace && note.kind == NoteKind::Trace {
+                    errors.push(TestParseError::new(
+                        "found `// Trace:` note in test without `trace` attribute",
+                        &pos.path,
+                        line,
+                    ));
+                }
+                notes.push(note);
+            }
             Err(message) => errors.push(TestParseError::new(message, &pos.path, line)),
         }
     }
@@ -468,6 +479,7 @@ fn parse_note_start(s: &mut Scanner) -> Option<NoteKind> {
         ("// Error:", NoteKind::Error),
         ("// Warning:", NoteKind::Warning),
         ("// Hint:", NoteKind::Hint),
+        ("// Trace:", NoteKind::Trace),
     ] {
         if s.eat_if(pattern) {
             return Some(kind);

--- a/tests/src/run.rs
+++ b/tests/src/run.rs
@@ -8,7 +8,7 @@ use typst::model::Document;
 use typst_bundle::Bundle;
 use typst_html::HtmlDocument;
 use typst_layout::PagedDocument;
-use typst_syntax::Spanned;
+use typst_syntax::{DiagSpan, Spanned};
 
 use crate::collect::{
     FileSize, Test, TestEval, TestOutput, TestOutputKind, TestStage, TestStages,
@@ -795,6 +795,20 @@ impl<'a> Runner<'a> {
             let emitted_hint =
                 Note::emitted(NoteKind::Hint, stage, hint, hint_span, &self.world);
             self.test.body.mark_seen_or_update(emitted_hint);
+        }
+
+        // Check traces.
+        if self.test.attrs.trace {
+            for (Spanned { v: point, span }, i) in diag.trace.iter().zip(1..) {
+                let emitted_hint = Note::emitted(
+                    NoteKind::Trace,
+                    stage,
+                    format!("({i}) {point}"),
+                    DiagSpan::from(*span),
+                    &self.world,
+                );
+                self.test.body.mark_seen_or_update(emitted_hint);
+            }
         }
     }
 }

--- a/tests/suite/foundations/array.typ
+++ b/tests/suite/foundations/array.typ
@@ -281,6 +281,10 @@
 // Error: 21-26 cannot subtract integer from string
 #("a",).filter(x => x - 2)
 
+--- array-reduce-wrong-return-type eval ---
+// Error: 19-29 expected boolean, found integer
+#(1, 2, 3).filter(i => i + 1)
+
 --- array-map eval ---
 // Test the `map` method.
 #test(().map(x => x * 2), ())

--- a/tests/suite/foundations/str.typ
+++ b/tests/suite/foundations/str.typ
@@ -288,7 +288,7 @@
 #test("aaa".replace("a", m => str(m.captures.len())), "000")
 
 --- string-replace-function-bad-type eval ---
-// Error: 23-24 expected string, found integer
+// Error: 23-29 expected string, found integer
 #"123".replace("123", m => 1)
 
 --- string-replace-bad-type eval ---

--- a/tests/suite/introspection/counter.typ
+++ b/tests/suite/introspection/counter.typ
@@ -260,6 +260,19 @@ $ 1 + 2 $ <eq>
 // Hint: 2-28 the `context` expression should wrap everything that depends on this function
 #counter("key").at(<label>)
 
+--- counter-update-panic paged trace ---
+// Error: 22-29 panicked
+#let page-count(n) = panic()
+
+// Trace: 2-34 (1) while calling `page-count`
+#state("page").update(page-count)
+
+// Trace: 1:10-3:2 (3) while calling function
+#context {
+  // Trace: 3-24 (2) while calling `final`
+  state("page").final()
+}
+
 --- issue-2480-counter-reset paged ---
 #let q = counter("question")
 #let step-show =  q.step() + context q.display("1")

--- a/tests/suite/layout/grid/styling.typ
+++ b/tests/suite/layout/grid/styling.typ
@@ -103,6 +103,19 @@ a
   [A], [B], [C],
 )
 
+--- grid-inset-func-panic-trace paged trace ---
+#let compute-inset(x, y) = "100"
+
+// Error: 18-31 expected relative length or dictionary, found string
+#set grid(inset: compute-inset)
+
+// Trace: 1:2-5:2 (1) while calling `grid`
+#grid(
+  columns: 2,
+  [A], [B],
+  [C], [D],
+)
+
 --- grid-inset-folding paged ---
 // Test inset folding
 #set grid(inset: 10pt)

--- a/tests/suite/math/cancel.typ
+++ b/tests/suite/math/cancel.typ
@@ -40,3 +40,10 @@ $cancel(x, angle: #0deg) + cancel(x, angle: #45deg) + cancel(x, angle: #90deg) +
 // Specifying cancel line angle with a function
 $x + cancel(y, angle: #{angle => angle + 90deg}) - cancel(z, angle: #(angle => angle + 135deg))$
 $ e + cancel((j + e)/(f + e)) - cancel((j + e)/(f + e), angle: #(angle => angle + 30deg)) $
+
+--- math-cancel-angle-func-panic paged trace ---
+// Error: 29-41 panicked with: 47.92deg
+#let compute-angle(angle) = panic(angle)
+
+// Trace: 35-48 (1) while calling `compute-angle`
+$ cancel((j + e)/(f + e), angle: #compute-angle) $

--- a/tests/suite/model/heading.typ
+++ b/tests/suite/model/heading.typ
@@ -147,6 +147,14 @@ Cannot be used as @intro
 #show par: highlight
 = Heading
 
+--- heading-supplement-panic-trace paged trace ---
+// Error: 51-64 panicked with: oops
+#set heading(supplement: (h) => if h.depth == 2 { panic("oops") })
+
+= A
+// Trace: 1-5 (1) while calling `heading`
+== B
+
 --- heading-html-basic html ---
 // level 1 => h2
 // ...

--- a/tests/suite/model/outline.typ
+++ b/tests/suite/model/outline.typ
@@ -121,6 +121,18 @@
 
 = Heading
 
+--- outline-indent-function-panic-trace paged trace ---
+// Error: 19-26 panicked
+#let compute(n) = panic()
+
+// Trace: 22-29 (1) while calling `compute`
+#set outline(indent: compute)
+
+// Trace: 2-11 (2) while calling `indented`
+#outline()
+
+= Heading
+
 --- outline-entry paged ---
 #set page(width: 150pt)
 #set heading(numbering: "1.")

--- a/tests/suite/model/outline.typ
+++ b/tests/suite/model/outline.typ
@@ -116,7 +116,7 @@
 = F
 
 --- outline-indent-bad-type paged ---
-// Error: 2-35 expected relative length, found dictionary
+// Error: 18-34 expected relative length, found dictionary
 #outline(indent: n => (a: "dict"))
 
 = Heading

--- a/tests/suite/styling/show.typ
+++ b/tests/suite/styling/show.typ
@@ -266,15 +266,27 @@ I am *strong*, I am _emphasized_, and I am #[special<special>].
 // Hint: 7-33 support for this is planned for the future
 #show selector(emph).within(par): set text(red)
 
---- show-delayed-error paged ---
+--- show-delayed-error paged trace ---
 // Error: 21-34 panicked with: hey1
 #show heading: _ => panic("hey1")
 
 // Error: 20-33 panicked with: hey2
 #show strong: _ => panic("hey2")
 
+// Trace: 1-8 (1) while showing heading element
 = Hello
+// Trace: 1-9 (1) while showing strong element
 *strong*
+
+--- show-error-trace paged trace ---
+// Error: 16-34 panicked with: Heading
+#let func(c) = panic(c.body.text)
+
+// Trace: 2-20 (1) while calling `func`
+#show heading: func
+
+// Trace: 1-10 (2) while showing heading element
+= Heading
 
 --- issue-5690-oom-par-box paged ---
 // Error: 3:6-5:1 maximum grouping depth exceeded


### PR DESCRIPTION
Closes #8831

I remembered the relevant code, and this seemed like a real simple fix.

The following code:
```typ
#let foo(body) = {
  panic()
}
#show: foo
```
will now produce this traceback:
```txt
error: panicked
  ┌─ test.typ:2:2
  │
2 │   panic()
  │   ^^^^^^^

  while applying show rule at test.typ:5:1
    show: foo
```

And this code:
```typ
#let foo(body) = {
  panic()
}

#show strong: foo

*strong*
```
Will now also include the show rule definition in its traceback:
```txt
error: panicked
  ┌─ test1.typ:2:2
  │
2 │   panic()
  │   ^^^^^^^

  while showing strong element at test1.typ:7:0
    *strong*
  while applying show rule at test1.typ:5:1
    show strong: foo
```