### PR TITLE
Display category and canonical path on search results

### DIFF
--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -1085,16 +1085,44 @@ nav.folding .search-results::before {
   color: #565565;
 }
 
-nav.folding .search-results .type {
-  margin-inline-start: 8px;
+nav.folding .search-results li > a {
+  display: grid;
+  grid-template:
+    "t c"
+    "p p"
+    "k k"
+    / 1fr auto;
+  align-items: baseline;
+  column-gap: 8px;
+}
+
+nav.folding .search-results .result-title {
+  grid-area: t;
+}
+
+nav.folding .search-results .result-category {
+  grid-area: c;
   text-transform: uppercase;
   font-weight: 600;
   font-size: 12px;
   color: #565565;
+  text-align: end;
+}
+
+nav.folding .search-results .result-path {
+  grid-area: p;
+  font-size: 14px;
+  padding-block: 2px;
+}
+
+nav.folding .search-results .result-kind {
+  grid-area: k;
+  font-size: 12px;
+  font-style: italic;
 }
 
 nav.folding .search-results a {
-  margin-block-end: 4px !important;
+  margin-block-end: 6px !important;
 }
 
 /* On this page navigation in right side bar */

--- a/docs/assets/docs.js
+++ b/docs/assets/docs.js
@@ -765,12 +765,28 @@ async function setUpGlobalSearch() {
       }
       const li = document.createElement("li");
       const a = document.createElement("a");
-      const span = document.createElement("span");
       a.href = url;
-      a.textContent = item.title;
-      span.classList.add("type");
-      span.textContent = item.kind;
-      a.appendChild(span);
+
+      const title = document.createElement("span");
+      title.classList.add("result-title");
+      title.textContent = item.title;
+      a.appendChild(title);
+
+      const category = document.createElement("span");
+      category.classList.add("result-category");
+      category.textContent = item.category;
+      a.appendChild(category);
+
+      const path = document.createElement("code");
+      path.classList.add("result-path");
+      path.textContent = item.path;
+      a.appendChild(path);
+
+      const type = document.createElement("span");
+      type.classList.add("result-kind");
+      type.textContent = item.kind;
+      a.appendChild(type);
+
       li.appendChild(a);
       return li;
     });

--- a/docs/components/category.typ
+++ b/docs/components/category.typ
@@ -188,7 +188,7 @@
 }
 
 // Displays the documentation for a single parameter.
-#let param-details(func, param, base-label, muted: false) = {
+#let param-details(func, param, base-label, category, muted: false) = {
   let param-label = label(str(def-label(func)) + "." + param.name)
   let input-types = flat-types(param.input)
 
@@ -204,8 +204,10 @@
       }
       if not muted {
         register-index-item(
+          category: category,
           kind: "Parameter of " + repr(func),
           title: title-case(param.name),
+          path: std-path-of(func) + "." + param.name,
           dest: it.location(),
         )
       }
@@ -260,6 +262,7 @@
   params,
   returns,
   base-label,
+  category,
   path: auto,
   indent: false,
   muted: false,
@@ -278,7 +281,7 @@
   }
 
   for param in params {
-    param-details(func, param, base-label, muted: muted)
+    param-details(func, param, base-label, category, muted: muted)
   }
 }
 
@@ -384,6 +387,7 @@
 // section.
 #let func-member(
   func,
+  category: none,
   base-label: none,
   binding-info: none,
   definitions-section: none,
@@ -399,8 +403,10 @@
       register-def(func, it.location())
       if not muted {
         register-index-item(
+          category: category,
           kind: "Function",
           title: info.title,
+          path: std-path-of(func),
           dest: it.location(),
           keywords: info.keywords,
         )
@@ -447,6 +453,7 @@
     params,
     info.returns,
     base-label,
+    category,
     path: path,
     indent: true,
     muted: muted,
@@ -455,12 +462,13 @@
   heading-offset(2, definitions-section(
     info.name,
     scope-from(info.scope, binding-info),
+    category,
     base-label: label(str(base-label) + "-definitions"),
   ))
 }
 
 // Documents the constructor of a type.
-#let constructor-section(func, path) = {
+#let constructor-section(func, category, path) = {
   let info = stdx.describe(func)
   let base-label = <constructor>
 
@@ -489,8 +497,9 @@
     func,
     info.params,
     info.returns,
-    path: path,
     base-label,
+    category,
+    path: path,
     indent: true,
   )
 }
@@ -498,6 +507,7 @@
 // Renders documentation for a type as part of a large documentation section.
 #let ty-member(
   ty,
+  category: none,
   base-label: none,
   binding-info: none,
   definitions-section: none,
@@ -511,8 +521,10 @@
     show heading: it => {
       register-def(ty, it.location())
       register-index-item(
+        category: category,
         kind: "Type",
         title: info.title,
+        path: std-path-of(ty),
         dest: it.location(),
         keywords: info.keywords,
       )
@@ -544,6 +556,7 @@
   if info.constructor != none {
     heading-offset(2, constructor-section(
       info.constructor,
+      category,
       std-path-of(ty).split("."),
     ))
   }
@@ -551,12 +564,13 @@
   heading-offset(2, definitions-section(
     info.short-name,
     scope-from(info.scope, binding-info),
+    category,
     base-label: label(str(base-label) + "-definitions"),
   ))
 }
 
 // Renders a section that documents definitions on a type or function.
-#let definitions-section(parent, scope, base-label: <definitions>) = {
+#let definitions-section(parent, scope, category, base-label: <definitions>) = {
   if scope.dict.len() == 0 {
     return
   }
@@ -577,6 +591,7 @@
     if type(value) == function {
       func-member(
         value,
+        category: category,
         base-label: base-label,
         binding-info: nested-binding(scope, name),
         definitions-section: definitions-section,
@@ -584,6 +599,7 @@
     } else if type(value) == type {
       ty-member(
         value,
+        category: category,
         base-label: base-label,
         binding-info: nested-binding(scope, name),
         definitions-section: definitions-section,
@@ -602,18 +618,23 @@
 #let func-or-ty-section(..args) = {
   show heading.where(level: 3): set text(16pt)
   show heading.where(level: 3): set block(below: 16pt)
-  docs-section(..args)
+  docs-section(
+    path: std-path-of(args.def-target),
+    ..args,
+  )
 }
 
 // Renders a section for a function.
 #let func-section(
   base-route,
+  category,
   name,
   func,
   info,
   binding-info,
 ) = {
   show: func-or-ty-section.with(
+    category: category,
     kind: "Function",
     route: base-route + "/" + name,
     title: info.title,
@@ -638,23 +659,26 @@
       info.params,
       info.returns,
       base-label,
+      category,
     )
   }
 
   definitions-section(
     info.name,
     scope-from(info.scope, binding-info),
+    category,
   )
 }
 
 // Renders a section for a type.
-#let ty-section(base-route, name, ty, ty-info, binding-info) = {
+#let ty-section(base-route, category, name, ty, ty-info, binding-info) = {
   show: func-or-ty-section.with(
     route: base-route + "/" + name,
     title: ty-info.title,
     title-fmt: ty-pill(ty, linked: false),
     subtitle: ty-subtitle(ty-info, binding-info),
     has-summary: true,
+    category: category,
     kind: "Type",
     keywords: ty-info.keywords,
     def-target: ty,
@@ -669,6 +693,7 @@
   if ty-info.constructor != none {
     constructor-section(
       ty-info.constructor,
+      category,
       std-path-of(ty).split("."),
     )
   }
@@ -676,6 +701,7 @@
   definitions-section(
     ty-info.short-name,
     scope-from(ty-info.scope, binding-info),
+    category,
   )
 }
 
@@ -691,9 +717,10 @@
 // Renders a section for grouped definitions.
 //
 // An example of this are the various groups like "Attach" in the math docs.
-#let group-section(base-route, base-target, info) = {
+#let group-section(base-route, category, base-target, info) = {
   let def-target = group-target(base-target, info)
   show: docs-section.with(
+    category: category,
     kind: "Group",
     route: base-route + "/" + info.name,
     title: info.title,
@@ -709,6 +736,7 @@
     for (key, value) in info.items {
       func-member(
         value,
+        category: category,
         base-label: base-label,
         binding-info: nested-binding(info.scope, key),
       )
@@ -724,7 +752,7 @@
   if info.title == "Typed HTML" {
     for param in stdx.describe(html.div).params {
       if stdx.is-global-html-attr(param.name) {
-        param-details(html.div, param, <global-attributes>, muted: true)
+        param-details(html.div, param, <global-attributes>, category, muted: true)
       }
     }
   }
@@ -850,6 +878,7 @@
 // Show a list of category definitions built by `build-category-definitions()`.
 #let category-definitions(
   route,
+  category,
   scope,
   def-target,
   definitions,
@@ -863,18 +892,18 @@
       let binding-info = if kind != "addition" { nested-binding(scope, name) }
 
       if kind == "category" {
-        func-category(route, name, value, info, binding-info)
+        func-category(route, category, name, value, info, binding-info)
       } else if type(value) == function {
-        func-section(route, name, value, info, binding-info)
+        func-section(route, category, name, value, info, binding-info)
       } else if type(value) == type {
-        ty-section(route, name, value, info, binding-info)
+        ty-section(route, category, name, value, info, binding-info)
       }
     } else if kind == "group" {
       let group = info
       if group.at("scope", default: none) == none {
         group.scope = scope
       }
-      group-section(route, def-target, group)
+      group-section(route, category, def-target, group)
     }
   }
 }
@@ -882,6 +911,8 @@
 // Renders a section for a combined type and category (used for export formats).
 #let func-category(
   base-route,
+  // The category under which the function is documented.
+  category,
   // The name of the function.
   name,
   // The value of the function.
@@ -906,6 +937,7 @@
   )
 
   func-or-ty-section(
+    category: category,
     kind: "Function",
     route: route,
     title: info.title,
@@ -929,6 +961,7 @@
           info.params,
           info.returns,
           base-label,
+          category,
         )
       }
 
@@ -940,6 +973,7 @@
 
   category-definitions(
     route,
+    category,
     scope,
     def-target,
     definitions,
@@ -947,8 +981,8 @@
   )
 }
 
-// Renders the docs for one category, including an overview section and sections
-// for all definitions in the category.
+// Renders the docs for one category in the Reference, including an overview
+// section and sections for all definitions in the category.
 #let docs-category(
   // The name of the category, e.g. `"foundations"`.
   category: none,
@@ -997,6 +1031,7 @@
     has-summary: true,
     route: route,
     def-target: def-target,
+    category: "Reference",
     kind: "Category",
     description: description,
     {
@@ -1009,6 +1044,7 @@
 
   category-definitions(
     route,
+    title,
     scope,
     def-target,
     definitions,

--- a/docs/components/search.typ
+++ b/docs/components/search.typ
@@ -9,14 +9,18 @@
 //
 // See `IndexItem` in the Rust sources for more details on the parameters.
 #let register-index-item(
+  category: none,
   kind: none,
   title: none,
+  path: none,
   dest: none,
   keywords: (),
 ) = labelled(
   metadata((
+    category: category,
     kind: kind,
     title: title,
+    path: path,
     dest: dest,
     keywords: keywords,
   )),

--- a/docs/components/section.typ
+++ b/docs/components/section.typ
@@ -69,7 +69,9 @@
   def-target: none,
   class: none,
   nav-buttons: none,
+  category: none,
   kind: none,
+  path: none,
   keywords: none,
   description: none,
   body,
@@ -95,8 +97,10 @@
     // The index item is placed here so that all body text of this HTML document
     // is considered part of this index item.
     register-index-item(
+      category: category,
       kind: kind,
       title: title,
+      path: path,
       dest: route,
       keywords: keywords,
     )
@@ -180,8 +184,12 @@
   // The navigation buttons at the bottom of the HTML page.
   nav-buttons: nav-prev-next(),
 
+  // The category under which this section appears.
+  category: none,
   // The kind of section. This is displayed in the search result for the page.
   kind: none,
+  // The canonical path for this item in Typst's standard library.
+  path: none,
   // Keywords for the page. The page can be found in search with these.
   keywords: (),
   // The plain-text description of the HTML page.
@@ -196,6 +204,9 @@
   assert.ne(def-target, none, message: "definition target is required")
   assert.ne(description, none, message: "description is required")
   assert.eq(type(description), str, message: "description must be a string")
+  if route != "/" {
+    assert.ne(category, none, message: "category is required " + route)
+  }
   assert.ne(kind, none, message: "kind is required")
   assert.eq(type(keywords), array, message: "keywords must be an array")
   assert(route.starts-with("/"), message: "route must start with slash")
@@ -229,7 +240,9 @@
       def-target: def-target,
       class: class,
       nav-buttons: nav-buttons,
+      category: category,
       kind: kind,
+      path: path,
       keywords: keywords,
       description: description,
       body,

--- a/docs/content/changelog/index.typ
+++ b/docs/content/changelog/index.typ
@@ -48,6 +48,7 @@
 #docs-chapter(
   title: "Changelog",
   route: "/changelog",
+  category: "Category",
   description: "Learn what has changed in the latest Typst releases and move your documents forward.",
 )[
   Learn what has changed in the latest Typst releases and move your documents forward. This section documents all changes to Typst since its initial public release.
@@ -95,6 +96,7 @@
         (Unreleased)
       ]
     },
+    category: "Changelogs",
     description: "Changes in Typst " + base-version,
     class: "changelog",
     context {
@@ -118,6 +120,7 @@
   title: "Earlier",
   title-fmt: [Changes in early, unversioned Typst],
   route: "/changelog/earlier",
+  category: "Changelogs",
   description: "Changes in early, unversioned Typst",
   context {
     set heading(outlined: false, bookmarked: true) if target() == "paged"

--- a/docs/content/guides/accessibility.typ
+++ b/docs/content/guides/accessibility.typ
@@ -5,6 +5,7 @@
 #show: docs-chapter.with(
   title: "Accessibility Guide",
   route: "/guides/accessibility",
+  category: "Guides",
   description: "Learn how to create accessible documents with Typst. This guide covers semantic markup, reading order, alt text, color contrast, language settings, and PDF/UA compliance to ensure your files work for all readers and Assistive Technology.",
   class: "a11y",
 )

--- a/docs/content/guides/for-latex-users.typ
+++ b/docs/content/guides/for-latex-users.typ
@@ -5,6 +5,7 @@
 #show: docs-chapter.with(
   title: "Guide for LaTeX Users",
   route: "/guides/for-latex-users",
+  category: "Guides",
   description: "Are you a LaTeX user? This guide explains the differences and similarities between Typst and LaTeX so you can get started quickly.",
 )
 

--- a/docs/content/guides/index.typ
+++ b/docs/content/guides/index.typ
@@ -5,6 +5,7 @@
 #docs-chapter(
   title: "Guides",
   route: "/guides",
+  category: "Category",
   description: "Guides for Typst.",
 )[
   Welcome to the Guides section! Here, you'll find helpful material for specific user groups or use cases. Please see the list below for the available guides. Feel free to propose other topics for guides!

--- a/docs/content/guides/page-setup.typ
+++ b/docs/content/guides/page-setup.typ
@@ -3,6 +3,7 @@
 #show: docs-chapter.with(
   title: "Page Setup Guide",
   route: "/guides/page-setup",
+  category: "Guides",
   description: "An in-depth guide to setting page dimensions, margins, and page numbers in Typst. Learn how to create appealing and clear layouts and get there quickly.",
 )
 

--- a/docs/content/guides/tables.typ
+++ b/docs/content/guides/tables.typ
@@ -3,6 +3,7 @@
 #show: docs-chapter.with(
   title: "Table Guide",
   route: "/guides/tables",
+  category: "Guides",
   description: "Not sure how to change table strokes? Need to rotate a table? This guide explains all you need to know about tables in Typst.",
 )
 

--- a/docs/content/reference/index.typ
+++ b/docs/content/reference/index.typ
@@ -5,6 +5,7 @@
 #docs-chapter(
   title: "Reference",
   route: "/reference",
+  category: "Category",
   description: "The Typst reference is a systematic and comprehensive guide to the Typst typesetting language.",
   introduction: true,
   class: "reference-index",

--- a/docs/content/reference/language/context.typ
+++ b/docs/content/reference/language/context.typ
@@ -3,6 +3,7 @@
 #show: docs-chapter.with(
   title: "Context",
   route: "/reference/context",
+  category: "Reference",
   description: "How to deal with content that reacts to its location in the document.",
 )
 

--- a/docs/content/reference/language/scripting.typ
+++ b/docs/content/reference/language/scripting.typ
@@ -3,6 +3,7 @@
 #show: docs-chapter.with(
   title: "Scripting",
   route: "/reference/scripting",
+  category: "Reference",
   description: "Automate your document with Typst's scripting capabilities.",
 )
 

--- a/docs/content/reference/language/styling.typ
+++ b/docs/content/reference/language/styling.typ
@@ -3,6 +3,7 @@
 #show: docs-chapter.with(
   title: "Styling",
   route: "/reference/styling",
+  category: "Reference",
   description: "All concepts needed to style your document with Typst.",
 )
 

--- a/docs/content/reference/language/syntax.typ
+++ b/docs/content/reference/language/syntax.typ
@@ -3,6 +3,7 @@
 #show: docs-chapter.with(
   title: "Syntax",
   route: "/reference/syntax",
+  category: "Reference",
   description: "A compact reference for Typst's syntax. Learn more about the language within markup, math, and code mode.",
 )
 

--- a/docs/content/reference/library/symbols.typ
+++ b/docs/content/reference/library/symbols.typ
@@ -313,7 +313,8 @@
 
 #let symbols-section(..args, mod: none, emoji: false, body) = docs-section(
   ..args,
-  kind: "Symbols",
+  category: "Symbols",
+  kind: "Symbol list",
   {
     prose-styling(body)
     context if target() == "html" {

--- a/docs/content/tutorial/1-writing.typ
+++ b/docs/content/tutorial/1-writing.typ
@@ -5,6 +5,7 @@
 #show: docs-chapter.with(
   title: "Writing in Typst",
   route: "/tutorial/writing-in-typst",
+  category: "Tutorial",
   description: "Typst's tutorial.",
 )
 

--- a/docs/content/tutorial/2-formatting.typ
+++ b/docs/content/tutorial/2-formatting.typ
@@ -5,6 +5,7 @@
 #show: docs-chapter.with(
   title: "Formatting",
   route: "/tutorial/formatting",
+  category: "Tutorial",
   description: "Typst's tutorial.",
 )
 

--- a/docs/content/tutorial/3-advanced.typ
+++ b/docs/content/tutorial/3-advanced.typ
@@ -6,6 +6,7 @@
 #show: docs-chapter.with(
   title: "Advanced Styling",
   route: "/tutorial/advanced-styling",
+  category: "Tutorial",
   description: "Typst's tutorial.",
 )
 

--- a/docs/content/tutorial/4-template.typ
+++ b/docs/content/tutorial/4-template.typ
@@ -3,6 +3,7 @@
 #show: docs-chapter.with(
   title: "Making a Template",
   route: "/tutorial/making-a-template",
+  category: "Tutorial",
   description: "Typst's tutorial.",
 )
 

--- a/docs/content/tutorial/index.typ
+++ b/docs/content/tutorial/index.typ
@@ -5,6 +5,7 @@
 #docs-chapter(
   title: "Tutorial",
   route: "/tutorial",
+  category: "Category",
   description: "Typst's tutorial.",
   introduction: true,
 )[

--- a/docs/src/search.rs
+++ b/docs/src/search.rs
@@ -42,10 +42,15 @@ pub struct SearchIndex {
 /// ```
 #[derive(Debug, Clone, Serialize)]
 pub struct IndexItem {
-    /// The category of item. Shown next to the match.
+    /// The category under which the item is documented. Shown next to the
+    /// match.
+    pub category: Option<EcoString>,
+    /// The kind of item. Shown below the match.
     pub kind: EcoString,
     /// The title-case name of the item. Shown as the match.
     pub title: EcoString,
+    /// The canonical path for this item, if any. Shown below the match.
+    pub path: Option<EcoString>,
     /// The full route to the matching page. May include a fragment.
     pub route: EcoString,
     /// Keywords with which the page can be found. The keywords are stored in
@@ -57,8 +62,10 @@ pub struct IndexItem {
 cast! {
     IndexItem,
     mut v: Dict => Self {
+        category: v.take("category")?.cast()?,
         kind: v.take("kind")?.cast()?,
         title: v.take("title")?.cast()?,
+        path: v.take("path")?.cast()?,
         route: v.take("route")?.cast()?,
         keywords: v.take("keywords")?.cast()?,
     }
@@ -133,8 +140,10 @@ fn parse_item_metadata(
     introspector: &dyn Introspector,
 ) -> HintedStrResult<IndexItem> {
     let mut dict = value.cast::<Dict>()?;
+    let category = dict.take("category")?.cast()?;
     let kind = dict.take("kind")?.cast()?;
     let title = dict.take("title")?.cast()?;
+    let path = dict.take("path")?.cast()?;
     let dest = dict.take("dest")?.cast::<ItemDestination>()?;
     let keywords = dict.take("keywords")?.cast()?;
     let route = match dest {
@@ -156,7 +165,7 @@ fn parse_item_metadata(
             if anchor.is_empty() { path.into() } else { eco_format!("{path}#{anchor}") }
         }
     };
-    Ok(IndexItem { kind, title, route, keywords })
+    Ok(IndexItem { category, kind, title, path, route, keywords })
 }
 
 /// The two kinds of destinations that can be stored in an index item's


### PR DESCRIPTION
This PR aims to improve the state of the search functionality in the documentation. It fixes https://github.com/typst/typst/issues/8273.

https://github.com/typst/typst/issues/8269 is related, but this PR does not close it because there are two remaining issues:
- The inability to search for fully qualified paths (such as "array.at").
- The inability to search for keywords (such as "show" or "set").

With this PR, search results now display their documentation category, which helps distinguishing similar results like `math.round` and `calc.round` (respectively from the "Math" and "Foundations" categories). In addition, it also displays the canonical path for library items.

<details>
<summary>Here are a few examples of what the new results look like.</summary>
<img width="222" height="956" alt="Searching for 'body' yields a lot of results that are now distinguishable." src="https://github.com/user-attachments/assets/e7c72aac-fc2e-412e-aee4-29a44386e300" />
<img width="222" height="982" alt="Searching for 'round', the fully qualified names as well as documentation category are now shown." src="https://github.com/user-attachments/assets/95846bf5-81bd-4b4d-96cf-2d3fb3ad8228" />
<img width="221" height="855" alt="Not every result has a canonical path: searching for 'symbol' yields the symbol list and multiple pages from the tutorial." src="https://github.com/user-attachments/assets/a8d8b7a3-dfd2-4a7a-9540-437e7b99769b" />
</details>

As you can see, the category is displayed where the kind used to be, and the kind is now displayed below the result, in italics. The search results are made quite dense with this PR, and I am unsure how to solve that, but I thought I would open this PR to get feedback, and at least now the infrastructure is implemented, so cosmetic changes are easy to implement.