### PR TITLE
Add keywords for `math.frak`

### DIFF
--- a/crates/typst-library/src/math/style.rs
+++ b/crates/typst-library/src/math/style.rs
@@ -123,7 +123,11 @@ pub fn scr(
 /// ```example
 /// $ frak(P) $
 /// ```
-#[func(title = "Fraktur", since = "forever", keywords = ["mathfrak"])]
+#[func(
+    title = "Fraktur",
+    since = "forever",
+    keywords = ["mathfrak", "blackletter", "gothic"],
+)]
 pub fn frak(
     /// The content to style.
     body: Content,


### PR DESCRIPTION
This adds two keywords for `math.frak`:
- "blackletter", a category of typefaces under which Fraktur falls.[^1]
- "gothic", a family of scripts blackletter is part of.[^2]

[^1]: https://en.wikipedia.org/wiki/Fraktur
[^2]: https://en.wikipedia.org/wiki/Blackletter