### PR TITLE
Add link to attach from under/over docs

### DIFF
--- a/docs/content/reference/library/math.typ
+++ b/docs/content/reference/library/math.typ
@@ -64,6 +64,8 @@
         Delimiters above or below parts of an equation.
 
         The braces and brackets further allow you to add an optional annotation below or above themselves.
+
+        If you want to place a formula over or under another, without delimiters, use the @math.attach[`attach`] function.
       ],
     ),
     (


### PR DESCRIPTION
Closes https://github.com/typst/typst/issues/8186 by adding a small comment. We could also add an image displaying the difference between `attach` and `under/over`, as suggested in the issue comments, but I think this is a good start.